### PR TITLE
feat: show LLM reasoning in test results and add evaluation criteria panel

### DIFF
--- a/.cursor/rules/app-details.md
+++ b/.cursor/rules/app-details.md
@@ -1963,11 +1963,11 @@ Key styling:
         </div>
       </div>
 
-      {/* Right panel - evaluation criteria (w-72), desktop only, shown when test selected */}
-      {selectedResult && (
+      {/* Right panel - evaluation criteria (w-72), desktop only, shown only after test completes */}
+      {selectedResult && (selectedResult.status === "passed" || selectedResult.status === "failed") && (
         <div className="hidden md:flex w-72 border-l border-border flex-col overflow-hidden">
           <div className="flex-1 overflow-y-auto">
-            <EvaluationCriteriaPanel evaluation={testCase?.evaluation} testType={test.type} />
+            <EvaluationCriteriaPanel evaluation={testCase?.evaluation} testType={testCase?.evaluation?.type} />
           </div>
         </div>
       )}
@@ -3398,8 +3398,13 @@ import {
 // Evaluation criteria panel - third column in test/benchmark runner dialogs
 // Shows test type badge ("Next Reply Text" blue / "Tool Call" purple), criteria text, expected tool calls
 // Desktop only (hidden on mobile), w-72, border-l
-// testType can come from TestData.type or inferred from evaluation.type / presence of evaluation.tool_calls
-<EvaluationCriteriaPanel evaluation={testCase?.evaluation} testType="response" />
+// IMPORTANT: Only rendered after test completes (status "passed" or "failed"). During running/pending/queued,
+// evaluation data isn't available yet, so showing the panel would display misleading defaults.
+// IMPORTANT: testType must come from evaluation.type (API data), NOT from test.type (synthesized data).
+// The hydration path for completed runs sets all placeholder tests to type:"response", which causes
+// tool-call tests to be misrendered as "Next Reply Text". Always prefer testCase.evaluation.type.
+// Fallback chain inside the component: testType -> evaluation.type -> infer from evaluation.tool_calls
+<EvaluationCriteriaPanel evaluation={testCase?.evaluation} testType={testCase?.evaluation?.type} />
 ```
 
 ---

--- a/.cursor/rules/app-details.md
+++ b/.cursor/rules/app-details.md
@@ -1932,9 +1932,9 @@ Key styling:
   </div>
 </div>
 
-// TestRunnerDialog - Two-panel with mobile navigation
+// TestRunnerDialog / BenchmarkResultsDialog - Three-panel with mobile navigation
 <div className="fixed inset-0 z-50 flex items-center p-0 md:p-4">
-  <div className="w-full max-w-5xl h-full md:h-[80vh] rounded-none md:rounded-xl flex flex-col">
+  <div className="w-full max-w-7xl h-full md:h-[80vh] rounded-none md:rounded-xl flex flex-col">
     {/* Header with stats (desktop only) */}
     <div className="px-4 md:px-6 py-3 md:py-4 border-b">
       <h2>Test Status</h2>
@@ -1945,24 +1945,32 @@ Key styling:
     </div>
 
     <div className="flex-1 flex overflow-hidden">
-      {/* Left panel - test list, hidden when test selected on mobile */}
+      {/* Left panel - test list (w-80), hidden when test selected on mobile */}
       <div className={`w-full md:w-80 ${selectedTest ? 'hidden md:flex' : 'flex'} flex-col`}>
         {/* Test list (no mobile stats - cleaner UI) */}
         {/* Uses button elements for list items with onTouchEnd for mobile support */}
       </div>
 
-      {/* Right panel - test details, hidden when no test selected on mobile */}
+      {/* Middle panel - conversation history, hidden when no test selected on mobile */}
       <div className={`flex-1 ${selectedTest ? 'flex' : 'hidden md:flex'} flex-col overflow-hidden`}>
         {/* Mobile back button - flex-shrink-0 to prevent squishing */}
         <div className="md:hidden px-4 py-3 border-b flex-shrink-0">
           <button onClick={() => setSelectedTest(null)}>Back to tests</button>
         </div>
         {/* Test details - flex-1 for remaining space */}
-        {/* Message bubbles use w-[70%] md:w-1/2 for better visual differentiation on mobile */}
         <div className="flex-1 overflow-y-auto">
           <TestDetailView />
         </div>
       </div>
+
+      {/* Right panel - evaluation criteria (w-72), desktop only, shown when test selected */}
+      {selectedResult && (
+        <div className="hidden md:flex w-72 border-l border-border flex-col overflow-hidden">
+          <div className="flex-1 overflow-y-auto">
+            <EvaluationCriteriaPanel evaluation={testCase?.evaluation} testType={test.type} />
+          </div>
+        </div>
+      )}
     </div>
   </div>
 </div>
@@ -1992,9 +2000,9 @@ Key styling:
 - **Metrics sidebar**: Full-page slide-in for add/edit metrics
 - **AddToolDialog**: Full-page slide-in for add/edit tools
 - **AddTestDialog**: Large centered modal for add/edit tests (fully responsive)
-- **TestRunnerDialog**: Test results viewer with two-panel layout (fully responsive with mobile navigation)
+- **TestRunnerDialog**: Test results viewer with three-panel layout on desktop (test list | conversation | evaluation criteria), two-panel mobile navigation
 - **Simulation Run Page**: `/simulations/[uuid]/runs/[runId]` - Responsive tabs (3 tabs on mobile: Results/Performance/Latency, 2 tabs on desktop: Performance/Latency), conditional content display, reduced font sizes on mobile
-- **BenchmarkResultsDialog**: Benchmark results viewer with two-panel layout (fully responsive with mobile navigation, same patterns as TestRunnerDialog)
+- **BenchmarkResultsDialog**: Benchmark results viewer with three-panel layout on desktop (providers/tests | conversation | evaluation criteria), two-panel mobile navigation (same patterns as TestRunnerDialog)
 
 **Gotchas:**
 
@@ -2008,9 +2016,10 @@ Key styling:
 - Input/button heights must be `h-9` on mobile for proper touch targets (not `h-8`)
 - Two-column layouts must stack vertically on mobile (`flex-col md:flex-row`)
 - Dialog heights need more space on mobile (`h-[95vh] md:h-[85vh]`)
-- For two-panel views, implement mobile navigation with hide/show panels and back buttons
+- For multi-panel views, implement mobile navigation with hide/show panels and back buttons
 - Stats/summary info should show in header on desktop only (mobile stats removed for cleaner UI in TestRunnerDialog)
-- Right panel in two-panel layouts needs proper flex structure: `flex-col overflow-hidden` parent, `flex-shrink-0` for fixed sections, `flex-1 overflow-y-auto` for scrollable content
+- Middle panel in three-panel layouts needs proper flex structure: `flex-col overflow-hidden` parent, `flex-shrink-0` for fixed sections, `flex-1 overflow-y-auto` for scrollable content
+- Third column (evaluation criteria) is desktop-only (`hidden md:flex`), fixed width `w-72`, with `border-l border-border`; only rendered when a test is selected
 - Use `useSidebarState()` hook from `@/lib/sidebar` for sidebar state - handles hydration-safe initialization (prevents SSR mismatch and mobile flash)
 - **Mobile touch handling for interactive lists**: Use `<button>` elements instead of `<div>` with `onClick` for list items to ensure reliable touch events on mobile. Add both `onClick` and `onTouchEnd` handlers for maximum compatibility. Include `type="button"` to prevent form submission and `w-full` to make entire area tappable. Example: TestRunnerDialog's TestListItem component
 
@@ -2367,9 +2376,9 @@ const getFilteredProviders = (language: LanguageOption) => {
     - **BenchmarkResultsDialog intermediate results**:
       - **When in progress**: Shows Outputs view directly (no tabs visible), all providers displayed immediately
       - **When done**: Shows both Leaderboard and Outputs tabs, auto-switches to Leaderboard tab
-      - **Fully responsive**: Two-panel layout with mobile navigation (same pattern as TestRunnerDialog)
-        - Mobile: Left panel (providers) and right panel (test details) toggle visibility, back button to return to provider list
-        - Desktop: Both panels always visible side-by-side
+      - **Fully responsive**: Three-panel layout on desktop, mobile navigation (same pattern as TestRunnerDialog)
+        - Mobile: Left panel (providers) and middle panel (test details) toggle visibility, back button to return to provider list; evaluation criteria panel hidden
+        - Desktop: All three panels visible — providers list (w-80) | conversation (flex-1) | evaluation criteria (w-72)
         - Uses `w-full md:w-80` for left panel, conditional hiding with `${selectedTest ? 'hidden md:flex' : 'flex'}`
       - Uses expandable provider toggles (not a dropdown) in the left panel
       - Each provider section shows: provider name, processing spinner (if still running), passed/failed counts (when complete)
@@ -3353,6 +3362,7 @@ import {
   TestDetailView,
   EmptyStateView,
   TestStats,
+  EvaluationCriteriaPanel,
 } from "@/components/test-results/shared";
 
 // Status indicator (passed/failed/running/queued/pending)
@@ -3384,6 +3394,12 @@ import {
 // Stats bar - shows passed/failed counts
 // In TestRunnerDialog: show in header on desktop, at top of list on mobile
 <TestStats passedCount={5} failedCount={2} />
+
+// Evaluation criteria panel - third column in test/benchmark runner dialogs
+// Shows test type badge ("Next Reply Text" blue / "Tool Call" purple), criteria text, expected tool calls
+// Desktop only (hidden on mobile), w-72, border-l
+// testType can come from TestData.type or inferred from evaluation.type / presence of evaluation.tool_calls
+<EvaluationCriteriaPanel evaluation={testCase?.evaluation} testType="response" />
 ```
 
 ---

--- a/src/components/BenchmarkResultsDialog.tsx
+++ b/src/components/BenchmarkResultsDialog.tsx
@@ -80,11 +80,11 @@ export function BenchmarkResultsDialog({
   useHideFloatingButton(isOpen);
 
   const [activeTab, setActiveTab] = useState<"leaderboard" | "outputs">(
-    "outputs"
+    "outputs",
   );
   // Track which providers are expanded
   const [expandedProviders, setExpandedProviders] = useState<Set<string>>(
-    new Set()
+    new Set(),
   );
   // Track selected test: { model, testIndex }
   const [selectedTest, setSelectedTest] = useState<{
@@ -171,7 +171,7 @@ export function BenchmarkResultsDialog({
             accept: "application/json",
             "ngrok-skip-browser-warning": "true",
           },
-        }
+        },
       );
 
       if (!response.ok) {
@@ -192,7 +192,7 @@ export function BenchmarkResultsDialog({
           setExpandedProviders((prev) => {
             if (prev.size === 0) {
               const firstWithResults = result.model_results!.find(
-                (m) => m.test_results && m.test_results.length > 0
+                (m) => m.test_results && m.test_results.length > 0,
               );
               if (firstWithResults) {
                 return new Set([firstWithResults.model]);
@@ -266,7 +266,7 @@ export function BenchmarkResultsDialog({
             test_uuids: testUuids,
             models: models,
           }),
-        }
+        },
       );
 
       if (!response.ok) {
@@ -292,7 +292,7 @@ export function BenchmarkResultsDialog({
       console.error("Error starting benchmark:", err);
       setIsInitialLoading(false);
       setError(
-        err instanceof Error ? err.message : "Failed to start benchmark"
+        err instanceof Error ? err.message : "Failed to start benchmark",
       );
     }
   };
@@ -317,7 +317,7 @@ export function BenchmarkResultsDialog({
   const getSelectedTestResult = (): BenchmarkTestResult | null => {
     if (!selectedTest) return null;
     const modelResult = modelResults.find(
-      (m) => m.model === selectedTest.model
+      (m) => m.model === selectedTest.model,
     );
     if (!modelResult?.test_results) return null;
     return modelResult.test_results[selectedTest.testIndex] || null;
@@ -371,7 +371,7 @@ export function BenchmarkResultsDialog({
 
   // Check if we have any results to show
   const hasAnyResults = modelResults.some(
-    (m) => m.test_results && m.test_results.length > 0
+    (m) => m.test_results && m.test_results.length > 0,
   );
 
   return (
@@ -447,7 +447,9 @@ export function BenchmarkResultsDialog({
                     d="M12 9v3.75m9-.75a9 9 0 11-18 0 9 9 0 0118 0zm-9 3.75h.008v.008H12v-.008z"
                   />
                 </svg>
-                <span className="font-medium text-red-500">Something went wrong</span>
+                <span className="font-medium text-red-500">
+                  Something went wrong
+                </span>
               </div>
               <p className="text-sm text-red-400 mb-4">
                 We&apos;re looking into it. Please reach out to us if this issue
@@ -628,7 +630,7 @@ export function BenchmarkResultsDialog({
                           <div className="flex items-center gap-3">
                             <SpinnerIcon className="w-5 h-5 animate-spin text-muted-foreground" />
                             <p className="text-muted-foreground">
-                              Running test...
+                              Running test
                             </p>
                           </div>
                         </div>
@@ -745,7 +747,7 @@ function ProviderSection({
             const expectedCount = Math.max(
               totalTests,
               testNames.length,
-              resultsCount
+              resultsCount,
             );
 
             if (expectedCount === 0 && !hasResults) {
@@ -778,8 +780,8 @@ function ProviderSection({
                     ? testResult.passed === null
                       ? "running"
                       : testResult.passed
-                      ? "passed"
-                      : "failed"
+                        ? "passed"
+                        : "failed"
                     : "running";
 
                   // Only make clickable if we have a result

--- a/src/components/BenchmarkResultsDialog.tsx
+++ b/src/components/BenchmarkResultsDialog.tsx
@@ -9,6 +9,7 @@ import {
   SpinnerIcon,
   TestDetailView,
   EmptyStateView,
+  EvaluationCriteriaPanel,
 } from "./test-results/shared";
 import { StatusBadge } from "@/components/ui";
 import { LeaderboardBarChart, getColorMap } from "./charts/LeaderboardBarChart";
@@ -19,6 +20,7 @@ import { useHideFloatingButton } from "@/components/AppLayout";
 type BenchmarkTestResult = {
   name?: string;
   passed: boolean | null; // null means still running
+  reasoning?: string;
   output?: TestCaseOutput;
   test_case?: TestCaseData;
 };
@@ -374,7 +376,7 @@ export function BenchmarkResultsDialog({
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center p-0 md:p-4 bg-black/50">
-      <div className="bg-background rounded-none md:rounded-xl w-full max-w-5xl h-full md:h-[80vh] flex flex-col shadow-2xl">
+      <div className="bg-background rounded-none md:rounded-xl w-full max-w-7xl h-full md:h-[80vh] flex flex-col shadow-2xl">
         {/* Header */}
         <div className="flex items-center justify-between px-4 md:px-6 py-3 md:py-4">
           <div className="flex items-center gap-2 md:gap-3 min-w-0">
@@ -635,6 +637,7 @@ export function BenchmarkResultsDialog({
                           history={selectedTestResult.test_case?.history || []}
                           output={selectedTestResult.output}
                           passed={selectedTestResult.passed}
+                          reasoning={selectedTestResult.reasoning}
                         />
                       )
                     ) : (
@@ -642,6 +645,17 @@ export function BenchmarkResultsDialog({
                     )}
                   </div>
                 </div>
+
+                {/* Right Panel - Evaluation Criteria */}
+                {selectedTestResult && selectedTestResult.passed !== null && (
+                  <div className="hidden md:flex w-72 border-l border-border flex-col overflow-hidden">
+                    <div className="flex-1 overflow-y-auto">
+                      <EvaluationCriteriaPanel
+                        evaluation={selectedTestResult.test_case?.evaluation}
+                      />
+                    </div>
+                  </div>
+                )}
               </div>
             )}
           </div>

--- a/src/components/TestRunnerDialog.tsx
+++ b/src/components/TestRunnerDialog.tsx
@@ -96,7 +96,7 @@ type TestRunnerDialogProps = {
       test_case?: { name?: string } | null;
     }[],
     passed?: number | null,
-    failed?: number | null
+    failed?: number | null,
   ) => void; // Called when run status changes (for coordinated polling)
 };
 
@@ -129,7 +129,7 @@ export function TestRunnerDialog({
     console.log("selectedTestUuid changed to:", selectedTestUuid);
     console.log(
       "testResults:",
-      testResults.map((r) => ({ uuid: r.test.uuid, name: r.test.name }))
+      testResults.map((r) => ({ uuid: r.test.uuid, name: r.test.name })),
     );
   }, [selectedTestUuid, testResults]);
 
@@ -240,7 +240,7 @@ export function TestRunnerDialog({
         setRunStatus(
           result.status === "completed"
             ? "done"
-            : (result.status as "queued" | "in_progress" | "done" | "failed")
+            : (result.status as "queued" | "in_progress" | "done" | "failed"),
         );
       }
 
@@ -248,7 +248,7 @@ export function TestRunnerDialog({
       setTestResults((prev) => {
         // Helper to determine test status from API result
         const getTestStatus = (
-          apiResult: TestCaseResult
+          apiResult: TestCaseResult,
         ): "passed" | "failed" | "running" => {
           // If passed is null, the test is still running
           if (apiResult.passed === null || apiResult.passed === undefined) {
@@ -289,7 +289,9 @@ export function TestRunnerDialog({
               reasoning: apiResult.reasoning,
               evaluation:
                 testStatus !== "running"
-                  ? apiResult.evaluation ?? { passed: testStatus === "passed" }
+                  ? (apiResult.evaluation ?? {
+                      passed: testStatus === "passed",
+                    })
                   : undefined,
               error: apiResult.error,
             };
@@ -300,13 +302,14 @@ export function TestRunnerDialog({
         const updatedResults: TestResult[] = prev.map((r, index) => {
           // First try to find by UUID in results
           let apiResult = result.results?.find(
-            (res) => res.test_uuid === r.test.uuid
+            (res) => res.test_uuid === r.test.uuid,
           );
 
           // If no UUID match, try to find by test name (check both name and test_name)
           if (!apiResult) {
             apiResult = result.results?.find(
-              (res) => res.test_name === r.test.name || res.name === r.test.name
+              (res) =>
+                res.test_name === r.test.name || res.name === r.test.name,
             );
           }
 
@@ -326,7 +329,9 @@ export function TestRunnerDialog({
               reasoning: apiResult.reasoning,
               evaluation:
                 testStatus !== "running"
-                  ? apiResult.evaluation ?? { passed: testStatus === "passed" }
+                  ? (apiResult.evaluation ?? {
+                      passed: testStatus === "passed",
+                    })
                   : undefined,
               error: apiResult.error,
             };
@@ -358,7 +363,7 @@ export function TestRunnerDialog({
           result.status,
           apiResults,
           result.passed,
-          result.failed
+          result.failed,
         );
       }
 
@@ -381,8 +386,8 @@ export function TestRunnerDialog({
             prev.map((r) =>
               r.status === "pending" || r.status === "running"
                 ? { ...r, status: "failed", error: result.error }
-                : r
-            )
+                : r,
+            ),
           );
         }
       }
@@ -436,7 +441,7 @@ export function TestRunnerDialog({
           body: JSON.stringify({
             test_uuids: testUuids,
           }),
-        }
+        },
       );
 
       if (response.status === 401) {
@@ -472,7 +477,7 @@ export function TestRunnerDialog({
           status: "failed",
           error:
             error instanceof Error ? error.message : "Failed to start test run",
-        }))
+        })),
       );
       setIsRunning(false);
     }
@@ -487,8 +492,8 @@ export function TestRunnerDialog({
       prev.map((r) =>
         r.test.uuid === testUuid
           ? { ...r, status: "running", error: undefined }
-          : r
-      )
+          : r,
+      ),
     );
 
     const backendUrl = process.env.NEXT_PUBLIC_BACKEND_URL;
@@ -501,8 +506,8 @@ export function TestRunnerDialog({
                 status: "failed",
                 error: "BACKEND_URL environment variable is not set",
               }
-            : r
-        )
+            : r,
+        ),
       );
       return;
     }
@@ -522,7 +527,7 @@ export function TestRunnerDialog({
           body: JSON.stringify({
             test_uuids: [testUuid],
           }),
-        }
+        },
       );
 
       if (response.status === 401) {
@@ -548,7 +553,7 @@ export function TestRunnerDialog({
                 "ngrok-skip-browser-warning": "true",
                 Authorization: `Bearer ${backendAccessToken}`,
               },
-            }
+            },
           );
 
           if (pollResponse.status === 401) {
@@ -568,7 +573,7 @@ export function TestRunnerDialog({
             pollResult.status === "failed"
           ) {
             const apiResult = pollResult.results?.find(
-              (res) => res.test_uuid === testUuid
+              (res) => res.test_uuid === testUuid,
             );
             if (apiResult) {
               setTestResults((prev) =>
@@ -582,16 +587,16 @@ export function TestRunnerDialog({
                         evaluation: apiResult.evaluation,
                         error: apiResult.error,
                       }
-                    : r
-                )
+                    : r,
+                ),
               );
             } else if (pollResult.error) {
               setTestResults((prev) =>
                 prev.map((r) =>
                   r.test.uuid === testUuid
                     ? { ...r, status: "failed", error: pollResult.error }
-                    : r
-                )
+                    : r,
+                ),
               );
             }
           } else {
@@ -608,8 +613,8 @@ export function TestRunnerDialog({
                     error:
                       error instanceof Error ? error.message : "Test failed",
                   }
-                : r
-            )
+                : r,
+            ),
           );
         }
       };
@@ -623,7 +628,7 @@ export function TestRunnerDialog({
         setTimeout(pollSingleTest, POLLING_INTERVAL_MS);
       } else if (result.status === "completed" || result.status === "done") {
         const apiResult = result.results?.find(
-          (res) => res.test_uuid === testUuid
+          (res) => res.test_uuid === testUuid,
         );
         if (apiResult) {
           setTestResults((prev) =>
@@ -636,8 +641,8 @@ export function TestRunnerDialog({
                     evaluation: apiResult.evaluation,
                     error: apiResult.error,
                   }
-                : r
-            )
+                : r,
+            ),
           );
         }
       }
@@ -650,8 +655,8 @@ export function TestRunnerDialog({
                 status: "failed",
                 error: error instanceof Error ? error.message : "Test failed",
               }
-            : r
-        )
+            : r,
+        ),
       );
     }
   };
@@ -680,8 +685,8 @@ export function TestRunnerDialog({
       prev.map((r) =>
         r.status === "failed"
           ? { ...r, status: "running", error: undefined }
-          : r
-      )
+          : r,
+      ),
     );
 
     try {
@@ -700,7 +705,7 @@ export function TestRunnerDialog({
           body: JSON.stringify({
             test_uuids: testUuids,
           }),
-        }
+        },
       );
 
       if (!response.ok) {
@@ -723,7 +728,7 @@ export function TestRunnerDialog({
           setTestResults((prev) =>
             prev.map((r) => {
               const apiResult = result.results?.find(
-                (res) => res.test_uuid === r.test.uuid
+                (res) => res.test_uuid === r.test.uuid,
               );
               if (apiResult) {
                 return {
@@ -735,7 +740,7 @@ export function TestRunnerDialog({
                 };
               }
               return r;
-            })
+            }),
           );
         }
         setIsRunning(false);
@@ -753,8 +758,8 @@ export function TestRunnerDialog({
                     ? error.message
                     : "Failed to retry tests",
               }
-            : r
-        )
+            : r,
+        ),
       );
       setIsRunning(false);
     }
@@ -763,7 +768,7 @@ export function TestRunnerDialog({
   const retryAll = async () => {
     // Reset all tests to pending
     setTestResults((prev) =>
-      prev.map((r) => ({ ...r, status: "pending", error: undefined }))
+      prev.map((r) => ({ ...r, status: "pending", error: undefined })),
     );
 
     const resetResults = testResults.map((r) => ({
@@ -774,7 +779,7 @@ export function TestRunnerDialog({
   };
 
   const selectedResult = testResults.find(
-    (r) => r.test.uuid === selectedTestUuid
+    (r) => r.test.uuid === selectedTestUuid,
   );
 
   // Debug: Log selectedResult
@@ -783,7 +788,7 @@ export function TestRunnerDialog({
       "selectedResult:",
       selectedResult
         ? { name: selectedResult.test.name, status: selectedResult.status }
-        : null
+        : null,
     );
   }, [selectedResult]);
 
@@ -859,168 +864,170 @@ export function TestRunnerDialog({
             </div>
           </div>
         ) : (
-        /* Content - Split panel */
-        <div className="flex-1 flex overflow-hidden">
-          {/* Left Panel - Test List */}
-          <div
-            className={`w-full md:w-80 border-r border-border flex flex-col overflow-hidden ${
-              selectedTestUuid ? "hidden md:flex" : "flex"
-            }`}
-          >
-            <div className="flex-1 overflow-y-auto">
-              {/* Failed Tests - Always shown first */}
-              {failedTests.length > 0 && (
-                <div className="p-4">
-                  <h3 className="text-sm font-medium text-muted-foreground mb-2 flex items-center gap-2">
-                    <div className="w-2 h-2 rounded-full bg-red-500"></div>
-                    Failed ({failedTests.length})
-                  </h3>
-                  <div className="space-y-1">
-                    {failedTests.map((result) => (
-                      <TestListItem
-                        key={result.test.uuid}
-                        result={result}
-                        isSelected={selectedTestUuid === result.test.uuid}
-                        onSelect={() => setSelectedTestUuid(result.test.uuid)}
-                      />
-                    ))}
-                  </div>
-                </div>
-              )}
-
-              {/* Passed Tests */}
-              {passedTests.length > 0 && (
-                <div className="p-4">
-                  <h3 className="text-sm font-medium text-muted-foreground mb-2 flex items-center gap-2">
-                    <div className="w-2 h-2 rounded-full bg-green-500"></div>
-                    Passed ({passedTests.length})
-                  </h3>
-                  <div className="space-y-1">
-                    {passedTests.map((result) => (
-                      <TestListItem
-                        key={result.test.uuid}
-                        result={result}
-                        isSelected={selectedTestUuid === result.test.uuid}
-                        onSelect={() => setSelectedTestUuid(result.test.uuid)}
-                      />
-                    ))}
-                  </div>
-                </div>
-              )}
-
-              {/* Queued Tests */}
-              {queuedTests.length > 0 && (
-                <div className="p-4">
-                  <h3 className="text-sm font-medium text-muted-foreground mb-2 flex items-center gap-2">
-                    <div className="w-2 h-2 rounded-full bg-gray-400"></div>
-                    Queued ({queuedTests.length})
-                  </h3>
-                  <div className="space-y-1">
-                    {queuedTests.map((result) => (
-                      <TestListItem
-                        key={result.test.uuid}
-                        result={result}
-                        isSelected={selectedTestUuid === result.test.uuid}
-                        onSelect={() => setSelectedTestUuid(result.test.uuid)}
-                      />
-                    ))}
-                  </div>
-                </div>
-              )}
-
-              {/* Running Tests */}
-              {runningTests.length > 0 && (
-                <div className="p-4">
-                  <h3 className="text-sm font-medium text-muted-foreground mb-2 flex items-center gap-2">
-                    <div className="w-2 h-2 rounded-full bg-yellow-500 animate-pulse"></div>
-                    Running ({runningTests.length})
-                  </h3>
-                  <div className="space-y-1">
-                    {runningTests.map((result) => (
-                      <TestListItem
-                        key={result.test.uuid}
-                        result={result}
-                        isSelected={selectedTestUuid === result.test.uuid}
-                        onSelect={() => setSelectedTestUuid(result.test.uuid)}
-                      />
-                    ))}
-                  </div>
-                </div>
-              )}
-
-              {/* Pending Tests */}
-              {pendingTests.length > 0 && (
-                <div className="p-4">
-                  <h3 className="text-sm font-medium text-muted-foreground mb-2 flex items-center gap-2">
-                    <div className="w-2 h-2 rounded-full bg-gray-400"></div>
-                    Pending ({pendingTests.length})
-                  </h3>
-                  <div className="space-y-1">
-                    {pendingTests.map((result) => (
-                      <TestListItem
-                        key={result.test.uuid}
-                        result={result}
-                        isSelected={selectedTestUuid === result.test.uuid}
-                        onSelect={() => setSelectedTestUuid(result.test.uuid)}
-                      />
-                    ))}
-                  </div>
-                </div>
-              )}
-            </div>
-          </div>
-
-          {/* Middle Panel - Conversation History */}
-          <div
-            className={`flex-1 ${
-              selectedTestUuid ? "flex" : "hidden md:flex"
-            } flex-col overflow-hidden`}
-          >
-            {selectedResult ? (
-              <>
-                {/* Mobile Back Button */}
-                <div className="md:hidden px-4 py-3 border-b border-border flex-shrink-0">
-                  <button
-                    onClick={() => setSelectedTestUuid(null)}
-                    className="flex items-center gap-2 text-sm text-foreground hover:text-muted-foreground transition-colors"
-                  >
-                    <svg
-                      className="w-4 h-4"
-                      fill="none"
-                      viewBox="0 0 24 24"
-                      stroke="currentColor"
-                      strokeWidth={2}
-                    >
-                      <path
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        d="M15 19l-7-7 7-7"
-                      />
-                    </svg>
-                    Back to tests
-                  </button>
-                </div>
-                <div className="flex-1 overflow-y-auto">
-                  <LocalTestDetailView result={selectedResult} />
-                </div>
-              </>
-            ) : (
-              <EmptyStateView message="Select a test to view details" />
-            )}
-          </div>
-
-          {/* Right Panel - Evaluation Criteria */}
-          {selectedResult && (
-            <div className="hidden md:flex w-72 border-l border-border flex-col overflow-hidden">
+          /* Content - Split panel */
+          <div className="flex-1 flex overflow-hidden">
+            {/* Left Panel - Test List */}
+            <div
+              className={`w-full md:w-80 border-r border-border flex flex-col overflow-hidden ${
+                selectedTestUuid ? "hidden md:flex" : "flex"
+              }`}
+            >
               <div className="flex-1 overflow-y-auto">
-                <EvaluationCriteriaPanel
-                  evaluation={selectedResult.testCase?.evaluation}
-                  testType={selectedResult.test.type}
-                />
+                {/* Failed Tests - Always shown first */}
+                {failedTests.length > 0 && (
+                  <div className="p-4">
+                    <h3 className="text-sm font-medium text-muted-foreground mb-2 flex items-center gap-2">
+                      <div className="w-2 h-2 rounded-full bg-red-500"></div>
+                      Failed ({failedTests.length})
+                    </h3>
+                    <div className="space-y-1">
+                      {failedTests.map((result) => (
+                        <TestListItem
+                          key={result.test.uuid}
+                          result={result}
+                          isSelected={selectedTestUuid === result.test.uuid}
+                          onSelect={() => setSelectedTestUuid(result.test.uuid)}
+                        />
+                      ))}
+                    </div>
+                  </div>
+                )}
+
+                {/* Passed Tests */}
+                {passedTests.length > 0 && (
+                  <div className="p-4">
+                    <h3 className="text-sm font-medium text-muted-foreground mb-2 flex items-center gap-2">
+                      <div className="w-2 h-2 rounded-full bg-green-500"></div>
+                      Passed ({passedTests.length})
+                    </h3>
+                    <div className="space-y-1">
+                      {passedTests.map((result) => (
+                        <TestListItem
+                          key={result.test.uuid}
+                          result={result}
+                          isSelected={selectedTestUuid === result.test.uuid}
+                          onSelect={() => setSelectedTestUuid(result.test.uuid)}
+                        />
+                      ))}
+                    </div>
+                  </div>
+                )}
+
+                {/* Queued Tests */}
+                {queuedTests.length > 0 && (
+                  <div className="p-4">
+                    <h3 className="text-sm font-medium text-muted-foreground mb-2 flex items-center gap-2">
+                      <div className="w-2 h-2 rounded-full bg-gray-400"></div>
+                      Queued ({queuedTests.length})
+                    </h3>
+                    <div className="space-y-1">
+                      {queuedTests.map((result) => (
+                        <TestListItem
+                          key={result.test.uuid}
+                          result={result}
+                          isSelected={selectedTestUuid === result.test.uuid}
+                          onSelect={() => setSelectedTestUuid(result.test.uuid)}
+                        />
+                      ))}
+                    </div>
+                  </div>
+                )}
+
+                {/* Running Tests */}
+                {runningTests.length > 0 && (
+                  <div className="p-4">
+                    <h3 className="text-sm font-medium text-muted-foreground mb-2 flex items-center gap-2">
+                      <div className="w-2 h-2 rounded-full bg-yellow-500 animate-pulse"></div>
+                      Running ({runningTests.length})
+                    </h3>
+                    <div className="space-y-1">
+                      {runningTests.map((result) => (
+                        <TestListItem
+                          key={result.test.uuid}
+                          result={result}
+                          isSelected={selectedTestUuid === result.test.uuid}
+                          onSelect={() => setSelectedTestUuid(result.test.uuid)}
+                        />
+                      ))}
+                    </div>
+                  </div>
+                )}
+
+                {/* Pending Tests */}
+                {pendingTests.length > 0 && (
+                  <div className="p-4">
+                    <h3 className="text-sm font-medium text-muted-foreground mb-2 flex items-center gap-2">
+                      <div className="w-2 h-2 rounded-full bg-gray-400"></div>
+                      Pending ({pendingTests.length})
+                    </h3>
+                    <div className="space-y-1">
+                      {pendingTests.map((result) => (
+                        <TestListItem
+                          key={result.test.uuid}
+                          result={result}
+                          isSelected={selectedTestUuid === result.test.uuid}
+                          onSelect={() => setSelectedTestUuid(result.test.uuid)}
+                        />
+                      ))}
+                    </div>
+                  </div>
+                )}
               </div>
             </div>
-          )}
-        </div>
+
+            {/* Middle Panel - Conversation History */}
+            <div
+              className={`flex-1 ${
+                selectedTestUuid ? "flex" : "hidden md:flex"
+              } flex-col overflow-hidden`}
+            >
+              {selectedResult ? (
+                <>
+                  {/* Mobile Back Button */}
+                  <div className="md:hidden px-4 py-3 border-b border-border flex-shrink-0">
+                    <button
+                      onClick={() => setSelectedTestUuid(null)}
+                      className="flex items-center gap-2 text-sm text-foreground hover:text-muted-foreground transition-colors"
+                    >
+                      <svg
+                        className="w-4 h-4"
+                        fill="none"
+                        viewBox="0 0 24 24"
+                        stroke="currentColor"
+                        strokeWidth={2}
+                      >
+                        <path
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          d="M15 19l-7-7 7-7"
+                        />
+                      </svg>
+                      Back to tests
+                    </button>
+                  </div>
+                  <div className="flex-1 overflow-y-auto">
+                    <LocalTestDetailView result={selectedResult} />
+                  </div>
+                </>
+              ) : (
+                <EmptyStateView message="Select a test to view details" />
+              )}
+            </div>
+
+            {/* Right Panel - Evaluation Criteria (only after test completes) */}
+            {selectedResult &&
+              (selectedResult.status === "passed" ||
+                selectedResult.status === "failed") && (
+                <div className="hidden md:flex w-72 border-l border-border flex-col overflow-hidden">
+                  <div className="flex-1 overflow-y-auto">
+                    <EvaluationCriteriaPanel
+                      evaluation={selectedResult.testCase?.evaluation}
+                      testType={selectedResult.testCase?.evaluation?.type}
+                    />
+                  </div>
+                </div>
+              )}
+          </div>
         )}
       </div>
     </div>
@@ -1084,7 +1091,7 @@ function LocalTestDetailView({ result }: { result: TestResult }) {
       <div className="flex items-center justify-center h-full">
         <div className="flex items-center gap-3">
           <SpinnerIcon className="w-5 h-5 animate-spin text-muted-foreground" />
-          <p className="text-muted-foreground">Running test...</p>
+          <p className="text-muted-foreground">Running test</p>
         </div>
       </div>
     );
@@ -1108,10 +1115,13 @@ function LocalTestDetailView({ result }: { result: TestResult }) {
                 d="M12 9v3.75m9-.75a9 9 0 11-18 0 9 9 0 0118 0zm-9 3.75h.008v.008H12v-.008z"
               />
             </svg>
-            <span className="font-medium text-red-500">Something went wrong</span>
+            <span className="font-medium text-red-500">
+              Something went wrong
+            </span>
           </div>
           <p className="text-sm text-red-400">
-            We&apos;re looking into it. Please reach out to us if this issue persists.
+            We&apos;re looking into it. Please reach out to us if this issue
+            persists.
           </p>
         </div>
       </div>

--- a/src/components/TestRunnerDialog.tsx
+++ b/src/components/TestRunnerDialog.tsx
@@ -12,6 +12,7 @@ import {
   TestDetailView as SharedTestDetailView,
   EmptyStateView,
   TestStats,
+  EvaluationCriteriaPanel,
 } from "./test-results/shared";
 import { POLLING_INTERVAL_MS } from "@/constants/polling";
 import { useHideFloatingButton } from "@/components/AppLayout";
@@ -39,6 +40,7 @@ type TestResult = {
   chatHistory?: ChatMessage[];
   output?: TestCaseOutput;
   testCase?: TestCaseData;
+  reasoning?: string;
   evaluation?: {
     passed: boolean;
     message?: string;
@@ -53,6 +55,7 @@ type TestCaseResult = {
   name?: string; // Test name from in-progress API response
   status?: "passed" | "failed" | "error";
   passed?: boolean | null; // null means test is still running
+  reasoning?: string;
   output?: TestCaseOutput | null;
   test_case?: TestCaseData | null;
   chat_history?: ChatMessage[];
@@ -283,6 +286,7 @@ export function TestRunnerDialog({
               chatHistory: apiResult.chat_history,
               output: apiResult.output ?? undefined,
               testCase: apiResult.test_case ?? undefined,
+              reasoning: apiResult.reasoning,
               evaluation:
                 testStatus !== "running"
                   ? apiResult.evaluation ?? { passed: testStatus === "passed" }
@@ -319,6 +323,7 @@ export function TestRunnerDialog({
               chatHistory: apiResult.chat_history,
               output: apiResult.output ?? undefined,
               testCase: apiResult.test_case ?? undefined,
+              reasoning: apiResult.reasoning,
               evaluation:
                 testStatus !== "running"
                   ? apiResult.evaluation ?? { passed: testStatus === "passed" }
@@ -798,7 +803,7 @@ export function TestRunnerDialog({
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-0 md:p-4">
-      <div className="bg-background rounded-none md:rounded-xl w-full max-w-5xl h-full md:h-[80vh] flex flex-col shadow-2xl">
+      <div className="bg-background rounded-none md:rounded-xl w-full max-w-7xl h-full md:h-[80vh] flex flex-col shadow-2xl">
         {/* Header */}
         <div className="flex items-center justify-between px-4 md:px-6 py-3 md:py-4 border-b border-border">
           <h2 className="text-base md:text-lg font-semibold text-foreground">
@@ -965,7 +970,7 @@ export function TestRunnerDialog({
             </div>
           </div>
 
-          {/* Right Panel - Test Details */}
+          {/* Middle Panel - Conversation History */}
           <div
             className={`flex-1 ${
               selectedTestUuid ? "flex" : "hidden md:flex"
@@ -1003,6 +1008,18 @@ export function TestRunnerDialog({
               <EmptyStateView message="Select a test to view details" />
             )}
           </div>
+
+          {/* Right Panel - Evaluation Criteria */}
+          {selectedResult && (
+            <div className="hidden md:flex w-72 border-l border-border flex-col overflow-hidden">
+              <div className="flex-1 overflow-y-auto">
+                <EvaluationCriteriaPanel
+                  evaluation={selectedResult.testCase?.evaluation}
+                  testType={selectedResult.test.type}
+                />
+              </div>
+            </div>
+          )}
         </div>
         )}
       </div>
@@ -1107,6 +1124,7 @@ function LocalTestDetailView({ result }: { result: TestResult }) {
       history={result.testCase?.history || []}
       output={result.output}
       passed={result.evaluation?.passed ?? false}
+      reasoning={result.reasoning}
     />
   );
 }

--- a/src/components/test-results/shared.tsx
+++ b/src/components/test-results/shared.tsx
@@ -166,10 +166,12 @@ export function TestDetailView({
   history,
   output,
   passed,
+  reasoning,
 }: {
   history: TestCaseHistory[];
   output?: TestCaseOutput;
   passed: boolean;
+  reasoning?: string;
 }) {
   return (
     <div className="p-4 md:p-6 space-y-4 md:space-y-6">
@@ -268,6 +270,11 @@ export function TestDetailView({
                 </span>
                 <SmallStatusBadge passed={passed} />
               </div>
+              {reasoning && (
+                <p className="text-xs text-muted-foreground italic mb-2">
+                  {reasoning}
+                </p>
+              )}
               <div className="w-[70%] md:w-1/2">
                 <div className="px-3 md:px-4 py-2.5 md:py-3 rounded-xl bg-background border border-border">
                   <p className="text-sm text-foreground whitespace-pre-wrap">
@@ -293,6 +300,11 @@ export function TestDetailView({
                 </span>
                 <SmallStatusBadge passed={passed} />
               </div>
+              {reasoning && (
+                <p className="text-xs text-muted-foreground italic mb-2">
+                  {reasoning}
+                </p>
+              )}
               <div className="space-y-3">
                 {output.tool_calls.map((toolCall, index) => (
                   <div key={index} className="w-[70%] md:w-1/2">
@@ -330,6 +342,87 @@ export function EmptyStateView({ message }: { message: string }) {
         </div>
         <p className="text-muted-foreground text-sm">{message}</p>
       </div>
+    </div>
+  );
+}
+
+// Evaluation Criteria Panel Component (third column)
+export function EvaluationCriteriaPanel({
+  evaluation,
+  testType,
+}: {
+  evaluation?: TestCaseEvaluation;
+  testType?: string;
+}) {
+  const resolvedType =
+    testType || evaluation?.type || (evaluation?.tool_calls ? "tool_call" : "response");
+  const isToolCall = resolvedType === "tool_call";
+  const displayType = isToolCall ? "Tool Call" : "Next Reply Text";
+
+  return (
+    <div className="p-4 md:p-6 space-y-4">
+      <h3 className="text-sm font-semibold text-foreground">
+        Evaluation Criteria
+      </h3>
+
+      {/* Test Type */}
+      <div>
+        <label className="text-xs font-medium text-muted-foreground mb-1.5 block">
+          Type
+        </label>
+        <span
+          className={`inline-flex items-center gap-1.5 px-2.5 py-1 rounded-md text-xs font-medium ${
+            isToolCall
+              ? "bg-purple-500/10 text-purple-400"
+              : "bg-blue-500/10 text-blue-400"
+          }`}
+        >
+          {isToolCall ? (
+            <ToolIcon className="w-3.5 h-3.5" />
+          ) : (
+            <DocumentIcon className="w-3.5 h-3.5" />
+          )}
+          {displayType}
+        </span>
+      </div>
+
+      {/* Criteria text */}
+      {evaluation?.criteria && (
+        <div>
+          <label className="text-xs font-medium text-muted-foreground mb-1.5 block">
+            Criteria
+          </label>
+          <p className="text-sm text-foreground whitespace-pre-wrap">
+            {evaluation.criteria}
+          </p>
+        </div>
+      )}
+
+      {/* Expected tool calls */}
+      {evaluation?.tool_calls && evaluation.tool_calls.length > 0 && (
+        <div>
+          <label className="text-xs font-medium text-muted-foreground mb-1.5 block">
+            Expected Tool Calls
+          </label>
+          <div className="space-y-2">
+            {evaluation.tool_calls.map((tc, i) => (
+              <ToolCallCard
+                key={i}
+                toolName={tc.tool}
+                args={tc.arguments || {}}
+              />
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Empty state when no detailed criteria */}
+      {!evaluation?.criteria &&
+        (!evaluation?.tool_calls || evaluation.tool_calls.length === 0) && (
+          <p className="text-xs text-muted-foreground">
+            No additional criteria specified
+          </p>
+        )}
     </div>
   );
 }


### PR DESCRIPTION
Fix #24

 Summary

- **Reasoning field**: The backend now returns a `reasoning` field on each test result. This is now displayed as italic muted text just above the agent message bubble (or tool call cards), beneath the pass/fail badge — visible in both TestRunnerDialog and BenchmarkResultsDialog.
- **Evaluation criteria panel**: Added a third desktop-only column (`w-72`) in both dialogs showing the test type badge (Next Reply Text / Tool Call), criteria text, and expected tool calls.
- **Layout**: Dialog max-width expanded from `max-w-5xl` to `max-w-7xl` to accommodate the three-panel layout.

## Test plan

- [x] Run a test in TestRunnerDialog — confirm reasoning text appears in italic above the agent message when present
- [x] Run a benchmark — confirm reasoning appears per test result in BenchmarkResultsDialog
- [x] Verify no reasoning text shown when field is absent/undefined
- [x] Check evaluation criteria panel renders correctly on desktop for both tool call and response type tests
- [x] Confirm evaluation criteria panel is hidden on mobile
- [x] Verify build passes with no TypeScript errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)