### PR TITLE
Public sharing, LLM runs tab, and UI polish

### DIFF
--- a/src/app/public/benchmark/[token]/page.tsx
+++ b/src/app/public/benchmark/[token]/page.tsx
@@ -1,0 +1,250 @@
+"use client";
+
+import React, { useState, useEffect } from "react";
+import { useParams } from "next/navigation";
+import {
+  TestCaseOutput,
+  TestCaseData,
+  StatusIcon,
+  TestDetailView,
+  EvaluationCriteriaPanel,
+} from "@/components/test-results/shared";
+import { LeaderboardBarChart, getColorMap } from "@/components/charts/LeaderboardBarChart";
+import { DownloadableTable } from "@/components/DownloadableTable";
+import { PublicPageLayout, PublicNotFound, PublicLoading } from "@/components/PublicPageLayout";
+
+type BenchmarkTestResult = {
+  name?: string;
+  passed: boolean | null;
+  reasoning?: string;
+  output?: TestCaseOutput;
+  test_case?: TestCaseData;
+};
+
+type ModelResult = {
+  model: string;
+  success: boolean | null;
+  message: string;
+  total_tests: number | null;
+  passed: number | null;
+  failed: number | null;
+  test_results: BenchmarkTestResult[] | null;
+};
+
+type LeaderboardSummary = {
+  model: string;
+  passed: string;
+  total: string;
+  pass_rate: string;
+};
+
+type BenchmarkStatusResponse = {
+  task_id: string;
+  status: string;
+  model_results?: ModelResult[];
+  leaderboard_summary?: LeaderboardSummary[];
+  error?: string;
+};
+
+export default function PublicBenchmarkPage() {
+  const params = useParams();
+  const token = params.token as string;
+
+  const [data, setData] = useState<BenchmarkStatusResponse | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [notFound, setNotFound] = useState(false);
+  const [activeTab, setActiveTab] = useState<"leaderboard" | "outputs">("leaderboard");
+  const [expandedModels, setExpandedModels] = useState<Set<string>>(new Set());
+  const [selectedTest, setSelectedTest] = useState<{ model: string; testIndex: number } | null>(null);
+
+  useEffect(() => { document.title = "Benchmark | Calibrate"; }, []);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const backendUrl = process.env.NEXT_PUBLIC_BACKEND_URL;
+        if (!backendUrl) throw new Error("Backend URL not configured");
+
+        const res = await fetch(`${backendUrl}/public/benchmark/${token}`, {
+          headers: { accept: "application/json", "ngrok-skip-browser-warning": "true" },
+        });
+
+        if (res.status === 404) { setNotFound(true); return; }
+        if (!res.ok) throw new Error("Failed to load results");
+
+        const result: BenchmarkStatusResponse = await res.json();
+        if (result.status !== "done" && result.status !== "completed") { setNotFound(true); return; }
+
+        setData(result);
+        // Auto-expand first model
+        if (result.model_results?.length) {
+          setExpandedModels(new Set([result.model_results[0].model]));
+        }
+      } catch {
+        setNotFound(true);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+    fetchData();
+  }, [token]);
+
+  if (isLoading) return <PublicPageLayout><PublicLoading /></PublicPageLayout>;
+  if (notFound || !data) return <PublicPageLayout><PublicNotFound /></PublicPageLayout>;
+
+  const toggleModel = (model: string) => {
+    setExpandedModels((prev) => {
+      const next = new Set(prev);
+      if (next.has(model)) next.delete(model);
+      else next.add(model);
+      return next;
+    });
+  };
+
+  const selectedModelResult = selectedTest
+    ? data.model_results?.find((m) => m.model === selectedTest.model)
+    : null;
+  const selectedTestResult = selectedModelResult?.test_results?.[selectedTest?.testIndex ?? -1] ?? null;
+
+  return (
+    <PublicPageLayout>
+      <div className="space-y-4 md:space-y-6">
+        {/* Tab nav */}
+        <div className="flex gap-2 border-b border-border">
+          {(["leaderboard", "outputs"] as const).map((tab) => (
+            <button
+              key={tab}
+              onClick={() => setActiveTab(tab)}
+              className={`px-4 py-2 text-[13px] font-medium border-b-2 transition-colors cursor-pointer capitalize ${activeTab === tab ? "border-foreground text-foreground" : "border-transparent text-muted-foreground hover:text-foreground"}`}
+            >
+              {tab}
+            </button>
+          ))}
+        </div>
+
+        {/* Leaderboard Tab */}
+        {activeTab === "leaderboard" && data.leaderboard_summary && data.leaderboard_summary.length > 0 && (
+          <div className="space-y-4 md:space-y-6">
+            <DownloadableTable
+              columns={[
+                { key: "model", header: "Model" },
+                { key: "passed", header: "Passed" },
+                { key: "total", header: "Total" },
+                {
+                  key: "pass_rate",
+                  header: "Pass Rate",
+                  render: (v) => {
+                    const pct = parseFloat(v) * 100;
+                    return `${pct.toFixed(1)}%`;
+                  },
+                },
+              ]}
+              data={data.leaderboard_summary}
+              filename="benchmark-leaderboard"
+            />
+            {(() => {
+              const models = data.leaderboard_summary!.map((s) => s.model);
+              const colorMap = getColorMap(models);
+              return (
+                <LeaderboardBarChart
+                  title="Pass Rate by Model"
+                  data={data.leaderboard_summary!.map((s) => ({
+                    label: s.model,
+                    value: parseFloat(s.pass_rate),
+                    colorKey: s.model,
+                  }))}
+                  colorMap={colorMap}
+                  yDomain={[0, 1]}
+                />
+              );
+            })()}
+          </div>
+        )}
+
+        {/* Outputs Tab */}
+        {activeTab === "outputs" && data.model_results && data.model_results.length > 0 && (
+          <div className="flex border border-border rounded-xl overflow-hidden" style={{ height: "calc(100vh - 260px)", minHeight: 520 }}>
+            {/* Left — model list + test list */}
+            <div className="w-72 shrink-0 border-r border-border flex flex-col overflow-hidden bg-muted/10">
+              <div className="overflow-y-auto flex-1">
+                {data.model_results.map((mr) => {
+                  const isExpanded = expandedModels.has(mr.model);
+                  const passRate = mr.total_tests && mr.passed != null
+                    ? `${mr.passed}/${mr.total_tests}`
+                    : null;
+                  return (
+                    <div key={mr.model} className="border-b border-border last:border-b-0">
+                      {/* Model row */}
+                      <button
+                        type="button"
+                        onClick={() => toggleModel(mr.model)}
+                        className="w-full px-4 py-3 flex items-center justify-between hover:bg-muted/50 transition-colors cursor-pointer"
+                      >
+                        <div className="flex items-center gap-2 min-w-0">
+                          <svg className={`w-4 h-4 text-muted-foreground shrink-0 transition-transform ${isExpanded ? "rotate-90" : ""}`} fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                            <path strokeLinecap="round" strokeLinejoin="round" d="M8.25 4.5l7.5 7.5-7.5 7.5" />
+                          </svg>
+                          <span className="text-[13px] font-medium text-foreground truncate">{mr.model}</span>
+                        </div>
+                        {passRate && (
+                          <span className="text-[12px] text-muted-foreground shrink-0 ml-2">{passRate}</span>
+                        )}
+                      </button>
+
+                      {/* Tests within this model */}
+                      {isExpanded && mr.test_results && (
+                        <div className="px-2 pb-2 space-y-0.5">
+                          {mr.test_results.map((tr, ti) => {
+                            const isSelected = selectedTest?.model === mr.model && selectedTest.testIndex === ti;
+                            const testStatus = tr.passed === true ? "passed" : tr.passed === false ? "failed" : "running";
+                            const name = tr.name || tr.test_case?.name || `Test ${ti + 1}`;
+                            return (
+                              <button
+                                key={ti}
+                                type="button"
+                                onClick={() => setSelectedTest({ model: mr.model, testIndex: ti })}
+                                className={`w-full flex items-center gap-2 px-3 py-2 rounded-lg cursor-pointer transition-colors text-left ${isSelected ? "bg-muted" : "hover:bg-muted/50"}`}
+                              >
+                                <StatusIcon status={testStatus} />
+                                <span className="text-[13px] text-foreground truncate">{name}</span>
+                              </button>
+                            );
+                          })}
+                        </div>
+                      )}
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+
+            {/* Right — test detail */}
+            <div className="flex-1 overflow-y-auto">
+              {selectedTestResult ? (
+                <div className="flex h-full">
+                  <div className="flex-1 overflow-y-auto p-4 md:p-6">
+                    <TestDetailView
+                      history={selectedTestResult.test_case?.history || []}
+                      output={selectedTestResult.output}
+                      passed={selectedTestResult.passed ?? false}
+                      reasoning={selectedTestResult.reasoning}
+                    />
+                  </div>
+                  {selectedTestResult.test_case?.evaluation && (
+                    <div className="w-72 shrink-0 border-l border-border overflow-y-auto">
+                      <EvaluationCriteriaPanel evaluation={selectedTestResult.test_case.evaluation} />
+                    </div>
+                  )}
+                </div>
+              ) : (
+                <div className="flex items-center justify-center h-full">
+                  <p className="text-[13px] text-muted-foreground">Select a test to view details</p>
+                </div>
+              )}
+            </div>
+          </div>
+        )}
+      </div>
+    </PublicPageLayout>
+  );
+}

--- a/src/app/public/simulation-run/[token]/page.tsx
+++ b/src/app/public/simulation-run/[token]/page.tsx
@@ -1,0 +1,493 @@
+"use client";
+
+import React, { useState, useEffect } from "react";
+import { useParams } from "next/navigation";
+import { Tooltip } from "@/components/Tooltip";
+import { PublicPageLayout, PublicNotFound, PublicLoading } from "@/components/PublicPageLayout";
+
+type MetricData = { mean: number; std: number; values: number[] };
+type Persona = { label: string; characteristics: string; gender: string; language: string };
+type Scenario = { name: string; description: string };
+type EvaluationResult = { name: string; value: number; reasoning: string };
+type TranscriptEntry = { role: string; content?: string; tool_calls?: any[] | null; tool_call_id?: string };
+
+type SimulationResult = {
+  simulation_name: string;
+  aborted?: boolean;
+  persona: Persona;
+  scenario: Scenario;
+  evaluation_results: EvaluationResult[] | null;
+  transcript?: TranscriptEntry[] | null;
+  audio_urls?: string[];
+  conversation_wav_url?: string;
+};
+
+type RunData = {
+  task_id: string;
+  name: string;
+  status: string;
+  type: "text" | "voice";
+  updated_at: string;
+  total_simulations: number;
+  metrics: {
+    tool_calls?: MetricData;
+    answer_completeness?: MetricData;
+    assistant_behavior?: MetricData;
+    question_completeness?: MetricData;
+    [key: string]: MetricData | undefined;
+  } | null;
+  simulation_results: SimulationResult[];
+  error: string | null;
+};
+
+const LATENCY_KEYS = ["stt/ttft", "llm/ttft", "tts/ttft", "stt/processing_time", "llm/processing_time", "tts/processing_time"];
+
+function getAudioUrlForEntry(
+  entry: TranscriptEntry,
+  entryIndex: number,
+  audioUrls: string[] | undefined,
+  filteredTranscript: TranscriptEntry[],
+  runType: "text" | "voice",
+): string | null {
+  if (!audioUrls || runType !== "voice") return null;
+  if (entry.role === "tool" || entry.tool_calls) return null;
+
+  let userCount = 0;
+  let assistantCount = 0;
+  for (let i = 0; i < entryIndex; i++) {
+    const msg = filteredTranscript[i];
+    if (msg?.role === "user") userCount++;
+    else if (msg?.role === "assistant" && !msg.tool_calls) assistantCount++;
+  }
+
+  let audioPattern: string;
+  if (entry.role === "user") audioPattern = `${userCount + 1}_user.wav`;
+  else if (entry.role === "assistant") audioPattern = `${assistantCount + 1}_bot.wav`;
+  else return null;
+
+  return audioUrls.find((url) => url.includes(audioPattern)) ?? null;
+}
+
+const getEvaluationResult = (sim: SimulationResult, key: string): number | null => {
+  if (!sim.evaluation_results) return null;
+  const mapped = key === "stt_llm_judge" ? "stt_llm_judge_score" : key;
+  const found = sim.evaluation_results.find((r) => r.name === key || r.name === mapped);
+  return found ? found.value : null;
+};
+
+const getEvaluationReasoning = (sim: SimulationResult, key: string): string | null => {
+  if (!sim.evaluation_results) return null;
+  const found = sim.evaluation_results.find((r) => r.name === key);
+  return found?.reasoning ?? null;
+};
+
+export default function PublicSimulationRunPage() {
+  const params = useParams();
+  const token = params.token as string;
+
+  const [data, setData] = useState<RunData | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [notFound, setNotFound] = useState(false);
+  const [activeMetricsTab, setActiveMetricsTab] = useState<"performance" | "latency">("performance");
+  const [selectedSim, setSelectedSim] = useState<SimulationResult | null>(null);
+
+  useEffect(() => { document.title = "Simulation Run | Calibrate"; }, []);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const backendUrl = process.env.NEXT_PUBLIC_BACKEND_URL;
+        if (!backendUrl) throw new Error("Backend URL not configured");
+
+        const res = await fetch(`${backendUrl}/public/simulation-run/${token}`, {
+          headers: { accept: "application/json", "ngrok-skip-browser-warning": "true" },
+        });
+
+        if (res.status === 404) { setNotFound(true); return; }
+        if (!res.ok) throw new Error("Failed to load results");
+
+        const result: RunData = await res.json();
+        if (result.status.toLowerCase() !== "done") { setNotFound(true); return; }
+
+        setData(result);
+      } catch {
+        setNotFound(true);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+    fetchData();
+  }, [token]);
+
+  if (isLoading) return <PublicPageLayout><PublicLoading /></PublicPageLayout>;
+  if (notFound || !data) return <PublicPageLayout><PublicNotFound /></PublicPageLayout>;
+
+  const isTextType = data.type === "text";
+
+  // Separate regular vs latency metrics
+  const regularMetrics: Array<[string, MetricData]> = [];
+  const latencyMetrics: Array<[string, MetricData]> = [];
+  if (data.metrics) {
+    Object.entries(data.metrics).forEach(([key, metric]) => {
+      if (!metric) return;
+      if (LATENCY_KEYS.includes(key)) latencyMetrics.push([key, metric]);
+      else regularMetrics.push([key, metric]);
+    });
+  }
+
+  // Derive metric keys for table columns
+  const latencyMetricKeys = LATENCY_KEYS;
+  let displayMetricKeys: string[] = [];
+  if (data.metrics) {
+    displayMetricKeys = Object.keys(data.metrics).filter((k) => !latencyMetricKeys.includes(k));
+  } else {
+    const metricSet = new Set<string>();
+    data.simulation_results.forEach((sim) => {
+      sim.evaluation_results?.forEach((r) => {
+        if (!latencyMetricKeys.includes(r.name)) metricSet.add(r.name);
+      });
+    });
+    displayMetricKeys = Array.from(metricSet);
+  }
+
+  return (
+    <PublicPageLayout
+      title={data.name}
+      pills={
+        <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-[11px] font-medium ${data.type === "voice" ? "bg-orange-100 text-orange-700 dark:bg-orange-500/20 dark:text-orange-400" : "bg-purple-100 text-purple-700 dark:bg-purple-500/20 dark:text-purple-400"}`}>
+          {data.type}
+        </span>
+      }
+    >
+      <div className="space-y-6 md:space-y-8">
+
+        {/* Overall Metrics */}
+        {data.metrics && (regularMetrics.length > 0 || latencyMetrics.length > 0) && (
+          <div>
+            <h2 className="text-base md:text-lg font-semibold mb-3">Overall Metrics</h2>
+            {!isTextType && (
+              <div className="flex gap-2 border-b border-border mb-4">
+                <button onClick={() => setActiveMetricsTab("performance")} className={`px-4 py-2 text-[13px] font-medium border-b-2 transition-colors cursor-pointer ${activeMetricsTab === "performance" ? "border-foreground text-foreground" : "border-transparent text-muted-foreground hover:text-foreground"}`}>Performance</button>
+                <button onClick={() => setActiveMetricsTab("latency")} className={`px-4 py-2 text-[13px] font-medium border-b-2 transition-colors cursor-pointer ${activeMetricsTab === "latency" ? "border-foreground text-foreground" : "border-transparent text-muted-foreground hover:text-foreground"}`}>Latency</button>
+              </div>
+            )}
+            {(isTextType || activeMetricsTab === "performance") && regularMetrics.length > 0 && (
+              <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+                {regularMetrics.map(([key, metric]) => (
+                  <div key={key} className="border border-border rounded-xl p-4 bg-muted/10">
+                    <div className="text-[12px] text-muted-foreground mb-1">{key}</div>
+                    <div className="text-[18px] font-semibold text-foreground">{Math.round(metric.mean * 100)}%</div>
+                  </div>
+                ))}
+              </div>
+            )}
+            {!isTextType && activeMetricsTab === "latency" && latencyMetrics.length > 0 && (
+              <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+                {latencyMetrics.map(([key, metric]) => (
+                  <div key={key} className="border border-border rounded-xl p-4 bg-muted/10">
+                    <div className="text-[12px] text-muted-foreground mb-1">{key}</div>
+                    <div className="text-[18px] font-semibold text-foreground">
+                      {metric.mean < 1 ? `${(metric.mean * 1000).toFixed(0)}ms` : `${metric.mean.toFixed(2)}s`}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+        )}
+
+        {/* Simulation Results Table */}
+        {data.simulation_results.length > 0 && (
+          <div>
+            <div className="flex items-baseline gap-3 mb-3 md:mb-4">
+              <h2 className="hidden md:block text-base md:text-lg font-semibold">
+                Simulation Results
+              </h2>
+              <p className="text-sm text-muted-foreground">
+                {data.simulation_results.length}{" "}
+                {data.simulation_results.length === 1 ? "simulation" : "simulations"}
+              </p>
+            </div>
+            <div className="border border-border rounded-xl overflow-hidden">
+              <div className="overflow-x-auto">
+                <table className="w-full">
+                  <thead className="bg-muted/50 border-b border-border">
+                    <tr>
+                      <th className="w-10 px-4 py-3 text-left text-[12px] font-medium text-muted-foreground"></th>
+                      <th className="px-4 py-3 text-left text-[12px] font-medium text-muted-foreground uppercase tracking-wider">Persona</th>
+                      <th className="px-4 py-3 text-left text-[12px] font-medium text-muted-foreground uppercase tracking-wider">Scenario</th>
+                      {displayMetricKeys.map((k) => (
+                        <th key={k} className="px-4 py-3 text-left text-[12px] font-medium text-muted-foreground tracking-wider whitespace-nowrap">{k}</th>
+                      ))}
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y divide-border">
+                    {data.simulation_results.map((sim, i) => (
+                      <tr key={i} className="hover:bg-muted/30 transition-colors">
+                        <td className="px-4 py-4">
+                          {(sim.transcript?.length ?? 0) > 0 && (
+                            <button
+                              onClick={() => setSelectedSim(sim)}
+                              className="flex items-center justify-center w-6 h-6 cursor-pointer hover:text-foreground text-muted-foreground transition-colors"
+                              title="View transcript"
+                            >
+                              <svg className={`w-4 h-4 ${sim.aborted ? "text-red-500" : ""}`} fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                                <path strokeLinecap="round" strokeLinejoin="round" d="M5.25 5.653c0-.856.917-1.398 1.667-.986l11.54 6.348a1.125 1.125 0 010 1.971l-11.54 6.347a1.125 1.125 0 01-1.667-.986V5.653z" />
+                              </svg>
+                            </button>
+                          )}
+                        </td>
+                        <td className="px-4 py-4 text-[13px] text-foreground whitespace-nowrap">{sim.persona.label}</td>
+                        <td className="px-4 py-4 text-[13px] text-foreground whitespace-nowrap">{sim.scenario.name}</td>
+                        {displayMetricKeys.map((key) => {
+                          const val = getEvaluationResult(sim, key);
+                          const reasoning = getEvaluationReasoning(sim, key);
+                          if (val === null) return (
+                            <td key={key} className="px-4 py-4">
+                              {sim.aborted ? <span className="text-xs text-muted-foreground">N/A</span> : <span className="text-xs text-muted-foreground">—</span>}
+                            </td>
+                          );
+                          const isPass = val === 1;
+                          return (
+                            <td key={key} className="px-4 py-4">
+                              <div className="flex items-center gap-1.5">
+                                <span className={`inline-flex items-center px-2.5 py-1 rounded-md text-xs font-medium ${isPass ? "bg-green-100 text-green-700 dark:bg-green-500/20 dark:text-green-400" : "bg-red-100 text-red-700 dark:bg-red-500/20 dark:text-red-400"}`}>
+                                  {isPass ? "Pass" : "Fail"}
+                                </span>
+                                {reasoning && (
+                                  <Tooltip content={reasoning}>
+                                    <button type="button" className="p-1 rounded-md hover:bg-muted transition-colors cursor-pointer">
+                                      <svg className="w-3.5 h-3.5 text-muted-foreground" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                                        <path strokeLinecap="round" strokeLinejoin="round" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                                      </svg>
+                                    </button>
+                                  </Tooltip>
+                                )}
+                              </div>
+                            </td>
+                          );
+                        })}
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* Transcript Dialog — identical to creator view */}
+      {selectedSim && (
+        <div className="fixed inset-0 z-50 flex justify-end">
+          {/* Backdrop */}
+          <div className="absolute inset-0 bg-black/50 backdrop-blur-sm" onClick={() => setSelectedSim(null)} />
+          {/* Sidebar - full width on mobile, 40% on desktop */}
+          <div className="relative w-full md:w-[40%] md:min-w-[500px] bg-background border-l border-border flex flex-col h-full shadow-2xl">
+            {/* Header */}
+            <div className="flex items-center justify-between px-4 md:px-6 py-4">
+              <div className="flex items-center gap-3">
+                <svg className="w-5 h-5 text-muted-foreground" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M8.625 12a.375.375 0 11-.75 0 .375.375 0 01.75 0zm0 0H8.25m4.125 0a.375.375 0 11-.75 0 .375.375 0 01.75 0zm0 0H12m4.125 0a.375.375 0 11-.75 0 .375.375 0 01.75 0zm0 0h-.375M21 12c0 4.556-4.03 8.25-9 8.25a9.764 9.764 0 01-2.555-.337A5.972 5.972 0 015.41 20.97a5.969 5.969 0 01-.474-.065 4.48 4.48 0 00.978-2.025c.09-.457-.133-.901-.467-1.226C3.93 16.178 3 14.189 3 12c0-4.556 4.03-8.25 9-8.25s9 3.694 9 8.25z" />
+                </svg>
+                <h2 className="text-base md:text-lg font-semibold">Transcript</h2>
+              </div>
+              <button onClick={() => setSelectedSim(null)} className="flex items-center justify-center w-8 h-8 rounded-md hover:bg-muted transition-colors cursor-pointer">
+                <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+                </svg>
+              </button>
+            </div>
+
+            {/* Full Conversation Audio Player */}
+            {selectedSim.conversation_wav_url && (
+              <div className="px-4 md:px-6 pb-4 border-b border-border">
+                <div className="flex items-center gap-2 mb-2">
+                  <span className="text-sm font-medium text-foreground">Hear the full conversation</span>
+                </div>
+                <audio key={selectedSim.conversation_wav_url} controls className="w-full h-10" src={selectedSim.conversation_wav_url}>
+                  Your browser does not support the audio element.
+                </audio>
+              </div>
+            )}
+
+            {/* Transcript content */}
+            <div className="flex-1 overflow-y-auto p-4 md:p-6">
+              <div className="space-y-4">
+                {(() => {
+                  const fullTranscript = selectedSim.transcript ?? [];
+                  const filteredTranscript = fullTranscript.filter((entry) => {
+                    if (entry.role === "end_reason") return false;
+                    if (entry.role === "tool") {
+                      try {
+                        const parsed = JSON.parse(entry.content || "");
+                        return parsed?.type === "webhook_response";
+                      } catch { return false; }
+                    }
+                    return true;
+                  });
+                  const lastEntry = fullTranscript[fullTranscript.length - 1];
+                  const endedDueToMaxTurns = lastEntry?.role === "end_reason" && lastEntry?.content === "max_turns";
+
+                  if (filteredTranscript.length === 0) {
+                    return (
+                      <div className="flex items-center justify-center py-8">
+                        <p className="text-sm text-muted-foreground">No transcript available yet</p>
+                      </div>
+                    );
+                  }
+
+                  return filteredTranscript.map((entry, index) => {
+                    const audioUrl = getAudioUrlForEntry(entry, index, selectedSim.audio_urls, filteredTranscript, data!.type);
+                    return (
+                      <div key={index} className={`space-y-2 ${entry.role === "user" ? "flex flex-col items-end" : ""}`}>
+                        {/* Agent header */}
+                        {entry.role === "assistant" && (
+                          <div className="flex items-center gap-2">
+                            <span className="text-sm font-medium text-foreground">
+                              {entry.tool_calls ? "Agent Tool Call" : "Agent"}
+                            </span>
+                          </div>
+                        )}
+
+                        {/* Per-message audio */}
+                        {audioUrl && (
+                          <div className="w-full md:w-1/2">
+                            <audio key={audioUrl} controls className="w-full h-8 mb-2" src={audioUrl}>
+                              Your browser does not support the audio element.
+                            </audio>
+                          </div>
+                        )}
+
+                        {/* User message */}
+                        {entry.role === "user" && entry.content && (
+                          <div className="w-full md:w-1/2">
+                            <div className="px-4 py-3 rounded-xl text-sm text-foreground bg-muted border border-border whitespace-pre-wrap">
+                              {entry.content}
+                            </div>
+                          </div>
+                        )}
+
+                        {/* Assistant text response */}
+                        {entry.role === "assistant" && entry.content && !entry.tool_calls && (
+                          <div className="w-full md:w-1/2">
+                            <div className="px-4 py-3 rounded-xl text-sm text-foreground bg-accent border border-border whitespace-pre-wrap">
+                              {entry.content}
+                            </div>
+                          </div>
+                        )}
+
+                        {/* Tool calls */}
+                        {entry.role === "assistant" && entry.tool_calls && (
+                          <div className="w-full md:w-1/2">
+                            {entry.tool_calls.map((toolCall: any, toolIndex: number) => {
+                              let parsedArgs: Record<string, any> = {};
+                              try { parsedArgs = JSON.parse(toolCall.function.arguments); } catch { parsedArgs = {}; }
+                              const formatValue = (val: any): string => {
+                                if (val === null) return "null";
+                                if (val === undefined) return "undefined";
+                                if (typeof val === "object") { try { return JSON.stringify(val, null, 2); } catch { return String(val); } }
+                                return String(val);
+                              };
+                              return (
+                                <div key={toolIndex} className="bg-muted border border-border rounded-2xl p-4 mb-2">
+                                  <div className="flex items-center gap-2 mb-2">
+                                    <svg className="w-4 h-4 text-muted-foreground" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+                                      <path strokeLinecap="round" strokeLinejoin="round" d="M11.42 15.17L17.25 21A2.652 2.652 0 0021 17.25l-5.877-5.877M11.42 15.17l2.496-3.03c.317-.384.74-.626 1.208-.766M11.42 15.17l-4.655 5.653a2.548 2.548 0 11-3.586-3.586l6.837-5.63m5.108-.233c.55-.164 1.163-.188 1.743-.14a4.5 4.5 0 004.486-6.336l-3.276 3.277a3.004 3.004 0 01-2.25-2.25l3.276-3.276a4.5 4.5 0 00-6.336 4.486c.091 1.076-.071 2.264-.904 2.95l-.102.085m-1.745 1.437L5.909 7.5H4.5L2.25 3.75l1.5-1.5L7.5 4.5v1.409l4.26 4.26m-1.745 1.437l1.745-1.437m6.615 8.206L15.75 15.75M4.867 19.125h.008v.008h-.008v-.008z" />
+                                    </svg>
+                                    <span className="text-sm font-medium text-foreground">{toolCall.function.name}</span>
+                                  </div>
+                                  {Object.keys(parsedArgs).filter((k) => k !== "headers").length > 0 && (
+                                    <div className="space-y-3 mt-3">
+                                      {Object.entries(parsedArgs).filter(([key]) => key !== "headers").map(([key, value], paramIndex) => {
+                                        const displayValue = formatValue(value);
+                                        const isMultiLine = displayValue.includes("\n");
+                                        return (
+                                          <div key={paramIndex}>
+                                            <label className="block text-sm font-medium text-foreground mb-1.5">{key}</label>
+                                            <div className={`px-3 py-2 bg-background border border-border rounded-lg text-sm text-muted-foreground whitespace-pre-wrap break-all ${isMultiLine ? "font-mono text-xs" : ""}`}>
+                                              {displayValue}
+                                            </div>
+                                          </div>
+                                        );
+                                      })}
+                                    </div>
+                                  )}
+                                </div>
+                              );
+                            })}
+                          </div>
+                        )}
+
+                        {/* Webhook response */}
+                        {entry.role === "tool" && entry.content && (() => {
+                          let parsed: any = null;
+                          try { parsed = JSON.parse(entry.content); } catch { return null; }
+                          if (parsed?.type !== "webhook_response") return null;
+                          const response = parsed.response;
+                          if (!response || typeof response !== "object") return null;
+                          const isError = parsed.status === "error";
+                          const jsonString = JSON.stringify(response, null, 2);
+                          return (
+                            <div className="w-full md:w-1/2">
+                              <div className="flex items-center gap-2 mb-2">
+                                {isError ? (
+                                  <>
+                                    <svg className="w-4 h-4 text-red-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                                      <path strokeLinecap="round" strokeLinejoin="round" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+                                    </svg>
+                                    <span className="text-sm font-medium text-red-500">Tool Response Error</span>
+                                  </>
+                                ) : (
+                                  <span className="text-sm font-medium text-foreground">Agent Tool Response</span>
+                                )}
+                              </div>
+                              <div className={`bg-muted rounded-2xl p-4 border ${isError ? "border-red-500" : "border-border"}`}>
+                                <pre className={`text-sm font-mono whitespace-pre-wrap break-all ${isError ? "text-red-400" : "text-foreground"}`}>{jsonString}</pre>
+                              </div>
+                            </div>
+                          );
+                        })()}
+                      </div>
+                    );
+                  });
+                })()}
+
+                {/* Max turns notice */}
+                {(() => {
+                  const fullTranscript = selectedSim.transcript ?? [];
+                  const lastEntry = fullTranscript[fullTranscript.length - 1];
+                  if (lastEntry?.role === "end_reason" && lastEntry?.content === "max_turns") {
+                    return (
+                      <div className="flex items-center justify-center py-4 mt-2">
+                        <div className="flex items-center gap-2 px-4 py-2 rounded-lg bg-yellow-500/10 border border-yellow-500/30">
+                          <svg className="w-4 h-4 text-yellow-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                            <path strokeLinecap="round" strokeLinejoin="round" d="M12 9v3.75m9-.75a9 9 0 11-18 0 9 9 0 0118 0zm-9 3.75h.008v.008H12v-.008z" />
+                          </svg>
+                          <span className="text-sm text-yellow-500">Maximum number of assistant turns reached</span>
+                        </div>
+                      </div>
+                    );
+                  }
+                  return null;
+                })()}
+
+                {/* Aborted notice */}
+                {selectedSim.aborted && (
+                  <div className="flex items-center justify-center py-4 mt-2">
+                    <div className="flex items-center gap-2 px-4 py-2 rounded-lg bg-red-500/10 border border-red-500/30">
+                      <svg className="w-4 h-4 text-red-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                        <path strokeLinecap="round" strokeLinejoin="round" d="M12 9v3.75m9-.75a9 9 0 11-18 0 9 9 0 0118 0zm-9 3.75h.008v.008H12v-.008z" />
+                      </svg>
+                      <span className="text-sm text-red-500">Simulation aborted by user</span>
+                    </div>
+                  </div>
+                )}
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+    </PublicPageLayout>
+  );
+}

--- a/src/app/public/stt/[token]/page.tsx
+++ b/src/app/public/stt/[token]/page.tsx
@@ -1,0 +1,390 @@
+"use client";
+
+import React, { useState, useEffect } from "react";
+import { useParams } from "next/navigation";
+import { sttProviders } from "@/components/agent-tabs/constants/providers";
+import { LeaderboardBarChart, getColorMap } from "@/components/charts/LeaderboardBarChart";
+import { DownloadableTable } from "@/components/DownloadableTable";
+import { Tooltip } from "@/components/Tooltip";
+import { PublicPageLayout, PublicNotFound, PublicLoading } from "@/components/PublicPageLayout";
+
+type ProviderMetrics = {
+  wer: number;
+  string_similarity: number;
+  llm_judge_score: number;
+};
+
+type ProviderResult = {
+  provider: string;
+  success: boolean;
+  message: string;
+  metrics: ProviderMetrics;
+  results: Array<{
+    id: string;
+    gt: string;
+    pred: string;
+    wer: string;
+    string_similarity: string;
+    llm_judge_score: string;
+    llm_judge_reasoning: string;
+  }>;
+};
+
+type LeaderboardSummary = {
+  run: string;
+  count: number;
+  wer: number;
+  string_similarity: number;
+  llm_judge_score: number;
+};
+
+type EvaluationResult = {
+  task_id: string;
+  status: "queued" | "in_progress" | "done" | "failed";
+  language?: string;
+  dataset_name?: string | null;
+  provider_results?: ProviderResult[];
+  leaderboard_summary?: LeaderboardSummary[];
+  error?: string | null;
+};
+
+const getProviderLabel = (value: string): string => {
+  const provider = sttProviders.find((p) => p.value === value);
+  return provider ? provider.label : value;
+};
+
+export default function PublicSTTPage() {
+  const params = useParams();
+  const token = params.token as string;
+
+  const [data, setData] = useState<EvaluationResult | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [notFound, setNotFound] = useState(false);
+  const [activeTab, setActiveTab] = useState<"leaderboard" | "outputs" | "about">("leaderboard");
+  const [activeProviderTab, setActiveProviderTab] = useState<string | null>(null);
+
+  useEffect(() => {
+    document.title = "Speech-to-text evaluation | Calibrate";
+  }, []);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const backendUrl = process.env.NEXT_PUBLIC_BACKEND_URL;
+        if (!backendUrl) throw new Error("Backend URL not configured");
+
+        const res = await fetch(`${backendUrl}/public/stt/${token}`, {
+          headers: { accept: "application/json", "ngrok-skip-browser-warning": "true" },
+        });
+
+        if (res.status === 404) { setNotFound(true); return; }
+        if (!res.ok) throw new Error("Failed to load results");
+
+        const result: EvaluationResult = await res.json();
+
+        if (result.status !== "done") { setNotFound(true); return; }
+
+        setData(result);
+        if (result.provider_results?.length) {
+          setActiveProviderTab(result.provider_results[0].provider);
+        }
+      } catch {
+        setNotFound(true);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+    fetchData();
+  }, [token]);
+
+  if (isLoading) return <PublicPageLayout><PublicLoading /></PublicPageLayout>;
+  if (notFound || !data) return <PublicPageLayout><PublicNotFound /></PublicPageLayout>;
+
+  return (
+    <PublicPageLayout
+      title="Speech-to-text evaluation"
+      pills={
+        <>
+          {data.language && (
+            <span className="px-2 py-0.5 text-[11px] font-medium bg-muted rounded-full text-muted-foreground capitalize">
+              {data.language}
+            </span>
+          )}
+          {data.dataset_name && (
+            <span className="flex items-center gap-1 px-2 py-0.5 text-[11px] font-medium bg-muted rounded-full text-muted-foreground">
+              <svg className="w-3 h-3 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                <path strokeLinecap="round" strokeLinejoin="round" d="M20.25 6.375c0 2.278-3.694 4.125-8.25 4.125S3.75 8.653 3.75 6.375m16.5 0c0-2.278-3.694-4.125-8.25 4.125S3.75 4.097 3.75 6.375m16.5 0v11.25c0 2.278-3.694 4.125-8.25 4.125s-8.25-1.847-8.25-4.125V6.375m16.5 0v3.75m-16.5-3.75v3.75m16.5 0v3.75C20.25 16.153 16.556 18 12 18s-8.25-1.847-8.25-4.125v-3.75m16.5 0c0 2.278-3.694 4.125-8.25 4.125s-8.25-1.847-8.25-4.125" />
+              </svg>
+              {data.dataset_name}
+            </span>
+          )}
+        </>
+      }
+    >
+      <div className="space-y-4 md:space-y-6">
+
+        {data.provider_results && data.provider_results.length > 0 && (
+          <>
+            {/* Tab Nav */}
+            <div className="flex gap-2 border-b border-border">
+              {(["leaderboard", "outputs", "about"] as const).map((tab) => (
+                <button
+                  key={tab}
+                  onClick={() => setActiveTab(tab)}
+                  className={`px-4 py-2 text-[13px] font-medium border-b-2 transition-colors cursor-pointer capitalize ${
+                    activeTab === tab
+                      ? "border-foreground text-foreground"
+                      : "border-transparent text-muted-foreground hover:text-foreground"
+                  }`}
+                >
+                  {tab}
+                </button>
+              ))}
+            </div>
+
+            {/* Leaderboard Tab */}
+            {activeTab === "leaderboard" && (
+              <div className="space-y-4 md:space-y-6">
+                {data.leaderboard_summary && data.leaderboard_summary.length > 0 && (
+                  <>
+                    <DownloadableTable
+                      columns={[
+                        { key: "run", header: "Run", render: (v) => getProviderLabel(v) },
+                        { key: "wer", header: "WER" },
+                        {
+                          key: "string_similarity",
+                          header: "String Similarity",
+                          render: (v) => v != null ? parseFloat(v.toFixed(4)) : "-",
+                        },
+                        { key: "llm_judge_score", header: "LLM Judge Score" },
+                      ]}
+                      data={data.leaderboard_summary}
+                      filename="stt-evaluation-leaderboard"
+                    />
+                    {(() => {
+                      const names = data.leaderboard_summary!.map((s) => s.run);
+                      const colorMap = getColorMap(names);
+                      return (
+                        <div className="space-y-4 md:space-y-6">
+                          <div className="grid grid-cols-1 md:grid-cols-2 gap-4 md:gap-6">
+                            <LeaderboardBarChart
+                              title="WER"
+                              data={data.leaderboard_summary!.map((s) => ({ label: getProviderLabel(s.run), value: s.wer, colorKey: s.run }))}
+                              colorMap={colorMap}
+                            />
+                            <LeaderboardBarChart
+                              title="String Similarity"
+                              data={data.leaderboard_summary!.map((s) => ({ label: getProviderLabel(s.run), value: s.string_similarity, colorKey: s.run }))}
+                              colorMap={colorMap}
+                              yDomain={[0, 1]}
+                            />
+                          </div>
+                          <div className="grid grid-cols-1 md:grid-cols-2 gap-4 md:gap-6">
+                            <LeaderboardBarChart
+                              title="LLM Judge Score"
+                              data={data.leaderboard_summary!.map((s) => ({ label: getProviderLabel(s.run), value: s.llm_judge_score, colorKey: s.run }))}
+                              colorMap={colorMap}
+                              yDomain={[0, 1]}
+                            />
+                          </div>
+                        </div>
+                      );
+                    })()}
+                  </>
+                )}
+              </div>
+            )}
+
+            {/* Outputs Tab */}
+            {activeTab === "outputs" && (
+              <div className="flex flex-col md:flex-row border border-border rounded-xl overflow-hidden" style={{ minHeight: 480 }}>
+                {/* Provider sidebar */}
+                <div className="md:w-64 border-b md:border-b-0 md:border-r border-border flex flex-col overflow-hidden bg-muted/10">
+                  <div className="overflow-x-auto md:overflow-x-visible md:overflow-y-auto md:flex-1 p-2">
+                    <div className="flex md:flex-col gap-1 min-w-max md:min-w-0">
+                      {data.provider_results!.map((pr) => {
+                        const isSelected = (activeProviderTab ?? data.provider_results![0]?.provider) === pr.provider;
+                        return (
+                          <div
+                            key={pr.provider}
+                            onClick={() => setActiveProviderTab(pr.provider)}
+                            className={`flex items-center gap-2 px-3 py-2 rounded-lg cursor-pointer transition-colors whitespace-nowrap ${isSelected ? "bg-muted" : "hover:bg-muted/50"}`}
+                          >
+                            {pr.success ? (
+                              <div className="w-5 h-5 rounded-full bg-green-500/20 flex items-center justify-center flex-shrink-0">
+                                <svg className="w-3 h-3 text-green-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={3}><path strokeLinecap="round" strokeLinejoin="round" d="M4.5 12.75l6 6 9-13.5" /></svg>
+                              </div>
+                            ) : (
+                              <div className="w-5 h-5 rounded-full bg-red-500/20 flex items-center justify-center flex-shrink-0">
+                                <svg className="w-3 h-3 text-red-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={3}><path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" /></svg>
+                              </div>
+                            )}
+                            <span className="text-sm text-foreground truncate">{getProviderLabel(pr.provider)}</span>
+                          </div>
+                        );
+                      })}
+                    </div>
+                  </div>
+                </div>
+
+                {/* Right panel */}
+                <div className="flex-1 overflow-y-auto p-4 md:p-6">
+                  {(() => {
+                    const selectedProvider = activeProviderTab ?? data.provider_results![0]?.provider;
+                    const pr = data.provider_results!.find((p) => p.provider === selectedProvider);
+                    if (!pr) return <p className="text-muted-foreground">Select a provider</p>;
+                    if (!pr.success) return (
+                      <div className="border border-red-500/50 bg-red-500/10 rounded-lg p-4 max-w-md text-center">
+                        <div className="text-red-500 text-[14px] font-medium">There was an error running this provider.</div>
+                      </div>
+                    );
+                    return (
+                      <div className="space-y-4 md:space-y-6">
+                        {/* Overall Metrics */}
+                        {pr.metrics && (
+                          <div className="border rounded-xl p-4 bg-muted/10">
+                            <h3 className="text-[15px] font-semibold mb-4">Overall Metrics</h3>
+                            <div className="grid grid-cols-3 gap-4">
+                              {[
+                                { label: "WER", value: pr.metrics.wer != null ? parseFloat(pr.metrics.wer.toFixed(4)) : "-" },
+                                { label: "String Similarity", value: pr.metrics.string_similarity != null ? parseFloat(pr.metrics.string_similarity.toFixed(4)) : "-" },
+                                { label: "LLM Judge Score", value: pr.metrics.llm_judge_score ?? "-" },
+                              ].map(({ label, value }) => (
+                                <div key={label}>
+                                  <div className="text-[12px] text-muted-foreground mb-1">{label}</div>
+                                  <div className="text-base md:text-[18px] font-semibold text-foreground">{String(value)}</div>
+                                </div>
+                              ))}
+                            </div>
+                          </div>
+                        )}
+
+                        {/* Results Table */}
+                        {pr.results && pr.results.length > 0 && (
+                          <div className="hidden md:block border rounded-xl overflow-hidden">
+                            <div className="overflow-x-auto">
+                              <table className="w-full table-fixed">
+                                <thead className="bg-muted/50 border-b border-border">
+                                  <tr>
+                                    <th className="w-12 px-4 py-3 text-left text-[12px] font-medium text-foreground">ID</th>
+                                    <th className="w-[28%] px-4 py-3 text-left text-[12px] font-medium text-foreground">Ground Truth</th>
+                                    <th className="w-[28%] px-4 py-3 text-left text-[12px] font-medium text-foreground">Prediction</th>
+                                    <th className="px-4 py-3 text-left text-[12px] font-medium text-foreground">WER</th>
+                                    <th className="px-4 py-3 text-left text-[12px] font-medium text-foreground">Similarity</th>
+                                    <th className="px-4 py-3 text-left text-[12px] font-medium text-foreground">LLM Judge</th>
+                                  </tr>
+                                </thead>
+                                <tbody>
+                                  {pr.results.map((row, i) => {
+                                    const isEmpty = !row.pred || row.pred.trim() === "";
+                                    const scoreStr = String(row.llm_judge_score || "").toLowerCase();
+                                    const passed = scoreStr === "true" || scoreStr === "1";
+                                    return (
+                                      <tr key={i} className={`border-b border-border last:border-b-0 ${isEmpty ? "bg-red-500/10" : ""}`}>
+                                        <td className="px-4 py-3 text-[13px] text-foreground">{i + 1}</td>
+                                        <td className="px-4 py-3 text-[13px] text-foreground break-words">{row.gt}</td>
+                                        <td className="px-4 py-3 text-[13px] break-words">
+                                          {isEmpty ? <span className="text-muted-foreground">No transcript generated</span> : <span className="text-foreground">{row.pred}</span>}
+                                        </td>
+                                        <td className="px-4 py-3 text-[13px] text-foreground">
+                                          {row.wer != null ? parseFloat(parseFloat(row.wer).toFixed(4)) : "-"}
+                                        </td>
+                                        <td className="px-4 py-3 text-[13px] text-foreground">
+                                          {row.string_similarity != null ? parseFloat(parseFloat(row.string_similarity).toFixed(4)) : "-"}
+                                        </td>
+                                        <td className="px-4 py-3">
+                                          <div className="flex items-center gap-1.5">
+                                            <span className={`inline-flex items-center px-2.5 py-1 rounded-md text-xs font-medium ${passed ? "bg-green-100 text-green-700 dark:bg-green-500/20 dark:text-green-400" : "bg-red-100 text-red-700 dark:bg-red-500/20 dark:text-red-400"}`}>
+                                              {passed ? "Pass" : "Fail"}
+                                            </span>
+                                            {row.llm_judge_reasoning && (
+                                              <Tooltip content={row.llm_judge_reasoning}>
+                                                <button type="button" className="p-1 rounded-md hover:bg-muted transition-colors cursor-pointer" aria-label="View reasoning">
+                                                  <svg className="w-4 h-4 text-muted-foreground" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                                                    <path strokeLinecap="round" strokeLinejoin="round" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                                                  </svg>
+                                                </button>
+                                              </Tooltip>
+                                            )}
+                                          </div>
+                                        </td>
+                                      </tr>
+                                    );
+                                  })}
+                                </tbody>
+                              </table>
+                            </div>
+                          </div>
+                        )}
+
+                        {/* Mobile cards */}
+                        {pr.results && pr.results.length > 0 && (
+                          <div className="md:hidden space-y-3">
+                            {pr.results.map((row, i) => {
+                              const isEmpty = !row.pred || row.pred.trim() === "";
+                              const scoreStr = String(row.llm_judge_score || "").toLowerCase();
+                              const passed = scoreStr === "true" || scoreStr === "1";
+                              return (
+                                <div key={i} className={`border border-border rounded-xl p-4 space-y-3 ${isEmpty ? "bg-red-500/10" : ""}`}>
+                                  <div className="flex items-center justify-between">
+                                    <span className="text-[12px] text-muted-foreground font-medium">#{i + 1}</span>
+                                    <span className={`inline-flex items-center px-2.5 py-1 rounded-md text-xs font-medium ${passed ? "bg-green-100 text-green-700 dark:bg-green-500/20 dark:text-green-400" : "bg-red-100 text-red-700 dark:bg-red-500/20 dark:text-red-400"}`}>
+                                      {passed ? "Pass" : "Fail"}
+                                    </span>
+                                  </div>
+                                  <div>
+                                    <span className="text-[11px] text-muted-foreground uppercase tracking-wide">Ground Truth</span>
+                                    <p className="text-[13px] text-foreground mt-0.5">{row.gt}</p>
+                                  </div>
+                                  <div>
+                                    <span className="text-[11px] text-muted-foreground uppercase tracking-wide">Prediction</span>
+                                    {isEmpty ? <p className="text-[13px] text-muted-foreground mt-0.5">No transcript generated</p> : <p className="text-[13px] text-foreground mt-0.5">{row.pred}</p>}
+                                  </div>
+                                </div>
+                              );
+                            })}
+                          </div>
+                        )}
+                      </div>
+                    );
+                  })()}
+                </div>
+              </div>
+            )}
+
+            {/* About Tab */}
+            {activeTab === "about" && (
+              <div className="border rounded-xl overflow-hidden">
+                <table className="w-full">
+                  <thead className="bg-muted/50 border-b border-border">
+                    <tr>
+                      {["Metric", "Description", "Preference", "Range"].map((h) => (
+                        <th key={h} className="px-4 py-3 text-left text-[13px] font-medium text-foreground">{h}</th>
+                      ))}
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {[
+                      { metric: "WER", description: "Word error rate measures the percentage of words that differ between reference and predicted transcription.", preference: "Lower is better", range: "0 - ∞" },
+                      { metric: "String Similarity", description: "Measures similarity between reference and predicted strings using string matching algorithms.", preference: "Higher is better", range: "0 - 1" },
+                      { metric: "LLM Judge", description: "Evaluates semantic equivalence rather than exact string matching, returning Pass if the transcription is semantically correct.", preference: "Pass is better", range: "Pass / Fail" },
+                      { metric: "TTFB", description: "Time to first byte measures the latency from when a request is sent until the first byte of the response is received.", preference: "Lower is better", range: "0 - ∞" },
+                      { metric: "Processing Time", description: "Total time taken to process the audio and generate the transcription.", preference: "Lower is better", range: "0 - ∞" },
+                    ].map((row) => (
+                      <tr key={row.metric} className="border-b border-border last:border-b-0">
+                        <td className="px-4 py-3 text-[13px] font-medium text-foreground">{row.metric}</td>
+                        <td className="px-4 py-3 text-[13px] text-foreground">{row.description}</td>
+                        <td className="px-4 py-3 text-[13px] text-foreground">{row.preference}</td>
+                        <td className="px-4 py-3 text-[13px] text-foreground">{row.range}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            )}
+          </>
+        )}
+      </div>
+    </PublicPageLayout>
+  );
+}

--- a/src/app/public/test-run/[token]/page.tsx
+++ b/src/app/public/test-run/[token]/page.tsx
@@ -1,0 +1,172 @@
+"use client";
+
+import React, { useState, useEffect } from "react";
+import { useParams } from "next/navigation";
+import {
+  TestCaseOutput,
+  TestCaseData,
+  StatusIcon,
+  TestDetailView,
+  EvaluationCriteriaPanel,
+} from "@/components/test-results/shared";
+import { PublicPageLayout, PublicNotFound, PublicLoading } from "@/components/PublicPageLayout";
+
+type ChatMessage = {
+  role: "user" | "agent" | "tool";
+  content: string;
+  tool_name?: string;
+  tool_args?: Record<string, any>;
+};
+
+type TestCaseResult = {
+  test_uuid?: string;
+  test_name?: string;
+  name?: string;
+  status?: "passed" | "failed" | "error";
+  passed?: boolean | null;
+  reasoning?: string;
+  output?: TestCaseOutput | null;
+  test_case?: TestCaseData | null;
+  chat_history?: ChatMessage[];
+  evaluation?: { passed: boolean; message?: string; details?: Record<string, any> };
+  error?: string;
+};
+
+type TestRunStatusResponse = {
+  task_id: string;
+  status: string;
+  total_tests?: number;
+  passed?: number;
+  failed?: number;
+  results?: TestCaseResult[];
+  error?: string;
+};
+
+// Map raw API result → display status
+function getStatus(r: TestCaseResult): "passed" | "failed" {
+  if (r.passed === true || r.status === "passed") return "passed";
+  return "failed";
+}
+
+export default function PublicTestRunPage() {
+  const params = useParams();
+  const token = params.token as string;
+
+  const [data, setData] = useState<TestRunStatusResponse | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [notFound, setNotFound] = useState(false);
+  const [selectedIndex, setSelectedIndex] = useState<number | null>(null);
+
+  useEffect(() => { document.title = "Test Run | Calibrate"; }, []);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const backendUrl = process.env.NEXT_PUBLIC_BACKEND_URL;
+        if (!backendUrl) throw new Error("Backend URL not configured");
+
+        const res = await fetch(`${backendUrl}/public/test-run/${token}`, {
+          headers: { accept: "application/json", "ngrok-skip-browser-warning": "true" },
+        });
+
+        if (res.status === 404) { setNotFound(true); return; }
+        if (!res.ok) throw new Error("Failed to load results");
+
+        const result: TestRunStatusResponse = await res.json();
+        if (result.status !== "done" && result.status !== "completed") { setNotFound(true); return; }
+
+        setData(result);
+        if (result.results?.length) setSelectedIndex(0);
+      } catch {
+        setNotFound(true);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+    fetchData();
+  }, [token]);
+
+  if (isLoading) return <PublicPageLayout><PublicLoading /></PublicPageLayout>;
+  if (notFound || !data) return <PublicPageLayout><PublicNotFound /></PublicPageLayout>;
+
+  const results = data.results ?? [];
+  const passed = results.filter((r) => getStatus(r) === "passed").length;
+  const failed = results.filter((r) => getStatus(r) === "failed").length;
+  const selected = selectedIndex !== null ? results[selectedIndex] : null;
+
+  return (
+    <PublicPageLayout>
+      <div className="space-y-4 md:space-y-6">
+        {/* Summary stats */}
+        <div className="flex items-center gap-4">
+          <div className="flex items-center gap-2">
+            <span className="inline-flex items-center px-2.5 py-1 rounded-md text-xs font-medium bg-green-100 text-green-700 dark:bg-green-500/20 dark:text-green-400">
+              {passed} passed
+            </span>
+            <span className="inline-flex items-center px-2.5 py-1 rounded-md text-xs font-medium bg-red-100 text-red-700 dark:bg-red-500/20 dark:text-red-400">
+              {failed} failed
+            </span>
+          </div>
+          <span className="text-[13px] text-muted-foreground">{results.length} total tests</span>
+        </div>
+
+        {results.length > 0 && (
+          <div className="flex border border-border rounded-xl overflow-hidden" style={{ height: "calc(100vh - 260px)", minHeight: 480 }}>
+            {/* Left panel — test list */}
+            <div className="w-64 shrink-0 border-r border-border flex flex-col overflow-hidden bg-muted/10">
+              <div className="overflow-y-auto flex-1 p-2 space-y-0.5">
+                {results.map((r, i) => {
+                  const status = getStatus(r);
+                  const name = r.name || r.test_case?.name || r.test_name || `Test ${i + 1}`;
+                  return (
+                    <button
+                      key={i}
+                      type="button"
+                      onClick={() => setSelectedIndex(i)}
+                      className={`w-full flex items-center gap-2 px-3 py-2 rounded-lg cursor-pointer transition-colors text-left ${selectedIndex === i ? "bg-muted" : "hover:bg-muted/50"}`}
+                    >
+                      <StatusIcon status={status} />
+                      <span className="text-[13px] text-foreground truncate">{name}</span>
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
+
+            {/* Right panel — detail */}
+            <div className="flex-1 overflow-y-auto">
+              {selected ? (
+                (() => {
+                  const status = getStatus(selected);
+                  return (
+                    <div className="flex h-full">
+                      {/* Conversation + output */}
+                      <div className="flex-1 overflow-y-auto p-4 md:p-6">
+                        <TestDetailView
+                          history={selected.test_case?.history || []}
+                          output={selected.output ?? undefined}
+                          passed={selected.evaluation?.passed ?? status === "passed"}
+                          reasoning={selected.reasoning}
+                        />
+                      </div>
+                      {/* Evaluation criteria panel */}
+                      {selected.test_case?.evaluation && (
+                        <div className="w-72 shrink-0 border-l border-border overflow-y-auto">
+                          <EvaluationCriteriaPanel evaluation={selected.test_case.evaluation} />
+                        </div>
+                      )}
+                    </div>
+                  );
+                })()
+              ) : (
+                <div className="flex items-center justify-center h-full">
+                  <p className="text-muted-foreground text-[13px]">Select a test to view details</p>
+                </div>
+              )}
+            </div>
+          </div>
+        )}
+      </div>
+    </PublicPageLayout>
+  );
+}

--- a/src/app/public/tts/[token]/page.tsx
+++ b/src/app/public/tts/[token]/page.tsx
@@ -1,0 +1,358 @@
+"use client";
+
+import React, { useState, useEffect } from "react";
+import { useParams } from "next/navigation";
+import { ttsProviders } from "@/components/agent-tabs/constants/providers";
+import { LeaderboardBarChart, getColorMap } from "@/components/charts/LeaderboardBarChart";
+import { DownloadableTable } from "@/components/DownloadableTable";
+import { Tooltip } from "@/components/Tooltip";
+import { PublicPageLayout, PublicNotFound, PublicLoading } from "@/components/PublicPageLayout";
+
+type LatencyMetric = { mean: number; std: number; values: number[] };
+
+type ProviderMetrics = {
+  llm_judge_score: number;
+  ttfb: LatencyMetric;
+  processing_time: LatencyMetric;
+};
+
+type ProviderResult = {
+  provider: string;
+  success: boolean | null;
+  message: string;
+  metrics: ProviderMetrics | null;
+  results: Array<{
+    id: string;
+    text: string;
+    audio_path: string;
+    llm_judge_score?: string;
+    llm_judge_reasoning?: string;
+  }> | null;
+};
+
+type LeaderboardSummary = {
+  run: string;
+  count: number;
+  llm_judge_score: number;
+  ttfb: number;
+  processing_time: number;
+};
+
+type EvaluationResult = {
+  task_id: string;
+  status: "queued" | "in_progress" | "done" | "failed";
+  language?: string;
+  dataset_name?: string | null;
+  provider_results?: ProviderResult[];
+  leaderboard_summary?: LeaderboardSummary[];
+  error?: string | null;
+};
+
+const getProviderLabel = (value: string): string => {
+  const provider = ttsProviders.find((p) => p.value === value);
+  return provider ? provider.label : value;
+};
+
+export default function PublicTTSPage() {
+  const params = useParams();
+  const token = params.token as string;
+
+  const [data, setData] = useState<EvaluationResult | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [notFound, setNotFound] = useState(false);
+  const [activeTab, setActiveTab] = useState<"leaderboard" | "outputs" | "about">("leaderboard");
+  const [activeProviderTab, setActiveProviderTab] = useState<string | null>(null);
+
+  useEffect(() => { document.title = "Text-to-speech evaluation | Calibrate"; }, []);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const backendUrl = process.env.NEXT_PUBLIC_BACKEND_URL;
+        if (!backendUrl) throw new Error("Backend URL not configured");
+
+        const res = await fetch(`${backendUrl}/public/tts/${token}`, {
+          headers: { accept: "application/json", "ngrok-skip-browser-warning": "true" },
+        });
+
+        if (res.status === 404) { setNotFound(true); return; }
+        if (!res.ok) throw new Error("Failed to load results");
+
+        const result: EvaluationResult = await res.json();
+        if (result.status !== "done") { setNotFound(true); return; }
+
+        setData(result);
+        if (result.provider_results?.length) {
+          setActiveProviderTab(result.provider_results[0].provider);
+        }
+      } catch {
+        setNotFound(true);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+    fetchData();
+  }, [token]);
+
+  if (isLoading) return <PublicPageLayout><PublicLoading /></PublicPageLayout>;
+  if (notFound || !data) return <PublicPageLayout><PublicNotFound /></PublicPageLayout>;
+
+  return (
+    <PublicPageLayout
+      title="Text-to-speech evaluation"
+      pills={
+        <>
+          {data.language && (
+            <span className="px-2 py-0.5 text-[11px] font-medium bg-muted rounded-full text-muted-foreground capitalize">
+              {data.language}
+            </span>
+          )}
+          {data.dataset_name && (
+            <span className="flex items-center gap-1 px-2 py-0.5 text-[11px] font-medium bg-muted rounded-full text-muted-foreground">
+              <svg className="w-3 h-3 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                <path strokeLinecap="round" strokeLinejoin="round" d="M20.25 6.375c0 2.278-3.694 4.125-8.25 4.125S3.75 8.653 3.75 6.375m16.5 0c0-2.278-3.694-4.125-8.25 4.125S3.75 4.097 3.75 6.375m16.5 0v11.25c0 2.278-3.694 4.125-8.25 4.125s-8.25-1.847-8.25-4.125V6.375m16.5 0v3.75m-16.5-3.75v3.75m16.5 0v3.75C20.25 16.153 16.556 18 12 18s-8.25-1.847-8.25-4.125v-3.75m16.5 0c0 2.278-3.694 4.125-8.25 4.125s-8.25-1.847-8.25-4.125" />
+              </svg>
+              {data.dataset_name}
+            </span>
+          )}
+        </>
+      }
+    >
+      <div className="space-y-4 md:space-y-6">
+
+        {data.provider_results && data.provider_results.length > 0 && (
+          <>
+            {/* Tab Nav */}
+            <div className="flex gap-2 border-b border-border">
+              {(["leaderboard", "outputs", "about"] as const).map((tab) => (
+                <button
+                  key={tab}
+                  onClick={() => setActiveTab(tab)}
+                  className={`px-4 py-2 text-[13px] font-medium border-b-2 transition-colors cursor-pointer capitalize ${
+                    activeTab === tab ? "border-foreground text-foreground" : "border-transparent text-muted-foreground hover:text-foreground"
+                  }`}
+                >
+                  {tab}
+                </button>
+              ))}
+            </div>
+
+            {/* Leaderboard Tab */}
+            {activeTab === "leaderboard" && (
+              <div className="space-y-4 md:space-y-6">
+                {data.leaderboard_summary && data.leaderboard_summary.length > 0 && (
+                  <>
+                    <DownloadableTable
+                      columns={[
+                        { key: "run", header: "Run", render: (v) => getProviderLabel(v) },
+                        { key: "llm_judge_score", header: "LLM Judge Score" },
+                        { key: "ttfb", header: "TTFB (s)", render: (v) => v != null ? parseFloat(v.toFixed(4)) : "-" },
+                      ]}
+                      data={data.leaderboard_summary}
+                      filename="tts-evaluation-leaderboard"
+                    />
+                    {(() => {
+                      const names = data.leaderboard_summary!.map((s) => s.run);
+                      const colorMap = getColorMap(names);
+                      return (
+                        <div className="grid grid-cols-1 md:grid-cols-2 gap-4 md:gap-6">
+                          <LeaderboardBarChart
+                            title="LLM Judge Score"
+                            data={data.leaderboard_summary!.map((s) => ({ label: getProviderLabel(s.run), value: s.llm_judge_score, colorKey: s.run }))}
+                            colorMap={colorMap}
+                            yDomain={[0, 1]}
+                          />
+                          <LeaderboardBarChart
+                            title="TTFB (s)"
+                            data={data.leaderboard_summary!.map((s) => ({ label: getProviderLabel(s.run), value: s.ttfb, colorKey: s.run }))}
+                            colorMap={colorMap}
+                          />
+                        </div>
+                      );
+                    })()}
+                  </>
+                )}
+              </div>
+            )}
+
+            {/* Outputs Tab */}
+            {activeTab === "outputs" && (
+              <div className="flex flex-col md:flex-row border border-border rounded-xl overflow-hidden" style={{ minHeight: 480 }}>
+                {/* Provider sidebar */}
+                <div className="md:w-64 border-b md:border-b-0 md:border-r border-border flex flex-col overflow-hidden bg-muted/10">
+                  <div className="overflow-x-auto md:overflow-x-visible md:overflow-y-auto md:flex-1 p-2">
+                    <div className="flex md:flex-col gap-1 min-w-max md:min-w-0">
+                      {data.provider_results!.map((pr) => {
+                        const isSelected = (activeProviderTab ?? data.provider_results![0]?.provider) === pr.provider;
+                        return (
+                          <div
+                            key={pr.provider}
+                            onClick={() => setActiveProviderTab(pr.provider)}
+                            className={`flex items-center gap-2 px-3 py-2 rounded-lg cursor-pointer transition-colors whitespace-nowrap ${isSelected ? "bg-muted" : "hover:bg-muted/50"}`}
+                          >
+                            {pr.success === true ? (
+                              <div className="w-5 h-5 rounded-full bg-green-500/20 flex items-center justify-center flex-shrink-0">
+                                <svg className="w-3 h-3 text-green-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={3}><path strokeLinecap="round" strokeLinejoin="round" d="M4.5 12.75l6 6 9-13.5" /></svg>
+                              </div>
+                            ) : (
+                              <div className="w-5 h-5 rounded-full bg-red-500/20 flex items-center justify-center flex-shrink-0">
+                                <svg className="w-3 h-3 text-red-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={3}><path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" /></svg>
+                              </div>
+                            )}
+                            <span className="text-sm text-foreground truncate">{getProviderLabel(pr.provider)}</span>
+                          </div>
+                        );
+                      })}
+                    </div>
+                  </div>
+                </div>
+
+                {/* Right panel */}
+                <div className="flex-1 overflow-y-auto p-4 md:p-6">
+                  {(() => {
+                    const selectedProvider = activeProviderTab ?? data.provider_results![0]?.provider;
+                    const pr = data.provider_results!.find((p) => p.provider === selectedProvider);
+                    if (!pr) return <p className="text-muted-foreground">Select a provider</p>;
+                    if (pr.success === false) return (
+                      <div className="border border-red-500/50 bg-red-500/10 rounded-lg p-4 max-w-md text-center">
+                        <div className="text-red-500 text-[14px] font-medium">There was an error running this provider.</div>
+                      </div>
+                    );
+
+                    return (
+                      <div className="space-y-4 md:space-y-6">
+                        {/* Overall Metrics */}
+                        {pr.metrics && (
+                          <div className="border rounded-xl p-4 bg-muted/10">
+                            <h3 className="text-[15px] font-semibold mb-4">Overall Metrics</h3>
+                            <div className="grid grid-cols-2 gap-4">
+                              <div>
+                                <div className="text-[12px] text-muted-foreground mb-1">LLM Judge Score</div>
+                                <div className="text-base md:text-[18px] font-semibold text-foreground">{pr.metrics.llm_judge_score ?? "-"}</div>
+                              </div>
+                              <div>
+                                <div className="text-[12px] text-muted-foreground mb-1">TTFB (s)</div>
+                                <div className="text-base md:text-[18px] font-semibold text-foreground">
+                                  {pr.metrics.ttfb?.mean != null ? parseFloat(pr.metrics.ttfb.mean.toFixed(4)) : "-"}
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                        )}
+
+                        {/* Results */}
+                        {pr.results && pr.results.length > 0 && (
+                          <>
+                            <div className="hidden md:block border rounded-xl overflow-hidden">
+                              <table className="w-full table-fixed">
+                                <thead className="bg-muted/50 border-b border-border">
+                                  <tr>
+                                    <th className="w-12 px-4 py-3 text-left text-[12px] font-medium text-foreground">ID</th>
+                                    <th className="w-[30%] px-4 py-3 text-left text-[12px] font-medium text-foreground">Text</th>
+                                    <th className="w-[50%] px-4 py-3 text-left text-[12px] font-medium text-foreground">Audio</th>
+                                    <th className="w-28 px-4 py-3 text-left text-[12px] font-medium text-foreground">LLM Judge</th>
+                                  </tr>
+                                </thead>
+                                <tbody>
+                                  {pr.results.map((row, i) => {
+                                    const scoreStr = String(row.llm_judge_score || "").toLowerCase();
+                                    const passed = scoreStr === "true" || scoreStr === "1";
+                                    return (
+                                      <tr key={i} className="border-b border-border last:border-b-0">
+                                        <td className="px-4 py-3 text-[13px] text-foreground">{i + 1}</td>
+                                        <td className="px-4 py-3 text-[13px] text-foreground break-words">{row.text}</td>
+                                        <td className="px-4 py-3">
+                                          {row.audio_path ? (
+                                            <audio controls src={row.audio_path} className="h-8 w-full" />
+                                          ) : (
+                                            <span className="text-muted-foreground text-[12px]">—</span>
+                                          )}
+                                        </td>
+                                        <td className="px-4 py-3">
+                                          {row.llm_judge_score ? (
+                                            <div className="flex items-center gap-1.5">
+                                              <span className={`inline-flex items-center px-2.5 py-1 rounded-md text-xs font-medium ${passed ? "bg-green-100 text-green-700 dark:bg-green-500/20 dark:text-green-400" : "bg-red-100 text-red-700 dark:bg-red-500/20 dark:text-red-400"}`}>
+                                                {passed ? "Pass" : "Fail"}
+                                              </span>
+                                              {row.llm_judge_reasoning && (
+                                                <Tooltip content={row.llm_judge_reasoning}>
+                                                  <button type="button" className="p-1 rounded-md hover:bg-muted transition-colors cursor-pointer">
+                                                    <svg className="w-4 h-4 text-muted-foreground" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}><path strokeLinecap="round" strokeLinejoin="round" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" /></svg>
+                                                  </button>
+                                                </Tooltip>
+                                              )}
+                                            </div>
+                                          ) : <span className="text-muted-foreground text-[12px]">—</span>}
+                                        </td>
+                                      </tr>
+                                    );
+                                  })}
+                                </tbody>
+                              </table>
+                            </div>
+
+                            {/* Mobile cards */}
+                            <div className="md:hidden space-y-3">
+                              {pr.results.map((row, i) => {
+                                const scoreStr = String(row.llm_judge_score || "").toLowerCase();
+                                const passed = scoreStr === "true" || scoreStr === "1";
+                                return (
+                                  <div key={i} className="border border-border rounded-xl p-4 space-y-3">
+                                    <span className="text-[12px] text-muted-foreground font-medium">#{i + 1}</span>
+                                    <div>
+                                      <span className="text-[11px] text-muted-foreground uppercase tracking-wide">Text</span>
+                                      <p className="text-[13px] text-foreground mt-0.5">{row.text}</p>
+                                    </div>
+                                    {row.audio_path && <audio controls src={row.audio_path} className="w-full h-8" />}
+                                    {row.llm_judge_score && (
+                                      <span className={`inline-flex items-center px-2.5 py-1 rounded-md text-xs font-medium ${passed ? "bg-green-100 text-green-700 dark:bg-green-500/20 dark:text-green-400" : "bg-red-100 text-red-700 dark:bg-red-500/20 dark:text-red-400"}`}>
+                                        {passed ? "Pass" : "Fail"}
+                                      </span>
+                                    )}
+                                  </div>
+                                );
+                              })}
+                            </div>
+                          </>
+                        )}
+                      </div>
+                    );
+                  })()}
+                </div>
+              </div>
+            )}
+
+            {/* About Tab */}
+            {activeTab === "about" && (
+              <div className="border rounded-xl overflow-hidden">
+                <table className="w-full">
+                  <thead className="bg-muted/50 border-b border-border">
+                    <tr>
+                      {["Metric", "Description", "Preference", "Range"].map((h) => (
+                        <th key={h} className="px-4 py-3 text-left text-[13px] font-medium text-foreground">{h}</th>
+                      ))}
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {[
+                      { metric: "LLM Judge", description: "Evaluates whether synthesized audio accurately matches the reference text, returning Pass if the audio correctly represents the input.", preference: "Pass is better", range: "Pass / Fail" },
+                      { metric: "TTFB (Time To First Byte)", description: "Latency from when a request is sent until the first byte of the response is received.", preference: "Lower is better", range: "0 - ∞" },
+                      { metric: "Processing Time", description: "Total time taken to synthesize the audio.", preference: "Lower is better", range: "0 - ∞" },
+                    ].map((row) => (
+                      <tr key={row.metric} className="border-b border-border last:border-b-0">
+                        <td className="px-4 py-3 text-[13px] font-medium text-foreground">{row.metric}</td>
+                        <td className="px-4 py-3 text-[13px] text-foreground">{row.description}</td>
+                        <td className="px-4 py-3 text-[13px] text-foreground">{row.preference}</td>
+                        <td className="px-4 py-3 text-[13px] text-foreground">{row.range}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            )}
+          </>
+        )}
+      </div>
+    </PublicPageLayout>
+  );
+}

--- a/src/app/simulations/[uuid]/runs/[runId]/page.tsx
+++ b/src/app/simulations/[uuid]/runs/[runId]/page.tsx
@@ -16,6 +16,7 @@ import { NotFoundState } from "@/components/ui";
 import { formatStatus, getStatusBadgeClass } from "@/lib/status";
 import { POLLING_INTERVAL_MS } from "@/constants/polling";
 import { useSidebarState } from "@/lib/sidebar";
+import { ShareButton } from "@/components/ShareButton";
 
 type MetricData = {
   mean: number;
@@ -75,6 +76,8 @@ type RunData = {
   simulation_results: SimulationResult[];
   results_s3_prefix: string;
   error: string | null;
+  is_public?: boolean;
+  share_token?: string | null;
 };
 
 export default function SimulationRunPage() {
@@ -648,6 +651,15 @@ export default function SimulationRunPage() {
               >
                 {runData.type}
               </span>
+              {runData.status.toLowerCase() === "done" && backendAccessToken && (
+                <ShareButton
+                  entityType="simulation-run"
+                  entityId={runId}
+                  accessToken={backendAccessToken}
+                  initialIsPublic={runData.is_public ?? false}
+                  initialShareToken={runData.share_token ?? null}
+                />
+              )}
               {(runData.status.toLowerCase() === "in_progress" ||
                 runData.status.toLowerCase() === "queued") && (
                 <button
@@ -838,13 +850,13 @@ export default function SimulationRunPage() {
                             key === "stt_llm_judge" ||
                             key === "stt_llm_judge_score";
                           return (
-                            <div key={key}>
-                              <div className="text-xs md:text-sm text-muted-foreground mb-2 flex items-center gap-1.5">
+                            <div key={key} className="border border-border rounded-xl p-4 bg-muted/10">
+                              <div className="text-[12px] text-muted-foreground mb-1 flex items-center gap-1.5">
                                 {key}
                                 {isSttLlmJudge && (
                                   <Tooltip content="This is the speech to text accuracy for the text spoken by the simulated user calculated by comparing it with the transcribed text by the agent">
                                     <svg
-                                      className="w-3.5 md:w-4 h-3.5 md:h-4 text-muted-foreground hover:text-foreground transition-colors cursor-pointer"
+                                      className="w-3.5 h-3.5 text-muted-foreground hover:text-foreground transition-colors cursor-pointer"
                                       fill="none"
                                       viewBox="0 0 24 24"
                                       stroke="currentColor"
@@ -859,7 +871,7 @@ export default function SimulationRunPage() {
                                   </Tooltip>
                                 )}
                               </div>
-                              <div className="text-sm md:text-base font-medium text-foreground">
+                              <div className="text-[18px] font-semibold text-foreground">
                                 {Math.round(mean * 100)}%
                               </div>
                             </div>
@@ -877,13 +889,13 @@ export default function SimulationRunPage() {
                             const mean = metric.mean;
                             const tooltipContent = getLatencyMetricTooltip(key);
                             return (
-                              <div key={key}>
-                                <div className="text-xs md:text-sm text-muted-foreground mb-2 flex items-center gap-1.5">
+                              <div key={key} className="border border-border rounded-xl p-4 bg-muted/10">
+                                <div className="text-[12px] text-muted-foreground mb-1 flex items-center gap-1.5">
                                   {key}
                                   {tooltipContent && (
                                     <Tooltip content={tooltipContent}>
                                       <svg
-                                        className="w-3.5 md:w-4 h-3.5 md:h-4 text-muted-foreground hover:text-foreground transition-colors cursor-pointer"
+                                        className="w-3.5 h-3.5 text-muted-foreground hover:text-foreground transition-colors cursor-pointer"
                                         fill="none"
                                         viewBox="0 0 24 24"
                                         stroke="currentColor"
@@ -898,9 +910,9 @@ export default function SimulationRunPage() {
                                     </Tooltip>
                                   )}
                                 </div>
-                                <div className="text-sm md:text-base font-medium text-foreground">
+                                <div className="text-[18px] font-semibold text-foreground">
                                   {mean < 1
-                                    ? `${(mean * 1000).toFixed(2)}ms`
+                                    ? `${(mean * 1000).toFixed(0)}ms`
                                     : `${mean.toFixed(2)}s`}
                                 </div>
                               </div>
@@ -962,9 +974,15 @@ export default function SimulationRunPage() {
 
                 return (
                   <>
-                    <h2 className="hidden md:block text-base md:text-lg font-semibold mb-3 md:mb-4">
-                      Simulation Results
-                    </h2>
+                    <div className="flex items-baseline gap-3 mb-3 md:mb-4">
+                      <h2 className="hidden md:block text-base md:text-lg font-semibold">
+                        Simulation Results
+                      </h2>
+                      <p className="text-sm text-muted-foreground">
+                        {runData.simulation_results.length}{" "}
+                        {runData.simulation_results.length === 1 ? "simulation" : "simulations"}
+                      </p>
+                    </div>
 
                     {/* Desktop Table View */}
                     <div className="hidden md:block border border-border rounded-xl overflow-hidden bg-muted/20">

--- a/src/app/stt/[uuid]/page.tsx
+++ b/src/app/stt/[uuid]/page.tsx
@@ -17,6 +17,7 @@ import { DownloadableTable } from "@/components/DownloadableTable";
 import { POLLING_INTERVAL_MS } from "@/constants/polling";
 import { useSidebarState } from "@/lib/sidebar";
 import { getDataset } from "@/lib/datasets";
+import { ShareButton } from "@/components/ShareButton";
 
 type ProviderMetrics = {
   wer: number;
@@ -57,6 +58,8 @@ type EvaluationResult = {
   provider_results?: ProviderResult[];
   leaderboard_summary?: LeaderboardSummary[];
   error?: string | null;
+  is_public?: boolean;
+  share_token?: string | null;
 };
 
 // Helper function to map provider value back to label
@@ -314,7 +317,7 @@ export default function STTEvaluationDetailPage() {
         {/* Evaluation Results */}
         {!isLoading && !error && !errorCode && evaluationResult && (
           <div className="space-y-4">
-            {/* Language Pill, Dataset link, and Status Badge */}
+            {/* Language Pill, Dataset link, Status Badge, and Share */}
             <div className="flex items-center gap-3 flex-wrap">
               {evaluationResult.language && (
                 <span className="px-3 py-1 text-[12px] font-medium bg-muted rounded-full text-foreground capitalize">
@@ -344,6 +347,15 @@ export default function STTEvaluationDetailPage() {
               )}
               {evaluationResult.status !== "done" && (
                 <StatusBadge status={evaluationResult.status} showSpinner />
+              )}
+              {evaluationResult.status === "done" && backendAccessToken && (
+                <ShareButton
+                  entityType="stt"
+                  entityId={taskId}
+                  accessToken={backendAccessToken}
+                  initialIsPublic={evaluationResult.is_public ?? false}
+                  initialShareToken={evaluationResult.share_token ?? null}
+                />
               )}
             </div>
 

--- a/src/app/stt/page.tsx
+++ b/src/app/stt/page.tsx
@@ -235,7 +235,7 @@ function STTPageInner() {
         {/* Tab Bar */}
         <div className="flex gap-1 border-b border-border">
           <button
-            onClick={() => setActiveTab("evaluations")}
+            onClick={() => { setActiveTab("evaluations"); router.replace("/stt", { scroll: false }); }}
             className={`px-4 py-2 text-sm font-medium transition-colors cursor-pointer border-b-2 -mb-px ${
               activeTab === "evaluations"
                 ? "border-foreground text-foreground"
@@ -245,7 +245,7 @@ function STTPageInner() {
             Evaluations
           </button>
           <button
-            onClick={() => setActiveTab("datasets")}
+            onClick={() => { setActiveTab("datasets"); router.replace("/stt?tab=datasets", { scroll: false }); }}
             className={`px-4 py-2 text-sm font-medium transition-colors cursor-pointer border-b-2 -mb-px ${
               activeTab === "datasets"
                 ? "border-foreground text-foreground"

--- a/src/app/tests/page.tsx
+++ b/src/app/tests/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useState, useEffect, useRef, useCallback } from "react";
-import { useRouter } from "next/navigation";
+import { useState, useEffect, useRef, useCallback, Suspense } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
 import { signOut } from "next-auth/react";
 import { useAccessToken } from "@/hooks";
 import { AppLayout } from "@/components/AppLayout";
@@ -12,6 +12,7 @@ import {
 } from "@/components/ToolPicker";
 import { DeleteConfirmationDialog } from "@/components/DeleteConfirmationDialog";
 import { TestRunnerDialog } from "@/components/TestRunnerDialog";
+import { BenchmarkResultsDialog } from "@/components/BenchmarkResultsDialog";
 import { RunTestDialog } from "@/components/RunTestDialog";
 import { AddTestDialog, TestConfig } from "@/components/AddTestDialog";
 import { BulkUploadTestsModal } from "@/components/BulkUploadTestsModal";
@@ -32,13 +33,98 @@ type Tool = {
   name: string;
 };
 
+type TestRunResult = {
+  name?: string;
+  passed: boolean | null;
+  output?: Record<string, any> | null;
+  test_case?: {
+    name?: string;
+    history?: { role: string; content: string }[];
+    evaluation?: Record<string, any>;
+  } | null;
+};
+
+type AllRun = {
+  uuid: string;
+  name: string;
+  status: string;
+  type: "llm-unit-test" | "llm-benchmark";
+  updated_at: string;
+  total_tests: number | null;
+  passed: number | null;
+  failed: number | null;
+  results?: TestRunResult[] | null;
+  model_results?: { model: string }[] | null;
+  leaderboard_summary?: null;
+  results_s3_prefix?: string;
+  error: boolean;
+  is_public: boolean;
+  share_token: string | null;
+  agent_id: string;
+  agent_name: string;
+};
+
+function getRunDisplayName(run: AllRun): string {
+  if (run.type === "llm-benchmark") {
+    const modelCount = run.model_results?.length ?? 0;
+    return `${modelCount} model${modelCount !== 1 ? "s" : ""}`;
+  }
+  const totalTests = run.total_tests ?? run.results?.length ?? 0;
+  if (totalTests === 1 && run.results?.[0]) {
+    const testName = run.results[0].name || run.results[0].test_case?.name;
+    if (testName) return testName;
+  }
+  return `${totalTests} test${totalTests !== 1 ? "s" : ""}`;
+}
+
+function formatRelativeTime(dateString: string): string {
+  let date: Date;
+  if (dateString.endsWith("Z") || dateString.includes("+")) {
+    date = new Date(dateString);
+  } else {
+    date = new Date(dateString.replace(" ", "T") + "Z");
+  }
+  const now = new Date();
+  const diffInSeconds = Math.floor((now.getTime() - date.getTime()) / 1000);
+  if (diffInSeconds < 60) return "now";
+  const diffInMinutes = Math.floor(diffInSeconds / 60);
+  if (diffInMinutes < 60) return `${diffInMinutes} min ago`;
+  const diffInHours = Math.floor(diffInMinutes / 60);
+  if (diffInHours < 24) return `${diffInHours}h ago`;
+  const diffInDays = Math.floor(diffInHours / 24);
+  if (diffInDays < 7) return diffInDays === 1 ? "yesterday" : `${diffInDays}d ago`;
+  const diffInWeeks = Math.floor(diffInDays / 7);
+  if (diffInWeeks < 4) return `${diffInWeeks}w ago`;
+  const diffInMonths = Math.floor(diffInDays / 30);
+  if (diffInMonths < 12) return `${diffInMonths}m ago`;
+  return `${Math.floor(diffInDays / 365)}y ago`;
+}
+
 // AddTestDialog and related types have been moved to @/components/AddTestDialog
 
-export default function LLMPage() {
+function LLMPageInner() {
   const router = useRouter();
+  const searchParams = useSearchParams();
   const backendAccessToken = useAccessToken();
   const [sidebarOpen, setSidebarOpen] = useSidebarState();
+  const [activeTab, setActiveTab] = useState<"tests" | "runs">(
+    searchParams.get("tab") === "runs" ? "runs" : "tests"
+  );
   const [searchQuery, setSearchQuery] = useState("");
+
+  // All runs state
+  const [allRuns, setAllRuns] = useState<AllRun[]>([]);
+  const [allRunsLoading, setAllRunsLoading] = useState(false);
+  const [runsTypeFilter, setRunsTypeFilter] = useState<"all" | "llm-unit-test" | "llm-benchmark">("all");
+  const [runsAgentFilter, setRunsAgentFilter] = useState<string>("all");
+  const [runsAgentDropdownOpen, setRunsAgentDropdownOpen] = useState(false);
+  const runsAgentDropdownRef = useRef<HTMLDivElement>(null);
+  const [runsStatusFilter, setRunsStatusFilter] = useState<"all" | "passed" | "failed" | "error">("all");
+
+  // Viewing a run from the Runs tab
+  const [selectedRun, setSelectedRun] = useState<AllRun | null>(null);
+  const [viewingRunTest, setViewingRunTest] = useState(false);
+  const [viewingRunBenchmark, setViewingRunBenchmark] = useState(false);
 
   // Set page title
   useEffect(() => {
@@ -129,6 +215,44 @@ export default function LLMPage() {
   useEffect(() => {
     fetchTests();
   }, [fetchTests]);
+
+  // Fetch all runs when Runs tab is activated
+  useEffect(() => {
+    if (activeTab !== "runs" || !backendAccessToken) return;
+    const fetchAllRuns = async () => {
+      try {
+        setAllRunsLoading(true);
+        const backendUrl = process.env.NEXT_PUBLIC_BACKEND_URL;
+        if (!backendUrl) throw new Error("BACKEND_URL not set");
+        const response = await fetch(`${backendUrl}/agent-tests/runs`, {
+          method: "GET",
+          headers: {
+            accept: "application/json",
+            "ngrok-skip-browser-warning": "true",
+            Authorization: `Bearer ${backendAccessToken}`,
+          },
+        });
+        if (response.status === 401) { await signOut({ callbackUrl: "/login" }); return; }
+        if (!response.ok) throw new Error("Failed to fetch runs");
+        const data = await response.json();
+        setAllRuns(data.runs || []);
+      } catch (err) {
+        console.error("Error fetching all runs:", err);
+      } finally {
+        setAllRunsLoading(false);
+      }
+    };
+    fetchAllRuns();
+  }, [activeTab, backendAccessToken]);
+
+  const handleRunClick = (run: AllRun) => {
+    setSelectedRun(run);
+    if (run.type === "llm-unit-test") {
+      setViewingRunTest(true);
+    } else {
+      setViewingRunBenchmark(true);
+    }
+  };
 
   const toggleTestSelection = (uuid: string) => {
     setSelectedTestUuids((prev) => {
@@ -513,32 +637,61 @@ export default function LLMPage() {
               Create and manage tests to evaluate your LLM
             </p>
           </div>
-          <div className="flex items-center gap-2">
-            {selectedTestUuids.size > 0 && (
+          {activeTab === "tests" && (
+            <div className="flex items-center gap-2">
+              {selectedTestUuids.size > 0 && (
+                <button
+                  onClick={openBulkDeleteDialog}
+                  className="h-9 md:h-10 px-4 rounded-md text-sm md:text-base font-medium border border-red-500 text-red-500 hover:bg-red-500/10 transition-colors cursor-pointer flex-shrink-0"
+                >
+                  Delete selected ({selectedTestUuids.size})
+                </button>
+              )}
               <button
-                onClick={openBulkDeleteDialog}
-                className="h-9 md:h-10 px-4 rounded-md text-sm md:text-base font-medium border border-red-500 text-red-500 hover:bg-red-500/10 transition-colors cursor-pointer flex-shrink-0"
+                onClick={() => setBulkUploadOpen(true)}
+                className="h-9 md:h-10 px-4 rounded-md text-sm md:text-base font-medium border border-border bg-background text-foreground hover:bg-muted/50 transition-colors cursor-pointer flex-shrink-0"
               >
-                Delete selected ({selectedTestUuids.size})
+                Bulk upload
               </button>
-            )}
-            <button
-              onClick={() => setBulkUploadOpen(true)}
-              className="h-9 md:h-10 px-4 rounded-md text-sm md:text-base font-medium border border-border bg-background text-foreground hover:bg-muted/50 transition-colors cursor-pointer flex-shrink-0"
-            >
-              Bulk upload
-            </button>
-            <button
-              onClick={() => {
-                resetForm();
-                setAddTestSidebarOpen(true);
-              }}
-              className="h-9 md:h-10 px-4 rounded-md text-sm md:text-base font-medium bg-foreground text-background hover:opacity-90 transition-opacity cursor-pointer flex-shrink-0"
-            >
-              Add test
-            </button>
-          </div>
+              <button
+                onClick={() => {
+                  resetForm();
+                  setAddTestSidebarOpen(true);
+                }}
+                className="h-9 md:h-10 px-4 rounded-md text-sm md:text-base font-medium bg-foreground text-background hover:opacity-90 transition-opacity cursor-pointer flex-shrink-0"
+              >
+                Add test
+              </button>
+            </div>
+          )}
         </div>
+
+        {/* Tab Bar */}
+        <div className="flex gap-1 border-b border-border">
+          <button
+            onClick={() => { setActiveTab("tests"); router.replace("/tests", { scroll: false }); }}
+            className={`px-4 py-2 text-sm font-medium transition-colors cursor-pointer border-b-2 -mb-px ${
+              activeTab === "tests"
+                ? "border-foreground text-foreground"
+                : "border-transparent text-muted-foreground hover:text-foreground"
+            }`}
+          >
+            Tests
+          </button>
+          <button
+            onClick={() => { setActiveTab("runs"); router.replace("/tests?tab=runs", { scroll: false }); }}
+            className={`px-4 py-2 text-sm font-medium transition-colors cursor-pointer border-b-2 -mb-px ${
+              activeTab === "runs"
+                ? "border-foreground text-foreground"
+                : "border-transparent text-muted-foreground hover:text-foreground"
+            }`}
+          >
+            Runs
+          </button>
+        </div>
+
+        {/* ── TESTS TAB ── */}
+        {activeTab === "tests" && <>
 
         {/* Search Input */}
         <div className="relative max-w-md">
@@ -882,6 +1035,255 @@ export default function LLMPage() {
             </div>
           </>
         )}
+
+        </> /* end Tests tab */}
+
+        {/* ── RUNS TAB ── */}
+        {activeTab === "runs" && (
+          <>
+            {/* Filters */}
+            <div className="flex flex-wrap items-center gap-3">
+              {/* Type filter */}
+              <div className="flex gap-1.5">
+                {(["all", "llm-unit-test", "llm-benchmark"] as const).map((f) => (
+                  <button
+                    key={f}
+                    onClick={() => setRunsTypeFilter(f)}
+                    className={`px-3 py-1.5 text-xs font-medium rounded-md border transition-colors cursor-pointer ${
+                      runsTypeFilter === f
+                        ? "bg-foreground text-background border-foreground"
+                        : "border-border text-muted-foreground hover:text-foreground"
+                    }`}
+                  >
+                    {f === "all" ? "All types" : f === "llm-unit-test" ? "Tests" : "Benchmarks"}
+                  </button>
+                ))}
+              </div>
+
+              {/* Status filter */}
+              <div className="flex gap-1.5">
+                {(["all", "passed", "failed", "error"] as const).map((f) => (
+                  <button
+                    key={f}
+                    onClick={() => setRunsStatusFilter(f)}
+                    className={`px-3 py-1.5 text-xs font-medium rounded-md border transition-colors cursor-pointer ${
+                      runsStatusFilter === f
+                        ? "bg-foreground text-background border-foreground"
+                        : "border-border text-muted-foreground hover:text-foreground"
+                    }`}
+                  >
+                    {f === "all" ? "All results" : f === "passed" ? "All passed" : f === "failed" ? "All failed" : "Error"}
+                  </button>
+                ))}
+              </div>
+
+              {/* Agent filter */}
+              {allRuns.length > 0 && (() => {
+                const agents = Array.from(new Map(allRuns.map((r) => [r.agent_id, r.agent_name])).entries());
+                if (agents.length <= 1) return null;
+                const selectedLabel = runsAgentFilter === "all"
+                  ? "All agents"
+                  : (agents.find(([id]) => id === runsAgentFilter)?.[1] ?? "All agents");
+                return (
+                  <div ref={runsAgentDropdownRef} className="relative">
+                    <button
+                      onClick={() => setRunsAgentDropdownOpen((o) => !o)}
+                      className="flex items-center gap-2 pl-3 pr-2.5 py-1.5 text-xs font-medium rounded-md border border-border bg-background text-foreground hover:border-muted-foreground transition-colors cursor-pointer"
+                    >
+                      {selectedLabel}
+                      <svg
+                        className={`w-3.5 h-3.5 text-muted-foreground transition-transform ${runsAgentDropdownOpen ? "rotate-180" : ""}`}
+                        fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}
+                      >
+                        <path strokeLinecap="round" strokeLinejoin="round" d="M19.5 8.25l-7.5 7.5-7.5-7.5" />
+                      </svg>
+                    </button>
+
+                    {runsAgentDropdownOpen && (
+                      <>
+                        <div className="fixed inset-0 z-[99]" onClick={() => setRunsAgentDropdownOpen(false)} />
+                        <div className="absolute left-0 top-full mt-1.5 bg-background border border-border rounded-xl shadow-xl z-[100] overflow-hidden min-w-[160px]">
+                          {([["all", "All agents"], ...agents] as [string, string][]).map(([id, name]) => (
+                            <button
+                              key={id}
+                              onClick={() => { setRunsAgentFilter(id); setRunsAgentDropdownOpen(false); }}
+                              className={`w-full px-3.5 py-2 text-left text-xs transition-colors cursor-pointer flex items-center justify-between gap-3 ${
+                                runsAgentFilter === id ? "bg-accent text-foreground" : "text-foreground hover:bg-muted"
+                              }`}
+                            >
+                              <span className="truncate">{name}</span>
+                              {runsAgentFilter === id && (
+                                <svg className="w-3.5 h-3.5 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5}>
+                                  <path strokeLinecap="round" strokeLinejoin="round" d="M4.5 12.75l6 6 9-13.5" />
+                                </svg>
+                              )}
+                            </button>
+                          ))}
+                        </div>
+                      </>
+                    )}
+                  </div>
+                );
+              })()}
+            </div>
+
+            {allRunsLoading ? (
+              <div className="flex items-center justify-center gap-3 py-8">
+                <svg className="w-5 h-5 animate-spin" fill="none" viewBox="0 0 24 24">
+                  <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                  <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
+                </svg>
+              </div>
+            ) : (() => {
+              const isRunning = (r: AllRun) =>
+                r.status === "pending" || r.status === "queued" || r.status === "in_progress";
+              const isError = (r: AllRun) => r.status === "failed" || r.error;
+              const isDone = (r: AllRun) => r.status === "done" && !r.error;
+              const isAllPassed = (r: AllRun) => isDone(r) && (r.failed === null || r.failed === 0);
+              const isAllFailed = (r: AllRun) => isDone(r) && r.failed !== null && r.failed > 0;
+
+              const filtered = allRuns.filter((r) => {
+                if (runsTypeFilter !== "all" && r.type !== runsTypeFilter) return false;
+                if (runsAgentFilter !== "all" && r.agent_id !== runsAgentFilter) return false;
+                if (runsStatusFilter === "passed" && (!isAllPassed(r) || isRunning(r))) return false;
+                if (runsStatusFilter === "failed" && (!isAllFailed(r) || isRunning(r))) return false;
+                if (runsStatusFilter === "error" && !isError(r)) return false;
+                return true;
+              });
+              if (filtered.length === 0) {
+                return (
+                  <div className="border border-border rounded-xl p-8 md:p-12 flex flex-col items-center justify-center bg-muted/20">
+                    <div className="w-12 h-12 md:w-14 md:h-14 rounded-xl bg-muted flex items-center justify-center mb-3 md:mb-4">
+                      <svg className="w-6 h-6 md:w-7 md:h-7 text-muted-foreground" viewBox="0 0 24 24" fill="currentColor">
+                        <path d="M9 3h6v2h-1v4.5l4.5 7.5c.5.83.5 1.5-.17 2.17-.67.67-1.34.83-2.33.83H8c-1 0-1.67-.17-2.33-.83-.67-.67-.67-1.34-.17-2.17L10 9.5V5H9V3zm3 8.5L8.5 17h7L12 11.5z" />
+                      </svg>
+                    </div>
+                    <h3 className="text-base md:text-lg font-semibold text-foreground mb-1">No runs yet</h3>
+                    <p className="text-sm md:text-base text-muted-foreground text-center">
+                      {(runsTypeFilter !== "all" || runsAgentFilter !== "all" || runsStatusFilter !== "all")
+                        ? "No runs match the selected filters"
+                        : "Run tests from an agent to see results here"}
+                    </p>
+                  </div>
+                );
+              }
+              return (
+                <>
+                  <p className="text-sm text-muted-foreground">
+                    {filtered.length} {filtered.length === 1 ? "run" : "runs"}
+                  </p>
+
+                  {/* Desktop Table */}
+                  <div className="hidden md:block border border-border rounded-xl overflow-hidden">
+                    <div className="grid grid-cols-[1fr_1fr_120px_140px_120px] gap-4 px-4 py-2 border-b border-border bg-muted/30">
+                      <div className="text-sm font-medium text-muted-foreground">Name</div>
+                      <div className="text-sm font-medium text-muted-foreground">Agent</div>
+                      <div className="text-sm font-medium text-muted-foreground">Type</div>
+                      <div className="text-sm font-medium text-muted-foreground">Result</div>
+                      <div className="text-sm font-medium text-muted-foreground">Updated</div>
+                    </div>
+                    {filtered.map((run) => (
+                      <div
+                        key={run.uuid}
+                        onClick={() => handleRunClick(run)}
+                        className="grid grid-cols-[1fr_1fr_120px_140px_120px] gap-4 px-4 py-2 border-b border-border last:border-b-0 hover:bg-muted/20 transition-colors cursor-pointer items-center"
+                      >
+                        <div className="min-w-0">
+                          <p className="text-sm font-medium text-foreground truncate">{run.name}</p>
+                          <p className="text-xs text-muted-foreground truncate">{getRunDisplayName(run)}</p>
+                        </div>
+                        <p className="text-sm text-muted-foreground truncate">{run.agent_name}</p>
+                        <span className={`inline-flex items-center px-2 py-0.5 rounded text-xs font-medium w-fit ${
+                          run.type === "llm-unit-test"
+                            ? "bg-blue-500/20 text-blue-400"
+                            : "bg-purple-500/20 text-purple-400"
+                        }`}>
+                          {run.type === "llm-unit-test" ? "Test" : "Benchmark"}
+                        </span>
+                        <div className="flex items-center gap-1.5 flex-wrap">
+                          {run.status === "pending" || run.status === "queued" || run.status === "in_progress" ? (
+                            <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded text-xs font-medium bg-yellow-500/20 text-yellow-500">
+                              <svg className="w-3 h-3 animate-spin" fill="none" viewBox="0 0 24 24">
+                                <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                                <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
+                              </svg>
+                              Running
+                            </span>
+                          ) : run.status === "failed" || run.error ? (
+                            <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-red-500/20 text-red-500">Error</span>
+                          ) : run.type === "llm-unit-test" ? (
+                            <>
+                              {run.passed !== null && run.passed > 0 && (
+                                <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-green-500/20 text-green-500">{run.passed} Pass</span>
+                              )}
+                              {run.failed !== null && run.failed > 0 && (
+                                <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-red-500/20 text-red-500">{run.failed} Fail</span>
+                              )}
+                            </>
+                          ) : (
+                            <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-green-500/20 text-green-500">Complete</span>
+                          )}
+                        </div>
+                        <p className="text-sm text-muted-foreground">{formatRelativeTime(run.updated_at)}</p>
+                      </div>
+                    ))}
+                  </div>
+
+                  {/* Mobile Card View */}
+                  <div className="md:hidden space-y-3">
+                    {filtered.map((run) => (
+                      <div
+                        key={run.uuid}
+                        onClick={() => handleRunClick(run)}
+                        className="border border-border rounded-xl p-4 bg-background hover:shadow-lg hover:border-foreground/20 transition-all duration-200 cursor-pointer"
+                      >
+                        <div className="flex items-start justify-between gap-2 mb-2">
+                          <div className="min-w-0">
+                            <p className="text-sm font-medium text-foreground truncate">{run.name}</p>
+                            <p className="text-xs text-muted-foreground truncate">{run.agent_name}</p>
+                          </div>
+                          <span className={`inline-flex items-center px-2 py-0.5 rounded text-xs font-medium shrink-0 ${
+                            run.type === "llm-unit-test" ? "bg-blue-500/20 text-blue-400" : "bg-purple-500/20 text-purple-400"
+                          }`}>
+                            {run.type === "llm-unit-test" ? "Test" : "Benchmark"}
+                          </span>
+                        </div>
+                        <div className="flex items-center justify-between">
+                          <div className="flex items-center gap-1.5 flex-wrap">
+                            {run.status === "pending" || run.status === "queued" || run.status === "in_progress" ? (
+                              <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded text-xs font-medium bg-yellow-500/20 text-yellow-500">
+                                <svg className="w-3 h-3 animate-spin" fill="none" viewBox="0 0 24 24">
+                                  <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                                  <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
+                                </svg>
+                                Running
+                              </span>
+                            ) : run.status === "failed" || run.error ? (
+                              <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-red-500/20 text-red-500">Error</span>
+                            ) : run.type === "llm-unit-test" ? (
+                              <>
+                                {run.passed !== null && run.passed > 0 && (
+                                  <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-green-500/20 text-green-500">{run.passed} Pass</span>
+                                )}
+                                {run.failed !== null && run.failed > 0 && (
+                                  <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-red-500/20 text-red-500">{run.failed} Fail</span>
+                                )}
+                              </>
+                            ) : (
+                              <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-green-500/20 text-green-500">Complete</span>
+                            )}
+                          </div>
+                          <span className="text-xs text-muted-foreground">{formatRelativeTime(run.updated_at)}</span>
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                </>
+              );
+            })()}
+          </>
+        )}
+
       </div>
 
       {/* Add Test Dialog */}
@@ -950,6 +1352,57 @@ export default function LLMPage() {
         onClose={() => setBulkUploadOpen(false)}
         onSuccess={fetchTests}
       />
+
+      {/* View Run — Test Runner Dialog (from Runs tab) */}
+      {selectedRun && selectedRun.type === "llm-unit-test" && (
+        <TestRunnerDialog
+          isOpen={viewingRunTest}
+          onClose={() => {
+            setViewingRunTest(false);
+            setSelectedRun(null);
+          }}
+          agentUuid={selectedRun.agent_id}
+          agentName={selectedRun.agent_name}
+          tests={
+            selectedRun.results?.map((r, i) => ({
+              uuid: `run-test-${i}`,
+              name: r.name || r.test_case?.name || `Test ${i + 1}`,
+              description: "",
+              type: "response" as const,
+              config: {},
+              created_at: "",
+              updated_at: "",
+            })) || []
+          }
+          taskId={selectedRun.uuid}
+          initialRunStatus={selectedRun.status}
+        />
+      )}
+
+      {/* View Run — Benchmark Results Dialog (from Runs tab) */}
+      {selectedRun && selectedRun.type === "llm-benchmark" && (
+        <BenchmarkResultsDialog
+          isOpen={viewingRunBenchmark}
+          onClose={() => {
+            setViewingRunBenchmark(false);
+            setSelectedRun(null);
+          }}
+          agentUuid={selectedRun.agent_id}
+          agentName={selectedRun.agent_name}
+          testUuids={[]}
+          testNames={[]}
+          models={[]}
+          taskId={selectedRun.uuid}
+        />
+      )}
     </AppLayout>
+  );
+}
+
+export default function LLMPage() {
+  return (
+    <Suspense>
+      <LLMPageInner />
+    </Suspense>
   );
 }

--- a/src/app/tts/[uuid]/page.tsx
+++ b/src/app/tts/[uuid]/page.tsx
@@ -17,6 +17,7 @@ import { DownloadableTable } from "@/components/DownloadableTable";
 import { POLLING_INTERVAL_MS } from "@/constants/polling";
 import { useSidebarState } from "@/lib/sidebar";
 import { getDataset } from "@/lib/datasets";
+import { ShareButton } from "@/components/ShareButton";
 
 type LatencyMetric = {
   mean: number;
@@ -61,6 +62,8 @@ type EvaluationResult = {
   provider_results?: ProviderResult[];
   leaderboard_summary?: LeaderboardSummary[];
   error?: string | null;
+  is_public?: boolean;
+  share_token?: string | null;
 };
 
 // Helper function to map provider value back to label
@@ -335,6 +338,15 @@ export default function TTSEvaluationDetailPage() {
               )}
               {evaluationResult.status !== "done" && (
                 <StatusBadge status={evaluationResult.status} showSpinner />
+              )}
+              {evaluationResult.status === "done" && backendAccessToken && (
+                <ShareButton
+                  entityType="tts"
+                  entityId={taskId}
+                  accessToken={backendAccessToken}
+                  initialIsPublic={evaluationResult.is_public ?? false}
+                  initialShareToken={evaluationResult.share_token ?? null}
+                />
               )}
             </div>
 

--- a/src/app/tts/page.tsx
+++ b/src/app/tts/page.tsx
@@ -232,7 +232,7 @@ function TTSPageInner() {
         {/* Tab Bar */}
         <div className="flex gap-1 border-b border-border">
           <button
-            onClick={() => setActiveTab("evaluations")}
+            onClick={() => { setActiveTab("evaluations"); router.replace("/tts", { scroll: false }); }}
             className={`px-4 py-2 text-sm font-medium transition-colors cursor-pointer border-b-2 -mb-px ${
               activeTab === "evaluations"
                 ? "border-foreground text-foreground"
@@ -242,7 +242,7 @@ function TTSPageInner() {
             Evaluations
           </button>
           <button
-            onClick={() => setActiveTab("datasets")}
+            onClick={() => { setActiveTab("datasets"); router.replace("/tts?tab=datasets", { scroll: false }); }}
             className={`px-4 py-2 text-sm font-medium transition-colors cursor-pointer border-b-2 -mb-px ${
               activeTab === "datasets"
                 ? "border-foreground text-foreground"

--- a/src/components/BenchmarkResultsDialog.tsx
+++ b/src/components/BenchmarkResultsDialog.tsx
@@ -16,6 +16,8 @@ import { LeaderboardBarChart, getColorMap } from "./charts/LeaderboardBarChart";
 import { DownloadableTable } from "./DownloadableTable";
 import { POLLING_INTERVAL_MS } from "@/constants/polling";
 import { useHideFloatingButton } from "@/components/AppLayout";
+import { ShareButton } from "@/components/ShareButton";
+import { useAccessToken } from "@/hooks";
 
 type BenchmarkTestResult = {
   name?: string;
@@ -44,11 +46,14 @@ type LeaderboardSummary = {
 
 type BenchmarkStatusResponse = {
   task_id: string;
+  name?: string;
   status: string;
   model_results?: ModelResult[];
   leaderboard_summary?: LeaderboardSummary[];
   results_s3_prefix?: string;
   error?: string;
+  is_public?: boolean;
+  share_token?: string | null;
 };
 
 type BenchmarkResultsDialogProps = {
@@ -100,6 +105,11 @@ export function BenchmarkResultsDialog({
     LeaderboardSummary[] | undefined
   >(undefined);
   const [error, setError] = useState<string | null>(null);
+  const [currentTaskId, setCurrentTaskId] = useState<string | null>(null);
+  const [runName, setRunName] = useState<string | null>(null);
+  const [isPublic, setIsPublic] = useState(false);
+  const [shareToken, setShareToken] = useState<string | null>(null);
+  const backendAccessToken = useAccessToken();
   const pollingIntervalRef = useRef<NodeJS.Timeout | null>(null);
 
   const isDone =
@@ -124,6 +134,9 @@ export function BenchmarkResultsDialog({
       setExpandedProviders(new Set(models.length > 0 ? [models[0]] : []));
       setSelectedTest(null);
       setActiveTab("outputs");
+      setIsPublic(false);
+      setShareToken(null);
+      setCurrentTaskId(taskId ?? null);
 
       if (taskId) {
         // View existing benchmark - poll the task immediately
@@ -182,6 +195,11 @@ export function BenchmarkResultsDialog({
 
       // Update task status for display
       setTaskStatus(result.status);
+
+      // Capture name and share state from backend
+      if (result.name) setRunName(result.name);
+      if (result.is_public !== undefined) setIsPublic(result.is_public);
+      if (result.share_token !== undefined) setShareToken(result.share_token ?? null);
 
       // Update model results (intermediate or final)
       if (result.model_results) {
@@ -274,6 +292,7 @@ export function BenchmarkResultsDialog({
 
       const result: BenchmarkStatusResponse = await response.json();
       const newTaskId = result.task_id;
+      setCurrentTaskId(newTaskId);
 
       // Notify parent about the new benchmark
       if (onBenchmarkCreated) {
@@ -379,14 +398,29 @@ export function BenchmarkResultsDialog({
         {/* Header */}
         <div className="flex items-center justify-between px-4 md:px-6 py-3 md:py-4">
           <div className="flex items-center gap-2 md:gap-3 min-w-0">
-            <h2 className="text-base md:text-lg font-semibold text-foreground truncate">
-              Benchmark for {agentName}
-            </h2>
+            <div className="min-w-0">
+              <h2 className="text-base md:text-lg font-semibold text-foreground truncate">
+                {runName ?? "Benchmark"}
+              </h2>
+              <p className="text-xs text-muted-foreground truncate">{agentName}</p>
+            </div>
             {!isDone && !isInitialLoading && (
               <StatusBadge status={taskStatus} showSpinner />
             )}
           </div>
           <div className="flex items-center gap-2">
+            {/* Share button — only shown when benchmark is done */}
+            {isDone && !error && currentTaskId && backendAccessToken && (
+              <div className="hidden md:block">
+                <ShareButton
+                  entityType="benchmark"
+                  entityId={currentTaskId}
+                  accessToken={backendAccessToken}
+                  initialIsPublic={isPublic}
+                  initialShareToken={shareToken}
+                />
+              </div>
+            )}
             {/* Rerun button - show when benchmark is complete (not loading and no error) */}
             {isDone && !error && onGoBack && (
               <button

--- a/src/components/PublicPageLayout.tsx
+++ b/src/components/PublicPageLayout.tsx
@@ -1,0 +1,171 @@
+"use client";
+
+import React from "react";
+import Link from "next/link";
+import { useAuth } from "@/hooks";
+
+interface PublicPageLayoutProps {
+  children: React.ReactNode;
+  title?: string;
+  pills?: React.ReactNode;
+}
+
+type Theme = "light" | "dark" | "device";
+
+function applyTheme(theme: Theme) {
+  const root = document.documentElement;
+  root.classList.remove("light", "dark");
+  if (theme === "device") {
+    root.classList.add(
+      window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light"
+    );
+  } else {
+    root.classList.add(theme);
+  }
+}
+
+function resolvedIsDark(theme: Theme): boolean {
+  if (theme === "dark") return true;
+  if (theme === "light") return false;
+  return window.matchMedia("(prefers-color-scheme: dark)").matches;
+}
+
+export function PublicPageLayout({ children, title, pills }: PublicPageLayoutProps) {
+  const { isAuthenticated, isLoading } = useAuth();
+  const [mounted, setMounted] = React.useState(false);
+  const [isDark, setIsDark] = React.useState(false);
+
+  // On mount: read saved theme (same localStorage key as AppLayout) and apply it
+  React.useEffect(() => {
+    const saved = (localStorage.getItem("theme") as Theme | null) ?? "device";
+    applyTheme(saved);
+    setIsDark(resolvedIsDark(saved));
+    setMounted(true);
+
+    // Also track system preference changes while on this page
+    const mq = window.matchMedia("(prefers-color-scheme: dark)");
+    const onSystemChange = () => {
+      const current = (localStorage.getItem("theme") as Theme | null) ?? "device";
+      if (current === "device") {
+        applyTheme("device");
+        setIsDark(mq.matches);
+      }
+    };
+    mq.addEventListener("change", onSystemChange);
+    return () => mq.removeEventListener("change", onSystemChange);
+  }, []);
+
+  const toggleTheme = () => {
+    const next: Theme = isDark ? "light" : "dark";
+    localStorage.setItem("theme", next);
+    applyTheme(next);
+    setIsDark(!isDark);
+  };
+
+  return (
+    <div className="min-h-screen bg-background text-foreground flex flex-col">
+      {/* Minimal top bar */}
+      <header className="border-b border-border px-4 md:px-8 py-3 flex items-center justify-between shrink-0">
+        <Link href="/" className="flex items-center gap-2 hover:opacity-80 transition-opacity">
+          <span className="text-[15px] font-semibold tracking-tight">Calibrate</span>
+        </Link>
+        {(title || pills) && (
+          <div className="flex items-center gap-2 truncate max-w-[50%]">
+            {title && (
+              <span className="text-[13px] text-muted-foreground truncate">{title}</span>
+            )}
+            {pills && (
+              <div className="flex items-center gap-1.5 shrink-0">{pills}</div>
+            )}
+          </div>
+        )}
+        {/* Right side: theme toggle + auth link — only after mount */}
+        {mounted && (
+          <div className="flex items-center gap-2 shrink-0">
+            {/* Theme toggle */}
+            <button
+              onClick={toggleTheme}
+              className="w-8 h-8 flex items-center justify-center rounded-md text-muted-foreground hover:text-foreground hover:bg-muted transition-colors cursor-pointer"
+              aria-label={isDark ? "Switch to light mode" : "Switch to dark mode"}
+            >
+              {isDark ? (
+                /* Sun icon */
+                <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M12 3v2.25m6.364.386-1.591 1.591M21 12h-2.25m-.386 6.364-1.591-1.591M12 18.75V21m-4.773-4.227-1.591 1.591M5.25 12H3m4.227-4.773L5.636 5.636M15.75 12a3.75 3.75 0 1 1-7.5 0 3.75 3.75 0 0 1 7.5 0Z" />
+                </svg>
+              ) : (
+                /* Moon icon */
+                <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M21.752 15.002A9.72 9.72 0 0 1 18 15.75c-5.385 0-9.75-4.365-9.75-9.75 0-1.33.266-2.597.748-3.752A9.753 9.753 0 0 0 3 11.25C3 16.635 7.365 21 12.75 21a9.753 9.753 0 0 0 9.002-5.998Z" />
+                </svg>
+              )}
+            </button>
+
+            {/* Auth link */}
+            {!isLoading && (
+              isAuthenticated ? (
+                <Link
+                  href="/agents"
+                  className="text-[13px] font-medium text-muted-foreground hover:text-foreground transition-colors"
+                >
+                  Go to app
+                </Link>
+              ) : (
+                <Link
+                  href="/login"
+                  className="inline-flex items-center px-4 py-1.5 rounded-lg text-[13px] font-medium bg-foreground text-background hover:opacity-90 transition-opacity"
+                >
+                  Sign in
+                </Link>
+              )
+            )}
+          </div>
+        )}
+      </header>
+
+      {/* Page content */}
+      <main className="flex-1 px-4 md:px-8 py-6 md:py-8 max-w-7xl w-full mx-auto">
+        {children}
+      </main>
+
+      {/* Minimal footer */}
+      <footer className="border-t border-border px-4 md:px-8 py-4 shrink-0">
+        <p className="text-[12px] text-muted-foreground text-center">
+          Shared via{" "}
+          <Link href="/" className="hover:text-foreground transition-colors underline underline-offset-2">
+            Calibrate
+          </Link>
+        </p>
+      </footer>
+    </div>
+  );
+}
+
+export function PublicNotFound({ message }: { message?: string }) {
+  return (
+    <div className="flex flex-col items-center justify-center py-24 gap-4">
+      <div className="w-12 h-12 rounded-full bg-muted flex items-center justify-center">
+        <svg className="w-6 h-6 text-muted-foreground" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+          <path strokeLinecap="round" strokeLinejoin="round" d="M13.5 10.5V6.75a4.5 4.5 0 119 0v3.75M3.75 21.75h10.5a2.25 2.25 0 002.25-2.25v-6.75a2.25 2.25 0 00-2.25-2.25H3.75a2.25 2.25 0 00-2.25 2.25v6.75a2.25 2.25 0 002.25 2.25z" />
+        </svg>
+      </div>
+      <p className="text-[15px] font-medium text-foreground">
+        {message ?? "This link is not available"}
+      </p>
+      <p className="text-[13px] text-muted-foreground text-center max-w-sm">
+        The results may have been made private, or the link may be incorrect.
+      </p>
+    </div>
+  );
+}
+
+export function PublicLoading() {
+  return (
+    <div className="flex items-center justify-center py-24">
+      <svg className="w-5 h-5 animate-spin text-muted-foreground" fill="none" viewBox="0 0 24 24">
+        <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+        <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
+      </svg>
+    </div>
+  );
+}

--- a/src/components/ShareButton.tsx
+++ b/src/components/ShareButton.tsx
@@ -1,0 +1,232 @@
+"use client";
+
+import React, { useState } from "react";
+import { Tooltip } from "@/components/Tooltip";
+
+export type ShareableEntityType =
+  | "stt"
+  | "tts"
+  | "test-run"
+  | "benchmark"
+  | "simulation-run";
+
+const VISIBILITY_ENDPOINTS: Record<
+  ShareableEntityType,
+  (id: string) => string
+> = {
+  stt: (id) => `/stt/evaluate/${id}/visibility`,
+  tts: (id) => `/tts/evaluate/${id}/visibility`,
+  "test-run": (id) => `/agent-tests/run/${id}/visibility`,
+  benchmark: (id) => `/agent-tests/benchmark/${id}/visibility`,
+  "simulation-run": (id) => `/simulations/run/${id}/visibility`,
+};
+
+const PUBLIC_PATHS: Record<ShareableEntityType, string> = {
+  stt: "stt",
+  tts: "tts",
+  "test-run": "test-run",
+  benchmark: "benchmark",
+  "simulation-run": "simulation-run",
+};
+
+interface ShareButtonProps {
+  entityType: ShareableEntityType;
+  entityId: string;
+  accessToken: string;
+  initialIsPublic: boolean;
+  initialShareToken: string | null;
+}
+
+export function ShareButton({
+  entityType,
+  entityId,
+  accessToken,
+  initialIsPublic,
+  initialShareToken,
+}: ShareButtonProps) {
+  const [isPublic, setIsPublic] = useState(initialIsPublic);
+  const [shareToken, setShareToken] = useState<string | null>(
+    initialShareToken,
+  );
+  const [isLoading, setIsLoading] = useState(false);
+  const [copied, setCopied] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const publicUrl = shareToken
+    ? `${window.location.origin}/public/${PUBLIC_PATHS[entityType]}/${shareToken}`
+    : null;
+
+  const toggle = async () => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const backendUrl = process.env.NEXT_PUBLIC_BACKEND_URL;
+      if (!backendUrl) throw new Error("Backend URL not configured");
+
+      const endpoint = VISIBILITY_ENDPOINTS[entityType](entityId);
+      const res = await fetch(`${backendUrl}${endpoint}`, {
+        method: "PATCH",
+        headers: {
+          "Content-Type": "application/json",
+          accept: "application/json",
+          "ngrok-skip-browser-warning": "true",
+          Authorization: `Bearer ${accessToken}`,
+        },
+        body: JSON.stringify({ is_public: !isPublic }),
+      });
+
+      if (!res.ok) throw new Error("Failed to update visibility");
+
+      const data = await res.json();
+      setIsPublic(data.is_public);
+      setShareToken(data.share_token ?? null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Something went wrong");
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const copyLink = async () => {
+    if (!publicUrl) return;
+    try {
+      await navigator.clipboard.writeText(publicUrl);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // Fallback for environments without clipboard API
+      const el = document.createElement("textarea");
+      el.value = publicUrl;
+      document.body.appendChild(el);
+      el.select();
+      document.execCommand("copy");
+      document.body.removeChild(el);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    }
+  };
+
+  return (
+    <div className="flex items-center gap-2">
+      {/* Toggle button */}
+      <Tooltip
+        content={
+          isPublic
+            ? "Make this benchmark private"
+            : "Make this benchmark publicly shareable"
+        }
+        position="bottom"
+      >
+        <button
+          onClick={toggle}
+          disabled={isLoading}
+          className={`flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-[13px] font-medium transition-colors border cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed ${
+            isPublic
+              ? "bg-blue-500/10 border-blue-500/30 text-blue-600 dark:text-blue-400 hover:bg-blue-500/20"
+              : "bg-muted border-border text-muted-foreground hover:text-foreground hover:bg-muted/70"
+          }`}
+        >
+          {isLoading ? (
+            <svg
+              className="w-3.5 h-3.5 animate-spin"
+              fill="none"
+              viewBox="0 0 24 24"
+            >
+              <circle
+                className="opacity-25"
+                cx="12"
+                cy="12"
+                r="10"
+                stroke="currentColor"
+                strokeWidth="4"
+              />
+              <path
+                className="opacity-75"
+                fill="currentColor"
+                d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+              />
+            </svg>
+          ) : isPublic ? (
+            /* Globe icon — public */
+            <svg
+              className="w-3.5 h-3.5"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              strokeWidth={2}
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M12 21a9.004 9.004 0 008.716-6.747M12 21a9.004 9.004 0 01-8.716-6.747M12 21c2.485 0 4.5-4.03 4.5-9S14.485 3 12 3m0 18c-2.485 0-4.5-4.03-4.5-9S9.515 3 12 3m0 0a8.997 8.997 0 017.843 4.582M12 3a8.997 8.997 0 00-7.843 4.582m15.686 0A11.953 11.953 0 0112 10.5c-2.998 0-5.74-1.1-7.843-2.918m15.686 0A8.959 8.959 0 0121 12c0 .778-.099 1.533-.284 2.253M3 12a8.959 8.959 0 01.284-2.253"
+              />
+            </svg>
+          ) : (
+            /* Lock icon — private */
+            <svg
+              className="w-3.5 h-3.5"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              strokeWidth={2}
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M16.5 10.5V6.75a4.5 4.5 0 10-9 0v3.75m-.75 11.25h10.5a2.25 2.25 0 002.25-2.25v-6.75a2.25 2.25 0 00-2.25-2.25H6.75a2.25 2.25 0 00-2.25 2.25v6.75a2.25 2.25 0 002.25 2.25z"
+              />
+            </svg>
+          )}
+          {isPublic ? "Public" : "Share"}
+        </button>
+      </Tooltip>
+
+      {/* Copy link — only shown when public */}
+      {isPublic && publicUrl && (
+        <button
+          onClick={copyLink}
+          className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-[13px] font-medium bg-muted border border-border text-muted-foreground hover:text-foreground hover:bg-muted/70 transition-colors cursor-pointer dark:bg-accent/20 dark:border-accent/40 dark:text-accent-foreground dark:hover:bg-accent/30"
+          title="Copy public link"
+        >
+          {copied ? (
+            <>
+              <svg
+                className="w-3.5 h-3.5 text-green-500"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+                strokeWidth={2}
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M4.5 12.75l6 6 9-13.5"
+                />
+              </svg>
+              <span className="text-green-600 dark:text-green-400">Copied</span>
+            </>
+          ) : (
+            <>
+              <svg
+                className="w-3.5 h-3.5"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+                strokeWidth={2}
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M13.19 8.688a4.5 4.5 0 011.242 7.244l-4.5 4.5a4.5 4.5 0 01-6.364-6.364l1.757-1.757m13.35-.622l1.757-1.757a4.5 4.5 0 00-6.364-6.364l-4.5 4.5a4.5 4.5 0 001.242 7.244"
+                />
+              </svg>
+              Copy link
+            </>
+          )}
+        </button>
+      )}
+
+      {error && <span className="text-[12px] text-red-500">{error}</span>}
+    </div>
+  );
+}

--- a/src/components/TestRunnerDialog.tsx
+++ b/src/components/TestRunnerDialog.tsx
@@ -16,6 +16,7 @@ import {
 } from "./test-results/shared";
 import { POLLING_INTERVAL_MS } from "@/constants/polling";
 import { useHideFloatingButton } from "@/components/AppLayout";
+import { ShareButton } from "@/components/ShareButton";
 
 type TestData = {
   uuid: string;
@@ -69,6 +70,7 @@ type TestCaseResult = {
 
 type TestRunStatusResponse = {
   task_id: string;
+  name?: string;
   status: string;
   total_tests?: number;
   passed?: number;
@@ -76,6 +78,8 @@ type TestRunStatusResponse = {
   results?: TestCaseResult[];
   results_s3_prefix?: string;
   error?: string;
+  is_public?: boolean;
+  share_token?: string | null;
 };
 
 type TestRunnerDialogProps = {
@@ -124,6 +128,9 @@ export function TestRunnerDialog({
     "queued" | "in_progress" | "done" | "failed"
   >("queued");
   const [currentTaskId, setCurrentTaskId] = useState<string | null>(null);
+  const [runName, setRunName] = useState<string | null>(null);
+  const [isPublic, setIsPublic] = useState(false);
+  const [shareToken, setShareToken] = useState<string | null>(null);
   const pollingIntervalRef = useRef<NodeJS.Timeout | null>(null);
 
   // Debug: Log when selectedTestUuid changes
@@ -153,6 +160,8 @@ export function TestRunnerDialog({
     // Initialize state for viewing existing run
     setSelectedTestUuid(null);
     setCurrentTaskId(taskId);
+    setIsPublic(false);
+    setShareToken(null);
 
     const isInProgress =
       initialRunStatus === "pending" ||
@@ -245,6 +254,11 @@ export function TestRunnerDialog({
             : (result.status as "queued" | "in_progress" | "done" | "failed"),
         );
       }
+
+      // Capture name and share state from backend
+      if (result.name) setRunName(result.name);
+      if (result.is_public !== undefined) setIsPublic(result.is_public);
+      if (result.share_token !== undefined) setShareToken(result.share_token ?? null);
 
       // Update test results based on polling response
       setTestResults((prev) => {
@@ -809,9 +823,12 @@ export function TestRunnerDialog({
       <div className="bg-background rounded-none md:rounded-xl w-full max-w-7xl h-full md:h-[85vh] flex flex-col shadow-2xl">
         {/* Header */}
         <div className="flex items-center justify-between px-4 md:px-6 py-3 md:py-4 border-b border-border">
-          <h2 className="text-base md:text-lg font-semibold text-foreground">
-            Test Status for {agentName}
-          </h2>
+          <div className="min-w-0">
+            <h2 className="text-base md:text-lg font-semibold text-foreground truncate">
+              {runName ?? "Test run"}
+            </h2>
+            <p className="text-xs text-muted-foreground truncate">{agentName}</p>
+          </div>
           <div className="flex items-center gap-3">
             {/* Passed/Failed counts - desktop only */}
             {!isOverallError &&
@@ -824,6 +841,18 @@ export function TestRunnerDialog({
                   />
                 </div>
               )}
+            {/* Share button — only shown when run is done and we have a taskId */}
+            {runStatus === "done" && (currentTaskId || taskId) && backendAccessToken && (
+              <div className="hidden md:block">
+                <ShareButton
+                  entityType="test-run"
+                  entityId={(currentTaskId || taskId)!}
+                  accessToken={backendAccessToken}
+                  initialIsPublic={isPublic}
+                  initialShareToken={shareToken}
+                />
+              </div>
+            )}
             <button
               onClick={onClose}
               className="flex items-center justify-center w-8 h-8 rounded-md hover:bg-muted transition-colors cursor-pointer"

--- a/src/components/simulation-tabs/SimulationRunsTab.tsx
+++ b/src/components/simulation-tabs/SimulationRunsTab.tsx
@@ -209,6 +209,10 @@ export function SimulationRunsTab({ simulationUuid }: SimulationRunsTabProps) {
         </button>
       </div>
 
+      <p className="text-sm text-muted-foreground mb-3">
+        {runs.length} {runs.length === 1 ? "run" : "runs"}
+      </p>
+
       {/* Desktop Table View */}
       <div className="hidden md:block border border-border rounded-xl overflow-hidden">
         {/* Table Header */}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -24,9 +24,10 @@ export default auth((req) => {
   const isAboutPage = req.nextUrl.pathname === "/about";
   const isTermsPage = req.nextUrl.pathname === "/terms";
   const isPrivacyPage = req.nextUrl.pathname === "/privacy";
+  const isPublicShareRoute = req.nextUrl.pathname.startsWith("/public/");
 
-  // Allow public pages: landing page, auth API, debug, docs, about, terms, privacy
-  if (isHomePage || isAuthRoute || isDebugRoute || isDocsRoute || isAboutPage || isTermsPage || isPrivacyPage) {
+  // Allow public pages: landing page, auth API, debug, docs, about, terms, privacy, public share links
+  if (isHomePage || isAuthRoute || isDebugRoute || isDocsRoute || isAboutPage || isTermsPage || isPrivacyPage || isPublicShareRoute) {
     return NextResponse.next();
   }
 


### PR DESCRIPTION
Fix #18 

## Summary

- **Public sharing** — share links for STT evals, TTS evals, simulation runs, test runs, and benchmarks accessible without login
- **LLM Evaluation page** — new Runs sub-tab showing all test/benchmark runs across agents with filtering by type, result, and agent
- **UI polish** — dialog headers, metric cards, column widths, theme toggle on public pages, tab state persistence

## What changed

### Public sharing
- `ShareButton` component: toggles `is_public` via PATCH visibility endpoint, shows styled Tooltip, copy-link button with improved dark mode coloring
- `PublicPageLayout`: minimal no-sidebar layout with hydration-safe auth header, dark/light theme toggle (reads saved Calibrate preference from `localStorage` or falls back to device setting), and a `pills` prop for header badges
- Public pages created under `/public/*` for all five entity types — bypass auth middleware, show `PublicNotFound` for non-`done` or 404 responses
- Public simulation transcript is pixel-identical to the authenticated view
- `ShareButton` integrated into STT/TTS detail pages, simulation run page, `TestRunnerDialog`, and `BenchmarkResultsDialog`

### LLM Evaluation page
- Two sub-tabs: **Tests** (existing list) and **Runs** (new)
- Runs tab fetches `GET /agent-tests/runs` across all agents, newest-first
- Filters: type (All / Tests / Benchmarks), result (All / All passed / All failed / Error), agent (custom styled dropdown matching `AgentPicker` visual style)
- Clicking a row opens `TestRunnerDialog` or `BenchmarkResultsDialog` in view-only mode (passes `taskId`)
- Active tab persisted in URL (`?tab=runs`) — same pattern as STT/TTS pages

### Dialog improvements
- `TestRunnerDialog` and `BenchmarkResultsDialog` headers now show the run **name** (e.g. "Run 3", "Benchmark 2") from the API response with agent name as a subtitle, replacing the generic "Test Status for X" / "Benchmark for X"

### Other polish
- STT and TTS pages now write `?tab=datasets` to URL on tab switch (were reading but not writing)
- Simulation run page metric items use card style (`border rounded-xl p-4 bg-muted/10`) matching the public page
- `SimulationRunsTab` shows run count above the table
- Simulation results count shown in both private and public run pages
- Public TTS page audio column uses `w-[50%]` matching the private page
- Public simulation run page: type badge moved to header pills, simulation count removed from badge row

## Test plan
- [ ] Share an STT/TTS eval, simulation run, test run, and benchmark — verify public link works without login
- [ ] Toggle public → private — verify public link returns 404/not-found state
- [ ] On public pages: verify theme toggle persists across reload and matches Calibrate app preference
- [ ] LLM Evaluation → Runs tab: verify runs appear, filters work, clicking opens correct dialog
- [ ] Reload `/tests?tab=runs`, `/stt?tab=datasets`, `/tts?tab=datasets` — verify correct tab restores
- [ ] Open a test run / benchmark from Runs tab — verify header shows run name + agent subtitle

🤖 Generated with [Claude Code](https://claude.com/claude-code)