### PR TITLE
Add audio playback to STT eval results and improve sidebar/layout

### DIFF
--- a/src/app/stt/[uuid]/page.tsx
+++ b/src/app/stt/[uuid]/page.tsx
@@ -589,7 +589,7 @@ export default function STTEvaluationDetailPage() {
 
                   {/* Leaderboard Tab */}
                   {activeTab === "leaderboard" && (
-                    <div className="space-y-4 md:space-y-6 -mx-4 md:-mx-8 px-4 md:px-8 w-[calc(100vw-32px)] md:w-[calc(100vw-260px)] ml-[calc((32px-100vw)/2+50%)] md:ml-[calc((260px-100vw)/2+50%)] relative">
+                    <div className="space-y-4 md:space-y-6 -mx-4 md:-mx-8 px-4 md:px-8 w-[calc(100vw-32px)] md:w-[calc(100vw-56px)] ml-[calc((32px-100vw)/2+50%)] md:ml-[calc((56px-100vw)/2+50%)] relative">
                       {evaluationResult.leaderboard_summary &&
                         evaluationResult.leaderboard_summary.length > 0 && (
                           <>

--- a/src/app/stt/[uuid]/page.tsx
+++ b/src/app/stt/[uuid]/page.tsx
@@ -31,6 +31,7 @@ type ProviderResult = {
   metrics: ProviderMetrics;
   results: Array<{
     id: string;
+    audio_url?: string;
     gt: string;
     pred: string;
     wer: string;
@@ -103,9 +104,10 @@ export default function STTEvaluationDetailPage() {
   const pollingIntervalRef = useRef<NodeJS.Timeout | null>(null);
   const tableContainerRef = useRef<HTMLDivElement | null>(null);
 
-  // Set page title
+  // Set page title and collapse main sidebar for more space
   useEffect(() => {
     document.title = "STT Evaluation | Calibrate";
+    setSidebarOpen(false);
   }, []);
 
   // Cleanup polling interval on unmount
@@ -679,7 +681,7 @@ export default function STTEvaluationDetailPage() {
                   {activeTab === "outputs" && (
                     <div className="flex flex-col md:flex-row border border-border rounded-xl overflow-hidden md:h-[calc(100vh-220px)]">
                       {/* Provider List - Horizontal scroll on mobile, vertical sidebar on desktop */}
-                      <div className="md:w-64 border-b md:border-b-0 md:border-r border-border flex flex-col overflow-hidden bg-muted/10">
+                      <div className="md:w-48 border-b md:border-b-0 md:border-r border-border flex flex-col overflow-hidden bg-muted/10">
                         <div className="overflow-x-auto md:overflow-x-visible md:overflow-y-auto md:flex-1 p-2">
                           <div className="flex md:flex-col gap-1 md:gap-1 min-w-max md:min-w-0">
                             {evaluationResult.provider_results!.map(
@@ -916,6 +918,10 @@ export default function STTEvaluationDetailPage() {
                                   const showMetrics =
                                     evaluationResult.status === "done" ||
                                     allRowsHaveMetrics;
+                                  const hasAudio =
+                                    providerResult.results.some(
+                                      (r) => !!r.audio_url,
+                                    );
 
                                   return (
                                     <>
@@ -928,36 +934,41 @@ export default function STTEvaluationDetailPage() {
                                           <table className="w-full table-fixed">
                                             <thead className="bg-muted/50 border-b border-border">
                                               <tr>
-                                                <th className="w-12 px-4 py-3 text-left text-[12px] font-medium text-foreground">
+                                                <th className="w-10 px-3 py-3 text-left text-[12px] font-medium text-foreground">
                                                   ID
                                                 </th>
+                                                {hasAudio && (
+                                                  <th className="w-[180px] px-3 py-3 text-left text-[12px] font-medium text-foreground">
+                                                    Audio
+                                                  </th>
+                                                )}
                                                 <th
                                                   className={`${
                                                     showMetrics
-                                                      ? "w-[30%]"
-                                                      : "w-[calc(50%-24px)]"
-                                                  } px-4 py-3 text-left text-[12px] font-medium text-foreground`}
+                                                      ? "w-[25%]"
+                                                      : "w-[calc(50%-20px)]"
+                                                  } px-3 py-3 text-left text-[12px] font-medium text-foreground`}
                                                 >
                                                   Ground Truth
                                                 </th>
                                                 <th
                                                   className={`${
                                                     showMetrics
-                                                      ? "w-[30%]"
-                                                      : "w-[calc(50%-24px)]"
-                                                  } px-4 py-3 text-left text-[12px] font-medium text-foreground`}
+                                                      ? "w-[25%]"
+                                                      : "w-[calc(50%-20px)]"
+                                                  } px-3 py-3 text-left text-[12px] font-medium text-foreground`}
                                                 >
                                                   Prediction
                                                 </th>
                                                 {showMetrics && (
                                                   <>
-                                                    <th className="px-4 py-3 text-left text-[12px] font-medium text-foreground">
+                                                    <th className="w-[72px] px-3 py-3 text-left text-[12px] font-medium text-foreground">
                                                       WER
                                                     </th>
-                                                    <th className="px-4 py-3 text-left text-[12px] font-medium text-foreground">
-                                                      String Similarity
+                                                    <th className="w-[100px] px-3 py-3 text-left text-[12px] font-medium text-foreground">
+                                                      Similarity
                                                     </th>
-                                                    <th className="px-4 py-3 text-left text-[12px] font-medium text-foreground">
+                                                    <th className="w-[90px] px-3 py-3 text-left text-[12px] font-medium text-foreground">
                                                       LLM Judge
                                                     </th>
                                                   </>
@@ -980,13 +991,27 @@ export default function STTEvaluationDetailPage() {
                                                           : ""
                                                       }`}
                                                     >
-                                                      <td className="px-4 py-3 text-[13px] text-foreground">
+                                                      <td className="px-3 py-3 text-[13px] text-foreground">
                                                         {index + 1}
                                                       </td>
-                                                      <td className="px-4 py-3 text-[13px] text-foreground break-words">
+                                                      {hasAudio && (
+                                                        <td className="px-3 py-3">
+                                                          {result.audio_url ? (
+                                                            <audio
+                                                              src={result.audio_url}
+                                                              controls
+                                                              preload="none"
+                                                              className="h-8 w-full max-w-[160px]"
+                                                            />
+                                                          ) : (
+                                                            <span className="text-[13px] text-muted-foreground">—</span>
+                                                          )}
+                                                        </td>
+                                                      )}
+                                                      <td className="px-3 py-3 text-[13px] text-foreground break-words">
                                                         {result.gt}
                                                       </td>
-                                                      <td className="px-4 py-3 text-[13px] break-words">
+                                                      <td className="px-3 py-3 text-[13px] break-words">
                                                         {isEmptyPrediction ? (
                                                           <span className="text-muted-foreground">
                                                             No transcript
@@ -1000,7 +1025,7 @@ export default function STTEvaluationDetailPage() {
                                                       </td>
                                                       {showMetrics && (
                                                         <>
-                                                          <td className="px-4 py-3 text-[13px] text-foreground">
+                                                          <td className="px-3 py-3 text-[13px] text-foreground">
                                                             {result.wer != null
                                                               ? parseFloat(
                                                                   parseFloat(
@@ -1009,7 +1034,7 @@ export default function STTEvaluationDetailPage() {
                                                                 )
                                                               : "-"}
                                                           </td>
-                                                          <td className="px-4 py-3 text-[13px] text-foreground">
+                                                          <td className="px-3 py-3 text-[13px] text-foreground">
                                                             {result.string_similarity !=
                                                             null
                                                               ? parseFloat(
@@ -1019,7 +1044,7 @@ export default function STTEvaluationDetailPage() {
                                                                 )
                                                               : "-"}
                                                           </td>
-                                                          <td className="px-4 py-3">
+                                                          <td className="px-3 py-3">
                                                             {(() => {
                                                               const scoreStr =
                                                                 String(
@@ -1138,6 +1163,21 @@ export default function STTEvaluationDetailPage() {
                                                       );
                                                     })()}
                                                 </div>
+                                                {result.audio_url && (
+                                                  <div>
+                                                    <span className="text-[11px] text-muted-foreground uppercase tracking-wide">
+                                                      Audio
+                                                    </span>
+                                                    <div className="mt-1">
+                                                      <audio
+                                                        src={result.audio_url}
+                                                        controls
+                                                        preload="none"
+                                                        className="w-full h-8"
+                                                      />
+                                                    </div>
+                                                  </div>
+                                                )}
                                                 <div>
                                                   <span className="text-[11px] text-muted-foreground uppercase tracking-wide">
                                                     Ground Truth

--- a/src/app/tts/[uuid]/page.tsx
+++ b/src/app/tts/[uuid]/page.tsx
@@ -506,7 +506,7 @@ export default function TTSEvaluationDetailPage() {
 
                   {/* Leaderboard Tab */}
                   {activeTab === "leaderboard" && (
-                    <div className="space-y-4 md:space-y-6 -mx-4 md:-mx-8 px-4 md:px-8 w-[calc(100vw-32px)] md:w-[calc(100vw-260px)] ml-[calc((32px-100vw)/2+50%)] md:ml-[calc((260px-100vw)/2+50%)] relative">
+                    <div className="space-y-4 md:space-y-6 -mx-4 md:-mx-8 px-4 md:px-8 w-[calc(100vw-32px)] md:w-[calc(100vw-56px)] ml-[calc((32px-100vw)/2+50%)] md:ml-[calc((56px-100vw)/2+50%)] relative">
                       {evaluationResult.leaderboard_summary &&
                         evaluationResult.leaderboard_summary.length > 0 && (
                           <>

--- a/src/app/tts/[uuid]/page.tsx
+++ b/src/app/tts/[uuid]/page.tsx
@@ -88,9 +88,10 @@ export default function TTSEvaluationDetailPage() {
   );
   const pollingIntervalRef = useRef<NodeJS.Timeout | null>(null);
 
-  // Set page title
+  // Set page title and collapse main sidebar for more space
   useEffect(() => {
     document.title = "TTS Evaluation | Calibrate";
+    setSidebarOpen(false);
   }, []);
 
   // Cleanup polling interval on unmount
@@ -580,7 +581,7 @@ export default function TTSEvaluationDetailPage() {
                   {activeTab === "outputs" && (
                     <div className="flex flex-col md:flex-row border border-border rounded-xl overflow-hidden md:h-[calc(100vh-220px)]">
                       {/* Provider List - Horizontal scroll on mobile, vertical sidebar on desktop */}
-                      <div className="md:w-64 border-b md:border-b-0 md:border-r border-border flex flex-col overflow-hidden bg-muted/10">
+                      <div className="md:w-48 border-b md:border-b-0 md:border-r border-border flex flex-col overflow-hidden bg-muted/10">
                         <div className="overflow-x-auto md:overflow-x-visible md:overflow-y-auto md:flex-1 p-2">
                           <div className="flex md:flex-col gap-1 md:gap-1 min-w-max md:min-w-0">
                             {evaluationResult.provider_results!.map(

--- a/src/components/AppLayout.tsx
+++ b/src/components/AppLayout.tsx
@@ -456,7 +456,7 @@ export function AppLayout({
           </div>
         </div>
 
-        {/* Navigation */}
+        {/* Navigation - Expanded */}
         {sidebarOpen && (
           <>
             <nav className="flex-1 overflow-y-auto py-4 px-3">
@@ -525,6 +525,49 @@ export function AppLayout({
               ))}
             </nav>
           </>
+        )}
+
+        {/* Navigation - Collapsed (icons only with tooltips) */}
+        {!sidebarOpen && (
+          <nav className="flex-1 py-4 px-2 overflow-visible">
+            {navSections.map((section, index) => (
+              <div key={section.title || index} className="mb-4">
+                {section.title && (
+                  <div className="h-px bg-border mx-1 mb-3" />
+                )}
+                <ul className="space-y-1">
+                  {section.items.map((item) => (
+                    <li key={item.id} className="relative group/tip">
+                      {item.id === "docs" ? (
+                        <a
+                          href={process.env.NEXT_PUBLIC_DOCS_URL}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="w-10 h-10 flex items-center justify-center rounded-md transition-colors cursor-pointer text-muted-foreground hover:bg-accent/50 hover:text-foreground"
+                        >
+                          {item.icon}
+                        </a>
+                      ) : (
+                        <Link
+                          href={`/${item.id}`}
+                          className={`w-10 h-10 flex items-center justify-center rounded-md transition-colors cursor-pointer ${
+                            activeItem === item.id
+                              ? "bg-accent text-accent-foreground"
+                              : "text-muted-foreground hover:bg-accent/50 hover:text-foreground"
+                          }`}
+                        >
+                          {item.icon}
+                        </Link>
+                      )}
+                      <div className="fixed ml-[3.5rem] -mt-9 px-2 py-1.5 rounded-md text-xs font-medium bg-popover text-popover-foreground border border-border shadow-md whitespace-nowrap opacity-0 pointer-events-none group-hover/tip:opacity-100 transition-opacity z-[9999]">
+                        {item.label}
+                      </div>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            ))}
+          </nav>
         )}
       </aside>
 

--- a/src/components/AppLayout.tsx
+++ b/src/components/AppLayout.tsx
@@ -543,6 +543,7 @@ export function AppLayout({
                           href={process.env.NEXT_PUBLIC_DOCS_URL}
                           target="_blank"
                           rel="noopener noreferrer"
+                          aria-label={item.label}
                           className="w-10 h-10 flex items-center justify-center rounded-md transition-colors cursor-pointer text-muted-foreground hover:bg-accent/50 hover:text-foreground"
                         >
                           {item.icon}
@@ -550,6 +551,7 @@ export function AppLayout({
                       ) : (
                         <Link
                           href={`/${item.id}`}
+                          aria-label={item.label}
                           className={`w-10 h-10 flex items-center justify-center rounded-md transition-colors cursor-pointer ${
                             activeItem === item.id
                               ? "bg-accent text-accent-foreground"


### PR DESCRIPTION
Fix #31 

## Summary

- **STT audio playback**: Each result row in the STT eval detail table now shows an inline `<audio>` player when the API returns `audio_url` per result. Works in both desktop table and mobile card layouts. Column only renders when audio data is present.
- **Auto-collapse sidebar on eval pages**: Main sidebar automatically closes when opening STT or TTS eval detail pages, giving the results table more horizontal space.
- **Collapsed sidebar icons with tooltips**: When the sidebar is collapsed, navigation icons are now visible and clickable. Hovering shows a tooltip with the full label (e.g., "Speech-to-Text", "Agents").
- **Narrower provider sidebar**: Provider list panel reduced from 256px to 192px in both STT and TTS eval detail pages.
- **Tighter STT table columns**: Ground Truth and Prediction reduced from 30% to 25% width. Metric columns (WER, Similarity, LLM Judge) now have explicit widths. Cell padding reduced from `px-4` to `px-3`.

## Test plan

- [ ] Open an STT eval detail page — sidebar should auto-collapse
- [ ] Hover over collapsed sidebar icons — tooltips should appear to the right
- [ ] Click collapsed sidebar icons — should navigate correctly
- [ ] Open an STT eval with audio — Audio column with players should appear between ID and Ground Truth
- [ ] Open an STT eval without audio — no Audio column should appear
- [ ] Check mobile card view for STT eval with audio
- [ ] Open a TTS eval detail page — sidebar should auto-collapse, provider panel should be narrower
- [ ] Verify metric columns (WER, Similarity, LLM Judge) are no longer squished

🤖 Generated with [Claude Code](https://claude.com/claude-code)