### PR TITLE
Remove ngrok-skip-browser-warning header

### DIFF
--- a/src/app/metrics/page.tsx
+++ b/src/app/metrics/page.tsx
@@ -73,7 +73,6 @@ export default function MetricsPage() {
           method: "GET",
           headers: {
             accept: "application/json",
-            "ngrok-skip-browser-warning": "true",
             Authorization: `Bearer ${backendAccessToken}`,
           },
         });
@@ -133,7 +132,6 @@ export default function MetricsPage() {
           method: "DELETE",
           headers: {
             accept: "application/json",
-            "ngrok-skip-browser-warning": "true",
             Authorization: `Bearer ${backendAccessToken}`,
           },
         }
@@ -182,7 +180,6 @@ export default function MetricsPage() {
           method: "GET",
           headers: {
             accept: "application/json",
-            "ngrok-skip-browser-warning": "true",
             Authorization: `Bearer ${backendAccessToken}`,
           },
         });
@@ -240,7 +237,6 @@ export default function MetricsPage() {
         headers: {
           accept: "application/json",
           "Content-Type": "application/json",
-          "ngrok-skip-browser-warning": "true",
           Authorization: `Bearer ${backendAccessToken}`,
         },
         body: JSON.stringify({
@@ -263,7 +259,6 @@ export default function MetricsPage() {
         method: "GET",
         headers: {
           accept: "application/json",
-          "ngrok-skip-browser-warning": "true",
           Authorization: `Bearer ${backendAccessToken}`,
         },
       });
@@ -303,7 +298,6 @@ export default function MetricsPage() {
         method: "GET",
         headers: {
           accept: "application/json",
-          "ngrok-skip-browser-warning": "true",
           Authorization: `Bearer ${backendAccessToken}`,
         },
       });
@@ -353,7 +347,6 @@ export default function MetricsPage() {
           headers: {
             accept: "application/json",
             "Content-Type": "application/json",
-            "ngrok-skip-browser-warning": "true",
             Authorization: `Bearer ${backendAccessToken}`,
           },
           body: JSON.stringify({
@@ -377,7 +370,6 @@ export default function MetricsPage() {
         method: "GET",
         headers: {
           accept: "application/json",
-          "ngrok-skip-browser-warning": "true",
           Authorization: `Bearer ${backendAccessToken}`,
         },
       });
@@ -939,7 +931,6 @@ function DuplicateMetricDialog({
           headers: {
             accept: "application/json",
             "Content-Type": "application/json",
-            "ngrok-skip-browser-warning": "true",
             Authorization: `Bearer ${backendAccessToken}`,
           },
           body: JSON.stringify({

--- a/src/app/personas/page.tsx
+++ b/src/app/personas/page.tsx
@@ -86,7 +86,6 @@ export default function PersonasPage() {
           method: "GET",
           headers: {
             accept: "application/json",
-            "ngrok-skip-browser-warning": "true",
             Authorization: `Bearer ${backendAccessToken}`,
           },
         });
@@ -146,7 +145,6 @@ export default function PersonasPage() {
           method: "DELETE",
           headers: {
             accept: "application/json",
-            "ngrok-skip-browser-warning": "true",
             Authorization: `Bearer ${backendAccessToken}`,
           },
         }
@@ -203,7 +201,6 @@ export default function PersonasPage() {
         headers: {
           accept: "application/json",
           "Content-Type": "application/json",
-          "ngrok-skip-browser-warning": "true",
           Authorization: `Bearer ${backendAccessToken}`,
         },
         body: JSON.stringify({
@@ -231,7 +228,6 @@ export default function PersonasPage() {
         method: "GET",
         headers: {
           accept: "application/json",
-          "ngrok-skip-browser-warning": "true",
           Authorization: `Bearer ${backendAccessToken}`,
         },
       });
@@ -271,7 +267,6 @@ export default function PersonasPage() {
         method: "GET",
         headers: {
           accept: "application/json",
-          "ngrok-skip-browser-warning": "true",
           Authorization: `Bearer ${backendAccessToken}`,
         },
       });
@@ -332,7 +327,6 @@ export default function PersonasPage() {
           headers: {
             accept: "application/json",
             "Content-Type": "application/json",
-            "ngrok-skip-browser-warning": "true",
             Authorization: `Bearer ${backendAccessToken}`,
           },
           body: JSON.stringify({
@@ -361,7 +355,6 @@ export default function PersonasPage() {
         method: "GET",
         headers: {
           accept: "application/json",
-          "ngrok-skip-browser-warning": "true",
           Authorization: `Bearer ${backendAccessToken}`,
         },
       });

--- a/src/app/scenarios/page.tsx
+++ b/src/app/scenarios/page.tsx
@@ -73,7 +73,6 @@ export default function ScenariosPage() {
           method: "GET",
           headers: {
             accept: "application/json",
-            "ngrok-skip-browser-warning": "true",
             Authorization: `Bearer ${backendAccessToken}`,
           },
         });
@@ -133,7 +132,6 @@ export default function ScenariosPage() {
           method: "DELETE",
           headers: {
             accept: "application/json",
-            "ngrok-skip-browser-warning": "true",
             Authorization: `Bearer ${backendAccessToken}`,
           },
         }
@@ -187,7 +185,6 @@ export default function ScenariosPage() {
         headers: {
           accept: "application/json",
           "Content-Type": "application/json",
-          "ngrok-skip-browser-warning": "true",
           Authorization: `Bearer ${backendAccessToken}`,
         },
         body: JSON.stringify({
@@ -210,7 +207,6 @@ export default function ScenariosPage() {
         method: "GET",
         headers: {
           accept: "application/json",
-          "ngrok-skip-browser-warning": "true",
           Authorization: `Bearer ${backendAccessToken}`,
         },
       });
@@ -250,7 +246,6 @@ export default function ScenariosPage() {
         method: "GET",
         headers: {
           accept: "application/json",
-          "ngrok-skip-browser-warning": "true",
           Authorization: `Bearer ${backendAccessToken}`,
         },
       });
@@ -304,7 +299,6 @@ export default function ScenariosPage() {
           headers: {
             accept: "application/json",
             "Content-Type": "application/json",
-            "ngrok-skip-browser-warning": "true",
             Authorization: `Bearer ${backendAccessToken}`,
           },
           body: JSON.stringify({
@@ -328,7 +322,6 @@ export default function ScenariosPage() {
         method: "GET",
         headers: {
           accept: "application/json",
-          "ngrok-skip-browser-warning": "true",
           Authorization: `Bearer ${backendAccessToken}`,
         },
       });

--- a/src/app/simulations/[uuid]/page.tsx
+++ b/src/app/simulations/[uuid]/page.tsx
@@ -204,7 +204,6 @@ export default function SimulationDetailPage() {
         headers: {
           accept: "application/json",
           "Content-Type": "application/json",
-          "ngrok-skip-browser-warning": "true",
           Authorization: `Bearer ${backendAccessToken}`,
         },
         body: JSON.stringify({
@@ -260,7 +259,6 @@ export default function SimulationDetailPage() {
         headers: {
           accept: "application/json",
           "Content-Type": "application/json",
-          "ngrok-skip-browser-warning": "true",
           Authorization: `Bearer ${backendAccessToken}`,
         },
         body: JSON.stringify(payload),
@@ -301,7 +299,6 @@ export default function SimulationDetailPage() {
           method: "GET",
           headers: {
             accept: "application/json",
-            "ngrok-skip-browser-warning": "true",
             Authorization: `Bearer ${backendAccessToken}`,
           },
         });
@@ -392,7 +389,6 @@ export default function SimulationDetailPage() {
           method: "GET",
           headers: {
             accept: "application/json",
-            "ngrok-skip-browser-warning": "true",
             Authorization: `Bearer ${backendAccessToken}`,
           },
         });
@@ -439,7 +435,6 @@ export default function SimulationDetailPage() {
           method: "GET",
           headers: {
             accept: "application/json",
-            "ngrok-skip-browser-warning": "true",
             Authorization: `Bearer ${backendAccessToken}`,
           },
         });
@@ -486,7 +481,6 @@ export default function SimulationDetailPage() {
           method: "GET",
           headers: {
             accept: "application/json",
-            "ngrok-skip-browser-warning": "true",
             Authorization: `Bearer ${backendAccessToken}`,
           },
         });

--- a/src/app/simulations/[uuid]/runs/[runId]/page.tsx
+++ b/src/app/simulations/[uuid]/runs/[runId]/page.tsx
@@ -112,7 +112,6 @@ export default function SimulationRunPage() {
         method: "GET",
         headers: {
           accept: "application/json",
-          "ngrok-skip-browser-warning": "true",
           Authorization: `Bearer ${backendAccessToken}`,
         },
       });
@@ -205,7 +204,6 @@ export default function SimulationRunPage() {
           method: "GET",
           headers: {
             accept: "application/json",
-            "ngrok-skip-browser-warning": "true",
             Authorization: `Bearer ${backendAccessToken}`,
           },
         });
@@ -253,7 +251,6 @@ export default function SimulationRunPage() {
           method: "GET",
           headers: {
             accept: "application/json",
-            "ngrok-skip-browser-warning": "true",
             Authorization: `Bearer ${backendAccessToken}`,
           },
         });
@@ -432,7 +429,6 @@ export default function SimulationRunPage() {
           method: "POST",
           headers: {
             accept: "application/json",
-            "ngrok-skip-browser-warning": "true",
             Authorization: `Bearer ${backendAccessToken}`,
           },
         }

--- a/src/app/simulations/page.tsx
+++ b/src/app/simulations/page.tsx
@@ -63,7 +63,6 @@ export default function SimulationsPage() {
           method: "GET",
           headers: {
             accept: "application/json",
-            "ngrok-skip-browser-warning": "true",
             Authorization: `Bearer ${backendAccessToken}`,
           },
         });
@@ -123,7 +122,6 @@ export default function SimulationsPage() {
           method: "DELETE",
           headers: {
             accept: "application/json",
-            "ngrok-skip-browser-warning": "true",
             Authorization: `Bearer ${backendAccessToken}`,
           },
         }

--- a/src/app/stt/[uuid]/page.tsx
+++ b/src/app/stt/[uuid]/page.tsx
@@ -130,7 +130,6 @@ export default function STTEvaluationDetailPage() {
           method: "GET",
           headers: {
             accept: "application/json",
-            "ngrok-skip-browser-warning": "true",
             Authorization: `Bearer ${backendAccessToken}`,
           },
         });
@@ -196,7 +195,6 @@ export default function STTEvaluationDetailPage() {
         method: "GET",
         headers: {
           accept: "application/json",
-          "ngrok-skip-browser-warning": "true",
           Authorization: `Bearer ${backendAccessToken}`,
         },
       });

--- a/src/app/stt/page.tsx
+++ b/src/app/stt/page.tsx
@@ -61,7 +61,6 @@ export default function STTPage() {
           method: "GET",
           headers: {
             accept: "application/json",
-            "ngrok-skip-browser-warning": "true",
             Authorization: `Bearer ${backendAccessToken}`,
           },
         });

--- a/src/app/tests/page.tsx
+++ b/src/app/tests/page.tsx
@@ -92,7 +92,6 @@ export default function LLMPage() {
           method: "GET",
           headers: {
             accept: "application/json",
-            "ngrok-skip-browser-warning": "true",
             Authorization: `Bearer ${backendAccessToken}`,
           },
         });
@@ -150,7 +149,6 @@ export default function LLMPage() {
         method: "DELETE",
         headers: {
           accept: "application/json",
-          "ngrok-skip-browser-warning": "true",
           Authorization: `Bearer ${backendAccessToken}`,
         },
       });
@@ -201,7 +199,6 @@ export default function LLMPage() {
           headers: {
             accept: "application/json",
             "Content-Type": "application/json",
-            "ngrok-skip-browser-warning": "true",
             Authorization: `Bearer ${backendAccessToken}`,
           },
           body: JSON.stringify({
@@ -252,7 +249,6 @@ export default function LLMPage() {
         headers: {
           accept: "application/json",
           "Content-Type": "application/json",
-          "ngrok-skip-browser-warning": "true",
           Authorization: `Bearer ${backendAccessToken}`,
         },
         body: JSON.stringify({
@@ -276,7 +272,6 @@ export default function LLMPage() {
         method: "GET",
         headers: {
           accept: "application/json",
-          "ngrok-skip-browser-warning": "true",
           Authorization: `Bearer ${backendAccessToken}`,
         },
       });
@@ -319,7 +314,6 @@ export default function LLMPage() {
         method: "GET",
         headers: {
           accept: "application/json",
-          "ngrok-skip-browser-warning": "true",
           Authorization: `Bearer ${backendAccessToken}`,
         },
       });
@@ -376,7 +370,6 @@ export default function LLMPage() {
         headers: {
           accept: "application/json",
           "Content-Type": "application/json",
-          "ngrok-skip-browser-warning": "true",
           Authorization: `Bearer ${backendAccessToken}`,
         },
         body: JSON.stringify({
@@ -400,7 +393,6 @@ export default function LLMPage() {
         method: "GET",
         headers: {
           accept: "application/json",
-          "ngrok-skip-browser-warning": "true",
           Authorization: `Bearer ${backendAccessToken}`,
         },
       });

--- a/src/app/tools/page.tsx
+++ b/src/app/tools/page.tsx
@@ -60,7 +60,6 @@ export default function ToolsPage() {
           method: "GET",
           headers: {
             accept: "application/json",
-            "ngrok-skip-browser-warning": "true",
             Authorization: `Bearer ${backendAccessToken}`,
           },
         });
@@ -118,7 +117,6 @@ export default function ToolsPage() {
         method: "DELETE",
         headers: {
           accept: "application/json",
-          "ngrok-skip-browser-warning": "true",
           Authorization: `Bearer ${backendAccessToken}`,
         },
       });

--- a/src/app/tts/[uuid]/page.tsx
+++ b/src/app/tts/[uuid]/page.tsx
@@ -115,7 +115,6 @@ export default function TTSEvaluationDetailPage() {
           method: "GET",
           headers: {
             accept: "application/json",
-            "ngrok-skip-browser-warning": "true",
             Authorization: `Bearer ${backendAccessToken}`,
           },
         });
@@ -183,7 +182,6 @@ export default function TTSEvaluationDetailPage() {
         method: "GET",
         headers: {
           accept: "application/json",
-          "ngrok-skip-browser-warning": "true",
           Authorization: `Bearer ${backendAccessToken}`,
         },
       });

--- a/src/app/tts/page.tsx
+++ b/src/app/tts/page.tsx
@@ -60,7 +60,6 @@ export default function TTSPage() {
           method: "GET",
           headers: {
             accept: "application/json",
-            "ngrok-skip-browser-warning": "true",
             Authorization: `Bearer ${backendAccessToken}`,
           },
         });

--- a/src/components/AddTestDialog.tsx
+++ b/src/components/AddTestDialog.tsx
@@ -445,7 +445,6 @@ export function AddTestDialog({
           method: "GET",
           headers: {
             accept: "application/json",
-            "ngrok-skip-browser-warning": "true",
             Authorization: `Bearer ${backendAccessToken}`,
           },
         });

--- a/src/components/AddToolDialog.tsx
+++ b/src/components/AddToolDialog.tsx
@@ -751,7 +751,6 @@ export function AddToolDialog({
         method: "GET",
         headers: {
           accept: "application/json",
-          "ngrok-skip-browser-warning": "true",
           Authorization: `Bearer ${backendAccessToken}`,
         },
       });
@@ -853,7 +852,6 @@ export function AddToolDialog({
       method: "GET",
       headers: {
         accept: "application/json",
-        "ngrok-skip-browser-warning": "true",
         Authorization: `Bearer ${backendAccessToken}`,
       },
     });
@@ -932,7 +930,6 @@ export function AddToolDialog({
         headers: {
           accept: "application/json",
           "Content-Type": "application/json",
-          "ngrok-skip-browser-warning": "true",
           Authorization: `Bearer ${backendAccessToken}`,
         },
         body: JSON.stringify({
@@ -1031,7 +1028,6 @@ export function AddToolDialog({
         headers: {
           accept: "application/json",
           "Content-Type": "application/json",
-          "ngrok-skip-browser-warning": "true",
           Authorization: `Bearer ${backendAccessToken}`,
         },
         body: JSON.stringify({

--- a/src/components/AgentDetail.tsx
+++ b/src/components/AgentDetail.tsx
@@ -154,7 +154,6 @@ export function AgentDetail({
           method: "GET",
           headers: {
             accept: "application/json",
-            "ngrok-skip-browser-warning": "true",
             Authorization: `Bearer ${backendAccessToken}`,
           },
         });
@@ -258,7 +257,6 @@ export function AgentDetail({
             method: "GET",
             headers: {
               accept: "application/json",
-              "ngrok-skip-browser-warning": "true",
               Authorization: `Bearer ${backendAccessToken}`,
             },
           }
@@ -305,7 +303,6 @@ export function AgentDetail({
           method: "GET",
           headers: {
             accept: "application/json",
-            "ngrok-skip-browser-warning": "true",
             Authorization: `Bearer ${backendAccessToken}`,
           },
         });
@@ -352,7 +349,6 @@ export function AgentDetail({
           headers: {
             accept: "application/json",
             "Content-Type": "application/json",
-            "ngrok-skip-browser-warning": "true",
             Authorization: `Bearer ${backendAccessToken}`,
           },
           body: JSON.stringify({
@@ -437,7 +433,6 @@ export function AgentDetail({
         headers: {
           accept: "application/json",
           "Content-Type": "application/json",
-          "ngrok-skip-browser-warning": "true",
           Authorization: `Bearer ${backendAccessToken}`,
         },
         body: JSON.stringify({

--- a/src/components/AgentPicker.tsx
+++ b/src/components/AgentPicker.tsx
@@ -48,7 +48,6 @@ export function AgentPicker({
           method: "GET",
           headers: {
             accept: "application/json",
-            "ngrok-skip-browser-warning": "true",
             Authorization: `Bearer ${backendAccessToken}`,
           },
         });

--- a/src/components/Agents.tsx
+++ b/src/components/Agents.tsx
@@ -75,7 +75,6 @@ export function Agents({ onNavigateToAgent }: AgentsProps) {
           method: "GET",
           headers: {
             accept: "application/json",
-            "ngrok-skip-browser-warning": "true",
             Authorization: `Bearer ${backendAccessToken}`,
           },
         });
@@ -180,7 +179,6 @@ export function Agents({ onNavigateToAgent }: AgentsProps) {
           method: "DELETE",
           headers: {
             accept: "application/json",
-            "ngrok-skip-browser-warning": "true",
             Authorization: `Bearer ${backendAccessToken}`,
           },
         }
@@ -655,7 +653,6 @@ function NewAgentDialog({
         headers: {
           accept: "application/json",
           "Content-Type": "application/json",
-          "ngrok-skip-browser-warning": "true",
           Authorization: `Bearer ${backendAccessToken}`,
         },
         body: JSON.stringify({
@@ -843,7 +840,6 @@ function DuplicateAgentDialog({
           headers: {
             accept: "application/json",
             "Content-Type": "application/json",
-            "ngrok-skip-browser-warning": "true",
             Authorization: `Bearer ${backendAccessToken}`,
           },
           body: JSON.stringify({

--- a/src/components/BenchmarkResultsDialog.tsx
+++ b/src/components/BenchmarkResultsDialog.tsx
@@ -167,7 +167,6 @@ export function BenchmarkResultsDialog({
           method: "GET",
           headers: {
             accept: "application/json",
-            "ngrok-skip-browser-warning": "true",
           },
         }
       );
@@ -258,7 +257,6 @@ export function BenchmarkResultsDialog({
           headers: {
             accept: "application/json",
             "Content-Type": "application/json",
-            "ngrok-skip-browser-warning": "true",
           },
           body: JSON.stringify({
             test_uuids: testUuids,

--- a/src/components/NewSimulationDialog.tsx
+++ b/src/components/NewSimulationDialog.tsx
@@ -40,7 +40,6 @@ export function NewSimulationDialog({
         headers: {
           accept: "application/json",
           "Content-Type": "application/json",
-          "ngrok-skip-browser-warning": "true",
           Authorization: `Bearer ${backendAccessToken}`,
         },
         body: JSON.stringify({

--- a/src/components/TestRunnerDialog.tsx
+++ b/src/components/TestRunnerDialog.tsx
@@ -210,7 +210,6 @@ export function TestRunnerDialog({
         method: "GET",
         headers: {
           accept: "application/json",
-          "ngrok-skip-browser-warning": "true",
           Authorization: `Bearer ${backendAccessToken}`,
         },
       });
@@ -425,7 +424,6 @@ export function TestRunnerDialog({
           headers: {
             accept: "application/json",
             "Content-Type": "application/json",
-            "ngrok-skip-browser-warning": "true",
             Authorization: `Bearer ${backendAccessToken}`,
           },
           body: JSON.stringify({
@@ -511,7 +509,6 @@ export function TestRunnerDialog({
           headers: {
             accept: "application/json",
             "Content-Type": "application/json",
-            "ngrok-skip-browser-warning": "true",
             Authorization: `Bearer ${backendAccessToken}`,
           },
           body: JSON.stringify({
@@ -540,7 +537,6 @@ export function TestRunnerDialog({
               method: "GET",
               headers: {
                 accept: "application/json",
-                "ngrok-skip-browser-warning": "true",
                 Authorization: `Bearer ${backendAccessToken}`,
               },
             }
@@ -689,7 +685,6 @@ export function TestRunnerDialog({
           headers: {
             accept: "application/json",
             "Content-Type": "application/json",
-            "ngrok-skip-browser-warning": "true",
             Authorization: `Bearer ${backendAccessToken}`,
           },
           body: JSON.stringify({

--- a/src/components/agent-tabs/AddToolDialog.tsx
+++ b/src/components/agent-tabs/AddToolDialog.tsx
@@ -62,7 +62,6 @@ export function AddToolDialog({
         headers: {
           accept: "application/json",
           "Content-Type": "application/json",
-          "ngrok-skip-browser-warning": "true",
           Authorization: `Bearer ${backendAccessToken}`,
         },
         body: JSON.stringify({

--- a/src/components/agent-tabs/DeleteToolDialog.tsx
+++ b/src/components/agent-tabs/DeleteToolDialog.tsx
@@ -56,7 +56,6 @@ export function DeleteToolDialog({
         headers: {
           accept: "application/json",
           "Content-Type": "application/json",
-          "ngrok-skip-browser-warning": "true",
           Authorization: `Bearer ${backendAccessToken}`,
         },
         body: JSON.stringify({

--- a/src/components/agent-tabs/TestsTabContent.tsx
+++ b/src/components/agent-tabs/TestsTabContent.tsx
@@ -206,7 +206,6 @@ export function TestsTabContent({
             method: "GET",
             headers: {
               accept: "application/json",
-              "ngrok-skip-browser-warning": "true",
               Authorization: `Bearer ${backendAccessToken}`,
             },
           }
@@ -253,7 +252,6 @@ export function TestsTabContent({
             method: "GET",
             headers: {
               accept: "application/json",
-              "ngrok-skip-browser-warning": "true",
               Authorization: `Bearer ${backendAccessToken}`,
             },
           });
@@ -319,7 +317,6 @@ export function TestsTabContent({
             method: "GET",
             headers: {
               accept: "application/json",
-              "ngrok-skip-browser-warning": "true",
               Authorization: `Bearer ${backendAccessToken}`,
             },
           }
@@ -402,7 +399,6 @@ export function TestsTabContent({
             method: "GET",
             headers: {
               accept: "application/json",
-              "ngrok-skip-browser-warning": "true",
               Authorization: `Bearer ${backendAccessToken}`,
             },
           });
@@ -509,7 +505,6 @@ export function TestsTabContent({
         headers: {
           accept: "application/json",
           "Content-Type": "application/json",
-          "ngrok-skip-browser-warning": "true",
           Authorization: `Bearer ${backendAccessToken}`,
         },
         body: JSON.stringify({
@@ -645,7 +640,6 @@ export function TestsTabContent({
         headers: {
           accept: "application/json",
           "Content-Type": "application/json",
-          "ngrok-skip-browser-warning": "true",
           Authorization: `Bearer ${backendAccessToken}`,
         },
         body: JSON.stringify({

--- a/src/components/evaluations/SpeechToTextEvaluation.tsx
+++ b/src/components/evaluations/SpeechToTextEvaluation.tsx
@@ -758,7 +758,6 @@ export function SpeechToTextEvaluation() {
         headers: {
           "Content-Type": "application/json",
           accept: "application/json",
-          "ngrok-skip-browser-warning": "true",
           Authorization: `Bearer ${backendAccessToken}`,
         },
         body: JSON.stringify({

--- a/src/components/evaluations/TextToSpeechEvaluation.tsx
+++ b/src/components/evaluations/TextToSpeechEvaluation.tsx
@@ -345,7 +345,6 @@ export function TextToSpeechEvaluation() {
         headers: {
           "Content-Type": "application/json",
           accept: "application/json",
-          "ngrok-skip-browser-warning": "true",
           Authorization: `Bearer ${backendAccessToken}`,
         },
         body: JSON.stringify({

--- a/src/components/simulation-tabs/SimulationRunsTab.tsx
+++ b/src/components/simulation-tabs/SimulationRunsTab.tsx
@@ -44,7 +44,6 @@ export function SimulationRunsTab({ simulationUuid }: SimulationRunsTabProps) {
             method: "GET",
             headers: {
               accept: "application/json",
-              "ngrok-skip-browser-warning": "true",
               Authorization: `Bearer ${backendAccessToken}`,
             },
           }

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -23,7 +23,6 @@ export function getBackendUrl(): string {
 export function getDefaultHeaders(accessToken?: string): Record<string, string> {
   const headers: Record<string, string> = {
     accept: "application/json",
-    "ngrok-skip-browser-warning": "true",
   };
   
   if (accessToken) {


### PR DESCRIPTION
## Summary

- Removes the `ngrok-skip-browser-warning: true` header from `getDefaultHeaders()` in `src/lib/api.ts`
- Strips all inline `"ngrok-skip-browser-warning": "true"` entries from fetch calls across 26 pages and components

This header was added to bypass ngrok's browser warning page during local dev tunnelling. It has no use in production and shouldn't be shipped.

## Test plan

- [x] `npm run build` passes with no TypeScript or compilation errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)