### PR TITLE
Extract shared eval components, add filters, fix share button sync

### DIFF
--- a/src/app/public/benchmark/[token]/page.tsx
+++ b/src/app/public/benchmark/[token]/page.tsx
@@ -2,34 +2,9 @@
 
 import React, { useState, useEffect } from "react";
 import { useParams } from "next/navigation";
-import {
-  TestCaseOutput,
-  TestCaseData,
-  StatusIcon,
-  TestDetailView,
-  EvaluationCriteriaPanel,
-} from "@/components/test-results/shared";
-import { LeaderboardBarChart, getColorMap } from "@/components/charts/LeaderboardBarChart";
-import { DownloadableTable } from "@/components/DownloadableTable";
 import { PublicPageLayout, PublicNotFound, PublicLoading } from "@/components/PublicPageLayout";
-
-type BenchmarkTestResult = {
-  name?: string;
-  passed: boolean | null;
-  reasoning?: string;
-  output?: TestCaseOutput;
-  test_case?: TestCaseData;
-};
-
-type ModelResult = {
-  model: string;
-  success: boolean | null;
-  message: string;
-  total_tests: number | null;
-  passed: number | null;
-  failed: number | null;
-  test_results: BenchmarkTestResult[] | null;
-};
+import { LeaderboardTab, BenchmarkOutputsPanel } from "@/components/eval-details";
+import type { BenchmarkTestResult, BenchmarkModelResult } from "@/components/eval-details";
 
 type LeaderboardSummary = {
   model: string;
@@ -41,7 +16,7 @@ type LeaderboardSummary = {
 type BenchmarkStatusResponse = {
   task_id: string;
   status: string;
-  model_results?: ModelResult[];
+  model_results?: BenchmarkModelResult[];
   leaderboard_summary?: LeaderboardSummary[];
   error?: string;
 };
@@ -76,7 +51,6 @@ export default function PublicBenchmarkPage() {
         if (result.status !== "done" && result.status !== "completed") { setNotFound(true); return; }
 
         setData(result);
-        // Auto-expand first model
         if (result.model_results?.length) {
           setExpandedModels(new Set([result.model_results[0].model]));
         }
@@ -101,11 +75,6 @@ export default function PublicBenchmarkPage() {
     });
   };
 
-  const selectedModelResult = selectedTest
-    ? data.model_results?.find((m) => m.model === selectedTest.model)
-    : null;
-  const selectedTestResult = selectedModelResult?.test_results?.[selectedTest?.testIndex ?? -1] ?? null;
-
   return (
     <PublicPageLayout title="LLM benchmark">
       <div className="space-y-4 md:space-y-6">
@@ -123,123 +92,35 @@ export default function PublicBenchmarkPage() {
         </div>
 
         {/* Leaderboard Tab */}
-        {activeTab === "leaderboard" && data.leaderboard_summary && data.leaderboard_summary.length > 0 && (
-          <div className="space-y-4 md:space-y-6">
-            <DownloadableTable
-              columns={[
-                { key: "model", header: "Model" },
-                { key: "passed", header: "Passed" },
-                { key: "total", header: "Total" },
-                {
-                  key: "pass_rate",
-                  header: "Test pass rate (%)",
-                  render: (v) => `${parseFloat(v).toFixed(1)}%`,
-                },
-              ]}
-              data={data.leaderboard_summary}
-              filename="benchmark-leaderboard"
-            />
-            {(() => {
-              const models = data.leaderboard_summary!.map((s) => s.model);
-              const colorMap = getColorMap(models);
-              return (
-                <LeaderboardBarChart
-                  title="Pass Rate by Model"
-                  data={data.leaderboard_summary!.map((s) => ({
-                    label: s.model,
-                    value: parseFloat(s.pass_rate),
-                    colorKey: s.model,
-                  }))}
-                  colorMap={colorMap}
-                  yDomain={[0, 100]}
-                  formatTooltip={(value) => `${value.toFixed(1)}%`}
-                />
-              );
-            })()}
-          </div>
+        {activeTab === "leaderboard" && data.leaderboard_summary && (
+          <LeaderboardTab
+            columns={[
+              { key: "model", header: "Model" },
+              { key: "passed", header: "Passed" },
+              { key: "total", header: "Total" },
+              { key: "pass_rate", header: "Test pass rate (%)", render: (v) => `${parseFloat(v).toFixed(1)}%` },
+            ]}
+            data={data.leaderboard_summary}
+            charts={[[{ title: "Pass Rate by Model", dataKey: "pass_rate", yDomain: [0, 100], formatTooltip: (v) => `${v.toFixed(1)}%` }]]}
+            filename="benchmark-leaderboard"
+            getLabel={(key) => key}
+            nameKey="model"
+          />
         )}
 
         {/* Outputs Tab */}
         {activeTab === "outputs" && data.model_results && data.model_results.length > 0 && (
-          <div className="flex border border-border rounded-xl overflow-hidden" style={{ height: "calc(100vh - 260px)", minHeight: 520 }}>
-            {/* Left — model list + test list */}
-            <div className="w-72 shrink-0 border-r border-border flex flex-col overflow-hidden bg-muted/10">
-              <div className="overflow-y-auto flex-1">
-                {data.model_results.map((mr) => {
-                  const isExpanded = expandedModels.has(mr.model);
-                  const passRate = mr.total_tests && mr.passed != null
-                    ? `${mr.passed}/${mr.total_tests}`
-                    : null;
-                  return (
-                    <div key={mr.model} className="border-b border-border last:border-b-0">
-                      {/* Model row */}
-                      <button
-                        type="button"
-                        onClick={() => toggleModel(mr.model)}
-                        className="w-full px-4 py-3 flex items-center justify-between hover:bg-muted/50 transition-colors cursor-pointer"
-                      >
-                        <div className="flex items-center gap-2 min-w-0">
-                          <svg className={`w-4 h-4 text-muted-foreground shrink-0 transition-transform ${isExpanded ? "rotate-90" : ""}`} fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-                            <path strokeLinecap="round" strokeLinejoin="round" d="M8.25 4.5l7.5 7.5-7.5 7.5" />
-                          </svg>
-                          <span className="text-[13px] font-medium text-foreground truncate">{mr.model}</span>
-                        </div>
-                        {passRate && (
-                          <span className="text-[12px] text-muted-foreground shrink-0 ml-2">{passRate}</span>
-                        )}
-                      </button>
-
-                      {/* Tests within this model */}
-                      {isExpanded && mr.test_results && (
-                        <div className="px-2 pb-2 space-y-0.5">
-                          {mr.test_results.map((tr, ti) => {
-                            const isSelected = selectedTest?.model === mr.model && selectedTest.testIndex === ti;
-                            const testStatus = tr.passed === true ? "passed" : tr.passed === false ? "failed" : "running";
-                            const name = tr.name || tr.test_case?.name || `Test ${ti + 1}`;
-                            return (
-                              <button
-                                key={ti}
-                                type="button"
-                                onClick={() => setSelectedTest({ model: mr.model, testIndex: ti })}
-                                className={`w-full flex items-center gap-2 px-3 py-2 rounded-lg cursor-pointer transition-colors text-left ${isSelected ? "bg-muted" : "hover:bg-muted/50"}`}
-                              >
-                                <StatusIcon status={testStatus} />
-                                <span className="text-[13px] text-foreground truncate">{name}</span>
-                              </button>
-                            );
-                          })}
-                        </div>
-                      )}
-                    </div>
-                  );
-                })}
-              </div>
-            </div>
-
-            {/* Right — test detail */}
-            <div className="flex-1 overflow-y-auto">
-              {selectedTestResult ? (
-                <div className="flex h-full">
-                  <div className="flex-1 overflow-y-auto p-4 md:p-6">
-                    <TestDetailView
-                      history={selectedTestResult.test_case?.history || []}
-                      output={selectedTestResult.output}
-                      passed={selectedTestResult.passed ?? false}
-                      reasoning={selectedTestResult.reasoning}
-                    />
-                  </div>
-                  {selectedTestResult.test_case?.evaluation && (
-                    <div className="w-72 shrink-0 border-l border-border overflow-y-auto">
-                      <EvaluationCriteriaPanel evaluation={selectedTestResult.test_case.evaluation} />
-                    </div>
-                  )}
-                </div>
-              ) : (
-                <div className="flex items-center justify-center h-full">
-                  <p className="text-[13px] text-muted-foreground">Select a test to view details</p>
-                </div>
-              )}
-            </div>
+          <div className="border border-border rounded-xl overflow-hidden" style={{ height: "calc(100vh - 260px)", minHeight: 520 }}>
+            <BenchmarkOutputsPanel
+              modelResults={data.model_results}
+              expandedModels={expandedModels}
+              onToggleModel={toggleModel}
+              onSetExpandedModels={setExpandedModels}
+              selectedTest={selectedTest}
+              onSelectTest={(model, testIndex) => setSelectedTest({ model, testIndex })}
+              onClearSelection={() => setSelectedTest(null)}
+              showControls={true}
+            />
           </div>
         )}
       </div>

--- a/src/app/public/simulation-run/[token]/page.tsx
+++ b/src/app/public/simulation-run/[token]/page.tsx
@@ -2,25 +2,14 @@
 
 import React, { useState, useEffect } from "react";
 import { useParams } from "next/navigation";
-import { Tooltip } from "@/components/Tooltip";
 import { PublicPageLayout, PublicNotFound, PublicLoading } from "@/components/PublicPageLayout";
-
-type MetricData = { mean: number; std: number; values: number[] };
-type Persona = { label: string; characteristics: string; gender: string; language: string };
-type Scenario = { name: string; description: string };
-type EvaluationResult = { name: string; value: number; reasoning: string };
-type TranscriptEntry = { role: string; content?: string; tool_calls?: any[] | null; tool_call_id?: string };
-
-type SimulationResult = {
-  simulation_name: string;
-  aborted?: boolean;
-  persona: Persona;
-  scenario: Scenario;
-  evaluation_results: EvaluationResult[] | null;
-  transcript?: TranscriptEntry[] | null;
-  audio_urls?: string[];
-  conversation_wav_url?: string;
-};
+import {
+  SimulationMetricsGrid,
+  SimulationResultsTable,
+  SimulationTranscriptDialog,
+  LATENCY_KEYS,
+} from "@/components/eval-details";
+import type { MetricData, SimulationResult } from "@/components/eval-details";
 
 type RunData = {
   task_id: string;
@@ -29,56 +18,9 @@ type RunData = {
   type: "text" | "voice";
   updated_at: string;
   total_simulations: number;
-  metrics: {
-    tool_calls?: MetricData;
-    answer_completeness?: MetricData;
-    assistant_behavior?: MetricData;
-    question_completeness?: MetricData;
-    [key: string]: MetricData | undefined;
-  } | null;
+  metrics: Record<string, MetricData | undefined> | null;
   simulation_results: SimulationResult[];
   error: string | null;
-};
-
-const LATENCY_KEYS = ["stt/ttft", "llm/ttft", "tts/ttft", "stt/processing_time", "llm/processing_time", "tts/processing_time"];
-
-function getAudioUrlForEntry(
-  entry: TranscriptEntry,
-  entryIndex: number,
-  audioUrls: string[] | undefined,
-  filteredTranscript: TranscriptEntry[],
-  runType: "text" | "voice",
-): string | null {
-  if (!audioUrls || runType !== "voice") return null;
-  if (entry.role === "tool" || entry.tool_calls) return null;
-
-  let userCount = 0;
-  let assistantCount = 0;
-  for (let i = 0; i < entryIndex; i++) {
-    const msg = filteredTranscript[i];
-    if (msg?.role === "user") userCount++;
-    else if (msg?.role === "assistant" && !msg.tool_calls) assistantCount++;
-  }
-
-  let audioPattern: string;
-  if (entry.role === "user") audioPattern = `${userCount + 1}_user.wav`;
-  else if (entry.role === "assistant") audioPattern = `${assistantCount + 1}_bot.wav`;
-  else return null;
-
-  return audioUrls.find((url) => url.includes(audioPattern)) ?? null;
-}
-
-const getEvaluationResult = (sim: SimulationResult, key: string): number | null => {
-  if (!sim.evaluation_results) return null;
-  const mapped = key === "stt_llm_judge" ? "stt_llm_judge_score" : key;
-  const found = sim.evaluation_results.find((r) => r.name === key || r.name === mapped);
-  return found ? found.value : null;
-};
-
-const getEvaluationReasoning = (sim: SimulationResult, key: string): string | null => {
-  if (!sim.evaluation_results) return null;
-  const found = sim.evaluation_results.find((r) => r.name === key);
-  return found?.reasoning ?? null;
 };
 
 export default function PublicSimulationRunPage() {
@@ -88,7 +30,6 @@ export default function PublicSimulationRunPage() {
   const [data, setData] = useState<RunData | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [notFound, setNotFound] = useState(false);
-  const [activeMetricsTab, setActiveMetricsTab] = useState<"performance" | "latency">("performance");
   const [selectedSim, setSelectedSim] = useState<SimulationResult | null>(null);
 
   useEffect(() => {
@@ -124,29 +65,15 @@ export default function PublicSimulationRunPage() {
   if (isLoading) return <PublicPageLayout><PublicLoading /></PublicPageLayout>;
   if (notFound || !data) return <PublicPageLayout><PublicNotFound /></PublicPageLayout>;
 
-  const isTextType = data.type === "text";
-
-  // Separate regular vs latency metrics
-  const regularMetrics: Array<[string, MetricData]> = [];
-  const latencyMetrics: Array<[string, MetricData]> = [];
-  if (data.metrics) {
-    Object.entries(data.metrics).forEach(([key, metric]) => {
-      if (!metric) return;
-      if (LATENCY_KEYS.includes(key)) latencyMetrics.push([key, metric]);
-      else regularMetrics.push([key, metric]);
-    });
-  }
-
-  // Derive metric keys for table columns
-  const latencyMetricKeys = LATENCY_KEYS;
+  // Derive metric keys for table columns (exclude latency keys)
   let displayMetricKeys: string[] = [];
   if (data.metrics) {
-    displayMetricKeys = Object.keys(data.metrics).filter((k) => !latencyMetricKeys.includes(k));
+    displayMetricKeys = Object.keys(data.metrics).filter((k) => !LATENCY_KEYS.includes(k));
   } else {
     const metricSet = new Set<string>();
     data.simulation_results.forEach((sim) => {
       sim.evaluation_results?.forEach((r) => {
-        if (!latencyMetricKeys.includes(r.name)) metricSet.add(r.name);
+        if (!LATENCY_KEYS.includes(r.name)) metricSet.add(r.name);
       });
     });
     displayMetricKeys = Array.from(metricSet);
@@ -162,333 +89,23 @@ export default function PublicSimulationRunPage() {
       }
     >
       <div className="space-y-6 md:space-y-8">
+        <SimulationMetricsGrid metrics={data.metrics} type={data.type} />
 
-        {/* Overall Metrics */}
-        {data.metrics && (regularMetrics.length > 0 || latencyMetrics.length > 0) && (
-          <div>
-            <h2 className="text-base md:text-lg font-semibold mb-3">Overall Metrics</h2>
-            {!isTextType && (
-              <div className="flex gap-2 border-b border-border mb-4">
-                <button onClick={() => setActiveMetricsTab("performance")} className={`px-4 py-2 text-[13px] font-medium border-b-2 transition-colors cursor-pointer ${activeMetricsTab === "performance" ? "border-foreground text-foreground" : "border-transparent text-muted-foreground hover:text-foreground"}`}>Performance</button>
-                <button onClick={() => setActiveMetricsTab("latency")} className={`px-4 py-2 text-[13px] font-medium border-b-2 transition-colors cursor-pointer ${activeMetricsTab === "latency" ? "border-foreground text-foreground" : "border-transparent text-muted-foreground hover:text-foreground"}`}>Latency</button>
-              </div>
-            )}
-            {(isTextType || activeMetricsTab === "performance") && regularMetrics.length > 0 && (
-              <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-                {regularMetrics.map(([key, metric]) => (
-                  <div key={key} className="border border-border rounded-xl p-4 bg-muted/10">
-                    <div className="text-[12px] text-muted-foreground mb-1">{key}</div>
-                    <div className="text-[18px] font-semibold text-foreground">{Math.round(metric.mean * 100)}%</div>
-                  </div>
-                ))}
-              </div>
-            )}
-            {!isTextType && activeMetricsTab === "latency" && latencyMetrics.length > 0 && (
-              <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-                {latencyMetrics.map(([key, metric]) => (
-                  <div key={key} className="border border-border rounded-xl p-4 bg-muted/10">
-                    <div className="text-[12px] text-muted-foreground mb-1">{key}</div>
-                    <div className="text-[18px] font-semibold text-foreground">
-                      {metric.mean < 1 ? `${(metric.mean * 1000).toFixed(0)}ms` : `${metric.mean.toFixed(2)}s`}
-                    </div>
-                  </div>
-                ))}
-              </div>
-            )}
-          </div>
-        )}
-
-        {/* Simulation Results Table */}
         {data.simulation_results.length > 0 && (
-          <div>
-            <div className="flex items-baseline gap-3 mb-3 md:mb-4">
-              <h2 className="hidden md:block text-base md:text-lg font-semibold">
-                Simulation Results
-              </h2>
-              <p className="text-sm text-muted-foreground">
-                {data.simulation_results.length}{" "}
-                {data.simulation_results.length === 1 ? "simulation" : "simulations"}
-              </p>
-            </div>
-            <div className="border border-border rounded-xl overflow-hidden">
-              <div className="overflow-x-auto">
-                <table className="w-full">
-                  <thead className="bg-muted/50 border-b border-border">
-                    <tr>
-                      <th className="w-10 px-4 py-3 text-left text-[12px] font-medium text-muted-foreground"></th>
-                      <th className="px-4 py-3 text-left text-[12px] font-medium text-muted-foreground uppercase tracking-wider">Persona</th>
-                      <th className="px-4 py-3 text-left text-[12px] font-medium text-muted-foreground uppercase tracking-wider">Scenario</th>
-                      {displayMetricKeys.map((k) => (
-                        <th key={k} className="px-4 py-3 text-left text-[12px] font-medium text-muted-foreground tracking-wider whitespace-nowrap">{k}</th>
-                      ))}
-                    </tr>
-                  </thead>
-                  <tbody className="divide-y divide-border">
-                    {data.simulation_results.map((sim, i) => (
-                      <tr key={i} className="hover:bg-muted/30 transition-colors">
-                        <td className="px-4 py-4">
-                          {(sim.transcript?.length ?? 0) > 0 && (
-                            <button
-                              onClick={() => setSelectedSim(sim)}
-                              className="flex items-center justify-center w-6 h-6 cursor-pointer hover:text-foreground text-muted-foreground transition-colors"
-                              title="View transcript"
-                            >
-                              <svg className={`w-4 h-4 ${sim.aborted ? "text-red-500" : ""}`} fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-                                <path strokeLinecap="round" strokeLinejoin="round" d="M5.25 5.653c0-.856.917-1.398 1.667-.986l11.54 6.348a1.125 1.125 0 010 1.971l-11.54 6.347a1.125 1.125 0 01-1.667-.986V5.653z" />
-                              </svg>
-                            </button>
-                          )}
-                        </td>
-                        <td className="px-4 py-4 text-[13px] text-foreground whitespace-nowrap">{sim.persona.label}</td>
-                        <td className="px-4 py-4 text-[13px] text-foreground whitespace-nowrap">{sim.scenario.name}</td>
-                        {displayMetricKeys.map((key) => {
-                          const val = getEvaluationResult(sim, key);
-                          const reasoning = getEvaluationReasoning(sim, key);
-                          if (val === null) return (
-                            <td key={key} className="px-4 py-4">
-                              {sim.aborted ? <span className="text-xs text-muted-foreground">N/A</span> : <span className="text-xs text-muted-foreground">—</span>}
-                            </td>
-                          );
-                          const isPass = val === 1;
-                          return (
-                            <td key={key} className="px-4 py-4">
-                              <div className="flex items-center gap-1.5">
-                                <span className={`inline-flex items-center px-2.5 py-1 rounded-md text-xs font-medium ${isPass ? "bg-green-100 text-green-700 dark:bg-green-500/20 dark:text-green-400" : "bg-red-100 text-red-700 dark:bg-red-500/20 dark:text-red-400"}`}>
-                                  {isPass ? "Pass" : "Fail"}
-                                </span>
-                                {reasoning && (
-                                  <Tooltip content={reasoning}>
-                                    <button type="button" className="p-1 rounded-md hover:bg-muted transition-colors cursor-pointer">
-                                      <svg className="w-3.5 h-3.5 text-muted-foreground" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-                                        <path strokeLinecap="round" strokeLinejoin="round" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
-                                      </svg>
-                                    </button>
-                                  </Tooltip>
-                                )}
-                              </div>
-                            </td>
-                          );
-                        })}
-                      </tr>
-                    ))}
-                  </tbody>
-                </table>
-              </div>
-            </div>
-          </div>
+          <SimulationResultsTable
+            simulations={data.simulation_results}
+            metricKeys={displayMetricKeys}
+            onSelectSimulation={setSelectedSim}
+          />
         )}
       </div>
 
-      {/* Transcript Dialog — identical to creator view */}
       {selectedSim && (
-        <div className="fixed inset-0 z-50 flex justify-end">
-          {/* Backdrop */}
-          <div className="absolute inset-0 bg-black/50 backdrop-blur-sm" onClick={() => setSelectedSim(null)} />
-          {/* Sidebar - full width on mobile, 40% on desktop */}
-          <div className="relative w-full md:w-[40%] md:min-w-[500px] bg-background border-l border-border flex flex-col h-full shadow-2xl">
-            {/* Header */}
-            <div className="flex items-center justify-between px-4 md:px-6 py-4">
-              <div className="flex items-center gap-3">
-                <svg className="w-5 h-5 text-muted-foreground" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
-                  <path strokeLinecap="round" strokeLinejoin="round" d="M8.625 12a.375.375 0 11-.75 0 .375.375 0 01.75 0zm0 0H8.25m4.125 0a.375.375 0 11-.75 0 .375.375 0 01.75 0zm0 0H12m4.125 0a.375.375 0 11-.75 0 .375.375 0 01.75 0zm0 0h-.375M21 12c0 4.556-4.03 8.25-9 8.25a9.764 9.764 0 01-2.555-.337A5.972 5.972 0 015.41 20.97a5.969 5.969 0 01-.474-.065 4.48 4.48 0 00.978-2.025c.09-.457-.133-.901-.467-1.226C3.93 16.178 3 14.189 3 12c0-4.556 4.03-8.25 9-8.25s9 3.694 9 8.25z" />
-                </svg>
-                <h2 className="text-base md:text-lg font-semibold">Transcript</h2>
-              </div>
-              <button onClick={() => setSelectedSim(null)} className="flex items-center justify-center w-8 h-8 rounded-md hover:bg-muted transition-colors cursor-pointer">
-                <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-                  <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
-                </svg>
-              </button>
-            </div>
-
-            {/* Full Conversation Audio Player */}
-            {selectedSim.conversation_wav_url && (
-              <div className="px-4 md:px-6 pb-4 border-b border-border">
-                <div className="flex items-center gap-2 mb-2">
-                  <span className="text-sm font-medium text-foreground">Hear the full conversation</span>
-                </div>
-                <audio key={selectedSim.conversation_wav_url} controls className="w-full h-10" src={selectedSim.conversation_wav_url}>
-                  Your browser does not support the audio element.
-                </audio>
-              </div>
-            )}
-
-            {/* Transcript content */}
-            <div className="flex-1 overflow-y-auto p-4 md:p-6">
-              <div className="space-y-4">
-                {(() => {
-                  const fullTranscript = selectedSim.transcript ?? [];
-                  const filteredTranscript = fullTranscript.filter((entry) => {
-                    if (entry.role === "end_reason") return false;
-                    if (entry.role === "tool") {
-                      try {
-                        const parsed = JSON.parse(entry.content || "");
-                        return parsed?.type === "webhook_response";
-                      } catch { return false; }
-                    }
-                    return true;
-                  });
-                  const lastEntry = fullTranscript[fullTranscript.length - 1];
-                  const endedDueToMaxTurns = lastEntry?.role === "end_reason" && lastEntry?.content === "max_turns";
-
-                  if (filteredTranscript.length === 0) {
-                    return (
-                      <div className="flex items-center justify-center py-8">
-                        <p className="text-sm text-muted-foreground">No transcript available yet</p>
-                      </div>
-                    );
-                  }
-
-                  return filteredTranscript.map((entry, index) => {
-                    const audioUrl = getAudioUrlForEntry(entry, index, selectedSim.audio_urls, filteredTranscript, data!.type);
-                    return (
-                      <div key={index} className={`space-y-2 ${entry.role === "user" ? "flex flex-col items-end" : ""}`}>
-                        {/* Agent header */}
-                        {entry.role === "assistant" && (
-                          <div className="flex items-center gap-2">
-                            <span className="text-sm font-medium text-foreground">
-                              {entry.tool_calls ? "Agent Tool Call" : "Agent"}
-                            </span>
-                          </div>
-                        )}
-
-                        {/* Per-message audio */}
-                        {audioUrl && (
-                          <div className="w-full md:w-1/2">
-                            <audio key={audioUrl} controls className="w-full h-8 mb-2" src={audioUrl}>
-                              Your browser does not support the audio element.
-                            </audio>
-                          </div>
-                        )}
-
-                        {/* User message */}
-                        {entry.role === "user" && entry.content && (
-                          <div className="w-full md:w-1/2">
-                            <div className="px-4 py-3 rounded-xl text-sm text-foreground bg-muted border border-border whitespace-pre-wrap">
-                              {entry.content}
-                            </div>
-                          </div>
-                        )}
-
-                        {/* Assistant text response */}
-                        {entry.role === "assistant" && entry.content && !entry.tool_calls && (
-                          <div className="w-full md:w-1/2">
-                            <div className="px-4 py-3 rounded-xl text-sm text-foreground bg-accent border border-border whitespace-pre-wrap">
-                              {entry.content}
-                            </div>
-                          </div>
-                        )}
-
-                        {/* Tool calls */}
-                        {entry.role === "assistant" && entry.tool_calls && (
-                          <div className="w-full md:w-1/2">
-                            {entry.tool_calls.map((toolCall: any, toolIndex: number) => {
-                              let parsedArgs: Record<string, any> = {};
-                              try { parsedArgs = JSON.parse(toolCall.function.arguments); } catch { parsedArgs = {}; }
-                              const formatValue = (val: any): string => {
-                                if (val === null) return "null";
-                                if (val === undefined) return "undefined";
-                                if (typeof val === "object") { try { return JSON.stringify(val, null, 2); } catch { return String(val); } }
-                                return String(val);
-                              };
-                              return (
-                                <div key={toolIndex} className="bg-muted border border-border rounded-2xl p-4 mb-2">
-                                  <div className="flex items-center gap-2 mb-2">
-                                    <svg className="w-4 h-4 text-muted-foreground" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
-                                      <path strokeLinecap="round" strokeLinejoin="round" d="M11.42 15.17L17.25 21A2.652 2.652 0 0021 17.25l-5.877-5.877M11.42 15.17l2.496-3.03c.317-.384.74-.626 1.208-.766M11.42 15.17l-4.655 5.653a2.548 2.548 0 11-3.586-3.586l6.837-5.63m5.108-.233c.55-.164 1.163-.188 1.743-.14a4.5 4.5 0 004.486-6.336l-3.276 3.277a3.004 3.004 0 01-2.25-2.25l3.276-3.276a4.5 4.5 0 00-6.336 4.486c.091 1.076-.071 2.264-.904 2.95l-.102.085m-1.745 1.437L5.909 7.5H4.5L2.25 3.75l1.5-1.5L7.5 4.5v1.409l4.26 4.26m-1.745 1.437l1.745-1.437m6.615 8.206L15.75 15.75M4.867 19.125h.008v.008h-.008v-.008z" />
-                                    </svg>
-                                    <span className="text-sm font-medium text-foreground">{toolCall.function.name}</span>
-                                  </div>
-                                  {Object.keys(parsedArgs).filter((k) => k !== "headers").length > 0 && (
-                                    <div className="space-y-3 mt-3">
-                                      {Object.entries(parsedArgs).filter(([key]) => key !== "headers").map(([key, value], paramIndex) => {
-                                        const displayValue = formatValue(value);
-                                        const isMultiLine = displayValue.includes("\n");
-                                        return (
-                                          <div key={paramIndex}>
-                                            <label className="block text-sm font-medium text-foreground mb-1.5">{key}</label>
-                                            <div className={`px-3 py-2 bg-background border border-border rounded-lg text-sm text-muted-foreground whitespace-pre-wrap break-all ${isMultiLine ? "font-mono text-xs" : ""}`}>
-                                              {displayValue}
-                                            </div>
-                                          </div>
-                                        );
-                                      })}
-                                    </div>
-                                  )}
-                                </div>
-                              );
-                            })}
-                          </div>
-                        )}
-
-                        {/* Webhook response */}
-                        {entry.role === "tool" && entry.content && (() => {
-                          let parsed: any = null;
-                          try { parsed = JSON.parse(entry.content); } catch { return null; }
-                          if (parsed?.type !== "webhook_response") return null;
-                          const response = parsed.response;
-                          if (!response || typeof response !== "object") return null;
-                          const isError = parsed.status === "error";
-                          const jsonString = JSON.stringify(response, null, 2);
-                          return (
-                            <div className="w-full md:w-1/2">
-                              <div className="flex items-center gap-2 mb-2">
-                                {isError ? (
-                                  <>
-                                    <svg className="w-4 h-4 text-red-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-                                      <path strokeLinecap="round" strokeLinejoin="round" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
-                                    </svg>
-                                    <span className="text-sm font-medium text-red-500">Tool Response Error</span>
-                                  </>
-                                ) : (
-                                  <span className="text-sm font-medium text-foreground">Agent Tool Response</span>
-                                )}
-                              </div>
-                              <div className={`bg-muted rounded-2xl p-4 border ${isError ? "border-red-500" : "border-border"}`}>
-                                <pre className={`text-sm font-mono whitespace-pre-wrap break-all ${isError ? "text-red-400" : "text-foreground"}`}>{jsonString}</pre>
-                              </div>
-                            </div>
-                          );
-                        })()}
-                      </div>
-                    );
-                  });
-                })()}
-
-                {/* Max turns notice */}
-                {(() => {
-                  const fullTranscript = selectedSim.transcript ?? [];
-                  const lastEntry = fullTranscript[fullTranscript.length - 1];
-                  if (lastEntry?.role === "end_reason" && lastEntry?.content === "max_turns") {
-                    return (
-                      <div className="flex items-center justify-center py-4 mt-2">
-                        <div className="flex items-center gap-2 px-4 py-2 rounded-lg bg-yellow-500/10 border border-yellow-500/30">
-                          <svg className="w-4 h-4 text-yellow-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-                            <path strokeLinecap="round" strokeLinejoin="round" d="M12 9v3.75m9-.75a9 9 0 11-18 0 9 9 0 0118 0zm-9 3.75h.008v.008H12v-.008z" />
-                          </svg>
-                          <span className="text-sm text-yellow-500">Maximum number of assistant turns reached</span>
-                        </div>
-                      </div>
-                    );
-                  }
-                  return null;
-                })()}
-
-                {/* Aborted notice */}
-                {selectedSim.aborted && (
-                  <div className="flex items-center justify-center py-4 mt-2">
-                    <div className="flex items-center gap-2 px-4 py-2 rounded-lg bg-red-500/10 border border-red-500/30">
-                      <svg className="w-4 h-4 text-red-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-                        <path strokeLinecap="round" strokeLinejoin="round" d="M12 9v3.75m9-.75a9 9 0 11-18 0 9 9 0 0118 0zm-9 3.75h.008v.008H12v-.008z" />
-                      </svg>
-                      <span className="text-sm text-red-500">Simulation aborted by user</span>
-                    </div>
-                  </div>
-                )}
-              </div>
-            </div>
-          </div>
-        </div>
+        <SimulationTranscriptDialog
+          simulation={selectedSim}
+          runType={data.type}
+          onClose={() => setSelectedSim(null)}
+        />
       )}
     </PublicPageLayout>
   );

--- a/src/app/public/stt/[token]/page.tsx
+++ b/src/app/public/stt/[token]/page.tsx
@@ -3,10 +3,14 @@
 import React, { useState, useEffect } from "react";
 import { useParams } from "next/navigation";
 import { sttProviders } from "@/components/agent-tabs/constants/providers";
-import { LeaderboardBarChart, getColorMap } from "@/components/charts/LeaderboardBarChart";
-import { DownloadableTable } from "@/components/DownloadableTable";
-import { Tooltip } from "@/components/Tooltip";
 import { PublicPageLayout, PublicNotFound, PublicLoading } from "@/components/PublicPageLayout";
+import {
+  ProviderSidebar,
+  ProviderMetricsCard,
+  STTResultsTable,
+  LeaderboardTab,
+  AboutMetricsTable,
+} from "@/components/eval-details";
 
 type ProviderMetrics = {
   wer: number;
@@ -42,7 +46,6 @@ type EvaluationResult = {
   task_id: string;
   status: "queued" | "in_progress" | "done" | "failed";
   language?: string;
-  dataset_name?: string | null;
   provider_results?: ProviderResult[];
   leaderboard_summary?: LeaderboardSummary[];
   error?: string | null;
@@ -52,6 +55,14 @@ const getProviderLabel = (value: string): string => {
   const provider = sttProviders.find((p) => p.value === value);
   return provider ? provider.label : value;
 };
+
+const STT_ABOUT_METRICS = [
+  { metric: "WER", description: "Word error rate measures the percentage of words that differ between reference and predicted transcription.", preference: "Lower is better", range: "0 - \u221E" },
+  { metric: "String Similarity", description: "Measures similarity between reference and predicted strings using string matching algorithms.", preference: "Higher is better", range: "0 - 1" },
+  { metric: "LLM Judge", description: "Evaluates semantic equivalence rather than exact string matching, returning Pass if the transcription is semantically correct.", preference: "Pass is better", range: "Pass / Fail" },
+  { metric: "TTFB", description: "Time to first byte measures the latency from when a request is sent until the first byte of the response is received.", preference: "Lower is better", range: "0 - \u221E" },
+  { metric: "Processing Time", description: "Total time taken to process the audio and generate the transcription.", preference: "Lower is better", range: "0 - \u221E" },
+];
 
 export default function PublicSTTPage() {
   const params = useParams();
@@ -63,9 +74,7 @@ export default function PublicSTTPage() {
   const [activeTab, setActiveTab] = useState<"leaderboard" | "outputs" | "about">("leaderboard");
   const [activeProviderTab, setActiveProviderTab] = useState<string | null>(null);
 
-  useEffect(() => {
-    document.title = "Speech-to-text evaluation | Calibrate";
-  }, []);
+  useEffect(() => { document.title = "Speech-to-text evaluation | Calibrate"; }, []);
 
   useEffect(() => {
     const fetchData = async () => {
@@ -81,7 +90,6 @@ export default function PublicSTTPage() {
         if (!res.ok) throw new Error("Failed to load results");
 
         const result: EvaluationResult = await res.json();
-
         if (result.status !== "done") { setNotFound(true); return; }
 
         setData(result);
@@ -100,21 +108,21 @@ export default function PublicSTTPage() {
   if (isLoading) return <PublicPageLayout><PublicLoading /></PublicPageLayout>;
   if (notFound || !data) return <PublicPageLayout><PublicNotFound /></PublicPageLayout>;
 
+  const selectedProvider = activeProviderTab ?? data.provider_results?.[0]?.provider;
+  const providerResult = data.provider_results?.find((p) => p.provider === selectedProvider);
+
   return (
     <PublicPageLayout
       title="Speech-to-text evaluation"
       pills={
-        <>
-          {data.language && (
-            <span className="px-2 py-0.5 text-[11px] font-medium bg-muted rounded-full text-muted-foreground capitalize">
-              {data.language}
-            </span>
-          )}
-        </>
+        data.language ? (
+          <span className="px-2 py-0.5 text-[11px] font-medium bg-muted rounded-full text-muted-foreground capitalize">
+            {data.language}
+          </span>
+        ) : undefined
       }
     >
       <div className="space-y-4 md:space-y-6">
-
         {data.provider_results && data.provider_results.length > 0 && (
           <>
             {/* Tab Nav */}
@@ -124,9 +132,7 @@ export default function PublicSTTPage() {
                   key={tab}
                   onClick={() => setActiveTab(tab)}
                   className={`px-4 py-2 text-[13px] font-medium border-b-2 transition-colors cursor-pointer capitalize ${
-                    activeTab === tab
-                      ? "border-foreground text-foreground"
-                      : "border-transparent text-muted-foreground hover:text-foreground"
+                    activeTab === tab ? "border-foreground text-foreground" : "border-transparent text-muted-foreground hover:text-foreground"
                   }`}
                 >
                   {tab}
@@ -135,245 +141,68 @@ export default function PublicSTTPage() {
             </div>
 
             {/* Leaderboard Tab */}
-            {activeTab === "leaderboard" && (
-              <div className="space-y-4 md:space-y-6">
-                {data.leaderboard_summary && data.leaderboard_summary.length > 0 && (
-                  <>
-                    <DownloadableTable
-                      columns={[
-                        { key: "run", header: "Run", render: (v) => getProviderLabel(v) },
-                        { key: "wer", header: "WER" },
-                        {
-                          key: "string_similarity",
-                          header: "String Similarity",
-                          render: (v) => v != null ? parseFloat(v.toFixed(4)) : "-",
-                        },
-                        { key: "llm_judge_score", header: "LLM Judge Score" },
-                      ]}
-                      data={data.leaderboard_summary}
-                      filename="stt-evaluation-leaderboard"
-                    />
-                    {(() => {
-                      const names = data.leaderboard_summary!.map((s) => s.run);
-                      const colorMap = getColorMap(names);
-                      return (
-                        <div className="space-y-4 md:space-y-6">
-                          <div className="grid grid-cols-1 md:grid-cols-2 gap-4 md:gap-6">
-                            <LeaderboardBarChart
-                              title="WER"
-                              data={data.leaderboard_summary!.map((s) => ({ label: getProviderLabel(s.run), value: s.wer, colorKey: s.run }))}
-                              colorMap={colorMap}
-                            />
-                            <LeaderboardBarChart
-                              title="String Similarity"
-                              data={data.leaderboard_summary!.map((s) => ({ label: getProviderLabel(s.run), value: s.string_similarity, colorKey: s.run }))}
-                              colorMap={colorMap}
-                              yDomain={[0, 1]}
-                            />
-                          </div>
-                          <div className="grid grid-cols-1 md:grid-cols-2 gap-4 md:gap-6">
-                            <LeaderboardBarChart
-                              title="LLM Judge Score"
-                              data={data.leaderboard_summary!.map((s) => ({ label: getProviderLabel(s.run), value: s.llm_judge_score, colorKey: s.run }))}
-                              colorMap={colorMap}
-                              yDomain={[0, 1]}
-                            />
-                          </div>
-                        </div>
-                      );
-                    })()}
-                  </>
-                )}
-              </div>
+            {activeTab === "leaderboard" && data.leaderboard_summary && (
+              <LeaderboardTab
+                columns={[
+                  { key: "run", header: "Run", render: (v) => getProviderLabel(v) },
+                  { key: "wer", header: "WER" },
+                  { key: "string_similarity", header: "String Similarity", render: (v) => v != null ? parseFloat(v.toFixed(4)) : "-" },
+                  { key: "llm_judge_score", header: "LLM Judge Score" },
+                ]}
+                data={data.leaderboard_summary}
+                charts={[
+                  [{ title: "WER", dataKey: "wer" }, { title: "String Similarity", dataKey: "string_similarity", yDomain: [0, 1] }],
+                  [{ title: "LLM Judge Score", dataKey: "llm_judge_score", yDomain: [0, 1] }],
+                ]}
+                filename="stt-evaluation-leaderboard"
+                getLabel={getProviderLabel}
+              />
             )}
 
             {/* Outputs Tab */}
             {activeTab === "outputs" && (
               <div className="flex flex-col md:flex-row border border-border rounded-xl overflow-hidden" style={{ minHeight: 480 }}>
-                {/* Provider sidebar */}
-                <div className="md:w-64 border-b md:border-b-0 md:border-r border-border flex flex-col overflow-hidden bg-muted/10">
-                  <div className="overflow-x-auto md:overflow-x-visible md:overflow-y-auto md:flex-1 p-2">
-                    <div className="flex md:flex-col gap-1 min-w-max md:min-w-0">
-                      {data.provider_results!.map((pr) => {
-                        const isSelected = (activeProviderTab ?? data.provider_results![0]?.provider) === pr.provider;
-                        return (
-                          <div
-                            key={pr.provider}
-                            onClick={() => setActiveProviderTab(pr.provider)}
-                            className={`flex items-center gap-2 px-3 py-2 rounded-lg cursor-pointer transition-colors whitespace-nowrap ${isSelected ? "bg-muted" : "hover:bg-muted/50"}`}
-                          >
-                            {pr.success ? (
-                              <div className="w-5 h-5 rounded-full bg-green-500/20 flex items-center justify-center flex-shrink-0">
-                                <svg className="w-3 h-3 text-green-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={3}><path strokeLinecap="round" strokeLinejoin="round" d="M4.5 12.75l6 6 9-13.5" /></svg>
-                              </div>
-                            ) : (
-                              <div className="w-5 h-5 rounded-full bg-red-500/20 flex items-center justify-center flex-shrink-0">
-                                <svg className="w-3 h-3 text-red-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={3}><path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" /></svg>
-                              </div>
-                            )}
-                            <span className="text-sm text-foreground truncate">{getProviderLabel(pr.provider)}</span>
-                          </div>
-                        );
-                      })}
-                    </div>
-                  </div>
-                </div>
+                <ProviderSidebar
+                  items={data.provider_results.map((pr) => ({
+                    key: pr.provider,
+                    label: getProviderLabel(pr.provider),
+                    success: pr.success,
+                  }))}
+                  activeKey={selectedProvider ?? null}
+                  onSelect={setActiveProviderTab}
+                />
 
-                {/* Right panel */}
                 <div className="flex-1 overflow-y-auto p-4 md:p-6">
-                  {(() => {
-                    const selectedProvider = activeProviderTab ?? data.provider_results![0]?.provider;
-                    const pr = data.provider_results!.find((p) => p.provider === selectedProvider);
-                    if (!pr) return <p className="text-muted-foreground">Select a provider</p>;
-                    if (!pr.success) return (
+                  {!providerResult ? (
+                    <p className="text-muted-foreground">Select a provider</p>
+                  ) : !providerResult.success ? (
+                    <div className="flex items-center justify-center h-full min-h-[200px]">
                       <div className="border border-red-500/50 bg-red-500/10 rounded-lg p-4 max-w-md text-center">
                         <div className="text-red-500 text-[14px] font-medium">There was an error running this provider.</div>
                       </div>
-                    );
-                    return (
-                      <div className="space-y-4 md:space-y-6">
-                        {/* Overall Metrics */}
-                        {pr.metrics && (
-                          <div className="border rounded-xl p-4 bg-muted/10">
-                            <h3 className="text-[15px] font-semibold mb-4">Overall Metrics</h3>
-                            <div className="grid grid-cols-3 gap-4">
-                              {[
-                                { label: "WER", value: pr.metrics.wer != null ? parseFloat(pr.metrics.wer.toFixed(4)) : "-" },
-                                { label: "String Similarity", value: pr.metrics.string_similarity != null ? parseFloat(pr.metrics.string_similarity.toFixed(4)) : "-" },
-                                { label: "LLM Judge Score", value: pr.metrics.llm_judge_score ?? "-" },
-                              ].map(({ label, value }) => (
-                                <div key={label}>
-                                  <div className="text-[12px] text-muted-foreground mb-1">{label}</div>
-                                  <div className="text-base md:text-[18px] font-semibold text-foreground">{String(value)}</div>
-                                </div>
-                              ))}
-                            </div>
-                          </div>
-                        )}
-
-                        {/* Results Table */}
-                        {pr.results && pr.results.length > 0 && (
-                          <div className="hidden md:block border rounded-xl overflow-hidden">
-                            <div className="overflow-x-auto">
-                              <table className="w-full table-fixed">
-                                <thead className="bg-muted/50 border-b border-border">
-                                  <tr>
-                                    <th className="w-12 px-4 py-3 text-left text-[12px] font-medium text-foreground">ID</th>
-                                    <th className="w-[28%] px-4 py-3 text-left text-[12px] font-medium text-foreground">Ground Truth</th>
-                                    <th className="w-[28%] px-4 py-3 text-left text-[12px] font-medium text-foreground">Prediction</th>
-                                    <th className="px-4 py-3 text-left text-[12px] font-medium text-foreground">WER</th>
-                                    <th className="px-4 py-3 text-left text-[12px] font-medium text-foreground">Similarity</th>
-                                    <th className="px-4 py-3 text-left text-[12px] font-medium text-foreground">LLM Judge</th>
-                                  </tr>
-                                </thead>
-                                <tbody>
-                                  {pr.results.map((row, i) => {
-                                    const isEmpty = !row.pred || row.pred.trim() === "";
-                                    const scoreStr = String(row.llm_judge_score || "").toLowerCase();
-                                    const passed = scoreStr === "true" || scoreStr === "1";
-                                    return (
-                                      <tr key={i} className={`border-b border-border last:border-b-0 ${isEmpty ? "bg-red-500/10" : ""}`}>
-                                        <td className="px-4 py-3 text-[13px] text-foreground">{i + 1}</td>
-                                        <td className="px-4 py-3 text-[13px] text-foreground break-words">{row.gt}</td>
-                                        <td className="px-4 py-3 text-[13px] break-words">
-                                          {isEmpty ? <span className="text-muted-foreground">No transcript generated</span> : <span className="text-foreground">{row.pred}</span>}
-                                        </td>
-                                        <td className="px-4 py-3 text-[13px] text-foreground">
-                                          {row.wer != null ? parseFloat(parseFloat(row.wer).toFixed(4)) : "-"}
-                                        </td>
-                                        <td className="px-4 py-3 text-[13px] text-foreground">
-                                          {row.string_similarity != null ? parseFloat(parseFloat(row.string_similarity).toFixed(4)) : "-"}
-                                        </td>
-                                        <td className="px-4 py-3">
-                                          <div className="flex items-center gap-1.5">
-                                            <span className={`inline-flex items-center px-2.5 py-1 rounded-md text-xs font-medium ${passed ? "bg-green-100 text-green-700 dark:bg-green-500/20 dark:text-green-400" : "bg-red-100 text-red-700 dark:bg-red-500/20 dark:text-red-400"}`}>
-                                              {passed ? "Pass" : "Fail"}
-                                            </span>
-                                            {row.llm_judge_reasoning && (
-                                              <Tooltip content={row.llm_judge_reasoning}>
-                                                <button type="button" className="p-1 rounded-md hover:bg-muted transition-colors cursor-pointer" aria-label="View reasoning">
-                                                  <svg className="w-4 h-4 text-muted-foreground" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-                                                    <path strokeLinecap="round" strokeLinejoin="round" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
-                                                  </svg>
-                                                </button>
-                                              </Tooltip>
-                                            )}
-                                          </div>
-                                        </td>
-                                      </tr>
-                                    );
-                                  })}
-                                </tbody>
-                              </table>
-                            </div>
-                          </div>
-                        )}
-
-                        {/* Mobile cards */}
-                        {pr.results && pr.results.length > 0 && (
-                          <div className="md:hidden space-y-3">
-                            {pr.results.map((row, i) => {
-                              const isEmpty = !row.pred || row.pred.trim() === "";
-                              const scoreStr = String(row.llm_judge_score || "").toLowerCase();
-                              const passed = scoreStr === "true" || scoreStr === "1";
-                              return (
-                                <div key={i} className={`border border-border rounded-xl p-4 space-y-3 ${isEmpty ? "bg-red-500/10" : ""}`}>
-                                  <div className="flex items-center justify-between">
-                                    <span className="text-[12px] text-muted-foreground font-medium">#{i + 1}</span>
-                                    <span className={`inline-flex items-center px-2.5 py-1 rounded-md text-xs font-medium ${passed ? "bg-green-100 text-green-700 dark:bg-green-500/20 dark:text-green-400" : "bg-red-100 text-red-700 dark:bg-red-500/20 dark:text-red-400"}`}>
-                                      {passed ? "Pass" : "Fail"}
-                                    </span>
-                                  </div>
-                                  <div>
-                                    <span className="text-[11px] text-muted-foreground uppercase tracking-wide">Ground Truth</span>
-                                    <p className="text-[13px] text-foreground mt-0.5">{row.gt}</p>
-                                  </div>
-                                  <div>
-                                    <span className="text-[11px] text-muted-foreground uppercase tracking-wide">Prediction</span>
-                                    {isEmpty ? <p className="text-[13px] text-muted-foreground mt-0.5">No transcript generated</p> : <p className="text-[13px] text-foreground mt-0.5">{row.pred}</p>}
-                                  </div>
-                                </div>
-                              );
-                            })}
-                          </div>
-                        )}
-                      </div>
-                    );
-                  })()}
+                    </div>
+                  ) : (
+                    <div className="space-y-4 md:space-y-6">
+                      {providerResult.metrics && (
+                        <ProviderMetricsCard
+                          metrics={[
+                            { label: "WER", value: providerResult.metrics.wer != null ? parseFloat(providerResult.metrics.wer.toFixed(4)) : "-" },
+                            { label: "String Similarity", value: providerResult.metrics.string_similarity != null ? parseFloat(providerResult.metrics.string_similarity.toFixed(4)) : "-" },
+                            { label: "LLM Judge Score", value: providerResult.metrics.llm_judge_score ?? "-" },
+                          ]}
+                        />
+                      )}
+                      {providerResult.results && providerResult.results.length > 0 && (
+                        <STTResultsTable results={providerResult.results} />
+                      )}
+                    </div>
+                  )}
                 </div>
               </div>
             )}
 
             {/* About Tab */}
-            {activeTab === "about" && (
-              <div className="border rounded-xl overflow-hidden">
-                <table className="w-full">
-                  <thead className="bg-muted/50 border-b border-border">
-                    <tr>
-                      {["Metric", "Description", "Preference", "Range"].map((h) => (
-                        <th key={h} className="px-4 py-3 text-left text-[13px] font-medium text-foreground">{h}</th>
-                      ))}
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {[
-                      { metric: "WER", description: "Word error rate measures the percentage of words that differ between reference and predicted transcription.", preference: "Lower is better", range: "0 - ∞" },
-                      { metric: "String Similarity", description: "Measures similarity between reference and predicted strings using string matching algorithms.", preference: "Higher is better", range: "0 - 1" },
-                      { metric: "LLM Judge", description: "Evaluates semantic equivalence rather than exact string matching, returning Pass if the transcription is semantically correct.", preference: "Pass is better", range: "Pass / Fail" },
-                      { metric: "TTFB", description: "Time to first byte measures the latency from when a request is sent until the first byte of the response is received.", preference: "Lower is better", range: "0 - ∞" },
-                      { metric: "Processing Time", description: "Total time taken to process the audio and generate the transcription.", preference: "Lower is better", range: "0 - ∞" },
-                    ].map((row) => (
-                      <tr key={row.metric} className="border-b border-border last:border-b-0">
-                        <td className="px-4 py-3 text-[13px] font-medium text-foreground">{row.metric}</td>
-                        <td className="px-4 py-3 text-[13px] text-foreground">{row.description}</td>
-                        <td className="px-4 py-3 text-[13px] text-foreground">{row.preference}</td>
-                        <td className="px-4 py-3 text-[13px] text-foreground">{row.range}</td>
-                      </tr>
-                    ))}
-                  </tbody>
-                </table>
-              </div>
-            )}
+            {activeTab === "about" && <AboutMetricsTable metrics={STT_ABOUT_METRICS} />}
           </>
         )}
       </div>

--- a/src/app/public/test-run/[token]/page.tsx
+++ b/src/app/public/test-run/[token]/page.tsx
@@ -2,21 +2,9 @@
 
 import React, { useState, useEffect } from "react";
 import { useParams } from "next/navigation";
-import {
-  TestCaseOutput,
-  TestCaseData,
-  StatusIcon,
-  TestDetailView,
-  EvaluationCriteriaPanel,
-} from "@/components/test-results/shared";
+import { TestCaseOutput, TestCaseData } from "@/components/test-results/shared";
 import { PublicPageLayout, PublicNotFound, PublicLoading } from "@/components/PublicPageLayout";
-
-type ChatMessage = {
-  role: "user" | "agent" | "tool";
-  content: string;
-  tool_name?: string;
-  tool_args?: Record<string, any>;
-};
+import { TestRunOutputsPanel } from "@/components/eval-details";
 
 type TestCaseResult = {
   test_uuid?: string;
@@ -27,7 +15,7 @@ type TestCaseResult = {
   reasoning?: string;
   output?: TestCaseOutput | null;
   test_case?: TestCaseData | null;
-  chat_history?: ChatMessage[];
+  chat_history?: { role: string; content: string }[];
   evaluation?: { passed: boolean; message?: string; details?: Record<string, any> };
   error?: string;
 };
@@ -42,7 +30,6 @@ type TestRunStatusResponse = {
   error?: string;
 };
 
-// Map raw API result → display status
 function getStatus(r: TestCaseResult): "passed" | "failed" {
   if (r.passed === true || r.status === "passed") return "passed";
   return "failed";
@@ -55,7 +42,7 @@ export default function PublicTestRunPage() {
   const [data, setData] = useState<TestRunStatusResponse | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [notFound, setNotFound] = useState(false);
-  const [selectedIndex, setSelectedIndex] = useState<number | null>(null);
+  const [selectedId, setSelectedId] = useState<string | null>(null);
 
   useEffect(() => { document.title = "LLM unit test | Calibrate"; }, []);
 
@@ -76,7 +63,7 @@ export default function PublicTestRunPage() {
         if (result.status !== "done" && result.status !== "completed") { setNotFound(true); return; }
 
         setData(result);
-        if (result.results?.length) setSelectedIndex(0);
+        if (result.results?.length) setSelectedId(`test-0`);
       } catch {
         setNotFound(true);
       } finally {
@@ -92,7 +79,6 @@ export default function PublicTestRunPage() {
   const results = data.results ?? [];
   const passed = results.filter((r) => getStatus(r) === "passed").length;
   const failed = results.filter((r) => getStatus(r) === "failed").length;
-  const selected = selectedIndex !== null ? results[selectedIndex] : null;
 
   return (
     <PublicPageLayout title="LLM unit test">
@@ -111,59 +97,22 @@ export default function PublicTestRunPage() {
         </div>
 
         {results.length > 0 && (
-          <div className="flex border border-border rounded-xl overflow-hidden" style={{ height: "calc(100vh - 260px)", minHeight: 480 }}>
-            {/* Left panel — test list */}
-            <div className="w-64 shrink-0 border-r border-border flex flex-col overflow-hidden bg-muted/10">
-              <div className="overflow-y-auto flex-1 p-2 space-y-0.5">
-                {results.map((r, i) => {
-                  const status = getStatus(r);
-                  const name = r.name || r.test_case?.name || r.test_name || `Test ${i + 1}`;
-                  return (
-                    <button
-                      key={i}
-                      type="button"
-                      onClick={() => setSelectedIndex(i)}
-                      className={`w-full flex items-center gap-2 px-3 py-2 rounded-lg cursor-pointer transition-colors text-left ${selectedIndex === i ? "bg-muted" : "hover:bg-muted/50"}`}
-                    >
-                      <StatusIcon status={status} />
-                      <span className="text-[13px] text-foreground truncate">{name}</span>
-                    </button>
-                  );
-                })}
-              </div>
-            </div>
-
-            {/* Right panel — detail */}
-            <div className="flex-1 overflow-y-auto">
-              {selected ? (
-                (() => {
-                  const status = getStatus(selected);
-                  return (
-                    <div className="flex h-full">
-                      {/* Conversation + output */}
-                      <div className="flex-1 overflow-y-auto p-4 md:p-6">
-                        <TestDetailView
-                          history={selected.test_case?.history || []}
-                          output={selected.output ?? undefined}
-                          passed={selected.evaluation?.passed ?? status === "passed"}
-                          reasoning={selected.reasoning}
-                        />
-                      </div>
-                      {/* Evaluation criteria panel */}
-                      {selected.test_case?.evaluation && (
-                        <div className="w-72 shrink-0 border-l border-border overflow-y-auto">
-                          <EvaluationCriteriaPanel evaluation={selected.test_case.evaluation} />
-                        </div>
-                      )}
-                    </div>
-                  );
-                })()
-              ) : (
-                <div className="flex items-center justify-center h-full">
-                  <p className="text-muted-foreground text-[13px]">Select a test to view details</p>
-                </div>
-              )}
-            </div>
+          <div className="border border-border rounded-xl overflow-hidden" style={{ height: "calc(100vh - 260px)", minHeight: 480 }}>
+            <TestRunOutputsPanel
+              results={results.map((r, i) => ({
+                id: `test-${i}`,
+                name: r.name || r.test_case?.name || r.test_name || `Test ${i + 1}`,
+                status: getStatus(r),
+                output: r.output ?? undefined,
+                testCase: r.test_case ?? undefined,
+                reasoning: r.reasoning,
+                evaluation: r.evaluation ?? { passed: getStatus(r) === "passed" },
+                error: r.error,
+              }))}
+              selectedId={selectedId}
+              onSelect={setSelectedId}
+              onClearSelection={() => setSelectedId(null)}
+            />
           </div>
         )}
       </div>

--- a/src/app/public/tts/[token]/page.tsx
+++ b/src/app/public/tts/[token]/page.tsx
@@ -3,10 +3,14 @@
 import React, { useState, useEffect } from "react";
 import { useParams } from "next/navigation";
 import { ttsProviders } from "@/components/agent-tabs/constants/providers";
-import { LeaderboardBarChart, getColorMap } from "@/components/charts/LeaderboardBarChart";
-import { DownloadableTable } from "@/components/DownloadableTable";
-import { Tooltip } from "@/components/Tooltip";
 import { PublicPageLayout, PublicNotFound, PublicLoading } from "@/components/PublicPageLayout";
+import {
+  ProviderSidebar,
+  ProviderMetricsCard,
+  TTSResultsTable,
+  LeaderboardTab,
+  AboutMetricsTable,
+} from "@/components/eval-details";
 
 type LatencyMetric = { mean: number; std: number; values: number[] };
 
@@ -53,6 +57,12 @@ const getProviderLabel = (value: string): string => {
   return provider ? provider.label : value;
 };
 
+const TTS_ABOUT_METRICS = [
+  { metric: "LLM Judge", description: "Evaluates whether synthesized audio accurately matches the reference text, returning Pass if the audio correctly represents the input.", preference: "Pass is better", range: "Pass / Fail" },
+  { metric: "TTFB (Time To First Byte)", description: "Latency from when a request is sent until the first byte of the response is received.", preference: "Lower is better", range: "0 - ∞" },
+  { metric: "Processing Time", description: "Total time taken to synthesize the audio.", preference: "Lower is better", range: "0 - ∞" },
+];
+
 export default function PublicTTSPage() {
   const params = useParams();
   const token = params.token as string;
@@ -97,21 +107,21 @@ export default function PublicTTSPage() {
   if (isLoading) return <PublicPageLayout><PublicLoading /></PublicPageLayout>;
   if (notFound || !data) return <PublicPageLayout><PublicNotFound /></PublicPageLayout>;
 
+  const selectedProvider = activeProviderTab ?? data.provider_results?.[0]?.provider;
+  const providerResult = data.provider_results?.find((p) => p.provider === selectedProvider);
+
   return (
     <PublicPageLayout
       title="Text-to-speech evaluation"
       pills={
-        <>
-          {data.language && (
-            <span className="px-2 py-0.5 text-[11px] font-medium bg-muted rounded-full text-muted-foreground capitalize">
-              {data.language}
-            </span>
-          )}
-        </>
+        data.language ? (
+          <span className="px-2 py-0.5 text-[11px] font-medium bg-muted rounded-full text-muted-foreground capitalize">
+            {data.language}
+          </span>
+        ) : undefined
       }
     >
       <div className="space-y-4 md:space-y-6">
-
         {data.provider_results && data.provider_results.length > 0 && (
           <>
             {/* Tab Nav */}
@@ -130,218 +140,66 @@ export default function PublicTTSPage() {
             </div>
 
             {/* Leaderboard Tab */}
-            {activeTab === "leaderboard" && (
-              <div className="space-y-4 md:space-y-6">
-                {data.leaderboard_summary && data.leaderboard_summary.length > 0 && (
-                  <>
-                    <DownloadableTable
-                      columns={[
-                        { key: "run", header: "Run", render: (v) => getProviderLabel(v) },
-                        { key: "llm_judge_score", header: "LLM Judge Score" },
-                        { key: "ttfb", header: "TTFB (s)", render: (v) => v != null ? parseFloat(v.toFixed(4)) : "-" },
-                      ]}
-                      data={data.leaderboard_summary}
-                      filename="tts-evaluation-leaderboard"
-                    />
-                    {(() => {
-                      const names = data.leaderboard_summary!.map((s) => s.run);
-                      const colorMap = getColorMap(names);
-                      return (
-                        <div className="grid grid-cols-1 md:grid-cols-2 gap-4 md:gap-6">
-                          <LeaderboardBarChart
-                            title="LLM Judge Score"
-                            data={data.leaderboard_summary!.map((s) => ({ label: getProviderLabel(s.run), value: s.llm_judge_score, colorKey: s.run }))}
-                            colorMap={colorMap}
-                            yDomain={[0, 1]}
-                          />
-                          <LeaderboardBarChart
-                            title="TTFB (s)"
-                            data={data.leaderboard_summary!.map((s) => ({ label: getProviderLabel(s.run), value: s.ttfb, colorKey: s.run }))}
-                            colorMap={colorMap}
-                          />
-                        </div>
-                      );
-                    })()}
-                  </>
-                )}
-              </div>
+            {activeTab === "leaderboard" && data.leaderboard_summary && (
+              <LeaderboardTab
+                columns={[
+                  { key: "run", header: "Run", render: (v) => getProviderLabel(v) },
+                  { key: "llm_judge_score", header: "LLM Judge Score" },
+                  { key: "ttfb", header: "TTFB (s)", render: (v) => v != null ? parseFloat(v.toFixed(4)) : "-" },
+                ]}
+                data={data.leaderboard_summary}
+                charts={[[
+                  { title: "LLM Judge Score", dataKey: "llm_judge_score", yDomain: [0, 1] },
+                  { title: "TTFB (s)", dataKey: "ttfb" },
+                ]]}
+                filename="tts-evaluation-leaderboard"
+                getLabel={getProviderLabel}
+              />
             )}
 
             {/* Outputs Tab */}
             {activeTab === "outputs" && (
               <div className="flex flex-col md:flex-row border border-border rounded-xl overflow-hidden" style={{ minHeight: 480 }}>
-                {/* Provider sidebar */}
-                <div className="md:w-64 border-b md:border-b-0 md:border-r border-border flex flex-col overflow-hidden bg-muted/10">
-                  <div className="overflow-x-auto md:overflow-x-visible md:overflow-y-auto md:flex-1 p-2">
-                    <div className="flex md:flex-col gap-1 min-w-max md:min-w-0">
-                      {data.provider_results!.map((pr) => {
-                        const isSelected = (activeProviderTab ?? data.provider_results![0]?.provider) === pr.provider;
-                        return (
-                          <div
-                            key={pr.provider}
-                            onClick={() => setActiveProviderTab(pr.provider)}
-                            className={`flex items-center gap-2 px-3 py-2 rounded-lg cursor-pointer transition-colors whitespace-nowrap ${isSelected ? "bg-muted" : "hover:bg-muted/50"}`}
-                          >
-                            {pr.success === true ? (
-                              <div className="w-5 h-5 rounded-full bg-green-500/20 flex items-center justify-center flex-shrink-0">
-                                <svg className="w-3 h-3 text-green-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={3}><path strokeLinecap="round" strokeLinejoin="round" d="M4.5 12.75l6 6 9-13.5" /></svg>
-                              </div>
-                            ) : (
-                              <div className="w-5 h-5 rounded-full bg-red-500/20 flex items-center justify-center flex-shrink-0">
-                                <svg className="w-3 h-3 text-red-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={3}><path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" /></svg>
-                              </div>
-                            )}
-                            <span className="text-sm text-foreground truncate">{getProviderLabel(pr.provider)}</span>
-                          </div>
-                        );
-                      })}
-                    </div>
-                  </div>
-                </div>
+                <ProviderSidebar
+                  items={data.provider_results.map((pr) => ({
+                    key: pr.provider,
+                    label: getProviderLabel(pr.provider),
+                    success: pr.success,
+                  }))}
+                  activeKey={selectedProvider ?? null}
+                  onSelect={setActiveProviderTab}
+                />
 
-                {/* Right panel */}
                 <div className="flex-1 overflow-y-auto p-4 md:p-6">
-                  {(() => {
-                    const selectedProvider = activeProviderTab ?? data.provider_results![0]?.provider;
-                    const pr = data.provider_results!.find((p) => p.provider === selectedProvider);
-                    if (!pr) return <p className="text-muted-foreground">Select a provider</p>;
-                    if (pr.success === false) return (
+                  {!providerResult ? (
+                    <p className="text-muted-foreground">Select a provider</p>
+                  ) : providerResult.success === false ? (
+                    <div className="flex items-center justify-center h-full min-h-[200px]">
                       <div className="border border-red-500/50 bg-red-500/10 rounded-lg p-4 max-w-md text-center">
                         <div className="text-red-500 text-[14px] font-medium">There was an error running this provider.</div>
                       </div>
-                    );
-
-                    return (
-                      <div className="space-y-4 md:space-y-6">
-                        {/* Overall Metrics */}
-                        {pr.metrics && (
-                          <div className="border rounded-xl p-4 bg-muted/10">
-                            <h3 className="text-[15px] font-semibold mb-4">Overall Metrics</h3>
-                            <div className="grid grid-cols-2 gap-4">
-                              <div>
-                                <div className="text-[12px] text-muted-foreground mb-1">LLM Judge Score</div>
-                                <div className="text-base md:text-[18px] font-semibold text-foreground">{pr.metrics.llm_judge_score ?? "-"}</div>
-                              </div>
-                              <div>
-                                <div className="text-[12px] text-muted-foreground mb-1">TTFB (s)</div>
-                                <div className="text-base md:text-[18px] font-semibold text-foreground">
-                                  {pr.metrics.ttfb?.mean != null ? parseFloat(pr.metrics.ttfb.mean.toFixed(4)) : "-"}
-                                </div>
-                              </div>
-                            </div>
-                          </div>
-                        )}
-
-                        {/* Results */}
-                        {pr.results && pr.results.length > 0 && (
-                          <>
-                            <div className="hidden md:block border rounded-xl overflow-hidden">
-                              <table className="w-full table-fixed">
-                                <thead className="bg-muted/50 border-b border-border">
-                                  <tr>
-                                    <th className="w-12 px-4 py-3 text-left text-[12px] font-medium text-foreground">ID</th>
-                                    <th className="w-[30%] px-4 py-3 text-left text-[12px] font-medium text-foreground">Text</th>
-                                    <th className="w-[50%] px-4 py-3 text-left text-[12px] font-medium text-foreground">Audio</th>
-                                    <th className="w-28 px-4 py-3 text-left text-[12px] font-medium text-foreground">LLM Judge</th>
-                                  </tr>
-                                </thead>
-                                <tbody>
-                                  {pr.results.map((row, i) => {
-                                    const scoreStr = String(row.llm_judge_score || "").toLowerCase();
-                                    const passed = scoreStr === "true" || scoreStr === "1";
-                                    return (
-                                      <tr key={i} className="border-b border-border last:border-b-0">
-                                        <td className="px-4 py-3 text-[13px] text-foreground">{i + 1}</td>
-                                        <td className="px-4 py-3 text-[13px] text-foreground break-words">{row.text}</td>
-                                        <td className="px-4 py-3">
-                                          {row.audio_path ? (
-                                            <audio controls src={row.audio_path} className="h-8 w-full" />
-                                          ) : (
-                                            <span className="text-muted-foreground text-[12px]">—</span>
-                                          )}
-                                        </td>
-                                        <td className="px-4 py-3">
-                                          {row.llm_judge_score ? (
-                                            <div className="flex items-center gap-1.5">
-                                              <span className={`inline-flex items-center px-2.5 py-1 rounded-md text-xs font-medium ${passed ? "bg-green-100 text-green-700 dark:bg-green-500/20 dark:text-green-400" : "bg-red-100 text-red-700 dark:bg-red-500/20 dark:text-red-400"}`}>
-                                                {passed ? "Pass" : "Fail"}
-                                              </span>
-                                              {row.llm_judge_reasoning && (
-                                                <Tooltip content={row.llm_judge_reasoning}>
-                                                  <button type="button" className="p-1 rounded-md hover:bg-muted transition-colors cursor-pointer">
-                                                    <svg className="w-4 h-4 text-muted-foreground" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}><path strokeLinecap="round" strokeLinejoin="round" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" /></svg>
-                                                  </button>
-                                                </Tooltip>
-                                              )}
-                                            </div>
-                                          ) : <span className="text-muted-foreground text-[12px]">—</span>}
-                                        </td>
-                                      </tr>
-                                    );
-                                  })}
-                                </tbody>
-                              </table>
-                            </div>
-
-                            {/* Mobile cards */}
-                            <div className="md:hidden space-y-3">
-                              {pr.results.map((row, i) => {
-                                const scoreStr = String(row.llm_judge_score || "").toLowerCase();
-                                const passed = scoreStr === "true" || scoreStr === "1";
-                                return (
-                                  <div key={i} className="border border-border rounded-xl p-4 space-y-3">
-                                    <span className="text-[12px] text-muted-foreground font-medium">#{i + 1}</span>
-                                    <div>
-                                      <span className="text-[11px] text-muted-foreground uppercase tracking-wide">Text</span>
-                                      <p className="text-[13px] text-foreground mt-0.5">{row.text}</p>
-                                    </div>
-                                    {row.audio_path && <audio controls src={row.audio_path} className="w-full h-8" />}
-                                    {row.llm_judge_score && (
-                                      <span className={`inline-flex items-center px-2.5 py-1 rounded-md text-xs font-medium ${passed ? "bg-green-100 text-green-700 dark:bg-green-500/20 dark:text-green-400" : "bg-red-100 text-red-700 dark:bg-red-500/20 dark:text-red-400"}`}>
-                                        {passed ? "Pass" : "Fail"}
-                                      </span>
-                                    )}
-                                  </div>
-                                );
-                              })}
-                            </div>
-                          </>
-                        )}
-                      </div>
-                    );
-                  })()}
+                    </div>
+                  ) : (
+                    <div className="space-y-4 md:space-y-6">
+                      {providerResult.metrics && (
+                        <ProviderMetricsCard
+                          metrics={[
+                            { label: "LLM Judge Score", value: providerResult.metrics.llm_judge_score ?? "-" },
+                            { label: "TTFB (s)", value: providerResult.metrics.ttfb?.mean != null ? parseFloat(providerResult.metrics.ttfb.mean.toFixed(4)) : "-" },
+                          ]}
+                        />
+                      )}
+                      {providerResult.results && providerResult.results.length > 0 && (
+                        <TTSResultsTable results={providerResult.results} />
+                      )}
+                    </div>
+                  )}
                 </div>
               </div>
             )}
 
             {/* About Tab */}
-            {activeTab === "about" && (
-              <div className="border rounded-xl overflow-hidden">
-                <table className="w-full">
-                  <thead className="bg-muted/50 border-b border-border">
-                    <tr>
-                      {["Metric", "Description", "Preference", "Range"].map((h) => (
-                        <th key={h} className="px-4 py-3 text-left text-[13px] font-medium text-foreground">{h}</th>
-                      ))}
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {[
-                      { metric: "LLM Judge", description: "Evaluates whether synthesized audio accurately matches the reference text, returning Pass if the audio correctly represents the input.", preference: "Pass is better", range: "Pass / Fail" },
-                      { metric: "TTFB (Time To First Byte)", description: "Latency from when a request is sent until the first byte of the response is received.", preference: "Lower is better", range: "0 - ∞" },
-                      { metric: "Processing Time", description: "Total time taken to synthesize the audio.", preference: "Lower is better", range: "0 - ∞" },
-                    ].map((row) => (
-                      <tr key={row.metric} className="border-b border-border last:border-b-0">
-                        <td className="px-4 py-3 text-[13px] font-medium text-foreground">{row.metric}</td>
-                        <td className="px-4 py-3 text-[13px] text-foreground">{row.description}</td>
-                        <td className="px-4 py-3 text-[13px] text-foreground">{row.preference}</td>
-                        <td className="px-4 py-3 text-[13px] text-foreground">{row.range}</td>
-                      </tr>
-                    ))}
-                  </tbody>
-                </table>
-              </div>
-            )}
+            {activeTab === "about" && <AboutMetricsTable metrics={TTS_ABOUT_METRICS} />}
           </>
         )}
       </div>

--- a/src/app/stt/[uuid]/page.tsx
+++ b/src/app/stt/[uuid]/page.tsx
@@ -7,14 +7,15 @@ import { signOut } from "next-auth/react";
 import { useAccessToken } from "@/hooks";
 import { AppLayout } from "@/components/AppLayout";
 import { BackHeader, StatusBadge, NotFoundState } from "@/components/ui";
-import { Tooltip } from "@/components/Tooltip";
 import { sttProviders } from "@/components/agent-tabs/constants/providers";
-import {
-  LeaderboardBarChart,
-  getColorMap,
-} from "@/components/charts/LeaderboardBarChart";
-import { DownloadableTable } from "@/components/DownloadableTable";
 import { POLLING_INTERVAL_MS } from "@/constants/polling";
+import {
+  ProviderSidebar,
+  ProviderMetricsCard,
+  STTResultsTable,
+  LeaderboardTab,
+  AboutMetricsTable,
+} from "@/components/eval-details";
 import { useSidebarState } from "@/lib/sidebar";
 import { getDataset } from "@/lib/datasets";
 import { ShareButton } from "@/components/ShareButton";
@@ -415,858 +416,118 @@ export default function STTEvaluationDetailPage() {
 
                   {/* About Tab */}
                   {activeTab === "about" && (
-                    <div className="space-y-4 md:space-y-6">
-                      {/* Desktop: Table layout */}
-                      <div className="hidden md:block border rounded-xl overflow-hidden">
-                        <table className="w-full">
-                          <thead className="bg-muted/50 border-b border-border">
-                            <tr>
-                              <th className="px-4 py-3 text-left text-[13px] font-medium text-foreground">
-                                Metric
-                              </th>
-                              <th className="px-4 py-3 text-left text-[13px] font-medium text-foreground">
-                                Description
-                              </th>
-                              <th className="px-4 py-3 text-left text-[13px] font-medium text-foreground">
-                                Preference
-                              </th>
-                              <th className="px-4 py-3 text-left text-[13px] font-medium text-foreground">
-                                Range
-                              </th>
-                            </tr>
-                          </thead>
-                          <tbody>
-                            <tr className="border-b border-border">
-                              <td className="px-4 py-3 text-[13px] font-medium text-foreground">
-                                WER (Word Error Rate)
-                              </td>
-                              <td className="px-4 py-3 text-[13px] text-foreground">
-                                Word error rate measures the percentage of words
-                                that differ between the reference transcription
-                                and the predicted transcription.
-                              </td>
-                              <td className="px-4 py-3 text-[13px] text-foreground">
-                                Lower is better
-                              </td>
-                              <td className="px-4 py-3 text-[13px] text-foreground">
-                                0 - ∞
-                              </td>
-                            </tr>
-                            <tr className="border-b border-border">
-                              <td className="px-4 py-3 text-[13px] font-medium text-foreground">
-                                String Similarity
-                              </td>
-                              <td className="px-4 py-3 text-[13px] text-foreground">
-                                Measures the similarity between the reference
-                                and predicted strings using string matching
-                                algorithms.
-                              </td>
-                              <td className="px-4 py-3 text-[13px] text-foreground">
-                                Higher is better
-                              </td>
-                              <td className="px-4 py-3 text-[13px] text-foreground">
-                                0 - 1
-                              </td>
-                            </tr>
-                            <tr className="border-b border-border">
-                              <td className="px-4 py-3 text-[13px] font-medium text-foreground">
-                                LLM Judge
-                              </td>
-                              <td className="px-4 py-3 text-[13px] text-foreground">
-                                This metric is used because WER and string
-                                similarity may not provide an accurate picture.
-                                For example, when a transcript says
-                                &quot;9&quot; but the model predicts
-                                &quot;nine&quot;, both might be considered
-                                correct for the agent&apos;s specific use case.
-                                The LLM judge evaluates semantic equivalence
-                                rather than exact string matching, returning
-                                Pass if the transcription is semantically
-                                correct.
-                              </td>
-                              <td className="px-4 py-3 text-[13px] text-foreground">
-                                Pass is better
-                              </td>
-                              <td className="px-4 py-3 text-[13px] text-foreground">
-                                Pass / Fail
-                              </td>
-                            </tr>
-                            <tr className="border-b border-border">
-                              <td className="px-4 py-3 text-[13px] font-medium text-foreground">
-                                TTFB (Time To First Byte)
-                              </td>
-                              <td className="px-4 py-3 text-[13px] text-foreground">
-                                Time to first byte measures the latency from
-                                when a request is sent until the first byte of
-                                the response is received.
-                              </td>
-                              <td className="px-4 py-3 text-[13px] text-foreground">
-                                Lower is better
-                              </td>
-                              <td className="px-4 py-3 text-[13px] text-foreground">
-                                0 - ∞
-                              </td>
-                            </tr>
-                            <tr className="border-b border-border last:border-b-0">
-                              <td className="px-4 py-3 text-[13px] font-medium text-foreground">
-                                Processing Time
-                              </td>
-                              <td className="px-4 py-3 text-[13px] text-foreground">
-                                Total time taken to process the audio and
-                                generate the transcription.
-                              </td>
-                              <td className="px-4 py-3 text-[13px] text-foreground">
-                                Lower is better
-                              </td>
-                              <td className="px-4 py-3 text-[13px] text-foreground">
-                                0 - ∞
-                              </td>
-                            </tr>
-                          </tbody>
-                        </table>
-                      </div>
-
-                      {/* Mobile: Card layout */}
-                      <div className="md:hidden space-y-3">
-                        {[
-                          {
-                            metric: "WER (Word Error Rate)",
-                            description:
-                              "Word error rate measures the percentage of words that differ between the reference transcription and the predicted transcription.",
-                            preference: "Lower is better",
-                            range: "0 - ∞",
-                          },
-                          {
-                            metric: "String Similarity",
-                            description:
-                              "Measures the similarity between the reference and predicted strings using string matching algorithms.",
-                            preference: "Higher is better",
-                            range: "0 - 1",
-                          },
-                          {
-                            metric: "LLM Judge",
-                            description:
-                              "This metric is used because WER and string similarity may not provide an accurate picture. The LLM judge evaluates semantic equivalence rather than exact string matching, returning Pass if the transcription is semantically correct.",
-                            preference: "Pass is better",
-                            range: "Pass / Fail",
-                          },
-                          {
-                            metric: "TTFB (Time To First Byte)",
-                            description:
-                              "Time to first byte measures the latency from when a request is sent until the first byte of the response is received.",
-                            preference: "Lower is better",
-                            range: "0 - ∞",
-                          },
-                          {
-                            metric: "Processing Time",
-                            description:
-                              "Total time taken to process the audio and generate the transcription.",
-                            preference: "Lower is better",
-                            range: "0 - ∞",
-                          },
-                        ].map((item) => (
-                          <div
-                            key={item.metric}
-                            className="border border-border rounded-xl p-4 space-y-2"
-                          >
-                            <h4 className="text-[13px] font-semibold text-foreground">
-                              {item.metric}
-                            </h4>
-                            <p className="text-[13px] text-muted-foreground">
-                              {item.description}
-                            </p>
-                            <div className="flex gap-4 pt-1">
-                              <div>
-                                <span className="text-[11px] text-muted-foreground uppercase tracking-wide">
-                                  Preference
-                                </span>
-                                <p className="text-[13px] text-foreground">
-                                  {item.preference}
-                                </p>
-                              </div>
-                              <div>
-                                <span className="text-[11px] text-muted-foreground uppercase tracking-wide">
-                                  Range
-                                </span>
-                                <p className="text-[13px] text-foreground">
-                                  {item.range}
-                                </p>
-                              </div>
-                            </div>
-                          </div>
-                        ))}
-                      </div>
-                    </div>
+                    <AboutMetricsTable
+                      metrics={[
+                        { metric: "WER (Word Error Rate)", description: "Word error rate measures the percentage of words that differ between the reference transcription and the predicted transcription.", preference: "Lower is better", range: "0 - \u221E" },
+                        { metric: "String Similarity", description: "Measures the similarity between the reference and predicted strings using string matching algorithms.", preference: "Higher is better", range: "0 - 1" },
+                        { metric: "LLM Judge", description: "This metric is used because WER and string similarity may not provide an accurate picture. For example, when a transcript says \"9\" but the model predicts \"nine\", both might be considered correct for the agent's specific use case. The LLM judge evaluates semantic equivalence rather than exact string matching, returning Pass if the transcription is semantically correct.", preference: "Pass is better", range: "Pass / Fail" },
+                        { metric: "TTFB (Time To First Byte)", description: "Time to first byte measures the latency from when a request is sent until the first byte of the response is received.", preference: "Lower is better", range: "0 - \u221E" },
+                        { metric: "Processing Time", description: "Total time taken to process the audio and generate the transcription.", preference: "Lower is better", range: "0 - \u221E" },
+                      ]}
+                    />
                   )}
 
                   {/* Leaderboard Tab */}
-                  {activeTab === "leaderboard" && (
-                    <div className="space-y-4 md:space-y-6 -mx-4 md:-mx-8 px-4 md:px-8 w-[calc(100vw-32px)] md:w-[calc(100vw-56px)] ml-[calc((32px-100vw)/2+50%)] md:ml-[calc((56px-100vw)/2+50%)] relative">
-                      {evaluationResult.leaderboard_summary &&
-                        evaluationResult.leaderboard_summary.length > 0 && (
-                          <>
-                            <DownloadableTable
-                              columns={[
-                                {
-                                  key: "run",
-                                  header: "Run",
-                                  render: (value) => getProviderLabel(value),
-                                },
-                                { key: "wer", header: "WER" },
-                                {
-                                  key: "string_similarity",
-                                  header: "String Similarity",
-                                  render: (value) =>
-                                    value != null
-                                      ? parseFloat(value.toFixed(4))
-                                      : "-",
-                                },
-                                {
-                                  key: "llm_judge_score",
-                                  header: "LLM Judge Score",
-                                },
-                              ]}
-                              data={evaluationResult.leaderboard_summary}
-                              filename="stt-evaluation-leaderboard"
-                            />
-
-                            {/* Charts Section */}
-                            {(() => {
-                              const providerNames =
-                                evaluationResult.leaderboard_summary.map(
-                                  (s) => s.run,
-                                );
-                              const colorMap = getColorMap(providerNames);
-                              return (
-                                <div className="space-y-4 md:space-y-6">
-                                  {/* Row 1: WER and String Similarity */}
-                                  <div className="grid grid-cols-1 md:grid-cols-2 gap-4 md:gap-6">
-                                    <LeaderboardBarChart
-                                      title="WER"
-                                      data={evaluationResult.leaderboard_summary.map(
-                                        (s) => ({
-                                          label: getProviderLabel(s.run),
-                                          value: s.wer,
-                                          colorKey: s.run,
-                                        }),
-                                      )}
-                                      colorMap={colorMap}
-                                    />
-                                    <LeaderboardBarChart
-                                      title="String Similarity"
-                                      data={evaluationResult.leaderboard_summary.map(
-                                        (s) => ({
-                                          label: getProviderLabel(s.run),
-                                          value: s.string_similarity,
-                                          colorKey: s.run,
-                                        }),
-                                      )}
-                                      colorMap={colorMap}
-                                      yDomain={[0, 1]}
-                                    />
-                                  </div>
-
-                                  {/* Row 2: LLM Judge Score */}
-                                  <div className="grid grid-cols-1 md:grid-cols-2 gap-4 md:gap-6">
-                                    <LeaderboardBarChart
-                                      title="LLM Judge Score"
-                                      data={evaluationResult.leaderboard_summary.map(
-                                        (s) => ({
-                                          label: getProviderLabel(s.run),
-                                          value: s.llm_judge_score,
-                                          colorKey: s.run,
-                                        }),
-                                      )}
-                                      colorMap={colorMap}
-                                      yDomain={[0, 1]}
-                                    />
-                                  </div>
-                                </div>
-                              );
-                            })()}
-                          </>
-                        )}
-                    </div>
+                  {activeTab === "leaderboard" && evaluationResult.leaderboard_summary && (
+                    <LeaderboardTab
+                      className="-mx-4 md:-mx-8 px-4 md:px-8 w-[calc(100vw-32px)] md:w-[calc(100vw-56px)] ml-[calc((32px-100vw)/2+50%)] md:ml-[calc((56px-100vw)/2+50%)] relative"
+                      columns={[
+                        { key: "run", header: "Run", render: (v) => getProviderLabel(v) },
+                        { key: "wer", header: "WER" },
+                        { key: "string_similarity", header: "String Similarity", render: (v) => v != null ? parseFloat(v.toFixed(4)) : "-" },
+                        { key: "llm_judge_score", header: "LLM Judge Score" },
+                      ]}
+                      data={evaluationResult.leaderboard_summary}
+                      charts={[
+                        [{ title: "WER", dataKey: "wer" }, { title: "String Similarity", dataKey: "string_similarity", yDomain: [0, 1] }],
+                        [{ title: "LLM Judge Score", dataKey: "llm_judge_score", yDomain: [0, 1] }],
+                      ]}
+                      filename="stt-evaluation-leaderboard"
+                      getLabel={getProviderLabel}
+                    />
                   )}
 
                   {/* Outputs Tab */}
                   {activeTab === "outputs" && (
                     <div className="flex flex-col md:flex-row border border-border rounded-xl overflow-hidden md:h-[calc(100vh-220px)]">
-                      {/* Provider List - Horizontal scroll on mobile, vertical sidebar on desktop */}
-                      <div className="md:w-48 border-b md:border-b-0 md:border-r border-border flex flex-col overflow-hidden bg-muted/10">
-                        <div className="overflow-x-auto md:overflow-x-visible md:overflow-y-auto md:flex-1 p-2">
-                          <div className="flex md:flex-col gap-1 md:gap-1 min-w-max md:min-w-0">
-                            {evaluationResult.provider_results!.map(
-                              (providerResult) => {
-                                const isSelected =
-                                  (activeProviderTab ||
-                                    evaluationResult.provider_results![0]
-                                      ?.provider) === providerResult.provider;
-                                return (
-                                  <div
-                                    key={providerResult.provider}
-                                    onClick={() => {
-                                      setActiveProviderTab(
-                                        providerResult.provider,
-                                      );
-                                      // Scroll to first empty prediction after a short delay
-                                      if (hasEmptyPredictions(providerResult)) {
-                                        setTimeout(() => {
-                                          const firstEmptyIndex =
-                                            getFirstEmptyPredictionIndex(
-                                              providerResult,
-                                            );
-                                          if (
-                                            firstEmptyIndex >= 0 &&
-                                            tableContainerRef.current
-                                          ) {
-                                            const row =
-                                              tableContainerRef.current.querySelector(
-                                                `[data-row-index="${firstEmptyIndex}"]`,
-                                              );
-                                            row?.scrollIntoView({
-                                              behavior: "smooth",
-                                              block: "center",
-                                            });
-                                          }
-                                        }, 100);
-                                      }
-                                    }}
-                                    className={`flex items-center gap-2 px-3 py-2 rounded-lg cursor-pointer transition-colors whitespace-nowrap ${
-                                      isSelected
-                                        ? "bg-muted"
-                                        : "hover:bg-muted/50"
-                                    }`}
-                                  >
-                                    {/* Status Icon */}
-                                    {providerResult.success === null ? (
-                                      // In progress - yellow dot
-                                      <div className="w-2 h-2 rounded-full bg-yellow-500 animate-pulse flex-shrink-0"></div>
-                                    ) : providerResult.success === true &&
-                                      !hasEmptyPredictions(providerResult) ? (
-                                      // Done, passed, no empty predictions - green tick
-                                      <div className="w-5 h-5 rounded-full bg-green-500/20 flex items-center justify-center flex-shrink-0">
-                                        <svg
-                                          className="w-3 h-3 text-green-500"
-                                          fill="none"
-                                          viewBox="0 0 24 24"
-                                          stroke="currentColor"
-                                          strokeWidth={3}
-                                        >
-                                          <path
-                                            strokeLinecap="round"
-                                            strokeLinejoin="round"
-                                            d="M4.5 12.75l6 6 9-13.5"
-                                          />
-                                        </svg>
-                                      </div>
-                                    ) : (
-                                      // Done, failed OR has empty predictions - red X
-                                      <div className="w-5 h-5 rounded-full bg-red-500/20 flex items-center justify-center flex-shrink-0">
-                                        <svg
-                                          className="w-3 h-3 text-red-500"
-                                          fill="none"
-                                          viewBox="0 0 24 24"
-                                          stroke="currentColor"
-                                          strokeWidth={3}
-                                        >
-                                          <path
-                                            strokeLinecap="round"
-                                            strokeLinejoin="round"
-                                            d="M6 18L18 6M6 6l12 12"
-                                          />
-                                        </svg>
-                                      </div>
-                                    )}
-                                    <span className="text-sm text-foreground truncate">
-                                      {getProviderLabel(
-                                        providerResult.provider,
-                                      )}
-                                    </span>
-                                  </div>
-                                );
-                              },
-                            )}
-                          </div>
-                        </div>
-                      </div>
+                      <ProviderSidebar
+                        items={evaluationResult.provider_results!.map((pr) => ({
+                          key: pr.provider,
+                          label: getProviderLabel(pr.provider),
+                          success: pr.success === true && !hasEmptyPredictions(pr) ? true : pr.success === null ? null : false,
+                        }))}
+                        activeKey={activeProviderTab || evaluationResult.provider_results![0]?.provider}
+                        onSelect={(key) => {
+                          setActiveProviderTab(key);
+                          const pr = evaluationResult.provider_results!.find((p) => p.provider === key);
+                          if (pr && hasEmptyPredictions(pr)) {
+                            setTimeout(() => {
+                              const firstEmptyIndex = getFirstEmptyPredictionIndex(pr);
+                              if (firstEmptyIndex >= 0 && tableContainerRef.current) {
+                                const row = tableContainerRef.current.querySelector(`[data-row-index="${firstEmptyIndex}"]`);
+                                row?.scrollIntoView({ behavior: "smooth", block: "center" });
+                              }
+                            }, 100);
+                          }
+                        }}
+                      />
 
-                      {/* Right Panel - Provider Details */}
                       <div className="flex-1 overflow-y-auto p-4 md:p-6">
                         {(() => {
                           const selectedProvider =
-                            activeProviderTab ||
-                            evaluationResult.provider_results[0]?.provider;
+                            activeProviderTab || evaluationResult.provider_results![0]?.provider;
                           const providerResult =
-                            evaluationResult.provider_results.find(
-                              (pr) => pr.provider === selectedProvider,
-                            );
+                            evaluationResult.provider_results!.find((pr) => pr.provider === selectedProvider);
 
                           if (!providerResult) {
                             return (
                               <div className="flex items-center justify-center h-full">
-                                <p className="text-muted-foreground">
-                                  Select a provider to view details
-                                </p>
+                                <p className="text-muted-foreground">Select a provider to view details</p>
                               </div>
                             );
                           }
 
-                          // Show spinner if provider is in progress and has no results yet
-                          if (
-                            providerResult.success === null &&
-                            (!providerResult.results ||
-                              providerResult.results.length === 0)
-                          ) {
+                          if (providerResult.success === null && (!providerResult.results || providerResult.results.length === 0)) {
                             return (
                               <div className="flex items-center justify-center h-full min-h-[200px]">
-                                <div className="flex items-center gap-3">
-                                  <svg
-                                    className="w-5 h-5 animate-spin text-muted-foreground"
-                                    fill="none"
-                                    viewBox="0 0 24 24"
-                                  >
-                                    <circle
-                                      className="opacity-25"
-                                      cx="12"
-                                      cy="12"
-                                      r="10"
-                                      stroke="currentColor"
-                                      strokeWidth="4"
-                                    ></circle>
-                                    <path
-                                      className="opacity-75"
-                                      fill="currentColor"
-                                      d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
-                                    ></path>
-                                  </svg>
-                                </div>
+                                <svg className="w-5 h-5 animate-spin text-muted-foreground" fill="none" viewBox="0 0 24 24">
+                                  <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
+                                  <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+                                </svg>
                               </div>
                             );
                           }
 
-                          // Show error banner if provider failed
                           if (providerResult.success === false) {
                             return (
                               <div className="flex items-center justify-center h-full min-h-[200px]">
                                 <div className="border border-red-500/50 bg-red-500/10 rounded-lg p-4 max-w-md text-center">
                                   <div className="text-red-500 text-[14px] font-medium mb-1">
-                                    There was an error running this provider.
-                                    Please contact us by posting your issue to
-                                    help us help you.
+                                    There was an error running this provider. Please contact us by posting your issue to help us help you.
                                   </div>
                                 </div>
                               </div>
                             );
                           }
 
+                          const showMetrics =
+                            evaluationResult.status === "done" ||
+                            (providerResult.results?.every((r) => r.wer !== undefined && r.wer !== "" && r.string_similarity !== undefined && r.string_similarity !== "" && r.llm_judge_score !== undefined && r.llm_judge_score !== "") ?? false);
+
                           return (
                             <div className="space-y-4 md:space-y-6">
-                              {/* Overall Metrics - Only show if success */}
-                              {providerResult.success &&
-                                providerResult.metrics && (
-                                  <div className="border rounded-xl p-4 bg-muted/10">
-                                    <h3 className="text-[15px] font-semibold mb-4">
-                                      Overall Metrics
-                                    </h3>
-                                    <div className="grid grid-cols-3 gap-4">
-                                      <div>
-                                        <div className="text-[12px] text-muted-foreground mb-1">
-                                          WER
-                                        </div>
-                                        <div className="text-base md:text-[18px] font-semibold text-foreground">
-                                          {providerResult.metrics.wer != null
-                                            ? parseFloat(
-                                                providerResult.metrics.wer.toFixed(
-                                                  4,
-                                                ),
-                                              )
-                                            : "-"}
-                                        </div>
-                                      </div>
-                                      <div>
-                                        <div className="text-[12px] text-muted-foreground mb-1">
-                                          String Similarity
-                                        </div>
-                                        <div className="text-base md:text-[18px] font-semibold text-foreground">
-                                          {providerResult.metrics
-                                            .string_similarity != null
-                                            ? parseFloat(
-                                                providerResult.metrics.string_similarity.toFixed(
-                                                  4,
-                                                ),
-                                              )
-                                            : "-"}
-                                        </div>
-                                      </div>
-                                      <div>
-                                        <div className="text-[12px] text-muted-foreground mb-1">
-                                          LLM Judge Score
-                                        </div>
-                                        <div className="text-base md:text-[18px] font-semibold text-foreground">
-                                          {providerResult.metrics
-                                            .llm_judge_score ?? "-"}
-                                        </div>
-                                      </div>
-                                    </div>
-                                  </div>
-                                )}
-
-                              {/* Results Table */}
-                              {providerResult.results &&
-                                providerResult.results.length > 0 &&
-                                (() => {
-                                  // Check if all rows have metrics available
-                                  const allRowsHaveMetrics =
-                                    providerResult.results.every(
-                                      (r) =>
-                                        r.wer !== undefined &&
-                                        r.wer !== "" &&
-                                        r.string_similarity !== undefined &&
-                                        r.string_similarity !== "" &&
-                                        r.llm_judge_score !== undefined &&
-                                        r.llm_judge_score !== "",
-                                    );
-                                  const showMetrics =
-                                    evaluationResult.status === "done" ||
-                                    allRowsHaveMetrics;
-                                  const hasAudio =
-                                    providerResult.results.some(
-                                      (r) => !!r.audio_url,
-                                    );
-
-                                  return (
-                                    <>
-                                      {/* Desktop: Table layout */}
-                                      <div
-                                        className="hidden md:block border rounded-xl overflow-visible"
-                                        ref={tableContainerRef}
-                                      >
-                                        <div className="overflow-x-auto rounded-xl">
-                                          <table className="w-full table-fixed">
-                                            <thead className="bg-muted/50 border-b border-border">
-                                              <tr>
-                                                <th className="w-10 px-3 py-3 text-left text-[12px] font-medium text-foreground">
-                                                  ID
-                                                </th>
-                                                {hasAudio && (
-                                                  <th className="w-[180px] px-3 py-3 text-left text-[12px] font-medium text-foreground">
-                                                    Audio
-                                                  </th>
-                                                )}
-                                                <th
-                                                  className={`${
-                                                    showMetrics
-                                                      ? "w-[25%]"
-                                                      : "w-[calc(50%-20px)]"
-                                                  } px-3 py-3 text-left text-[12px] font-medium text-foreground`}
-                                                >
-                                                  Ground Truth
-                                                </th>
-                                                <th
-                                                  className={`${
-                                                    showMetrics
-                                                      ? "w-[25%]"
-                                                      : "w-[calc(50%-20px)]"
-                                                  } px-3 py-3 text-left text-[12px] font-medium text-foreground`}
-                                                >
-                                                  Prediction
-                                                </th>
-                                                {showMetrics && (
-                                                  <>
-                                                    <th className="w-[72px] px-3 py-3 text-left text-[12px] font-medium text-foreground">
-                                                      WER
-                                                    </th>
-                                                    <th className="w-[100px] px-3 py-3 text-left text-[12px] font-medium text-foreground">
-                                                      Similarity
-                                                    </th>
-                                                    <th className="w-[90px] px-3 py-3 text-left text-[12px] font-medium text-foreground">
-                                                      LLM Judge
-                                                    </th>
-                                                  </>
-                                                )}
-                                              </tr>
-                                            </thead>
-                                            <tbody>
-                                              {providerResult.results.map(
-                                                (result, index) => {
-                                                  const isEmptyPrediction =
-                                                    !result.pred ||
-                                                    result.pred.trim() === "";
-                                                  return (
-                                                    <tr
-                                                      key={index}
-                                                      data-row-index={index}
-                                                      className={`border-b border-border last:border-b-0 ${
-                                                        isEmptyPrediction
-                                                          ? "bg-red-500/10"
-                                                          : ""
-                                                      }`}
-                                                    >
-                                                      <td className="px-3 py-3 text-[13px] text-foreground">
-                                                        {index + 1}
-                                                      </td>
-                                                      {hasAudio && (
-                                                        <td className="px-3 py-3">
-                                                          {result.audio_url ? (
-                                                            <audio
-                                                              src={result.audio_url}
-                                                              controls
-                                                              preload="none"
-                                                              className="h-8 w-full max-w-[160px]"
-                                                            />
-                                                          ) : (
-                                                            <span className="text-[13px] text-muted-foreground">—</span>
-                                                          )}
-                                                        </td>
-                                                      )}
-                                                      <td className="px-3 py-3 text-[13px] text-foreground break-words">
-                                                        {result.gt}
-                                                      </td>
-                                                      <td className="px-3 py-3 text-[13px] break-words">
-                                                        {isEmptyPrediction ? (
-                                                          <span className="text-muted-foreground">
-                                                            No transcript
-                                                            generated
-                                                          </span>
-                                                        ) : (
-                                                          <span className="text-foreground">
-                                                            {result.pred}
-                                                          </span>
-                                                        )}
-                                                      </td>
-                                                      {showMetrics && (
-                                                        <>
-                                                          <td className="px-3 py-3 text-[13px] text-foreground">
-                                                            {result.wer != null
-                                                              ? parseFloat(
-                                                                  parseFloat(
-                                                                    result.wer,
-                                                                  ).toFixed(4),
-                                                                )
-                                                              : "-"}
-                                                          </td>
-                                                          <td className="px-3 py-3 text-[13px] text-foreground">
-                                                            {result.string_similarity !=
-                                                            null
-                                                              ? parseFloat(
-                                                                  parseFloat(
-                                                                    result.string_similarity,
-                                                                  ).toFixed(4),
-                                                                )
-                                                              : "-"}
-                                                          </td>
-                                                          <td className="px-3 py-3">
-                                                            {(() => {
-                                                              const scoreStr =
-                                                                String(
-                                                                  result.llm_judge_score ||
-                                                                    "",
-                                                                ).toLowerCase();
-                                                              const passed =
-                                                                scoreStr ===
-                                                                  "true" ||
-                                                                scoreStr ===
-                                                                  "1";
-                                                              const tooltipContent =
-                                                                result.llm_judge_reasoning
-                                                                  ? result.llm_judge_reasoning
-                                                                  : `Score: ${result.llm_judge_score}`;
-                                                              return (
-                                                                <div className="flex items-center gap-1.5">
-                                                                  <span
-                                                                    className={`inline-flex items-center px-2.5 py-1 rounded-md text-xs font-medium ${
-                                                                      passed
-                                                                        ? "bg-green-100 text-green-700 dark:bg-green-500/20 dark:text-green-400"
-                                                                        : "bg-red-100 text-red-700 dark:bg-red-500/20 dark:text-red-400"
-                                                                    }`}
-                                                                  >
-                                                                    {passed
-                                                                      ? "Pass"
-                                                                      : "Fail"}
-                                                                  </span>
-                                                                  <Tooltip
-                                                                    content={
-                                                                      tooltipContent
-                                                                    }
-                                                                  >
-                                                                    <button
-                                                                      type="button"
-                                                                      className="p-1 rounded-md hover:bg-muted transition-colors cursor-pointer"
-                                                                      aria-label="View reasoning"
-                                                                    >
-                                                                      <svg
-                                                                        className="w-4 h-4 text-muted-foreground"
-                                                                        fill="none"
-                                                                        viewBox="0 0 24 24"
-                                                                        stroke="currentColor"
-                                                                        strokeWidth={
-                                                                          2
-                                                                        }
-                                                                      >
-                                                                        <path
-                                                                          strokeLinecap="round"
-                                                                          strokeLinejoin="round"
-                                                                          d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
-                                                                        />
-                                                                      </svg>
-                                                                    </button>
-                                                                  </Tooltip>
-                                                                </div>
-                                                              );
-                                                            })()}
-                                                          </td>
-                                                        </>
-                                                      )}
-                                                    </tr>
-                                                  );
-                                                },
-                                              )}
-                                            </tbody>
-                                          </table>
-                                        </div>
-                                      </div>
-
-                                      {/* Mobile: Card layout */}
-                                      <div
-                                        className="md:hidden space-y-3"
-                                        ref={tableContainerRef}
-                                      >
-                                        {providerResult.results.map(
-                                          (result, index) => {
-                                            const isEmptyPrediction =
-                                              !result.pred ||
-                                              result.pred.trim() === "";
-                                            return (
-                                              <div
-                                                key={index}
-                                                data-row-index={index}
-                                                className={`border border-border rounded-xl p-4 space-y-3 ${
-                                                  isEmptyPrediction
-                                                    ? "bg-red-500/10"
-                                                    : ""
-                                                }`}
-                                              >
-                                                <div className="flex items-center justify-between">
-                                                  <span className="text-[12px] text-muted-foreground font-medium">
-                                                    #{index + 1}
-                                                  </span>
-                                                  {showMetrics &&
-                                                    (() => {
-                                                      const scoreStr = String(
-                                                        result.llm_judge_score ||
-                                                          "",
-                                                      ).toLowerCase();
-                                                      const passed =
-                                                        scoreStr === "true" ||
-                                                        scoreStr === "1";
-                                                      return (
-                                                        <span
-                                                          className={`inline-flex items-center px-2.5 py-1 rounded-md text-xs font-medium ${
-                                                            passed
-                                                              ? "bg-green-100 text-green-700 dark:bg-green-500/20 dark:text-green-400"
-                                                              : "bg-red-100 text-red-700 dark:bg-red-500/20 dark:text-red-400"
-                                                          }`}
-                                                        >
-                                                          {passed
-                                                            ? "Pass"
-                                                            : "Fail"}
-                                                        </span>
-                                                      );
-                                                    })()}
-                                                </div>
-                                                {result.audio_url && (
-                                                  <div>
-                                                    <span className="text-[11px] text-muted-foreground uppercase tracking-wide">
-                                                      Audio
-                                                    </span>
-                                                    <div className="mt-1">
-                                                      <audio
-                                                        src={result.audio_url}
-                                                        controls
-                                                        preload="none"
-                                                        className="w-full h-8"
-                                                      />
-                                                    </div>
-                                                  </div>
-                                                )}
-                                                <div>
-                                                  <span className="text-[11px] text-muted-foreground uppercase tracking-wide">
-                                                    Ground Truth
-                                                  </span>
-                                                  <p className="text-[13px] text-foreground mt-0.5">
-                                                    {result.gt}
-                                                  </p>
-                                                </div>
-                                                <div>
-                                                  <span className="text-[11px] text-muted-foreground uppercase tracking-wide">
-                                                    Prediction
-                                                  </span>
-                                                  {isEmptyPrediction ? (
-                                                    <p className="text-[13px] text-muted-foreground mt-0.5">
-                                                      No transcript generated
-                                                    </p>
-                                                  ) : (
-                                                    <p className="text-[13px] text-foreground mt-0.5">
-                                                      {result.pred}
-                                                    </p>
-                                                  )}
-                                                </div>
-                                                {showMetrics && (
-                                                  <div className="space-y-2 pt-1 border-t border-border">
-                                                    <div className="flex gap-4">
-                                                      <div>
-                                                        <span className="text-[11px] text-muted-foreground uppercase tracking-wide">
-                                                          WER
-                                                        </span>
-                                                        <p className="text-[13px] text-foreground">
-                                                          {result.wer != null
-                                                            ? parseFloat(
-                                                                parseFloat(
-                                                                  result.wer,
-                                                                ).toFixed(4),
-                                                              )
-                                                            : "-"}
-                                                        </p>
-                                                      </div>
-                                                      <div>
-                                                        <span className="text-[11px] text-muted-foreground uppercase tracking-wide">
-                                                          Similarity
-                                                        </span>
-                                                        <p className="text-[13px] text-foreground">
-                                                          {result.string_similarity !=
-                                                          null
-                                                            ? parseFloat(
-                                                                parseFloat(
-                                                                  result.string_similarity,
-                                                                ).toFixed(4),
-                                                              )
-                                                            : "-"}
-                                                        </p>
-                                                      </div>
-                                                    </div>
-                                                    {result.llm_judge_reasoning && (
-                                                      <div>
-                                                        <span className="text-[11px] text-muted-foreground uppercase tracking-wide">
-                                                          LLM Judge Reasoning
-                                                        </span>
-                                                        <p className="text-[12px] text-muted-foreground mt-0.5">
-                                                          {
-                                                            result.llm_judge_reasoning
-                                                          }
-                                                        </p>
-                                                      </div>
-                                                    )}
-                                                  </div>
-                                                )}
-                                              </div>
-                                            );
-                                          },
-                                        )}
-                                      </div>
-                                    </>
-                                  );
-                                })()}
+                              {providerResult.success && providerResult.metrics && (
+                                <ProviderMetricsCard
+                                  metrics={[
+                                    { label: "WER", value: providerResult.metrics.wer != null ? parseFloat(providerResult.metrics.wer.toFixed(4)) : "-" },
+                                    { label: "String Similarity", value: providerResult.metrics.string_similarity != null ? parseFloat(providerResult.metrics.string_similarity.toFixed(4)) : "-" },
+                                    { label: "LLM Judge Score", value: providerResult.metrics.llm_judge_score ?? "-" },
+                                  ]}
+                                />
+                              )}
+                              {providerResult.results && providerResult.results.length > 0 && (
+                                <STTResultsTable results={providerResult.results} showMetrics={showMetrics} tableRef={tableContainerRef} />
+                              )}
                             </div>
                           );
                         })()}

--- a/src/app/tts/[uuid]/page.tsx
+++ b/src/app/tts/[uuid]/page.tsx
@@ -7,14 +7,15 @@ import { signOut } from "next-auth/react";
 import { useAccessToken } from "@/hooks";
 import { AppLayout } from "@/components/AppLayout";
 import { BackHeader, StatusBadge, NotFoundState } from "@/components/ui";
-import { Tooltip } from "@/components/Tooltip";
 import { ttsProviders } from "@/components/agent-tabs/constants/providers";
-import {
-  LeaderboardBarChart,
-  getColorMap,
-} from "@/components/charts/LeaderboardBarChart";
-import { DownloadableTable } from "@/components/DownloadableTable";
 import { POLLING_INTERVAL_MS } from "@/constants/polling";
+import {
+  ProviderSidebar,
+  ProviderMetricsCard,
+  TTSResultsTable,
+  LeaderboardTab,
+  AboutMetricsTable,
+} from "@/components/eval-details";
 import { useSidebarState } from "@/lib/sidebar";
 import { getDataset } from "@/lib/datasets";
 import { ShareButton } from "@/components/ShareButton";
@@ -405,593 +406,101 @@ export default function TTSEvaluationDetailPage() {
 
                   {/* About Tab */}
                   {activeTab === "about" && (
-                    <div className="space-y-4 md:space-y-6">
-                      {/* Desktop: Table layout */}
-                      <div className="hidden md:block border rounded-xl overflow-hidden">
-                        <table className="w-full">
-                          <thead className="bg-muted/50 border-b border-border">
-                            <tr>
-                              <th className="px-4 py-3 text-left text-[13px] font-medium text-foreground">
-                                Metric
-                              </th>
-                              <th className="px-4 py-3 text-left text-[13px] font-medium text-foreground">
-                                Description
-                              </th>
-                              <th className="px-4 py-3 text-left text-[13px] font-medium text-foreground">
-                                Preference
-                              </th>
-                              <th className="px-4 py-3 text-left text-[13px] font-medium text-foreground">
-                                Range
-                              </th>
-                            </tr>
-                          </thead>
-                          <tbody>
-                            <tr className="border-b border-border">
-                              <td className="px-4 py-3 text-[13px] font-medium text-foreground">
-                                LLM Judge
-                              </td>
-                              <td className="px-4 py-3 text-[13px] text-foreground">
-                                The LLM judge evaluates whether the synthesized
-                                audio accurately matches the reference text. It
-                                checks for semantic equivalence and
-                                pronunciation accuracy, returning Pass if the
-                                audio correctly represents the input text.
-                              </td>
-                              <td className="px-4 py-3 text-[13px] text-foreground">
-                                Pass is better
-                              </td>
-                              <td className="px-4 py-3 text-[13px] text-foreground">
-                                Pass / Fail
-                              </td>
-                            </tr>
-                            <tr className="border-b border-border">
-                              <td className="px-4 py-3 text-[13px] font-medium text-foreground">
-                                TTFB (Time To First Byte)
-                              </td>
-                              <td className="px-4 py-3 text-[13px] text-foreground">
-                                Time to first byte measures the latency from
-                                when a request is sent until the first byte of
-                                the response is received.
-                              </td>
-                              <td className="px-4 py-3 text-[13px] text-foreground">
-                                Lower is better
-                              </td>
-                              <td className="px-4 py-3 text-[13px] text-foreground">
-                                0 - ∞
-                              </td>
-                            </tr>
-                          </tbody>
-                        </table>
-                      </div>
-
-                      {/* Mobile: Card layout */}
-                      <div className="md:hidden space-y-3">
-                        {[
-                          {
-                            metric: "LLM Judge",
-                            description:
-                              "The LLM judge evaluates whether the synthesized audio accurately matches the reference text. It checks for semantic equivalence and pronunciation accuracy, returning Pass if the audio correctly represents the input text.",
-                            preference: "Pass is better",
-                            range: "Pass / Fail",
-                          },
-                          {
-                            metric: "TTFB (Time To First Byte)",
-                            description:
-                              "Time to first byte measures the latency from when a request is sent until the first byte of the response is received.",
-                            preference: "Lower is better",
-                            range: "0 - ∞",
-                          },
-                        ].map((item) => (
-                          <div
-                            key={item.metric}
-                            className="border border-border rounded-xl p-4 space-y-2"
-                          >
-                            <h4 className="text-[13px] font-semibold text-foreground">
-                              {item.metric}
-                            </h4>
-                            <p className="text-[13px] text-muted-foreground">
-                              {item.description}
-                            </p>
-                            <div className="flex gap-4 pt-1">
-                              <div>
-                                <span className="text-[11px] text-muted-foreground uppercase tracking-wide">
-                                  Preference
-                                </span>
-                                <p className="text-[13px] text-foreground">
-                                  {item.preference}
-                                </p>
-                              </div>
-                              <div>
-                                <span className="text-[11px] text-muted-foreground uppercase tracking-wide">
-                                  Range
-                                </span>
-                                <p className="text-[13px] text-foreground">
-                                  {item.range}
-                                </p>
-                              </div>
-                            </div>
-                          </div>
-                        ))}
-                      </div>
-                    </div>
+                    <AboutMetricsTable
+                      metrics={[
+                        { metric: "LLM Judge", description: "The LLM judge evaluates whether the synthesized audio accurately matches the reference text. It checks for semantic equivalence and pronunciation accuracy, returning Pass if the audio correctly represents the input text.", preference: "Pass is better", range: "Pass / Fail" },
+                        { metric: "TTFB (Time To First Byte)", description: "Time to first byte measures the latency from when a request is sent until the first byte of the response is received.", preference: "Lower is better", range: "0 - ∞" },
+                      ]}
+                    />
                   )}
 
                   {/* Leaderboard Tab */}
-                  {activeTab === "leaderboard" && (
-                    <div className="space-y-4 md:space-y-6 -mx-4 md:-mx-8 px-4 md:px-8 w-[calc(100vw-32px)] md:w-[calc(100vw-56px)] ml-[calc((32px-100vw)/2+50%)] md:ml-[calc((56px-100vw)/2+50%)] relative">
-                      {evaluationResult.leaderboard_summary &&
-                        evaluationResult.leaderboard_summary.length > 0 && (
-                          <>
-                            <DownloadableTable
-                              columns={[
-                                {
-                                  key: "run",
-                                  header: "Run",
-                                  render: (value) => getProviderLabel(value),
-                                },
-                                {
-                                  key: "llm_judge_score",
-                                  header: "LLM Judge Score",
-                                },
-                                {
-                                  key: "ttfb",
-                                  header: "TTFB (s)",
-                                  render: (value) =>
-                                    value != null
-                                      ? parseFloat(value.toFixed(4))
-                                      : "-",
-                                },
-                              ]}
-                              data={evaluationResult.leaderboard_summary}
-                              filename="tts-evaluation-leaderboard"
-                            />
-
-                            {/* Charts Section */}
-                            {(() => {
-                              const providerNames =
-                                evaluationResult.leaderboard_summary.map(
-                                  (s) => s.run
-                                );
-                              const colorMap = getColorMap(providerNames);
-                              return (
-                                <div className="space-y-4 md:space-y-6">
-                                  {/* Row 1: LLM Judge Score and TTFB */}
-                                  <div className="grid grid-cols-1 md:grid-cols-2 gap-4 md:gap-6">
-                                    <LeaderboardBarChart
-                                      title="LLM Judge Score"
-                                      data={evaluationResult.leaderboard_summary.map(
-                                        (s) => ({
-                                          label: getProviderLabel(s.run),
-                                          value: s.llm_judge_score,
-                                          colorKey: s.run,
-                                        })
-                                      )}
-                                      colorMap={colorMap}
-                                      yDomain={[0, 1]}
-                                    />
-                                    <LeaderboardBarChart
-                                      title="TTFB (s)"
-                                      data={evaluationResult.leaderboard_summary.map(
-                                        (s) => ({
-                                          label: getProviderLabel(s.run),
-                                          value: s.ttfb,
-                                          colorKey: s.run,
-                                        })
-                                      )}
-                                      colorMap={colorMap}
-                                    />
-                                  </div>
-                                </div>
-                              );
-                            })()}
-                          </>
-                        )}
-                    </div>
+                  {activeTab === "leaderboard" && evaluationResult.leaderboard_summary && (
+                    <LeaderboardTab
+                      className="-mx-4 md:-mx-8 px-4 md:px-8 w-[calc(100vw-32px)] md:w-[calc(100vw-56px)] ml-[calc((32px-100vw)/2+50%)] md:ml-[calc((56px-100vw)/2+50%)] relative"
+                      columns={[
+                        { key: "run", header: "Run", render: (v) => getProviderLabel(v) },
+                        { key: "llm_judge_score", header: "LLM Judge Score" },
+                        { key: "ttfb", header: "TTFB (s)", render: (v) => v != null ? parseFloat(v.toFixed(4)) : "-" },
+                      ]}
+                      data={evaluationResult.leaderboard_summary}
+                      charts={[[
+                        { title: "LLM Judge Score", dataKey: "llm_judge_score", yDomain: [0, 1] },
+                        { title: "TTFB (s)", dataKey: "ttfb" },
+                      ]]}
+                      filename="tts-evaluation-leaderboard"
+                      getLabel={getProviderLabel}
+                    />
                   )}
 
                   {/* Outputs Tab */}
                   {activeTab === "outputs" && (
                     <div className="flex flex-col md:flex-row border border-border rounded-xl overflow-hidden md:h-[calc(100vh-220px)]">
-                      {/* Provider List - Horizontal scroll on mobile, vertical sidebar on desktop */}
-                      <div className="md:w-48 border-b md:border-b-0 md:border-r border-border flex flex-col overflow-hidden bg-muted/10">
-                        <div className="overflow-x-auto md:overflow-x-visible md:overflow-y-auto md:flex-1 p-2">
-                          <div className="flex md:flex-col gap-1 md:gap-1 min-w-max md:min-w-0">
-                            {evaluationResult.provider_results!.map(
-                              (providerResult) => {
-                                const isSelected =
-                                  (activeProviderTab ||
-                                    evaluationResult.provider_results![0]
-                                      ?.provider) === providerResult.provider;
-                                return (
-                                  <div
-                                    key={providerResult.provider}
-                                    onClick={() =>
-                                      setActiveProviderTab(
-                                        providerResult.provider
-                                      )
-                                    }
-                                    className={`flex items-center gap-2 px-3 py-2 rounded-lg cursor-pointer transition-colors whitespace-nowrap ${
-                                      isSelected
-                                        ? "bg-muted"
-                                        : "hover:bg-muted/50"
-                                    }`}
-                                  >
-                                    {/* Status Icon */}
-                                    {providerResult.success === null ? (
-                                      // In progress - yellow dot
-                                      <div className="w-2 h-2 rounded-full bg-yellow-500 animate-pulse flex-shrink-0"></div>
-                                    ) : providerResult.success === true ? (
-                                      // Done, passed - green tick
-                                      <div className="w-5 h-5 rounded-full bg-green-500/20 flex items-center justify-center flex-shrink-0">
-                                        <svg
-                                          className="w-3 h-3 text-green-500"
-                                          fill="none"
-                                          viewBox="0 0 24 24"
-                                          stroke="currentColor"
-                                          strokeWidth={3}
-                                        >
-                                          <path
-                                            strokeLinecap="round"
-                                            strokeLinejoin="round"
-                                            d="M4.5 12.75l6 6 9-13.5"
-                                          />
-                                        </svg>
-                                      </div>
-                                    ) : (
-                                      // Done, failed - red X
-                                      <div className="w-5 h-5 rounded-full bg-red-500/20 flex items-center justify-center flex-shrink-0">
-                                        <svg
-                                          className="w-3 h-3 text-red-500"
-                                          fill="none"
-                                          viewBox="0 0 24 24"
-                                          stroke="currentColor"
-                                          strokeWidth={3}
-                                        >
-                                          <path
-                                            strokeLinecap="round"
-                                            strokeLinejoin="round"
-                                            d="M6 18L18 6M6 6l12 12"
-                                          />
-                                        </svg>
-                                      </div>
-                                    )}
-                                    <span className="text-sm text-foreground truncate">
-                                      {getProviderLabel(
-                                        providerResult.provider
-                                      )}
-                                    </span>
-                                  </div>
-                                );
-                              }
-                            )}
-                          </div>
-                        </div>
-                      </div>
+                      <ProviderSidebar
+                        items={evaluationResult.provider_results!.map((pr) => ({
+                          key: pr.provider,
+                          label: getProviderLabel(pr.provider),
+                          success: pr.success,
+                        }))}
+                        activeKey={activeProviderTab || evaluationResult.provider_results![0]?.provider}
+                        onSelect={setActiveProviderTab}
+                      />
 
-                      {/* Right Panel - Provider Details */}
                       <div className="flex-1 overflow-y-auto p-4 md:p-6">
                         {(() => {
                           const selectedProvider =
-                            activeProviderTab ||
-                            evaluationResult.provider_results![0]?.provider;
+                            activeProviderTab || evaluationResult.provider_results![0]?.provider;
                           const providerResult =
-                            evaluationResult.provider_results!.find(
-                              (pr) => pr.provider === selectedProvider
-                            );
+                            evaluationResult.provider_results!.find((pr) => pr.provider === selectedProvider);
 
                           if (!providerResult) {
                             return (
                               <div className="flex items-center justify-center h-full">
-                                <p className="text-muted-foreground">
-                                  Select a provider to view details
-                                </p>
+                                <p className="text-muted-foreground">Select a provider to view details</p>
                               </div>
                             );
                           }
 
-                          // Show spinner if provider is in progress and has no results yet
-                          if (
-                            providerResult.success === null &&
-                            (!providerResult.results ||
-                              providerResult.results.length === 0)
-                          ) {
+                          if (providerResult.success === null && (!providerResult.results || providerResult.results.length === 0)) {
                             return (
                               <div className="flex items-center justify-center h-full min-h-[200px]">
-                                <div className="flex items-center gap-3">
-                                  <svg
-                                    className="w-5 h-5 animate-spin text-muted-foreground"
-                                    fill="none"
-                                    viewBox="0 0 24 24"
-                                  >
-                                    <circle
-                                      className="opacity-25"
-                                      cx="12"
-                                      cy="12"
-                                      r="10"
-                                      stroke="currentColor"
-                                      strokeWidth="4"
-                                    ></circle>
-                                    <path
-                                      className="opacity-75"
-                                      fill="currentColor"
-                                      d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
-                                    ></path>
-                                  </svg>
-                                </div>
+                                <svg className="w-5 h-5 animate-spin text-muted-foreground" fill="none" viewBox="0 0 24 24">
+                                  <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
+                                  <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+                                </svg>
                               </div>
                             );
                           }
 
-                          // Show error banner if provider failed
                           if (providerResult.success === false) {
                             return (
                               <div className="flex items-center justify-center h-full min-h-[200px]">
                                 <div className="border border-red-500/50 bg-red-500/10 rounded-lg p-4 max-w-md text-center">
                                   <div className="text-red-500 text-[14px] font-medium mb-1">
-                                    There was an error running this provider.
-                                    Please contact us by posting your issue to
-                                    help us help you.
+                                    There was an error running this provider. Please contact us by posting your issue to help us help you.
                                   </div>
                                 </div>
                               </div>
                             );
                           }
 
+                          const showMetrics =
+                            evaluationResult.status === "done" ||
+                            (providerResult.results?.every((r) => r.llm_judge_score !== undefined && r.llm_judge_score !== "") ?? false);
+
                           return (
                             <div className="space-y-4 md:space-y-6">
-                              {/* Overall Metrics - Only show if success */}
-                              {providerResult.success &&
-                                providerResult.metrics && (
-                                  <div className="border rounded-xl p-4 bg-muted/10">
-                                    <h3 className="text-[15px] font-semibold mb-4">
-                                      Overall Metrics
-                                    </h3>
-                                    <div className="grid grid-cols-2 gap-4">
-                                      <div>
-                                        <div className="text-[12px] text-muted-foreground mb-1">
-                                          LLM Judge Score
-                                        </div>
-                                        <div className="text-base md:text-[18px] font-semibold text-foreground">
-                                          {providerResult.metrics
-                                            .llm_judge_score ?? "-"}
-                                        </div>
-                                      </div>
-                                      <div>
-                                        <div className="text-[12px] text-muted-foreground mb-1">
-                                          TTFB (s)
-                                        </div>
-                                        <div className="text-base md:text-[18px] font-semibold text-foreground">
-                                          {providerResult.metrics.ttfb?.mean !=
-                                          null
-                                            ? parseFloat(
-                                                providerResult.metrics.ttfb.mean.toFixed(
-                                                  4
-                                                )
-                                              )
-                                            : "-"}
-                                        </div>
-                                      </div>
-                                    </div>
-                                  </div>
-                                )}
-
-                              {/* Results - Desktop: Table, Mobile: Cards */}
-                              {providerResult.results &&
-                                providerResult.results.length > 0 &&
-                                (() => {
-                                  // Check if all rows have metrics available
-                                  const allRowsHaveMetrics =
-                                    providerResult.results.every(
-                                      (r) =>
-                                        r.llm_judge_score !== undefined &&
-                                        r.llm_judge_score !== ""
-                                    );
-                                  const showMetrics =
-                                    evaluationResult.status === "done" ||
-                                    allRowsHaveMetrics;
-
-                                  return (
-                                    <>
-                                      {/* Desktop: Table layout */}
-                                      <div className="hidden md:block border rounded-xl overflow-visible">
-                                        <div className="overflow-hidden rounded-xl">
-                                          <table className="w-full table-fixed">
-                                            <thead className="bg-muted/50 border-b border-border">
-                                              <tr>
-                                                <th className="w-12 px-4 py-3 text-left text-[12px] font-medium text-foreground">
-                                                  ID
-                                                </th>
-                                                <th
-                                                  className={`${
-                                                    showMetrics
-                                                      ? "w-[30%]"
-                                                      : "w-[calc(50%-24px)]"
-                                                  } px-4 py-3 text-left text-[12px] font-medium text-foreground`}
-                                                >
-                                                  Text
-                                                </th>
-                                                <th
-                                                  className={`${
-                                                    showMetrics
-                                                      ? "w-[50%]"
-                                                      : "w-[calc(50%-24px)]"
-                                                  } px-4 py-3 text-left text-[12px] font-medium text-foreground`}
-                                                >
-                                                  Audio
-                                                </th>
-                                                {showMetrics && (
-                                                  <th className="px-4 py-3 text-left text-[12px] font-medium text-foreground">
-                                                    LLM Judge
-                                                  </th>
-                                                )}
-                                              </tr>
-                                            </thead>
-                                            <tbody>
-                                              {providerResult.results.map(
-                                                (result, index) => (
-                                                  <tr
-                                                    key={index}
-                                                    className="border-b border-border last:border-b-0"
-                                                  >
-                                                    <td className="px-4 py-3 text-[13px] text-foreground">
-                                                      {index + 1}
-                                                    </td>
-                                                    <td className="px-4 py-3 text-[13px] text-foreground break-words">
-                                                      {result.text}
-                                                    </td>
-                                                    <td className="px-4 py-3 text-[13px] text-foreground">
-                                                      <audio
-                                                        controls
-                                                        className="w-full min-w-[280px]"
-                                                        src={result.audio_path}
-                                                      >
-                                                        Your browser does not
-                                                        support the audio
-                                                        element.
-                                                      </audio>
-                                                    </td>
-                                                    {showMetrics && (
-                                                      <td className="px-4 py-3">
-                                                        {(() => {
-                                                          const scoreStr =
-                                                            String(
-                                                              result.llm_judge_score ||
-                                                                ""
-                                                            ).toLowerCase();
-                                                          const passed =
-                                                            scoreStr ===
-                                                              "true" ||
-                                                            scoreStr === "1";
-                                                          const tooltipContent =
-                                                            result.llm_judge_reasoning
-                                                              ? result.llm_judge_reasoning
-                                                              : `Score: ${result.llm_judge_score}`;
-                                                          return (
-                                                            <div className="flex items-center gap-1.5">
-                                                              <span
-                                                                className={`inline-flex items-center px-2.5 py-1 rounded-md text-xs font-medium ${
-                                                                  passed
-                                                                    ? "bg-green-100 text-green-700 dark:bg-green-500/20 dark:text-green-400"
-                                                                    : "bg-red-100 text-red-700 dark:bg-red-500/20 dark:text-red-400"
-                                                                }`}
-                                                              >
-                                                                {passed
-                                                                  ? "Pass"
-                                                                  : "Fail"}
-                                                              </span>
-                                                              <Tooltip
-                                                                content={
-                                                                  tooltipContent
-                                                                }
-                                                              >
-                                                                <button
-                                                                  type="button"
-                                                                  className="p-1 rounded-md hover:bg-muted transition-colors cursor-pointer"
-                                                                  aria-label="View reasoning"
-                                                                >
-                                                                  <svg
-                                                                    className="w-4 h-4 text-muted-foreground"
-                                                                    fill="none"
-                                                                    viewBox="0 0 24 24"
-                                                                    stroke="currentColor"
-                                                                    strokeWidth={
-                                                                      2
-                                                                    }
-                                                                  >
-                                                                    <path
-                                                                      strokeLinecap="round"
-                                                                      strokeLinejoin="round"
-                                                                      d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
-                                                                    />
-                                                                  </svg>
-                                                                </button>
-                                                              </Tooltip>
-                                                            </div>
-                                                          );
-                                                        })()}
-                                                      </td>
-                                                    )}
-                                                  </tr>
-                                                )
-                                              )}
-                                            </tbody>
-                                          </table>
-                                        </div>
-                                      </div>
-
-                                      {/* Mobile: Card layout */}
-                                      <div className="md:hidden space-y-3">
-                                        {providerResult.results.map(
-                                          (result, index) => {
-                                            const scoreStr = String(
-                                              result.llm_judge_score || ""
-                                            ).toLowerCase();
-                                            const passed =
-                                              scoreStr === "true" ||
-                                              scoreStr === "1";
-                                            return (
-                                              <div
-                                                key={index}
-                                                className="border border-border rounded-xl p-4 space-y-3"
-                                              >
-                                                <div className="flex items-center justify-between">
-                                                  <span className="text-[12px] text-muted-foreground font-medium">
-                                                    #{index + 1}
-                                                  </span>
-                                                  {showMetrics && (
-                                                    <span
-                                                      className={`inline-flex items-center px-2.5 py-1 rounded-md text-xs font-medium ${
-                                                        passed
-                                                          ? "bg-green-100 text-green-700 dark:bg-green-500/20 dark:text-green-400"
-                                                          : "bg-red-100 text-red-700 dark:bg-red-500/20 dark:text-red-400"
-                                                      }`}
-                                                    >
-                                                      {passed ? "Pass" : "Fail"}
-                                                    </span>
-                                                  )}
-                                                </div>
-                                                <div>
-                                                  <span className="text-[11px] text-muted-foreground uppercase tracking-wide">
-                                                    Text
-                                                  </span>
-                                                  <p className="text-[13px] text-foreground mt-0.5">
-                                                    {result.text}
-                                                  </p>
-                                                </div>
-                                                <div>
-                                                  <span className="text-[11px] text-muted-foreground uppercase tracking-wide">
-                                                    Audio
-                                                  </span>
-                                                  <audio
-                                                    controls
-                                                    className="w-full mt-1"
-                                                    src={result.audio_path}
-                                                  >
-                                                    Your browser does not
-                                                    support the audio element.
-                                                  </audio>
-                                                </div>
-                                                {showMetrics &&
-                                                  result.llm_judge_reasoning && (
-                                                    <div className="pt-1 border-t border-border">
-                                                      <span className="text-[11px] text-muted-foreground uppercase tracking-wide">
-                                                        LLM Judge Reasoning
-                                                      </span>
-                                                      <p className="text-[12px] text-muted-foreground mt-0.5">
-                                                        {
-                                                          result.llm_judge_reasoning
-                                                        }
-                                                      </p>
-                                                    </div>
-                                                  )}
-                                              </div>
-                                            );
-                                          }
-                                        )}
-                                      </div>
-                                    </>
-                                  );
-                                })()}
+                              {providerResult.success && providerResult.metrics && (
+                                <ProviderMetricsCard
+                                  metrics={[
+                                    { label: "LLM Judge Score", value: providerResult.metrics.llm_judge_score ?? "-" },
+                                    { label: "TTFB (s)", value: providerResult.metrics.ttfb?.mean != null ? parseFloat(providerResult.metrics.ttfb.mean.toFixed(4)) : "-" },
+                                  ]}
+                                />
+                              )}
+                              {providerResult.results && providerResult.results.length > 0 && (
+                                <TTSResultsTable results={providerResult.results} showMetrics={showMetrics} />
+                              )}
                             </div>
                           );
                         })()}

--- a/src/components/BenchmarkResultsDialog.tsx
+++ b/src/components/BenchmarkResultsDialog.tsx
@@ -4,13 +4,10 @@ import React, { useState, useEffect, useRef } from "react";
 import {
   TestCaseOutput,
   TestCaseData,
-  StatusIcon,
   CloseIcon,
   SpinnerIcon,
-  TestDetailView,
-  EmptyStateView,
-  EvaluationCriteriaPanel,
 } from "./test-results/shared";
+import { BenchmarkOutputsPanel } from "./eval-details";
 import { StatusBadge } from "@/components/ui";
 import { LeaderboardBarChart, getColorMap } from "./charts/LeaderboardBarChart";
 import { DownloadableTable } from "./DownloadableTable";
@@ -331,16 +328,6 @@ export function BenchmarkResultsDialog({
     setSelectedTest({ model, testIndex });
   };
 
-  // Get the selected test result
-  const getSelectedTestResult = (): BenchmarkTestResult | null => {
-    if (!selectedTest) return null;
-    const modelResult = modelResults.find(
-      (m) => m.model === selectedTest.model,
-    );
-    if (!modelResult?.test_results) return null;
-    return modelResult.test_results[selectedTest.testIndex] || null;
-  };
-
   // Get providers to display (includes placeholders for models without results yet)
   const getProvidersToDisplay = (): ModelResult[] => {
     // When in progress and no results yet, show all models as placeholders
@@ -380,8 +367,6 @@ export function BenchmarkResultsDialog({
   const providersToDisplay = getProvidersToDisplay();
 
   if (!isOpen) return null;
-
-  const selectedTestResult = getSelectedTestResult();
 
   // Get color map for charts
   const modelNames = leaderboardSummary?.map((s) => s.model) || [];
@@ -594,268 +579,23 @@ export function BenchmarkResultsDialog({
 
             {/* Outputs Tab - Show during progress and when outputs tab is active when done */}
             {(!isDone || activeTab === "outputs") && (
-              <div className="flex h-full overflow-hidden">
-                {/* Left Panel - Provider Toggles with Tests */}
-                <div
-                  className={`w-full md:w-80 border-r border-border flex flex-col overflow-hidden ${
-                    selectedTest ? "hidden md:flex" : "flex"
-                  }`}
-                >
-                  <div className="flex-1 overflow-y-auto">
-                    {providersToDisplay.length > 0 ? (
-                      providersToDisplay.map((modelResult) => (
-                        <ProviderSection
-                          key={modelResult.model}
-                          modelResult={modelResult}
-                          isExpanded={expandedProviders.has(modelResult.model)}
-                          onToggle={() => toggleProvider(modelResult.model)}
-                          selectedTest={selectedTest}
-                          onTestSelect={(testIndex) =>
-                            handleTestSelect(modelResult.model, testIndex)
-                          }
-                          testNames={testNames}
-                        />
-                      ))
-                    ) : (
-                      <div className="p-4 text-sm text-muted-foreground">
-                        Waiting for results...
-                      </div>
-                    )}
-                  </div>
-                </div>
-
-                {/* Right Panel - Test Details */}
-                <div
-                  className={`flex-1 ${
-                    selectedTest ? "flex" : "hidden md:flex"
-                  } flex-col overflow-hidden`}
-                >
-                  {/* Mobile Back Button */}
-                  {selectedTest && (
-                    <div className="md:hidden px-4 md:px-6 py-3 md:py-4 border-b border-border flex-shrink-0">
-                      <button
-                        onClick={() => setSelectedTest(null)}
-                        className="flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground transition-colors"
-                      >
-                        <svg
-                          className="w-4 h-4"
-                          fill="none"
-                          viewBox="0 0 24 24"
-                          stroke="currentColor"
-                          strokeWidth={2}
-                        >
-                          <path
-                            strokeLinecap="round"
-                            strokeLinejoin="round"
-                            d="M10 19l-7-7m0 0l7-7m-7 7h18"
-                          />
-                        </svg>
-                        Back to models
-                      </button>
-                    </div>
-                  )}
-
-                  {/* Test Details Content */}
-                  <div className="flex-1 overflow-y-auto">
-                    {selectedTestResult ? (
-                      selectedTestResult.passed === null ? (
-                        <div className="flex items-center justify-center h-full">
-                          <div className="flex items-center gap-3">
-                            <SpinnerIcon className="w-5 h-5 animate-spin text-muted-foreground" />
-                            <p className="text-muted-foreground">
-                              Running test...
-                            </p>
-                          </div>
-                        </div>
-                      ) : (
-                        <TestDetailView
-                          history={selectedTestResult.test_case?.history || []}
-                          output={selectedTestResult.output}
-                          passed={selectedTestResult.passed}
-                          reasoning={selectedTestResult.reasoning}
-                        />
-                      )
-                    ) : (
-                      <EmptyStateView message="Select a test to view details" />
-                    )}
-                  </div>
-                </div>
-
-                {/* Right Panel - Evaluation Criteria */}
-                {selectedTestResult && selectedTestResult.passed !== null && (
-                  <div className="hidden md:flex w-72 border-l border-border flex-col overflow-hidden">
-                    <div className="flex-1 overflow-y-auto">
-                      <EvaluationCriteriaPanel
-                        evaluation={selectedTestResult.test_case?.evaluation}
-                      />
-                    </div>
-                  </div>
-                )}
-              </div>
+              <BenchmarkOutputsPanel
+                modelResults={providersToDisplay}
+                expandedModels={expandedProviders}
+                onToggleModel={toggleProvider}
+                onSetExpandedModels={setExpandedProviders}
+                selectedTest={selectedTest}
+                onSelectTest={handleTestSelect}
+                onClearSelection={() => setSelectedTest(null)}
+                testNames={testNames}
+                formatModelName={(n) => n.replace("__", "/")}
+                showControls={isDone}
+                showRunningSpinner={true}
+              />
             )}
           </div>
         )}
       </div>
-    </div>
-  );
-}
-
-// Provider Section Component with toggle and test list
-function ProviderSection({
-  modelResult,
-  isExpanded,
-  onToggle,
-  selectedTest,
-  onTestSelect,
-  testNames,
-}: {
-  modelResult: ModelResult;
-  isExpanded: boolean;
-  onToggle: () => void;
-  selectedTest: { model: string; testIndex: number } | null;
-  onTestSelect: (testIndex: number) => void;
-  testNames: string[];
-}) {
-  const isProcessing = modelResult.success === null;
-  const hasResults =
-    modelResult.test_results && modelResult.test_results.length > 0;
-
-  // Get test status counts
-  const passedCount = modelResult.passed ?? 0;
-  const failedCount = modelResult.failed ?? 0;
-  const totalTests = modelResult.total_tests ?? testNames.length;
-
-  return (
-    <div className="border-b border-border">
-      {/* Provider Header */}
-      <button
-        onClick={onToggle}
-        className="w-full px-4 py-3 flex items-center justify-between hover:bg-muted/50 transition-colors cursor-pointer"
-      >
-        <div className="flex items-center gap-2 min-w-0">
-          {/* Expand/Collapse Icon */}
-          <svg
-            className={`w-4 h-4 text-muted-foreground transition-transform flex-shrink-0 ${
-              isExpanded ? "rotate-90" : ""
-            }`}
-            fill="none"
-            viewBox="0 0 24 24"
-            stroke="currentColor"
-            strokeWidth={2}
-          >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              d="M8.25 4.5l7.5 7.5-7.5 7.5"
-            />
-          </svg>
-          {/* Provider Name */}
-          <span className="text-sm font-medium text-foreground truncate">
-            {modelResult.model.replace("__", "/")}
-          </span>
-          {/* Processing Spinner */}
-          {isProcessing && (
-            <SpinnerIcon className="w-3.5 h-3.5 animate-spin text-yellow-500 flex-shrink-0" />
-          )}
-        </div>
-        {/* Stats */}
-        {!isProcessing && modelResult.success !== null && (
-          <div className="flex items-center gap-2 text-xs flex-shrink-0">
-            {passedCount > 0 && (
-              <span className="text-green-500">{passedCount} passed</span>
-            )}
-            {failedCount > 0 && (
-              <span className="text-red-500">{failedCount} failed</span>
-            )}
-          </div>
-        )}
-      </button>
-
-      {/* Test List */}
-      {isExpanded && (
-        <div className="px-4 pb-3">
-          {(() => {
-            // Build a combined list of tests: results we have + placeholders for missing ones
-            const resultsCount = modelResult.test_results?.length ?? 0;
-            const expectedCount = Math.max(
-              totalTests,
-              testNames.length,
-              resultsCount,
-            );
-
-            if (expectedCount === 0 && !hasResults) {
-              return (
-                <div className="ml-4 px-3 py-2 text-sm text-muted-foreground">
-                  {isProcessing ? "Processing..." : "No test results"}
-                </div>
-              );
-            }
-
-            return (
-              <div className="space-y-1 ml-4">
-                {Array.from({ length: expectedCount }).map((_, index) => {
-                  const testResult = modelResult.test_results?.[index];
-                  const hasResult = !!testResult;
-                  const isSelected =
-                    selectedTest?.model === modelResult.model &&
-                    selectedTest?.testIndex === index;
-
-                  // Get test name from result, or fall back to testNames array
-                  const testName = hasResult
-                    ? testResult.name ||
-                      testResult.test_case?.name ||
-                      testNames[index] ||
-                      `Test ${index + 1}`
-                    : testNames[index] || `Test ${index + 1}`;
-
-                  // Determine status: if we have a result use it, otherwise show as running
-                  const status = hasResult
-                    ? testResult.passed === null
-                      ? "running"
-                      : testResult.passed
-                        ? "passed"
-                        : "failed"
-                    : "running";
-
-                  // Only make clickable if we have a result
-                  if (hasResult) {
-                    return (
-                      <button
-                        key={index}
-                        type="button"
-                        onClick={() => onTestSelect(index)}
-                        className={`w-full flex items-center gap-2 px-3 py-2 rounded-lg cursor-pointer transition-colors ${
-                          isSelected ? "bg-muted" : "hover:bg-muted/50"
-                        }`}
-                      >
-                        <StatusIcon
-                          status={status as "running" | "passed" | "failed"}
-                        />
-                        <span className="text-sm text-foreground truncate">
-                          {testName}
-                        </span>
-                      </button>
-                    );
-                  }
-
-                  // No result yet - show as running placeholder (not clickable)
-                  return (
-                    <div
-                      key={index}
-                      className="flex items-center gap-2 px-3 py-2 rounded-lg"
-                    >
-                      <StatusIcon status="running" />
-                      <span className="text-sm text-foreground truncate">
-                        {testName}
-                      </span>
-                    </div>
-                  );
-                })}
-              </div>
-            );
-          })()}
-        </div>
-      )}
     </div>
   );
 }

--- a/src/components/ShareButton.tsx
+++ b/src/components/ShareButton.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import { Tooltip } from "@/components/Tooltip";
 
 export type ShareableEntityType =
@@ -49,6 +49,15 @@ export function ShareButton({
     initialShareToken,
   );
   const [isLoading, setIsLoading] = useState(false);
+
+  // Sync internal state when parent props change (e.g. after polling fetches actual share state)
+  useEffect(() => {
+    setIsPublic(initialIsPublic);
+  }, [initialIsPublic]);
+
+  useEffect(() => {
+    setShareToken(initialShareToken);
+  }, [initialShareToken]);
   const [copied, setCopied] = useState(false);
   const [error, setError] = useState<string | null>(null);
 

--- a/src/components/TestRunnerDialog.tsx
+++ b/src/components/TestRunnerDialog.tsx
@@ -156,8 +156,6 @@ export function TestRunnerDialog({
     // Initialize state for viewing existing run
     setSelectedTestUuid(null);
     setCurrentTaskId(taskId);
-    setIsPublic(false);
-    setShareToken(null);
 
     const isInProgress =
       initialRunStatus === "pending" ||

--- a/src/components/TestRunnerDialog.tsx
+++ b/src/components/TestRunnerDialog.tsx
@@ -6,17 +6,13 @@ import { useAccessToken } from "@/hooks";
 import {
   TestCaseOutput,
   TestCaseData,
-  StatusIcon,
   CloseIcon,
-  SpinnerIcon,
-  TestDetailView as SharedTestDetailView,
-  EmptyStateView,
   TestStats,
-  EvaluationCriteriaPanel,
 } from "./test-results/shared";
 import { POLLING_INTERVAL_MS } from "@/constants/polling";
 import { useHideFloatingButton } from "@/components/AppLayout";
 import { ShareButton } from "@/components/ShareButton";
+import { TestRunOutputsPanel } from "./eval-details";
 
 type TestData = {
   uuid: string;
@@ -891,276 +887,25 @@ export function TestRunnerDialog({
           </div>
         ) : (
           /* Content - Split panel */
-          <div className="flex-1 flex overflow-hidden">
-            {/* Left Panel - Test List */}
-            <div
-              className={`w-full md:w-80 border-r border-border flex flex-col overflow-hidden ${
-                selectedTestUuid ? "hidden md:flex" : "flex"
-              }`}
-            >
-              <div className="flex-1 overflow-y-auto">
-                {/* Failed Tests - Always shown first */}
-                {failedTests.length > 0 && (
-                  <div className="p-4">
-                    <h3 className="text-sm font-medium text-muted-foreground mb-2 flex items-center gap-2">
-                      <div className="w-2 h-2 rounded-full bg-red-500"></div>
-                      Failed ({failedTests.length})
-                    </h3>
-                    <div className="space-y-1">
-                      {failedTests.map((result) => (
-                        <TestListItem
-                          key={result.test.uuid}
-                          result={result}
-                          isSelected={selectedTestUuid === result.test.uuid}
-                          onSelect={() => setSelectedTestUuid(result.test.uuid)}
-                        />
-                      ))}
-                    </div>
-                  </div>
-                )}
-
-                {/* Passed Tests */}
-                {passedTests.length > 0 && (
-                  <div className="p-4">
-                    <h3 className="text-sm font-medium text-muted-foreground mb-2 flex items-center gap-2">
-                      <div className="w-2 h-2 rounded-full bg-green-500"></div>
-                      Passed ({passedTests.length})
-                    </h3>
-                    <div className="space-y-1">
-                      {passedTests.map((result) => (
-                        <TestListItem
-                          key={result.test.uuid}
-                          result={result}
-                          isSelected={selectedTestUuid === result.test.uuid}
-                          onSelect={() => setSelectedTestUuid(result.test.uuid)}
-                        />
-                      ))}
-                    </div>
-                  </div>
-                )}
-
-                {/* Queued Tests */}
-                {queuedTests.length > 0 && (
-                  <div className="p-4">
-                    <h3 className="text-sm font-medium text-muted-foreground mb-2 flex items-center gap-2">
-                      <div className="w-2 h-2 rounded-full bg-gray-400"></div>
-                      Queued ({queuedTests.length})
-                    </h3>
-                    <div className="space-y-1">
-                      {queuedTests.map((result) => (
-                        <TestListItem
-                          key={result.test.uuid}
-                          result={result}
-                          isSelected={selectedTestUuid === result.test.uuid}
-                          onSelect={() => setSelectedTestUuid(result.test.uuid)}
-                        />
-                      ))}
-                    </div>
-                  </div>
-                )}
-
-                {/* Running Tests */}
-                {runningTests.length > 0 && (
-                  <div className="p-4">
-                    <h3 className="text-sm font-medium text-muted-foreground mb-2 flex items-center gap-2">
-                      <div className="w-2 h-2 rounded-full bg-yellow-500 animate-pulse"></div>
-                      Running ({runningTests.length})
-                    </h3>
-                    <div className="space-y-1">
-                      {runningTests.map((result) => (
-                        <TestListItem
-                          key={result.test.uuid}
-                          result={result}
-                          isSelected={selectedTestUuid === result.test.uuid}
-                          onSelect={() => setSelectedTestUuid(result.test.uuid)}
-                        />
-                      ))}
-                    </div>
-                  </div>
-                )}
-
-                {/* Pending Tests */}
-                {pendingTests.length > 0 && (
-                  <div className="p-4">
-                    <h3 className="text-sm font-medium text-muted-foreground mb-2 flex items-center gap-2">
-                      <div className="w-2 h-2 rounded-full bg-gray-400"></div>
-                      Pending ({pendingTests.length})
-                    </h3>
-                    <div className="space-y-1">
-                      {pendingTests.map((result) => (
-                        <TestListItem
-                          key={result.test.uuid}
-                          result={result}
-                          isSelected={selectedTestUuid === result.test.uuid}
-                          onSelect={() => setSelectedTestUuid(result.test.uuid)}
-                        />
-                      ))}
-                    </div>
-                  </div>
-                )}
-              </div>
-            </div>
-
-            {/* Middle Panel - Conversation History */}
-            <div
-              className={`flex-1 ${
-                selectedTestUuid ? "flex" : "hidden md:flex"
-              } flex-col overflow-hidden`}
-            >
-              {selectedResult ? (
-                <>
-                  {/* Mobile Back Button */}
-                  <div className="md:hidden px-4 py-3 border-b border-border flex-shrink-0">
-                    <button
-                      onClick={() => setSelectedTestUuid(null)}
-                      className="flex items-center gap-2 text-sm text-foreground hover:text-muted-foreground transition-colors"
-                    >
-                      <svg
-                        className="w-4 h-4"
-                        fill="none"
-                        viewBox="0 0 24 24"
-                        stroke="currentColor"
-                        strokeWidth={2}
-                      >
-                        <path
-                          strokeLinecap="round"
-                          strokeLinejoin="round"
-                          d="M15 19l-7-7 7-7"
-                        />
-                      </svg>
-                      Back to tests
-                    </button>
-                  </div>
-                  <div className="flex-1 overflow-y-auto">
-                    <LocalTestDetailView result={selectedResult} />
-                  </div>
-                </>
-              ) : (
-                <EmptyStateView message="Select a test to view details" />
-              )}
-            </div>
-
-            {/* Right Panel - Evaluation Criteria (only after test completes) */}
-            {selectedResult &&
-              (selectedResult.status === "passed" ||
-                selectedResult.status === "failed") && (
-                <div className="hidden md:flex w-72 border-l border-border flex-col overflow-hidden">
-                  <div className="flex-1 overflow-y-auto">
-                    <EvaluationCriteriaPanel
-                      evaluation={selectedResult.testCase?.evaluation}
-                      testType={selectedResult.testCase?.evaluation?.type}
-                    />
-                  </div>
-                </div>
-              )}
+          <div className="flex-1 overflow-hidden">
+            <TestRunOutputsPanel
+              results={testResults.map((r) => ({
+                id: r.test.uuid,
+                name: r.test.name,
+                status: r.status as "passed" | "failed" | "running" | "pending" | "queued",
+                output: r.output,
+                testCase: r.testCase,
+                reasoning: r.reasoning,
+                evaluation: r.evaluation,
+                error: r.error,
+              }))}
+              selectedId={selectedTestUuid}
+              onSelect={setSelectedTestUuid}
+              onClearSelection={() => setSelectedTestUuid(null)}
+            />
           </div>
         )}
       </div>
     </div>
-  );
-}
-
-// Test List Item Component
-function TestListItem({
-  result,
-  isSelected,
-  onSelect,
-}: {
-  result: TestResult;
-  isSelected: boolean;
-  onSelect: () => void;
-}) {
-  const handleClick = (e: React.MouseEvent | React.TouchEvent) => {
-    e.preventDefault();
-    e.stopPropagation();
-    console.log("TestListItem clicked:", result.test.name, result.test.uuid);
-    onSelect();
-  };
-
-  return (
-    <button
-      type="button"
-      onClick={handleClick}
-      onTouchEnd={handleClick}
-      className={`w-full flex items-center gap-2 px-3 py-2 rounded-lg cursor-pointer transition-colors ${
-        isSelected ? "bg-muted" : "hover:bg-muted/50"
-      }`}
-    >
-      <StatusIcon status={result.status} />
-      <span className="text-sm text-foreground truncate">
-        {result.test.name}
-      </span>
-    </button>
-  );
-}
-
-// Local Test Detail View Component with error/pending/running state handling
-function LocalTestDetailView({ result }: { result: TestResult }) {
-  if (result.status === "pending") {
-    return (
-      <div className="flex items-center justify-center h-full">
-        <p className="text-muted-foreground">Test is pending</p>
-      </div>
-    );
-  }
-
-  if (result.status === "queued") {
-    return (
-      <div className="flex items-center justify-center h-full">
-        <p className="text-muted-foreground">Test is queued</p>
-      </div>
-    );
-  }
-
-  if (result.status === "running") {
-    return (
-      <div className="flex items-center justify-center h-full">
-        <div className="flex items-center gap-3">
-          <SpinnerIcon className="w-5 h-5 animate-spin text-muted-foreground" />
-          <p className="text-muted-foreground">Running test</p>
-        </div>
-      </div>
-    );
-  }
-
-  if (result.error) {
-    return (
-      <div className="p-4 md:p-6">
-        <div className="bg-red-500/10 border border-red-500/30 rounded-lg p-4">
-          <div className="flex items-center gap-2 mb-2">
-            <svg
-              className="w-5 h-5 text-red-500"
-              fill="none"
-              viewBox="0 0 24 24"
-              stroke="currentColor"
-              strokeWidth={2}
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                d="M12 9v3.75m9-.75a9 9 0 11-18 0 9 9 0 0118 0zm-9 3.75h.008v.008H12v-.008z"
-              />
-            </svg>
-            <span className="font-medium text-red-500">
-              Something went wrong
-            </span>
-          </div>
-          <p className="text-sm text-red-400">
-            We&apos;re looking into it. Please reach out to us if this issue
-            persists.
-          </p>
-        </div>
-      </div>
-    );
-  }
-
-  // Use shared component for main content
-  return (
-    <SharedTestDetailView
-      history={result.testCase?.history || []}
-      output={result.output}
-      passed={result.evaluation?.passed ?? false}
-      reasoning={result.reasoning}
-    />
   );
 }

--- a/src/components/eval-details/AboutMetricsTable.tsx
+++ b/src/components/eval-details/AboutMetricsTable.tsx
@@ -1,0 +1,62 @@
+import React from "react";
+
+export type MetricDescription = {
+  metric: string;
+  description: string;
+  preference: string;
+  range: string;
+};
+
+type AboutMetricsTableProps = {
+  metrics: MetricDescription[];
+};
+
+export function AboutMetricsTable({ metrics }: AboutMetricsTableProps) {
+  return (
+    <div className="space-y-4 md:space-y-6">
+      {/* Desktop: Table layout */}
+      <div className="hidden md:block border rounded-xl overflow-hidden">
+        <table className="w-full">
+          <thead className="bg-muted/50 border-b border-border">
+            <tr>
+              <th className="px-4 py-3 text-left text-[13px] font-medium text-foreground">Metric</th>
+              <th className="px-4 py-3 text-left text-[13px] font-medium text-foreground">Description</th>
+              <th className="px-4 py-3 text-left text-[13px] font-medium text-foreground">Preference</th>
+              <th className="px-4 py-3 text-left text-[13px] font-medium text-foreground">Range</th>
+            </tr>
+          </thead>
+          <tbody>
+            {metrics.map((item, i) => (
+              <tr key={item.metric} className={`border-b border-border ${i === metrics.length - 1 ? "last:border-b-0" : ""}`}>
+                <td className="px-4 py-3 text-[13px] font-medium text-foreground">{item.metric}</td>
+                <td className="px-4 py-3 text-[13px] text-foreground">{item.description}</td>
+                <td className="px-4 py-3 text-[13px] text-foreground">{item.preference}</td>
+                <td className="px-4 py-3 text-[13px] text-foreground">{item.range}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      {/* Mobile: Card layout */}
+      <div className="md:hidden space-y-3">
+        {metrics.map((item) => (
+          <div key={item.metric} className="border border-border rounded-xl p-4 space-y-2">
+            <h4 className="text-[13px] font-semibold text-foreground">{item.metric}</h4>
+            <p className="text-[13px] text-muted-foreground">{item.description}</p>
+            <div className="flex gap-4 pt-1">
+              <div>
+                <span className="text-[11px] text-muted-foreground uppercase tracking-wide">Preference</span>
+                <p className="text-[13px] text-foreground">{item.preference}</p>
+              </div>
+              <div>
+                <span className="text-[11px] text-muted-foreground uppercase tracking-wide">Range</span>
+                <p className="text-[13px] text-foreground">{item.range}</p>
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/eval-details/BenchmarkOutputsPanel.tsx
+++ b/src/components/eval-details/BenchmarkOutputsPanel.tsx
@@ -1,0 +1,329 @@
+import React, { useState } from "react";
+import {
+  TestCaseOutput,
+  TestCaseData,
+  StatusIcon,
+  TestDetailView,
+  EmptyStateView,
+  EvaluationCriteriaPanel,
+} from "@/components/test-results/shared";
+
+export type BenchmarkTestResult = {
+  name?: string;
+  passed: boolean | null;
+  reasoning?: string;
+  output?: TestCaseOutput;
+  test_case?: TestCaseData;
+};
+
+export type BenchmarkModelResult = {
+  model: string;
+  success: boolean | null;
+  message: string;
+  total_tests: number | null;
+  passed: number | null;
+  failed: number | null;
+  test_results: BenchmarkTestResult[] | null;
+};
+
+type BenchmarkOutputsPanelProps = {
+  modelResults: BenchmarkModelResult[];
+  expandedModels: Set<string>;
+  onToggleModel: (model: string) => void;
+  onSetExpandedModels?: (models: Set<string>) => void;
+  selectedTest: { model: string; testIndex: number } | null;
+  onSelectTest: (model: string, testIndex: number) => void;
+  onClearSelection?: () => void;
+  /** Placeholder test names for in-progress runs */
+  testNames?: string[];
+  formatModelName?: (name: string) => string;
+  /** Show filter pills + collapse/expand controls */
+  showControls?: boolean;
+  /** Show spinner for running tests */
+  showRunningSpinner?: boolean;
+  height?: string;
+};
+
+export function BenchmarkOutputsPanel({
+  modelResults,
+  expandedModels,
+  onToggleModel,
+  onSetExpandedModels,
+  selectedTest,
+  onSelectTest,
+  onClearSelection,
+  testNames = [],
+  formatModelName = (n) => n,
+  showControls = true,
+  showRunningSpinner = false,
+  height,
+}: BenchmarkOutputsPanelProps) {
+  const [statusFilter, setStatusFilter] = useState<"all" | "passed" | "failed">("all");
+
+  const getSelectedTestResult = (): BenchmarkTestResult | null => {
+    if (!selectedTest) return null;
+    const modelResult = modelResults.find((m) => m.model === selectedTest.model);
+    if (!modelResult?.test_results) return null;
+    return modelResult.test_results[selectedTest.testIndex] || null;
+  };
+
+  const selectedTestResult = getSelectedTestResult();
+
+  return (
+    <div className="flex h-full overflow-hidden" style={height ? { height } : undefined}>
+      {/* Left Panel - Model list with tests */}
+      <div
+        className={`w-full md:w-80 border-r border-border flex flex-col overflow-hidden ${
+          selectedTest ? "hidden md:flex" : "flex"
+        }`}
+      >
+        {/* Filter pills + collapse/expand */}
+        {showControls && modelResults.length > 0 && (
+          <div className="shrink-0 border-b border-border flex items-center justify-between px-3 py-2">
+            <div className="flex items-center gap-1.5">
+              <button
+                type="button"
+                onClick={() => setStatusFilter(statusFilter === "passed" ? "all" : "passed")}
+                className={`inline-flex items-center px-2.5 py-1 rounded-md text-xs font-medium cursor-pointer transition-colors ${
+                  statusFilter === "passed"
+                    ? "bg-green-100 text-green-700 dark:bg-green-500/30 dark:text-green-400 ring-1 ring-green-500/50"
+                    : "bg-green-100/50 text-green-700/60 dark:bg-green-500/10 dark:text-green-400/60 hover:bg-green-100 hover:dark:bg-green-500/20"
+                }`}
+              >
+                Passed
+              </button>
+              <button
+                type="button"
+                onClick={() => setStatusFilter(statusFilter === "failed" ? "all" : "failed")}
+                className={`inline-flex items-center px-2.5 py-1 rounded-md text-xs font-medium cursor-pointer transition-colors ${
+                  statusFilter === "failed"
+                    ? "bg-red-100 text-red-700 dark:bg-red-500/30 dark:text-red-400 ring-1 ring-red-500/50"
+                    : "bg-red-100/50 text-red-700/60 dark:bg-red-500/10 dark:text-red-400/60 hover:bg-red-100 hover:dark:bg-red-500/20"
+                }`}
+              >
+                Failed
+              </button>
+            </div>
+            <button
+              type="button"
+              onClick={() => {
+                const allModels = modelResults.map((m) => m.model);
+                const allExpanded = allModels.every((m) => expandedModels.has(m));
+                if (onSetExpandedModels) {
+                  onSetExpandedModels(allExpanded ? new Set() : new Set(allModels));
+                } else {
+                  // Fallback: toggle individually
+                  const toToggle = allExpanded ? allModels : allModels.filter((m) => !expandedModels.has(m));
+                  toToggle.forEach((m) => onToggleModel(m));
+                }
+              }}
+              className="text-[11px] text-muted-foreground hover:text-foreground transition-colors cursor-pointer"
+            >
+              {modelResults.every((m) => expandedModels.has(m.model))
+                ? "Collapse all"
+                : "Expand all"}
+            </button>
+          </div>
+        )}
+        <div className="flex-1 overflow-y-auto">
+          {modelResults.length > 0 ? (
+            modelResults.map((modelResult) => (
+              <ModelSection
+                key={modelResult.model}
+                modelResult={modelResult}
+                isExpanded={expandedModels.has(modelResult.model)}
+                onToggle={() => onToggleModel(modelResult.model)}
+                selectedTest={selectedTest}
+                onTestSelect={(testIndex) => onSelectTest(modelResult.model, testIndex)}
+                testNames={testNames}
+                statusFilter={statusFilter}
+                formatModelName={formatModelName}
+              />
+            ))
+          ) : (
+            <div className="p-4 text-sm text-muted-foreground">
+              Waiting for results...
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Middle Panel - Test Details */}
+      <div
+        className={`flex-1 ${selectedTest ? "flex" : "hidden md:flex"} flex-col overflow-hidden`}
+      >
+        {/* Mobile Back Button */}
+        {selectedTest && onClearSelection && (
+          <div className="md:hidden px-4 py-3 border-b border-border flex-shrink-0">
+            <button
+              onClick={onClearSelection}
+              className="flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground transition-colors"
+            >
+              <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                <path strokeLinecap="round" strokeLinejoin="round" d="M10 19l-7-7m0 0l7-7m-7 7h18" />
+              </svg>
+              Back to models
+            </button>
+          </div>
+        )}
+
+        <div className="flex-1 overflow-y-auto">
+          {selectedTestResult ? (
+            selectedTestResult.passed === null && showRunningSpinner ? (
+              <div className="flex items-center justify-center h-full">
+                <div className="flex items-center gap-3">
+                  <svg className="w-5 h-5 animate-spin text-muted-foreground" fill="none" viewBox="0 0 24 24">
+                    <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
+                    <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+                  </svg>
+                  <p className="text-muted-foreground">Running test...</p>
+                </div>
+              </div>
+            ) : (
+              <TestDetailView
+                history={selectedTestResult.test_case?.history || []}
+                output={selectedTestResult.output}
+                passed={selectedTestResult.passed ?? false}
+                reasoning={selectedTestResult.reasoning}
+              />
+            )
+          ) : (
+            <EmptyStateView message="Select a test to view details" />
+          )}
+        </div>
+      </div>
+
+      {/* Right Panel - Evaluation Criteria */}
+      {selectedTestResult && selectedTestResult.passed !== null && (
+        <div className="hidden md:flex w-72 border-l border-border flex-col overflow-hidden">
+          <div className="flex-1 overflow-y-auto">
+            <EvaluationCriteriaPanel evaluation={selectedTestResult.test_case?.evaluation} />
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// Model Section with toggle and nested test list
+function ModelSection({
+  modelResult,
+  isExpanded,
+  onToggle,
+  selectedTest,
+  onTestSelect,
+  testNames,
+  statusFilter,
+  formatModelName,
+}: {
+  modelResult: BenchmarkModelResult;
+  isExpanded: boolean;
+  onToggle: () => void;
+  selectedTest: { model: string; testIndex: number } | null;
+  onTestSelect: (testIndex: number) => void;
+  testNames: string[];
+  statusFilter: "all" | "passed" | "failed";
+  formatModelName: (name: string) => string;
+}) {
+  const isProcessing = modelResult.success === null;
+  const hasResults = modelResult.test_results && modelResult.test_results.length > 0;
+  const passedCount = modelResult.passed ?? 0;
+  const failedCount = modelResult.failed ?? 0;
+  const totalTests = modelResult.total_tests ?? testNames.length;
+
+  return (
+    <div className="border-b border-border">
+      <button
+        onClick={onToggle}
+        className="w-full px-4 py-3 flex items-center justify-between hover:bg-muted/50 transition-colors cursor-pointer"
+      >
+        <div className="flex items-center gap-2 min-w-0">
+          <svg
+            className={`w-4 h-4 text-muted-foreground transition-transform flex-shrink-0 ${isExpanded ? "rotate-90" : ""}`}
+            fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}
+          >
+            <path strokeLinecap="round" strokeLinejoin="round" d="M8.25 4.5l7.5 7.5-7.5 7.5" />
+          </svg>
+          <span className="text-sm font-medium text-foreground truncate">
+            {formatModelName(modelResult.model)}
+          </span>
+          {isProcessing && (
+            <svg className="w-3.5 h-3.5 animate-spin text-yellow-500 flex-shrink-0" fill="none" viewBox="0 0 24 24">
+              <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
+              <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+            </svg>
+          )}
+        </div>
+        {!isProcessing && modelResult.success !== null && (
+          <div className="flex items-center gap-2 text-xs flex-shrink-0">
+            {(statusFilter === "all" || statusFilter === "passed") && (
+              <span className="text-green-500">{passedCount} passed</span>
+            )}
+            {(statusFilter === "all" || statusFilter === "failed") && (
+              <span className="text-red-500">{failedCount} failed</span>
+            )}
+          </div>
+        )}
+      </button>
+
+      {isExpanded && (
+        <div className="px-4 pb-3">
+          {(() => {
+            const resultsCount = modelResult.test_results?.length ?? 0;
+            const expectedCount = Math.max(totalTests, testNames.length, resultsCount);
+
+            if (expectedCount === 0 && !hasResults) {
+              return (
+                <div className="ml-4 px-3 py-2 text-sm text-muted-foreground">
+                  {isProcessing ? "Processing..." : "No test results"}
+                </div>
+              );
+            }
+
+            return (
+              <div className="space-y-1 ml-4">
+                {Array.from({ length: expectedCount }).map((_, index) => {
+                  const testResult = modelResult.test_results?.[index];
+                  const hasResult = !!testResult;
+                  const status = hasResult
+                    ? testResult.passed === null ? "running" : testResult.passed ? "passed" : "failed"
+                    : "running";
+
+                  if (statusFilter !== "all" && status !== statusFilter) return null;
+
+                  const isSelected = selectedTest?.model === modelResult.model && selectedTest?.testIndex === index;
+                  const testName = hasResult
+                    ? testResult.name || testResult.test_case?.name || testNames[index] || `Test ${index + 1}`
+                    : testNames[index] || `Test ${index + 1}`;
+
+                  if (hasResult) {
+                    return (
+                      <button
+                        key={index}
+                        type="button"
+                        onClick={() => onTestSelect(index)}
+                        className={`w-full flex items-center gap-2 px-3 py-2 rounded-lg cursor-pointer transition-colors ${
+                          isSelected ? "bg-muted" : "hover:bg-muted/50"
+                        }`}
+                      >
+                        <StatusIcon status={status as "running" | "passed" | "failed"} />
+                        <span className="text-sm text-foreground truncate">{testName}</span>
+                      </button>
+                    );
+                  }
+
+                  return (
+                    <div key={index} className="flex items-center gap-2 px-3 py-2 rounded-lg">
+                      <StatusIcon status="running" />
+                      <span className="text-sm text-foreground truncate">{testName}</span>
+                    </div>
+                  );
+                })}
+              </div>
+            );
+          })()}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/eval-details/BenchmarkOutputsPanel.tsx
+++ b/src/components/eval-details/BenchmarkOutputsPanel.tsx
@@ -138,6 +138,7 @@ export function BenchmarkOutputsPanel({
                 testNames={testNames}
                 statusFilter={statusFilter}
                 formatModelName={formatModelName}
+                showRunningSpinner={showRunningSpinner}
               />
             ))
           ) : (
@@ -215,6 +216,7 @@ function ModelSection({
   testNames,
   statusFilter,
   formatModelName,
+  showRunningSpinner = false,
 }: {
   modelResult: BenchmarkModelResult;
   isExpanded: boolean;
@@ -224,6 +226,7 @@ function ModelSection({
   testNames: string[];
   statusFilter: "all" | "passed" | "failed";
   formatModelName: (name: string) => string;
+  showRunningSpinner?: boolean;
 }) {
   const isProcessing = modelResult.success === null;
   const hasResults = modelResult.test_results && modelResult.test_results.length > 0;
@@ -285,6 +288,10 @@ function ModelSection({
                 {Array.from({ length: expectedCount }).map((_, index) => {
                   const testResult = modelResult.test_results?.[index];
                   const hasResult = !!testResult;
+
+                  // Skip placeholder rows for completed benchmarks — only show running placeholders during in-progress
+                  if (!hasResult && !showRunningSpinner) return null;
+
                   const status = hasResult
                     ? testResult.passed === null ? "running" : testResult.passed ? "passed" : "failed"
                     : "running";

--- a/src/components/eval-details/LeaderboardTab.tsx
+++ b/src/components/eval-details/LeaderboardTab.tsx
@@ -1,0 +1,67 @@
+import React from "react";
+import { LeaderboardBarChart, getColorMap } from "@/components/charts/LeaderboardBarChart";
+import { DownloadableTable } from "@/components/DownloadableTable";
+
+export type LeaderboardColumn = {
+  key: string;
+  header: string;
+  render?: (value: any) => React.ReactNode;
+};
+
+export type ChartConfig = {
+  title: string;
+  dataKey: string;
+  yDomain?: [number, number];
+  formatTooltip?: (value: number) => string;
+};
+
+type LeaderboardTabProps = {
+  columns: LeaderboardColumn[];
+  data: Record<string, any>[];
+  /** Array of chart rows — each row is an array of charts rendered in a grid */
+  charts: ChartConfig[][];
+  filename: string;
+  getLabel: (key: string) => string;
+  nameKey?: string;
+  className?: string;
+};
+
+export function LeaderboardTab({
+  columns,
+  data,
+  charts,
+  filename,
+  getLabel,
+  nameKey = "run",
+  className,
+}: LeaderboardTabProps) {
+  if (!data || data.length === 0) return null;
+
+  const names = data.map((s) => s[nameKey]);
+  const colorMap = getColorMap(names);
+
+  return (
+    <div className={`space-y-4 md:space-y-6 ${className || ""}`}>
+      <DownloadableTable columns={columns} data={data} filename={filename} />
+
+      {charts.map((row, rowIndex) => (
+        <div key={rowIndex} className={`grid grid-cols-1 ${row.length >= 2 ? "md:grid-cols-2" : ""} gap-4 md:gap-6`}>
+          {row.map((chart) => (
+            <LeaderboardBarChart
+              key={chart.title}
+              title={chart.title}
+              data={data.map((s) => ({
+                label: getLabel(s[nameKey]),
+                value: s[chart.dataKey],
+                colorKey: s[nameKey],
+              }))}
+              colorMap={colorMap}
+              yDomain={chart.yDomain}
+              formatTooltip={chart.formatTooltip}
+            />
+          ))}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/components/eval-details/ProviderMetricsCard.tsx
+++ b/src/components/eval-details/ProviderMetricsCard.tsx
@@ -1,0 +1,28 @@
+import React from "react";
+
+export type MetricItem = {
+  label: string;
+  value: string | number;
+};
+
+type ProviderMetricsCardProps = {
+  metrics: MetricItem[];
+};
+
+export function ProviderMetricsCard({ metrics }: ProviderMetricsCardProps) {
+  return (
+    <div className="border rounded-xl p-4 bg-muted/10">
+      <h3 className="text-[15px] font-semibold mb-4">Overall Metrics</h3>
+      <div className="grid gap-4" style={{ gridTemplateColumns: `repeat(${metrics.length}, minmax(0, 1fr))` }}>
+        {metrics.map((m) => (
+          <div key={m.label}>
+            <div className="text-[12px] text-muted-foreground mb-1">{m.label}</div>
+            <div className="text-base md:text-[18px] font-semibold text-foreground">
+              {m.value ?? "-"}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/eval-details/ProviderSidebar.tsx
+++ b/src/components/eval-details/ProviderSidebar.tsx
@@ -1,0 +1,53 @@
+import React from "react";
+
+export type ProviderSidebarItem = {
+  key: string;
+  label: string;
+  success: boolean | null;
+};
+
+type ProviderSidebarProps = {
+  items: ProviderSidebarItem[];
+  activeKey: string | null;
+  onSelect: (key: string) => void;
+};
+
+export function ProviderSidebar({ items, activeKey, onSelect }: ProviderSidebarProps) {
+  return (
+    <div className="md:w-48 border-b md:border-b-0 md:border-r border-border flex flex-col overflow-hidden bg-muted/10">
+      <div className="overflow-x-auto md:overflow-x-visible md:overflow-y-auto md:flex-1 p-2">
+        <div className="flex md:flex-col gap-1 md:gap-1 min-w-max md:min-w-0">
+          {items.map((item) => {
+            const isSelected = activeKey === item.key;
+            return (
+              <div
+                key={item.key}
+                onClick={() => onSelect(item.key)}
+                className={`flex items-center gap-2 px-3 py-2 rounded-lg cursor-pointer transition-colors whitespace-nowrap ${
+                  isSelected ? "bg-muted" : "hover:bg-muted/50"
+                }`}
+              >
+                {item.success === null ? (
+                  <div className="w-2 h-2 rounded-full bg-yellow-500 animate-pulse flex-shrink-0"></div>
+                ) : item.success === true ? (
+                  <div className="w-5 h-5 rounded-full bg-green-500/20 flex items-center justify-center flex-shrink-0">
+                    <svg className="w-3 h-3 text-green-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={3}>
+                      <path strokeLinecap="round" strokeLinejoin="round" d="M4.5 12.75l6 6 9-13.5" />
+                    </svg>
+                  </div>
+                ) : (
+                  <div className="w-5 h-5 rounded-full bg-red-500/20 flex items-center justify-center flex-shrink-0">
+                    <svg className="w-3 h-3 text-red-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={3}>
+                      <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+                    </svg>
+                  </div>
+                )}
+                <span className="text-sm text-foreground truncate">{item.label}</span>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/eval-details/STTResultsTable.tsx
+++ b/src/components/eval-details/STTResultsTable.tsx
@@ -1,0 +1,192 @@
+import React from "react";
+import { Tooltip } from "@/components/Tooltip";
+
+export type STTResultRow = {
+  id: string;
+  audio_url?: string;
+  gt: string;
+  pred: string;
+  wer: string;
+  string_similarity: string;
+  llm_judge_score: string;
+  llm_judge_reasoning: string;
+};
+
+type STTResultsTableProps = {
+  results: STTResultRow[];
+  showMetrics?: boolean;
+  tableRef?: React.RefObject<HTMLDivElement | null>;
+};
+
+export function STTResultsTable({ results, showMetrics = true, tableRef }: STTResultsTableProps) {
+  const hasAudio = results.some((r) => !!r.audio_url);
+
+  return (
+    <>
+      {/* Desktop: Table layout */}
+      <div className="hidden md:block border rounded-xl overflow-visible" ref={tableRef}>
+        <div className="overflow-x-auto rounded-xl">
+          <table className="w-full table-fixed">
+            <thead className="bg-muted/50 border-b border-border">
+              <tr>
+                <th className="w-10 px-3 py-3 text-left text-[12px] font-medium text-foreground">ID</th>
+                {hasAudio && (
+                  <th className="w-[180px] px-3 py-3 text-left text-[12px] font-medium text-foreground">Audio</th>
+                )}
+                <th className={`${showMetrics ? "w-[25%]" : "w-[calc(50%-20px)]"} px-3 py-3 text-left text-[12px] font-medium text-foreground`}>Ground Truth</th>
+                <th className={`${showMetrics ? "w-[25%]" : "w-[calc(50%-20px)]"} px-3 py-3 text-left text-[12px] font-medium text-foreground`}>Prediction</th>
+                {showMetrics && (
+                  <>
+                    <th className="w-[72px] px-3 py-3 text-left text-[12px] font-medium text-foreground">WER</th>
+                    <th className="w-[100px] px-3 py-3 text-left text-[12px] font-medium text-foreground">Similarity</th>
+                    <th className="w-[90px] px-3 py-3 text-left text-[12px] font-medium text-foreground">LLM Judge</th>
+                  </>
+                )}
+              </tr>
+            </thead>
+            <tbody>
+              {results.map((result, index) => {
+                const isEmptyPrediction = !result.pred || result.pred.trim() === "";
+                return (
+                  <tr
+                    key={index}
+                    data-row-index={index}
+                    className={`border-b border-border last:border-b-0 ${isEmptyPrediction ? "bg-red-500/10" : ""}`}
+                  >
+                    <td className="px-3 py-3 text-[13px] text-foreground">{index + 1}</td>
+                    {hasAudio && (
+                      <td className="px-3 py-3">
+                        {result.audio_url ? (
+                          <audio src={result.audio_url} controls preload="none" className="h-8 w-full max-w-[160px]" />
+                        ) : (
+                          <span className="text-[13px] text-muted-foreground">&mdash;</span>
+                        )}
+                      </td>
+                    )}
+                    <td className="px-3 py-3 text-[13px] text-foreground break-words">{result.gt}</td>
+                    <td className="px-3 py-3 text-[13px] break-words">
+                      {isEmptyPrediction ? (
+                        <span className="text-muted-foreground">No transcript generated</span>
+                      ) : (
+                        <span className="text-foreground">{result.pred}</span>
+                      )}
+                    </td>
+                    {showMetrics && (
+                      <>
+                        <td className="px-4 py-3 text-[13px] text-foreground">
+                          {result.wer != null ? parseFloat(parseFloat(result.wer).toFixed(4)) : "-"}
+                        </td>
+                        <td className="px-4 py-3 text-[13px] text-foreground">
+                          {result.string_similarity != null ? parseFloat(parseFloat(result.string_similarity).toFixed(4)) : "-"}
+                        </td>
+                        <td className="px-4 py-3">
+                          <LLMJudgeBadge score={result.llm_judge_score} reasoning={result.llm_judge_reasoning} />
+                        </td>
+                      </>
+                    )}
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      {/* Mobile: Card layout */}
+      <div className="md:hidden space-y-3">
+        {results.map((result, index) => {
+          const isEmptyPrediction = !result.pred || result.pred.trim() === "";
+          const scoreStr = String(result.llm_judge_score || "").toLowerCase();
+          const passed = scoreStr === "true" || scoreStr === "1";
+          return (
+            <div
+              key={index}
+              data-row-index={index}
+              className={`border border-border rounded-xl p-4 space-y-3 ${isEmptyPrediction ? "bg-red-500/10" : ""}`}
+            >
+              <div className="flex items-center justify-between">
+                <span className="text-[12px] text-muted-foreground font-medium">#{index + 1}</span>
+                {showMetrics && result.llm_judge_score && (
+                  <span className={`inline-flex items-center px-2.5 py-1 rounded-md text-xs font-medium ${
+                    passed
+                      ? "bg-green-100 text-green-700 dark:bg-green-500/20 dark:text-green-400"
+                      : "bg-red-100 text-red-700 dark:bg-red-500/20 dark:text-red-400"
+                  }`}>
+                    {passed ? "Pass" : "Fail"}
+                  </span>
+                )}
+              </div>
+              {result.audio_url && (
+                <div>
+                  <span className="text-[11px] text-muted-foreground uppercase tracking-wide">Audio</span>
+                  <div className="mt-1">
+                    <audio src={result.audio_url} controls preload="none" className="w-full h-8" />
+                  </div>
+                </div>
+              )}
+              <div>
+                <span className="text-[11px] text-muted-foreground uppercase tracking-wide">Ground Truth</span>
+                <p className="text-[13px] text-foreground mt-0.5">{result.gt}</p>
+              </div>
+              <div>
+                <span className="text-[11px] text-muted-foreground uppercase tracking-wide">Prediction</span>
+                {isEmptyPrediction ? (
+                  <p className="text-[13px] text-muted-foreground mt-0.5">No transcript generated</p>
+                ) : (
+                  <p className="text-[13px] text-foreground mt-0.5">{result.pred}</p>
+                )}
+              </div>
+              {showMetrics && (
+                <div className="space-y-2 pt-1 border-t border-border">
+                  <div className="flex gap-4">
+                    <div>
+                      <span className="text-[11px] text-muted-foreground uppercase tracking-wide">WER</span>
+                      <p className="text-[13px] text-foreground">{result.wer != null ? parseFloat(parseFloat(result.wer).toFixed(4)) : "-"}</p>
+                    </div>
+                    <div>
+                      <span className="text-[11px] text-muted-foreground uppercase tracking-wide">Similarity</span>
+                      <p className="text-[13px] text-foreground">{result.string_similarity != null ? parseFloat(parseFloat(result.string_similarity).toFixed(4)) : "-"}</p>
+                    </div>
+                  </div>
+                  {result.llm_judge_reasoning && (
+                    <div>
+                      <span className="text-[11px] text-muted-foreground uppercase tracking-wide">LLM Judge Reasoning</span>
+                      <p className="text-[12px] text-muted-foreground mt-0.5">{result.llm_judge_reasoning}</p>
+                    </div>
+                  )}
+                </div>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </>
+  );
+}
+
+function LLMJudgeBadge({ score, reasoning }: { score?: string; reasoning?: string }) {
+  if (!score) return <span className="text-muted-foreground text-[12px]">-</span>;
+
+  const scoreStr = String(score).toLowerCase();
+  const passed = scoreStr === "true" || scoreStr === "1";
+  const tooltipContent = reasoning || `Score: ${score}`;
+
+  return (
+    <div className="flex items-center gap-1.5">
+      <span className={`inline-flex items-center px-2.5 py-1 rounded-md text-xs font-medium ${
+        passed
+          ? "bg-green-100 text-green-700 dark:bg-green-500/20 dark:text-green-400"
+          : "bg-red-100 text-red-700 dark:bg-red-500/20 dark:text-red-400"
+      }`}>
+        {passed ? "Pass" : "Fail"}
+      </span>
+      <Tooltip content={tooltipContent}>
+        <button type="button" className="p-1 rounded-md hover:bg-muted transition-colors cursor-pointer" aria-label="View reasoning">
+          <svg className="w-4 h-4 text-muted-foreground" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+            <path strokeLinecap="round" strokeLinejoin="round" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+          </svg>
+        </button>
+      </Tooltip>
+    </div>
+  );
+}

--- a/src/components/eval-details/SimulationMetricsGrid.tsx
+++ b/src/components/eval-details/SimulationMetricsGrid.tsx
@@ -1,0 +1,78 @@
+import React, { useState } from "react";
+
+export type MetricData = { mean: number; std: number; values: number[] };
+
+type SimulationMetricsGridProps = {
+  metrics: Record<string, MetricData | undefined> | null;
+  type: "text" | "voice";
+};
+
+const LATENCY_KEYS = ["stt/ttft", "llm/ttft", "tts/ttft", "stt/processing_time", "llm/processing_time", "tts/processing_time"];
+
+export function SimulationMetricsGrid({ metrics, type }: SimulationMetricsGridProps) {
+  const [activeTab, setActiveTab] = useState<"performance" | "latency">("performance");
+
+  if (!metrics) return null;
+
+  const regularMetrics: Array<[string, MetricData]> = [];
+  const latencyMetrics: Array<[string, MetricData]> = [];
+  Object.entries(metrics).forEach(([key, metric]) => {
+    if (!metric) return;
+    if (LATENCY_KEYS.includes(key)) latencyMetrics.push([key, metric]);
+    else regularMetrics.push([key, metric]);
+  });
+
+  if (regularMetrics.length === 0 && latencyMetrics.length === 0) return null;
+
+  const isTextType = type === "text";
+
+  return (
+    <div>
+      <h2 className="text-base md:text-lg font-semibold mb-3">Overall Metrics</h2>
+      {!isTextType && (
+        <div className="flex gap-2 border-b border-border mb-4">
+          <button
+            onClick={() => setActiveTab("performance")}
+            className={`px-4 py-2 text-[13px] font-medium border-b-2 transition-colors cursor-pointer ${
+              activeTab === "performance" ? "border-foreground text-foreground" : "border-transparent text-muted-foreground hover:text-foreground"
+            }`}
+          >
+            Performance
+          </button>
+          <button
+            onClick={() => setActiveTab("latency")}
+            className={`px-4 py-2 text-[13px] font-medium border-b-2 transition-colors cursor-pointer ${
+              activeTab === "latency" ? "border-foreground text-foreground" : "border-transparent text-muted-foreground hover:text-foreground"
+            }`}
+          >
+            Latency
+          </button>
+        </div>
+      )}
+      {(isTextType || activeTab === "performance") && regularMetrics.length > 0 && (
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+          {regularMetrics.map(([key, metric]) => (
+            <div key={key} className="border border-border rounded-xl p-4 bg-muted/10">
+              <div className="text-[12px] text-muted-foreground mb-1">{key}</div>
+              <div className="text-[18px] font-semibold text-foreground">{Math.round(metric.mean * 100)}%</div>
+            </div>
+          ))}
+        </div>
+      )}
+      {!isTextType && activeTab === "latency" && latencyMetrics.length > 0 && (
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+          {latencyMetrics.map(([key, metric]) => (
+            <div key={key} className="border border-border rounded-xl p-4 bg-muted/10">
+              <div className="text-[12px] text-muted-foreground mb-1">{key}</div>
+              <div className="text-[18px] font-semibold text-foreground">
+                {metric.mean < 1 ? `${(metric.mean * 1000).toFixed(0)}ms` : `${metric.mean.toFixed(2)}s`}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export { LATENCY_KEYS };

--- a/src/components/eval-details/SimulationResultsTable.tsx
+++ b/src/components/eval-details/SimulationResultsTable.tsx
@@ -1,0 +1,115 @@
+import React from "react";
+import { Tooltip } from "@/components/Tooltip";
+
+export type EvaluationResult = { name: string; value: number; reasoning: string };
+export type Persona = { label: string; characteristics: string; gender: string; language: string };
+export type Scenario = { name: string; description: string };
+export type TranscriptEntry = { role: string; content?: string; tool_calls?: any[] | null; tool_call_id?: string };
+
+export type SimulationResult = {
+  simulation_name: string;
+  aborted?: boolean;
+  persona: Persona;
+  scenario: Scenario;
+  evaluation_results: EvaluationResult[] | null;
+  transcript?: TranscriptEntry[] | null;
+  audio_urls?: string[];
+  conversation_wav_url?: string;
+};
+
+type SimulationResultsTableProps = {
+  simulations: SimulationResult[];
+  metricKeys: string[];
+  onSelectSimulation: (sim: SimulationResult) => void;
+};
+
+const getEvaluationResult = (sim: SimulationResult, key: string): number | null => {
+  if (!sim.evaluation_results) return null;
+  const mapped = key === "stt_llm_judge" ? "stt_llm_judge_score" : key;
+  const found = sim.evaluation_results.find((r) => r.name === key || r.name === mapped);
+  return found ? found.value : null;
+};
+
+const getEvaluationReasoning = (sim: SimulationResult, key: string): string | null => {
+  if (!sim.evaluation_results) return null;
+  const found = sim.evaluation_results.find((r) => r.name === key);
+  return found?.reasoning ?? null;
+};
+
+export function SimulationResultsTable({ simulations, metricKeys, onSelectSimulation }: SimulationResultsTableProps) {
+  return (
+    <div>
+      <div className="flex items-baseline gap-3 mb-3 md:mb-4">
+        <h2 className="hidden md:block text-base md:text-lg font-semibold">Simulation Results</h2>
+        <p className="text-sm text-muted-foreground">
+          {simulations.length} {simulations.length === 1 ? "simulation" : "simulations"}
+        </p>
+      </div>
+      <div className="border border-border rounded-xl overflow-hidden">
+        <div className="overflow-x-auto">
+          <table className="w-full">
+            <thead className="bg-muted/50 border-b border-border">
+              <tr>
+                <th className="w-10 px-4 py-3 text-left text-[12px] font-medium text-muted-foreground"></th>
+                <th className="px-4 py-3 text-left text-[12px] font-medium text-muted-foreground uppercase tracking-wider">Persona</th>
+                <th className="px-4 py-3 text-left text-[12px] font-medium text-muted-foreground uppercase tracking-wider">Scenario</th>
+                {metricKeys.map((k) => (
+                  <th key={k} className="px-4 py-3 text-left text-[12px] font-medium text-muted-foreground tracking-wider whitespace-nowrap">{k}</th>
+                ))}
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-border">
+              {simulations.map((sim, i) => (
+                <tr key={i} className="hover:bg-muted/30 transition-colors">
+                  <td className="px-4 py-4">
+                    {(sim.transcript?.length ?? 0) > 0 && (
+                      <button
+                        onClick={() => onSelectSimulation(sim)}
+                        className="flex items-center justify-center w-6 h-6 cursor-pointer hover:text-foreground text-muted-foreground transition-colors"
+                        title="View transcript"
+                      >
+                        <svg className={`w-4 h-4 ${sim.aborted ? "text-red-500" : ""}`} fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                          <path strokeLinecap="round" strokeLinejoin="round" d="M5.25 5.653c0-.856.917-1.398 1.667-.986l11.54 6.348a1.125 1.125 0 010 1.971l-11.54 6.347a1.125 1.125 0 01-1.667-.986V5.653z" />
+                        </svg>
+                      </button>
+                    )}
+                  </td>
+                  <td className="px-4 py-4 text-[13px] text-foreground whitespace-nowrap">{sim.persona.label}</td>
+                  <td className="px-4 py-4 text-[13px] text-foreground whitespace-nowrap">{sim.scenario.name}</td>
+                  {metricKeys.map((key) => {
+                    const val = getEvaluationResult(sim, key);
+                    const reasoning = getEvaluationReasoning(sim, key);
+                    if (val === null) return (
+                      <td key={key} className="px-4 py-4">
+                        {sim.aborted ? <span className="text-xs text-muted-foreground">N/A</span> : <span className="text-xs text-muted-foreground">&mdash;</span>}
+                      </td>
+                    );
+                    const isPass = val === 1;
+                    return (
+                      <td key={key} className="px-4 py-4">
+                        <div className="flex items-center gap-1.5">
+                          <span className={`inline-flex items-center px-2.5 py-1 rounded-md text-xs font-medium ${isPass ? "bg-green-100 text-green-700 dark:bg-green-500/20 dark:text-green-400" : "bg-red-100 text-red-700 dark:bg-red-500/20 dark:text-red-400"}`}>
+                            {isPass ? "Pass" : "Fail"}
+                          </span>
+                          {reasoning && (
+                            <Tooltip content={reasoning}>
+                              <button type="button" className="p-1 rounded-md hover:bg-muted transition-colors cursor-pointer">
+                                <svg className="w-3.5 h-3.5 text-muted-foreground" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                                  <path strokeLinecap="round" strokeLinejoin="round" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                                </svg>
+                              </button>
+                            </Tooltip>
+                          )}
+                        </div>
+                      </td>
+                    );
+                  })}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/eval-details/SimulationTranscriptDialog.tsx
+++ b/src/components/eval-details/SimulationTranscriptDialog.tsx
@@ -1,0 +1,227 @@
+import React from "react";
+import type { SimulationResult, TranscriptEntry } from "./SimulationResultsTable";
+
+type SimulationTranscriptDialogProps = {
+  simulation: SimulationResult;
+  runType: "text" | "voice";
+  onClose: () => void;
+  onAudioError?: () => void;
+};
+
+function getAudioUrlForEntry(
+  entry: TranscriptEntry,
+  entryIndex: number,
+  audioUrls: string[] | undefined,
+  filteredTranscript: TranscriptEntry[],
+  runType: "text" | "voice",
+): string | null {
+  if (!audioUrls || runType !== "voice") return null;
+  if (entry.role === "tool" || entry.tool_calls) return null;
+
+  let userCount = 0;
+  let assistantCount = 0;
+  for (let i = 0; i < entryIndex; i++) {
+    const msg = filteredTranscript[i];
+    if (msg?.role === "user") userCount++;
+    else if (msg?.role === "assistant" && !msg.tool_calls) assistantCount++;
+  }
+
+  let audioPattern: string;
+  if (entry.role === "user") audioPattern = `${userCount + 1}_user.wav`;
+  else if (entry.role === "assistant") audioPattern = `${assistantCount + 1}_bot.wav`;
+  else return null;
+
+  return audioUrls.find((url) => url.includes(audioPattern)) ?? null;
+}
+
+export function SimulationTranscriptDialog({ simulation, runType, onClose, onAudioError }: SimulationTranscriptDialogProps) {
+  const fullTranscript = simulation.transcript ?? [];
+  const filteredTranscript = fullTranscript.filter((entry) => {
+    if (entry.role === "end_reason") return false;
+    if (entry.role === "tool") {
+      try {
+        const parsed = JSON.parse(entry.content || "");
+        return parsed?.type === "webhook_response";
+      } catch { return false; }
+    }
+    return true;
+  });
+  const lastEntry = fullTranscript[fullTranscript.length - 1];
+  const endedDueToMaxTurns = lastEntry?.role === "end_reason" && lastEntry?.content === "max_turns";
+
+  return (
+    <div className="fixed inset-0 z-50 flex justify-end">
+      <div className="absolute inset-0 bg-black/50 backdrop-blur-sm" onClick={onClose} />
+      <div className="relative w-full md:w-[40%] md:min-w-[500px] bg-background border-l border-border flex flex-col h-full shadow-2xl">
+        {/* Header */}
+        <div className="flex items-center justify-between px-4 md:px-6 py-4">
+          <div className="flex items-center gap-3">
+            <svg className="w-5 h-5 text-muted-foreground" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M8.625 12a.375.375 0 11-.75 0 .375.375 0 01.75 0zm0 0H8.25m4.125 0a.375.375 0 11-.75 0 .375.375 0 01.75 0zm0 0H12m4.125 0a.375.375 0 11-.75 0 .375.375 0 01.75 0zm0 0h-.375M21 12c0 4.556-4.03 8.25-9 8.25a9.764 9.764 0 01-2.555-.337A5.972 5.972 0 015.41 20.97a5.969 5.969 0 01-.474-.065 4.48 4.48 0 00.978-2.025c.09-.457-.133-.901-.467-1.226C3.93 16.178 3 14.189 3 12c0-4.556 4.03-8.25 9-8.25s9 3.694 9 8.25z" />
+            </svg>
+            <h2 className="text-base md:text-lg font-semibold">Transcript</h2>
+          </div>
+          <button onClick={onClose} className="flex items-center justify-center w-8 h-8 rounded-md hover:bg-muted transition-colors cursor-pointer">
+            <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+
+        {/* Full Conversation Audio Player */}
+        {simulation.conversation_wav_url && (
+          <div className="px-4 md:px-6 pb-4 border-b border-border">
+            <div className="flex items-center gap-2 mb-2">
+              <span className="text-sm font-medium text-foreground">Hear the full conversation</span>
+            </div>
+            <audio key={simulation.conversation_wav_url} controls className="w-full h-10" src={simulation.conversation_wav_url} onError={onAudioError}>
+              Your browser does not support the audio element.
+            </audio>
+          </div>
+        )}
+
+        {/* Transcript content */}
+        <div className="flex-1 overflow-y-auto p-4 md:p-6">
+          <div className="space-y-4">
+            {filteredTranscript.length === 0 ? (
+              <div className="flex items-center justify-center py-8">
+                <p className="text-sm text-muted-foreground">No transcript available yet</p>
+              </div>
+            ) : (
+              filteredTranscript.map((entry, index) => {
+                const audioUrl = getAudioUrlForEntry(entry, index, simulation.audio_urls, filteredTranscript, runType);
+                return (
+                  <div key={index} className={`space-y-2 ${entry.role === "user" ? "flex flex-col items-end" : ""}`}>
+                    {entry.role === "assistant" && (
+                      <div className="flex items-center gap-2">
+                        <span className="text-sm font-medium text-foreground">
+                          {entry.tool_calls ? "Agent Tool Call" : "Agent"}
+                        </span>
+                      </div>
+                    )}
+
+                    {audioUrl && (
+                      <div className="w-full md:w-1/2">
+                        <audio key={audioUrl} controls className="w-full h-8 mb-2" src={audioUrl} onError={onAudioError}>
+                          Your browser does not support the audio element.
+                        </audio>
+                      </div>
+                    )}
+
+                    {entry.role === "user" && entry.content && (
+                      <div className="w-full md:w-1/2">
+                        <div className="px-4 py-3 rounded-xl text-sm text-foreground bg-muted border border-border whitespace-pre-wrap">
+                          {entry.content}
+                        </div>
+                      </div>
+                    )}
+
+                    {entry.role === "assistant" && entry.content && !entry.tool_calls && (
+                      <div className="w-full md:w-1/2">
+                        <div className="px-4 py-3 rounded-xl text-sm text-foreground bg-accent border border-border whitespace-pre-wrap">
+                          {entry.content}
+                        </div>
+                      </div>
+                    )}
+
+                    {entry.role === "assistant" && entry.tool_calls && (
+                      <div className="w-full md:w-1/2">
+                        {entry.tool_calls.map((toolCall: any, toolIndex: number) => {
+                          let parsedArgs: Record<string, any> = {};
+                          try { parsedArgs = JSON.parse(toolCall.function.arguments); } catch { parsedArgs = {}; }
+                          const formatValue = (val: any): string => {
+                            if (val === null) return "null";
+                            if (val === undefined) return "undefined";
+                            if (typeof val === "object") { try { return JSON.stringify(val, null, 2); } catch { return String(val); } }
+                            return String(val);
+                          };
+                          return (
+                            <div key={toolIndex} className="bg-muted border border-border rounded-2xl p-4 mb-2">
+                              <div className="flex items-center gap-2 mb-2">
+                                <svg className="w-4 h-4 text-muted-foreground" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+                                  <path strokeLinecap="round" strokeLinejoin="round" d="M11.42 15.17L17.25 21A2.652 2.652 0 0021 17.25l-5.877-5.877M11.42 15.17l2.496-3.03c.317-.384.74-.626 1.208-.766M11.42 15.17l-4.655 5.653a2.548 2.548 0 11-3.586-3.586l6.837-5.63m5.108-.233c.55-.164 1.163-.188 1.743-.14a4.5 4.5 0 004.486-6.336l-3.276 3.277a3.004 3.004 0 01-2.25-2.25l3.276-3.276a4.5 4.5 0 00-6.336 4.486c.091 1.076-.071 2.264-.904 2.95l-.102.085m-1.745 1.437L5.909 7.5H4.5L2.25 3.75l1.5-1.5L7.5 4.5v1.409l4.26 4.26m-1.745 1.437l1.745-1.437m6.615 8.206L15.75 15.75M4.867 19.125h.008v.008h-.008v-.008z" />
+                                </svg>
+                                <span className="text-sm font-medium text-foreground">{toolCall.function.name}</span>
+                              </div>
+                              {Object.keys(parsedArgs).filter((k) => k !== "headers").length > 0 && (
+                                <div className="space-y-3 mt-3">
+                                  {Object.entries(parsedArgs).filter(([key]) => key !== "headers").map(([key, value], paramIndex) => {
+                                    const displayValue = formatValue(value);
+                                    const isMultiLine = displayValue.includes("\n");
+                                    return (
+                                      <div key={paramIndex}>
+                                        <label className="block text-sm font-medium text-foreground mb-1.5">{key}</label>
+                                        <div className={`px-3 py-2 bg-background border border-border rounded-lg text-sm text-muted-foreground whitespace-pre-wrap break-all ${isMultiLine ? "font-mono text-xs" : ""}`}>
+                                          {displayValue}
+                                        </div>
+                                      </div>
+                                    );
+                                  })}
+                                </div>
+                              )}
+                            </div>
+                          );
+                        })}
+                      </div>
+                    )}
+
+                    {entry.role === "tool" && entry.content && (() => {
+                      let parsed: any = null;
+                      try { parsed = JSON.parse(entry.content); } catch { return null; }
+                      if (parsed?.type !== "webhook_response") return null;
+                      const response = parsed.response;
+                      if (!response || typeof response !== "object") return null;
+                      const isError = parsed.status === "error";
+                      const jsonString = JSON.stringify(response, null, 2);
+                      return (
+                        <div className="w-full md:w-1/2">
+                          <div className="flex items-center gap-2 mb-2">
+                            {isError ? (
+                              <>
+                                <svg className="w-4 h-4 text-red-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                                  <path strokeLinecap="round" strokeLinejoin="round" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+                                </svg>
+                                <span className="text-sm font-medium text-red-500">Tool Response Error</span>
+                              </>
+                            ) : (
+                              <span className="text-sm font-medium text-foreground">Agent Tool Response</span>
+                            )}
+                          </div>
+                          <div className={`bg-muted rounded-2xl p-4 border ${isError ? "border-red-500" : "border-border"}`}>
+                            <pre className={`text-sm font-mono whitespace-pre-wrap break-all ${isError ? "text-red-400" : "text-foreground"}`}>{jsonString}</pre>
+                          </div>
+                        </div>
+                      );
+                    })()}
+                  </div>
+                );
+              })
+            )}
+
+            {endedDueToMaxTurns && (
+              <div className="flex items-center justify-center py-4 mt-2">
+                <div className="flex items-center gap-2 px-4 py-2 rounded-lg bg-yellow-500/10 border border-yellow-500/30">
+                  <svg className="w-4 h-4 text-yellow-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M12 9v3.75m9-.75a9 9 0 11-18 0 9 9 0 0118 0zm-9 3.75h.008v.008H12v-.008z" />
+                  </svg>
+                  <span className="text-sm text-yellow-500">Maximum number of assistant turns reached</span>
+                </div>
+              </div>
+            )}
+
+            {simulation.aborted && (
+              <div className="flex items-center justify-center py-4 mt-2">
+                <div className="flex items-center gap-2 px-4 py-2 rounded-lg bg-red-500/10 border border-red-500/30">
+                  <svg className="w-4 h-4 text-red-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M12 9v3.75m9-.75a9 9 0 11-18 0 9 9 0 0118 0zm-9 3.75h.008v.008H12v-.008z" />
+                  </svg>
+                  <span className="text-sm text-red-500">Simulation aborted by user</span>
+                </div>
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/eval-details/TTSResultsTable.tsx
+++ b/src/components/eval-details/TTSResultsTable.tsx
@@ -1,0 +1,124 @@
+import React from "react";
+import { Tooltip } from "@/components/Tooltip";
+
+export type TTSResultRow = {
+  id: string;
+  text: string;
+  audio_path: string;
+  llm_judge_score?: string;
+  llm_judge_reasoning?: string;
+};
+
+type TTSResultsTableProps = {
+  results: TTSResultRow[];
+  showMetrics?: boolean;
+};
+
+export function TTSResultsTable({ results, showMetrics = true }: TTSResultsTableProps) {
+  return (
+    <>
+      {/* Desktop: Table layout */}
+      <div className="hidden md:block border rounded-xl overflow-visible">
+        <div className="overflow-hidden rounded-xl">
+          <table className="w-full table-fixed">
+            <thead className="bg-muted/50 border-b border-border">
+              <tr>
+                <th className="w-12 px-4 py-3 text-left text-[12px] font-medium text-foreground">ID</th>
+                <th className={`${showMetrics ? "w-[30%]" : "w-[calc(50%-24px)]"} px-4 py-3 text-left text-[12px] font-medium text-foreground`}>Text</th>
+                <th className={`${showMetrics ? "w-[50%]" : "w-[calc(50%-24px)]"} px-4 py-3 text-left text-[12px] font-medium text-foreground`}>Audio</th>
+                {showMetrics && (
+                  <th className="px-4 py-3 text-left text-[12px] font-medium text-foreground">LLM Judge</th>
+                )}
+              </tr>
+            </thead>
+            <tbody>
+              {results.map((result, index) => (
+                <tr key={index} className="border-b border-border last:border-b-0">
+                  <td className="px-4 py-3 text-[13px] text-foreground">{index + 1}</td>
+                  <td className="px-4 py-3 text-[13px] text-foreground break-words">{result.text}</td>
+                  <td className="px-4 py-3 text-[13px] text-foreground">
+                    <audio controls className="w-full min-w-[280px]" src={result.audio_path}>
+                      Your browser does not support the audio element.
+                    </audio>
+                  </td>
+                  {showMetrics && (
+                    <td className="px-4 py-3">
+                      <LLMJudgeBadge score={result.llm_judge_score} reasoning={result.llm_judge_reasoning} />
+                    </td>
+                  )}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      {/* Mobile: Card layout */}
+      <div className="md:hidden space-y-3">
+        {results.map((result, index) => {
+          const scoreStr = String(result.llm_judge_score || "").toLowerCase();
+          const passed = scoreStr === "true" || scoreStr === "1";
+          return (
+            <div key={index} className="border border-border rounded-xl p-4 space-y-3">
+              <div className="flex items-center justify-between">
+                <span className="text-[12px] text-muted-foreground font-medium">#{index + 1}</span>
+                {showMetrics && result.llm_judge_score && (
+                  <span className={`inline-flex items-center px-2.5 py-1 rounded-md text-xs font-medium ${
+                    passed
+                      ? "bg-green-100 text-green-700 dark:bg-green-500/20 dark:text-green-400"
+                      : "bg-red-100 text-red-700 dark:bg-red-500/20 dark:text-red-400"
+                  }`}>
+                    {passed ? "Pass" : "Fail"}
+                  </span>
+                )}
+              </div>
+              <div>
+                <span className="text-[11px] text-muted-foreground uppercase tracking-wide">Text</span>
+                <p className="text-[13px] text-foreground mt-0.5">{result.text}</p>
+              </div>
+              <div>
+                <span className="text-[11px] text-muted-foreground uppercase tracking-wide">Audio</span>
+                <audio controls className="w-full mt-1" src={result.audio_path}>
+                  Your browser does not support the audio element.
+                </audio>
+              </div>
+              {showMetrics && result.llm_judge_reasoning && (
+                <div className="pt-1 border-t border-border">
+                  <span className="text-[11px] text-muted-foreground uppercase tracking-wide">LLM Judge Reasoning</span>
+                  <p className="text-[12px] text-muted-foreground mt-0.5">{result.llm_judge_reasoning}</p>
+                </div>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </>
+  );
+}
+
+function LLMJudgeBadge({ score, reasoning }: { score?: string; reasoning?: string }) {
+  if (!score) return <span className="text-muted-foreground text-[12px]">-</span>;
+
+  const scoreStr = String(score).toLowerCase();
+  const passed = scoreStr === "true" || scoreStr === "1";
+  const tooltipContent = reasoning || `Score: ${score}`;
+
+  return (
+    <div className="flex items-center gap-1.5">
+      <span className={`inline-flex items-center px-2.5 py-1 rounded-md text-xs font-medium ${
+        passed
+          ? "bg-green-100 text-green-700 dark:bg-green-500/20 dark:text-green-400"
+          : "bg-red-100 text-red-700 dark:bg-red-500/20 dark:text-red-400"
+      }`}>
+        {passed ? "Pass" : "Fail"}
+      </span>
+      <Tooltip content={tooltipContent}>
+        <button type="button" className="p-1 rounded-md hover:bg-muted transition-colors cursor-pointer" aria-label="View reasoning">
+          <svg className="w-4 h-4 text-muted-foreground" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+            <path strokeLinecap="round" strokeLinejoin="round" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+          </svg>
+        </button>
+      </Tooltip>
+    </div>
+  );
+}

--- a/src/components/eval-details/TestRunOutputsPanel.tsx
+++ b/src/components/eval-details/TestRunOutputsPanel.tsx
@@ -1,0 +1,211 @@
+import React, { useState } from "react";
+import {
+  TestCaseOutput,
+  TestCaseData,
+  StatusIcon,
+  TestDetailView as SharedTestDetailView,
+  EmptyStateView,
+  EvaluationCriteriaPanel,
+} from "@/components/test-results/shared";
+
+export type TestRunResult = {
+  id: string;
+  name: string;
+  status: "passed" | "failed" | "running" | "pending" | "queued";
+  output?: TestCaseOutput;
+  testCase?: TestCaseData;
+  reasoning?: string;
+  evaluation?: { passed: boolean; message?: string; details?: Record<string, any> };
+  error?: string;
+};
+
+type TestRunOutputsPanelProps = {
+  results: TestRunResult[];
+  selectedId: string | null;
+  onSelect: (id: string) => void;
+  onClearSelection?: () => void;
+  height?: string;
+};
+
+type StatusGroup = {
+  key: string;
+  label: string;
+  dotColor: string;
+  items: TestRunResult[];
+};
+
+export function TestRunOutputsPanel({
+  results,
+  selectedId,
+  onSelect,
+  onClearSelection,
+  height,
+}: TestRunOutputsPanelProps) {
+  const [collapsedSections, setCollapsedSections] = useState<Set<string>>(new Set());
+
+  const toggleSection = (key: string) => {
+    setCollapsedSections((prev) => {
+      const next = new Set(prev);
+      next.has(key) ? next.delete(key) : next.add(key);
+      return next;
+    });
+  };
+
+  const groups: StatusGroup[] = [
+    { key: "failed", label: "Failed", dotColor: "bg-red-500", items: results.filter((r) => r.status === "failed") },
+    { key: "passed", label: "Passed", dotColor: "bg-green-500", items: results.filter((r) => r.status === "passed") },
+    { key: "queued", label: "Queued", dotColor: "bg-gray-400", items: results.filter((r) => r.status === "queued") },
+    { key: "running", label: "Running", dotColor: "bg-yellow-500 animate-pulse", items: results.filter((r) => r.status === "running") },
+    { key: "pending", label: "Pending", dotColor: "bg-gray-400", items: results.filter((r) => r.status === "pending") },
+  ].filter((g) => g.items.length > 0);
+
+  const selectedResult = results.find((r) => r.id === selectedId);
+
+  return (
+    <div className="flex h-full overflow-hidden" style={height ? { height } : undefined}>
+      {/* Left Panel - Test List */}
+      <div
+        className={`w-full md:w-80 border-r border-border flex flex-col overflow-hidden ${
+          selectedId ? "hidden md:flex" : "flex"
+        }`}
+      >
+        <div className="flex-1 overflow-y-auto">
+          {groups.map((group) => (
+            <div key={group.key} className="p-4">
+              <button
+                type="button"
+                onClick={() => toggleSection(group.key)}
+                className="w-full text-sm font-medium text-muted-foreground mb-2 flex items-center gap-2 cursor-pointer hover:text-foreground transition-colors"
+              >
+                <svg
+                  className={`w-3 h-3 text-muted-foreground transition-transform shrink-0 ${collapsedSections.has(group.key) ? "" : "rotate-90"}`}
+                  fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}
+                >
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M8.25 4.5l7.5 7.5-7.5 7.5" />
+                </svg>
+                <div className={`w-2 h-2 rounded-full ${group.dotColor}`}></div>
+                {group.label} ({group.items.length})
+              </button>
+              {!collapsedSections.has(group.key) && (
+                <div className="space-y-1">
+                  {group.items.map((result) => (
+                    <button
+                      key={result.id}
+                      type="button"
+                      onClick={() => onSelect(result.id)}
+                      className={`w-full flex items-center gap-2 px-3 py-2 rounded-lg cursor-pointer transition-colors ${
+                        selectedId === result.id ? "bg-muted" : "hover:bg-muted/50"
+                      }`}
+                    >
+                      <StatusIcon status={result.status} />
+                      <span className="text-sm text-foreground truncate">{result.name}</span>
+                    </button>
+                  ))}
+                </div>
+              )}
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* Middle Panel - Test Details */}
+      <div
+        className={`flex-1 ${selectedId ? "flex" : "hidden md:flex"} flex-col overflow-hidden`}
+      >
+        {selectedResult ? (
+          <>
+            {/* Mobile Back Button */}
+            {onClearSelection && (
+              <div className="md:hidden px-4 py-3 border-b border-border flex-shrink-0">
+                <button
+                  onClick={onClearSelection}
+                  className="flex items-center gap-2 text-sm text-foreground hover:text-muted-foreground transition-colors"
+                >
+                  <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M15 19l-7-7 7-7" />
+                  </svg>
+                  Back to tests
+                </button>
+              </div>
+            )}
+            <div className="flex-1 overflow-y-auto">
+              <TestResultDetail result={selectedResult} />
+            </div>
+          </>
+        ) : (
+          <EmptyStateView message="Select a test to view details" />
+        )}
+      </div>
+
+      {/* Right Panel - Evaluation Criteria */}
+      {selectedResult && (selectedResult.status === "passed" || selectedResult.status === "failed") && (
+        <div className="hidden md:flex w-72 border-l border-border flex-col overflow-hidden">
+          <div className="flex-1 overflow-y-auto">
+            <EvaluationCriteriaPanel
+              evaluation={selectedResult.testCase?.evaluation}
+            />
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function TestResultDetail({ result }: { result: TestRunResult }) {
+  if (result.status === "pending") {
+    return (
+      <div className="flex items-center justify-center h-full">
+        <p className="text-muted-foreground">Test is pending</p>
+      </div>
+    );
+  }
+
+  if (result.status === "queued") {
+    return (
+      <div className="flex items-center justify-center h-full">
+        <p className="text-muted-foreground">Test is queued</p>
+      </div>
+    );
+  }
+
+  if (result.status === "running") {
+    return (
+      <div className="flex items-center justify-center h-full">
+        <div className="flex items-center gap-3">
+          <svg className="w-5 h-5 animate-spin text-muted-foreground" fill="none" viewBox="0 0 24 24">
+            <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
+            <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+          </svg>
+          <p className="text-muted-foreground">Running test</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (result.error) {
+    return (
+      <div className="p-4 md:p-6">
+        <div className="bg-red-500/10 border border-red-500/30 rounded-lg p-4">
+          <div className="flex items-center gap-2 mb-2">
+            <svg className="w-5 h-5 text-red-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M12 9v3.75m9-.75a9 9 0 11-18 0 9 9 0 0118 0zm-9 3.75h.008v.008H12v-.008z" />
+            </svg>
+            <span className="font-medium text-red-500">Something went wrong</span>
+          </div>
+          <p className="text-sm text-red-400">
+            We&apos;re looking into it. Please reach out to us if this issue persists.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <SharedTestDetailView
+      history={result.testCase?.history || []}
+      output={result.output}
+      passed={result.evaluation?.passed ?? false}
+      reasoning={result.reasoning}
+    />
+  );
+}

--- a/src/components/eval-details/index.ts
+++ b/src/components/eval-details/index.ts
@@ -1,0 +1,31 @@
+export { ProviderSidebar } from "./ProviderSidebar";
+export type { ProviderSidebarItem } from "./ProviderSidebar";
+
+export { ProviderMetricsCard } from "./ProviderMetricsCard";
+export type { MetricItem } from "./ProviderMetricsCard";
+
+export { TTSResultsTable } from "./TTSResultsTable";
+export type { TTSResultRow } from "./TTSResultsTable";
+
+export { STTResultsTable } from "./STTResultsTable";
+export type { STTResultRow } from "./STTResultsTable";
+
+export { LeaderboardTab } from "./LeaderboardTab";
+export type { LeaderboardColumn, ChartConfig } from "./LeaderboardTab";
+
+export { AboutMetricsTable } from "./AboutMetricsTable";
+export type { MetricDescription } from "./AboutMetricsTable";
+
+export { BenchmarkOutputsPanel } from "./BenchmarkOutputsPanel";
+export type { BenchmarkTestResult, BenchmarkModelResult } from "./BenchmarkOutputsPanel";
+
+export { TestRunOutputsPanel } from "./TestRunOutputsPanel";
+export type { TestRunResult } from "./TestRunOutputsPanel";
+
+export { SimulationMetricsGrid, LATENCY_KEYS } from "./SimulationMetricsGrid";
+export type { MetricData } from "./SimulationMetricsGrid";
+
+export { SimulationResultsTable } from "./SimulationResultsTable";
+export type { SimulationResult, EvaluationResult as SimEvaluationResult, Persona, Scenario, TranscriptEntry } from "./SimulationResultsTable";
+
+export { SimulationTranscriptDialog } from "./SimulationTranscriptDialog";


### PR DESCRIPTION
## Summary

- **Extract shared eval display components** into `src/components/eval-details/` so public and private pages reuse the same rendering code. 13 components extracted, ~1,100 net lines removed across 9 files.
- **Add filter/collapse controls** to LLM test runner (collapsible status sections), benchmark outputs (Passed/Failed pills + Collapse/Expand all), and public pages
- **Fix ShareButton not reflecting public state** — `useState(initialIsPublic)` only reads on first mount, so the button always showed "not public" when opening an already-shared test run. Added `useEffect` to sync when props update after polling.
- **Show share button for failed TTS/STT evals** (previously only shown for "done")
- **Remove dataset pill from public TTS/STT views**

## Shared components created

| Component | Used by |
|---|---|
| `ProviderSidebar` | TTS, STT (private + public) |
| `ProviderMetricsCard` | TTS, STT (private + public) |
| `TTSResultsTable` | TTS (private + public) |
| `STTResultsTable` | STT (private + public) — includes audio_url support |
| `LeaderboardTab` | TTS, STT, Benchmark (private + public) |
| `AboutMetricsTable` | TTS, STT (private + public) |
| `BenchmarkOutputsPanel` | BenchmarkResultsDialog, public benchmark |
| `TestRunOutputsPanel` | TestRunnerDialog, public test-run |
| `SimulationMetricsGrid` | Public simulation |
| `SimulationResultsTable` | Public simulation |
| `SimulationTranscriptDialog` | Public simulation |

## Test plan

- [ ] Open a TTS eval (private) — verify Leaderboard, Outputs, About tabs render correctly
- [ ] Open a public TTS eval — verify same tabs render identically
- [ ] Open an STT eval with audio results — verify audio column appears in results table
- [ ] Open a benchmark — verify filter pills (Passed/Failed) and Collapse/Expand all work
- [ ] Open an LLM test run — verify collapsible Failed/Passed sections work
- [ ] Open an already-public test run — verify Share button shows "Public" immediately, not "Share"
- [ ] Open a failed TTS/STT eval — verify Share button appears
- [ ] Check public simulation page — verify metrics grid + results table + transcript dialog work
- [ ] Test mobile responsiveness (provider sidebar horizontal scroll, mobile cards)

🤖 Generated with [Claude Code](https://claude.com/claude-code)