### PR TITLE
Enhancements to tests UI

### DIFF
--- a/.cursor/rules/app-details.md
+++ b/.cursor/rules/app-details.md
@@ -215,8 +215,8 @@ Provider website links (external link icons) are shown only on the new evaluatio
 
 - **Two-column layout**: When the tab shows the main tests UI (not the **complete** empty state below), the layout is tests table on the left, Past runs panel (560px at `xl`) on the right — `flex flex-col lg:flex-row`.
 - **Empty states (`TestsTabContent`)**:
-  - **Complete empty** (no attached tests, past runs finished loading with **zero** runs): single full-width card — icon, "No tests attached", short description, outline **Add test** — **no** Past runs panel.
-  - **No tests but history or loading** (`agentTests.length === 0` and (`pastRunsLoading` **or** `pastRuns.length > 0`)): same two-column shell as when tests exist — left: outline **Add test** (`renderAddTestOutlineControl()`) plus a card explaining past runs are on the right; right: shared **`pastRunsPanel`** (so past runs stay visible after tests are removed or while runs are still loading).
+  - **Complete empty** (no attached tests, past runs finished loading with **zero** runs): single full-width card — icon, "No tests attached", short description, **primary** **Add test** (`renderAddTestControl("primary")`) — **no** Past runs panel.
+  - **No tests but history or loading** (`agentTests.length === 0` and (`pastRunsLoading` **or** `pastRuns.length > 0`)): two-column shell — left: a single empty-state **card** (icon + copy) with **primary** **Add test** centered **below** the description text (`renderAddTestControl("primary")`); there is **no** duplicate Add control in a row above the card; right: shared **`pastRunsPanel`** (past runs stay visible after tests are removed or while runs are still loading).
   - **Has tests**: header with Add / Run all / Compare (when applicable), search, table or cards, plus **`pastRunsPanel`** on the right.
 - **Tests table**: Shows attached tests with name, type (Tool Call/Next Reply), run button, delete button
   - **Desktop grid columns**: `grid-cols-[40px_minmax(0,1fr)_120px_auto_auto]` — Checkbox (40px), Name (fills remaining space, horizontally scrollable via `overflow-x-auto whitespace-nowrap` when text overflows), Type (fixed 120px), Run button (auto), Delete button (auto)
@@ -2317,6 +2317,17 @@ STT/TTS evaluation detail pages and simulation run detail pages use these respon
 - Text sizes scale: `text-base md:text-lg` for headings, `text-xl md:text-2xl` for titles
 - Margins scale: `mb-3 md:mb-4` for consistent spacing
 
+### Dataset detail page (`/datasets/[id]`)
+
+**Implementation**: `src/app/datasets/[id]/page.tsx`. Loads the dataset with `getDataset`; renders **`STTDatasetEditor`** or **`TTSDatasetEditor`** depending on `dataset_type`, with sorted `savedItems`, `onDeleteSavedItem` (API delete + parent `item_count` / `items` update), **`onHasPendingChangesChange`** → `hasPendingChanges`, and **`maxRowsPerEval`** from **`useMaxRowsPerEval`**. **`AppLayout`** uses **`activeItem={dataset.dataset_type}`** (`"stt"` or `"tts"`) so the sidebar highlights the STT or TTS area.
+
+**Header actions** (same row as the title, right-aligned):
+
+- **Save** — Rendered only when **`hasPendingChanges`**. It is the **primary** action (`bg-foreground text-background`, **`font-semibold`**, **`shadow-sm`**) so unsaved edits draw attention before starting an evaluation.
+- **New evaluation** — Navigates to **`/{stt|tts}/new?dataset={uuid}`**. **Disabled** when **`item_count === 0`** (nothing persisted to run against) **or** **`hasPendingChanges`** (the create flow uses saved dataset rows; draft edits must be saved first). When enabled, it uses the same **primary** solid styling; when disabled, **outline / muted** styling. **Tooltip on disabled state**: use shared **`@/components/Tooltip`** with **`position="top"`** (not the native `title` attribute), following the same **disabled-button + `pointer-events-none`** wrapper pattern documented under the Tooltip component — otherwise hover never reaches the trigger. Tooltip copy: if there are pending changes, explain **save first**; else explain **add at least one row**.
+
+**Order**: **Save** (when visible), then **New evaluation**.
+
 ### Evaluation Page Pattern (TTS/STT)
 
 Both TTS and STT evaluation pages follow the same list → new → detail pattern:
@@ -2349,6 +2360,7 @@ Both TTS and STT evaluation pages follow the same list → new → detail patter
 - Both components use the same tab layout:
   - **Settings tab**: Language selection dropdown + provider selection (responsive: table on desktop, cards on mobile) + evaluator selection (`MultiSelectPicker`)
   - **Dataset tab**: Sample rows + add sample button (TTS also has CSV upload with OR divider and sample download)
+  - **Choosing a saved dataset** (`DatasetPicker`, `src/components/evaluations/DatasetPicker.tsx`): Shared by **`SpeechToTextEvaluation`** and **`TextToSpeechEvaluation`** when picking an existing dataset. Datasets with **`item_count === 0`** are not selectable (disabled row styling). The reason is shown with **`@/components/Tooltip`** (`position="top"`), not secondary text under the name — same tooltip shell as elsewhere. **`SpeechToTextEvaluation`** and **`TextToSpeechEvaluation`** both clear **`selectedDatasetId`** when a refetch of **`listDatasets`** shows the current selection has **`item_count === 0`** (covers deleting all rows or stale URL state).
 - **Provider selection UI** (responsive):
   - **Desktop** (`hidden md:block`): Table with border, rounded corners (`border border-border rounded-lg`)
     - Header row with select-all checkbox and column titles (`bg-muted/50 border-b`)
@@ -3702,6 +3714,8 @@ import { Tooltip } from "@/components/Tooltip";
 **Viewport clamping**: The tooltip automatically clamps its position to stay within viewport boundaries (12px padding from edges). This prevents long content (like evaluator reasoning) from going off-screen.
 
 **Styling**: White background, rounded corners, shadow, 256px max width (`w-64`), text wraps within the container. Arrow indicator points to trigger element.
+
+**Disabled controls and hover**: Disabled native **`<button>`** elements often do not receive pointer events, so wrapping only the button breaks hover for the tooltip. Use this pattern when the trigger must stay a real button (e.g. disabled row in **`DatasetPicker`**, disabled **New evaluation** on **`/datasets/[id]`**): **`Tooltip`** → inner wrapper **`div`** → **`button`** with **`disabled`**, **`tabIndex={-1}`**, **`aria-disabled`**, and **`pointer-events-none`** on the button so the tooltip’s outer wrapper receives **`mouseenter` / `mouseleave`**. Do not rely on the **`title`** attribute for these explanations if the product standard is the shared tooltip.
 
 ### UI Components (`@/components/ui`)
 

--- a/.cursor/rules/app-details.md
+++ b/.cursor/rules/app-details.md
@@ -213,19 +213,24 @@ Provider website links (external link icons) are shown only on the new evaluatio
 
 **Tests Tab Features:**
 
-- **Two-column layout**: Tests table on left, Past runs panel (560px) on right
+- **Two-column layout**: When the tab shows the main tests UI (not the **complete** empty state below), the layout is tests table on the left, Past runs panel (560px at `xl`) on the right — `flex flex-col lg:flex-row`.
+- **Empty states (`TestsTabContent`)**:
+  - **Complete empty** (no attached tests, past runs finished loading with **zero** runs): single full-width card — icon, "No tests attached", short description, outline **Add test** — **no** Past runs panel.
+  - **No tests but history or loading** (`agentTests.length === 0` and (`pastRunsLoading` **or** `pastRuns.length > 0`)): same two-column shell as when tests exist — left: outline **Add test** (`renderAddTestOutlineControl()`) plus a card explaining past runs are on the right; right: shared **`pastRunsPanel`** (so past runs stay visible after tests are removed or while runs are still loading).
+  - **Has tests**: header with Add / Run all / Compare (when applicable), search, table or cards, plus **`pastRunsPanel`** on the right.
 - **Tests table**: Shows attached tests with name, type (Tool Call/Next Reply), run button, delete button
   - **Desktop grid columns**: `grid-cols-[40px_minmax(0,1fr)_120px_auto_auto]` — Checkbox (40px), Name (fills remaining space, horizontally scrollable via `overflow-x-auto whitespace-nowrap` when text overflows), Type (fixed 120px), Run button (auto), Delete button (auto)
   - **Individual run button**: Play button on each test row runs only that specific test (not all tests)
 - **Past runs panel**: Has "Past runs" heading with `bg-muted/30` background, showing history of test runs (no column headers):
   - **Row content**: Name/count, Run Type pill, Time, Result badges
+  - **Row layout (`TestsTabContent`)**: From `sm` breakpoint up, each row is a 4-column CSS grid with **fixed-width tracks** for Type, Time, and Status so those columns stay aligned when the first column (name) varies in length: `sm:grid-cols-[minmax(0,1fr)_5.75rem_5rem_9.25rem]` and **`xl:grid-cols-[minmax(0,1fr)_6.25rem_5.75rem_11.5rem]`** (fixed columns are slightly tighter than the maximum pill/time text needs so **`minmax(0, 1fr)` on column 1 gets more space** for long test names). **`sm:items-start`** (top-align so multi-line names don’t vertically center the other columns), **`sm:justify-items-stretch`**. Gaps: **`sm:gap-2`**, **`xl:gap-3`** (tighter gaps help the name column on the `lg:w-[400px]` past-runs panel). **Column 1 markup**: outer **`flex items-start justify-between gap-2 sm:block min-w-0`**; display name in a **`span`** with **`block min-w-0 break-words`** (wraps long test names and aggregate labels like `N tests` instead of the old **`truncate`** ellipsis). The Type pill is **`hidden sm:flex`** with **`sm:justify-center`** in its cell so "Test" / "Benchmark" stay centered in the fixed type column. Time uses **`text-right tabular-nums`** (no per-cell `w-24` — width comes from the grid track). The result column is a flex row with **`sm:flex-nowrap`** and **`whitespace-nowrap` on each status pill**. Below `sm`, the row stacks with `flex flex-col`. **Gotcha**: Do not use **`auto`** for grid columns 2–4 — that made Type/Time stagger between rows. Do not add a **narrow `w-32` / `sm:w-32`** on the badges flex wrapper (forces pill wrapping); the grid column supplies width. **`break-words`** breaks at word boundaries; unbroken long strings (e.g. no spaces) may still need **`break-all`** if that ever shows up in display names.
   - **Name display logic** (via `getTestRunDisplayName` helper):
     - Single-test runs: Shows `results[0].name` (in-progress) or `results[0].test_case.name` (completed)
     - Multi-test runs: Shows "N tests" (e.g., "2 tests")
     - Benchmarks: Shows "N models" (e.g., "3 models")
   - **Run Type**: "Test" (blue pill) or "Benchmark" (purple pill) based on `type` field
   - **Time**: Short relative time format (e.g., "now", "5 min ago", "7h ago", "2d ago", "3w ago", "2m ago", "1y ago")
-  - **Result**: "Running" (yellow, with spinner) for pending/queued/in_progress; "Failed" (red) for `status === "failed"` (entire run errored); "N Success" and/or "M Fail" badges for completed `llm-unit-test`; "Complete" for completed `llm-benchmark`
+  - **Result**: "Running" (yellow, with spinner) for pending/queued/in_progress; **"Error"** (red) for `status === "failed"` (entire run errored); "N Success" and/or "M Fail" badges for completed `llm-unit-test`; "Complete" for completed `llm-benchmark`
 - **Clickable rows**: Clicking a past run row opens the appropriate results dialog:
   - `llm-unit-test` → Opens `TestRunnerDialog` in view mode with `taskId`, `tests` (from `results`), and `initialRunStatus`
   - `llm-benchmark` → Opens `BenchmarkResultsDialog` in view mode (with `taskId` prop)
@@ -950,7 +955,7 @@ Don't introduce new pill colors here; reuse the per-type Tailwind classes alread
     - **Mobile**: Full-screen dialog (`w-full`), padding reduced to `px-4 py-4`, all message bubbles use `w-full` (simulation transcripts need full width due to audio players)
     - **Desktop**: 40% width sidebar (`md:w-[40%] md:min-w-[500px]`), standard padding `md:px-6 md:py-4`, message bubbles use `md:w-1/2`
     - Smooth transition between layouts as viewport changes
-    - **Note**: Simulation transcript bubbles use full width on mobile, unlike test runner messages which use 70% width for visual differentiation
+    - **Note**: Simulation transcript bubbles use full width on mobile. **Test / benchmark result** conversation (`TestDetailView` in `shared.tsx` — middle column of `TestRunnerDialog` / `BenchmarkOutputsPanel`) uses **`w-[88%] md:w-3/4`** for user/agent/tool bubbles (wider than the previous 70% / half-column pattern). **`AddTestDialog`**’s conversation editor preview still uses **`w-1/2`** where its layout defines message columns — not the same width tokens as `TestDetailView`.
 
   - **Live updates with freeze-on-complete**: Dialog stays in sync with polling while simulation is in progress, then freezes:
 
@@ -2640,7 +2645,7 @@ const getFilteredProviders = (language: LanguageOption) => {
      - Dropdown contains: user info (name, email), theme switcher, logout button
      - Logout button clears localStorage (`access_token`, `user`), cookie (`access_token`), then calls `signOut({ callbackUrl: "/login" })`
      - Click outside closes dropdown (uses `useRef` + `mousedown` event)
-7. **CSV Export**: Two complementary patterns for exporting tabular data as CSV.
+7. **CSV export and share header actions**:
    - **`DownloadableTable`** (`@/components/DownloadableTable`): A full table component with a built-in "Download CSV" button in the top-right corner. Use when the same data should both render as a visible table and be exportable.
      - Props: `columns` (array of `{key, header, render?}`), `data`, `filename`, `title`
      - Custom cell rendering via optional `render` function in column definition
@@ -2650,7 +2655,9 @@ const getFilteredProviders = (language: LanguageOption) => {
      - Quotes/escapes commas, double quotes, and newlines per RFC 4180; `null`/`undefined` becomes empty cell; objects are JSON-stringified before quoting
      - Shared CSV column shapes for LLM test runs and benchmarks live in `@/lib/exportTestResults` (`buildTestRunCsv`, `buildBenchmarkCsv`) so the in-app dialogs and the public share pages export identical schemas. Column order — unit-test runs: `Test name | Status | Conversation history | Agent response | Tool calls | Next reply | Error`; benchmarks: same with `Model` prepended and `Error` dropped. Two columns are populated **mutually exclusively** based on test type (`testCase.evaluation.type`, falling back to "tool_call when `output.tool_calls` is non-empty, else response"): tool-call tests fill **Tool calls** and leave Next reply empty; response tests fill **Next reply** and leave Tool calls empty. The standalone `Reasoning` column is gone — for response tests it's folded into the per-evaluator blocks in Next reply, and tool-call reasoning is intentionally not exported. Cell formats: **Conversation history** stays JSON-stringified (`historyToString`); **Tool calls** is multi-line plain text — one block per call, `Tool: <name>` + `Arguments: <json>`, blocks separated by blank lines (uses `normalizeToolCall` so historical `{name, arguments}` / `{tool, arguments}` / `{function: {…}}` shapes all render identically); **Next reply** is multi-line plain text — one block per `JudgeResult`, with a `<name>: <verdict>` line (`Pass`/`Fail` for binary; `<score> / <scale_max>` or `Score: N` for rating), an indented `Variables:` list when `variable_values` is non-empty (`  <name>: <value>` per line), and a final `Reasoning: <text>` line. Legacy response runs without `judge_results` fall back to a single `Reasoning: <top-level reasoning>` block (the historical default-`default-llm-next-reply` reasoning). Callers must pass `judgeResults` (`r.judgeResults` from `TestResult` / `tr.judge_results` from the API) into `ExportTestRow.judgeResults` / `ExportBenchmarkRow.judgeResults` so the per-evaluator structure renders.
      - Used in: `TestRunnerDialog` and `BenchmarkResultsDialog` headers (next to `ShareButton`, desktop only via `hidden md:block`); public share pages `/public/test-run/[token]` and `/public/benchmark/[token]`.
+     - **Default styling** (`ExportResultsButton`): **teal**-tinted border/background/text (download/export — distinct from share/copy hues).
      - Visibility rules: only render once results exist (`testResults.length > 0` / `hasAnyResults`) and the run is done — never during loading/in-progress, since CSV columns key off the final per-test outputs.
+   - **`ShareButton`** (`@/components/ShareButton`) — **not CSV**; sits beside export on finished test/benchmark runs. PATCHes public visibility per entity (`stt` | `tts` | `test-run` | `benchmark` | `simulation-run`); when public, shows **Copy link** (copies `/public/{segment}/{share_token}`). **Styling**: private → **violet**; public → **sky**; **Copy link** → **amber**; **Copied** → **rose** (brief success — distinct from **ExportResultsButton** **teal**, **Share** violet/sky, and **Copy link** amber).
 8. **Charts with PNG Export**: `LeaderboardBarChart` component includes built-in PNG download
    - Props: `title`, `data`, `height?`, `yDomain?`, `formatTooltip?`, `colorMap?`, `filename?`
    - "PNG" download button in top-right corner of chart card
@@ -2726,6 +2733,7 @@ const getFilteredProviders = (language: LanguageOption) => {
         - Uses `Math.max(totalTests, testNames.length, resultsCount)` to determine expected test count, ensuring tests don't disappear during polling
       - As results arrive from API, running indicators update to green checkmarks or red X marks
       - **Auto-expand behavior**: First provider (from `models` prop) is expanded immediately when dialog opens, not waiting for results
+      - **Outputs tab — default selected test**: When polling first returns a `model_results` row with non-empty `test_results`, the dialog auto-selects **`testIndex: 0`** for a qualifying model so the middle/detail panel is populated without an extra click. **Selection order**: walk the **`models` prop** in order and pick the first model id that appears on a `model_results` entry with results; if none match (configured id vs API `model` string mismatch), fall back to the **first** API row that has `test_results`. If **`models` is empty** — e.g. **view past benchmark** from the Tests tab or `/tests` Runs, where parents pass **`models={[]}`** and only **`taskId`** — use that API-order fallback only. A ref (`hasAutoSelectedFirstBenchmarkTestRef`) ensures this runs **once per dialog open**. The chosen model id is also merged into **`expandedProviders`** so that provider section stays open in the left list.
       - **Merged providers**: `getProvidersToDisplay()` function merges `modelResults` from API with placeholders for any models that don't have results yet
       - Types support null values: `success: boolean | null`, `test_results: BenchmarkTestResult[] | null`, `passed: boolean | null`
       - **Header status badge**: Uses `StatusBadge` component (same as STT/TTS evaluation pages) to show task status ("Queued" with gray badge, "Running" with yellow badge) plus spinner while benchmark is in progress
@@ -2735,6 +2743,7 @@ const getFilteredProviders = (language: LanguageOption) => {
       - `taskId`: The run UUID to fetch results for
       - `tests`: Array converted from `pastRun.results` to show test names while loading (TestRunnerDialog only)
       - `initialRunStatus`: Determines initialization behavior (TestRunnerDialog only)
+      - **BenchmarkResultsDialog**: Parents that only have the run id (e.g. Tests tab / `/tests` past benchmark row) may pass **`models={[]}`** and **`testNames={[]}`** — polling supplies `model_results` and test rows; default Outputs selection and placeholders must not depend on those props being non-empty (see **Outputs tab — default selected test** above).
     - **Callback props for coordinated updates**:
       - `onRunCreated` / `onBenchmarkCreated`: Notifies parent when a new run/benchmark is created
       - `onStatusUpdate`: Called during polling (only when `isRunning` is true) to sync status changes back to parent (TestRunnerDialog only)
@@ -2759,7 +2768,7 @@ const getFilteredProviders = (language: LanguageOption) => {
       - Without proper UUIDs, React's key prop receives empty strings, causing "duplicate key" console errors
       - Solution: Generate a unique fallback key using the array index and test name: `apiResult.test_uuid || \`generated-${index}-${testName}\``
       - This ensures unique keys even when the backend doesn't provide UUIDs, while preserving real UUIDs when available
-    - **Per-evaluator verdicts** (response tests): both dialogs thread the `judge_results: JudgeResult[] | null` field straight through from the API to `TestRunOutputsPanel` / `BenchmarkOutputsPanel`, which in turn pass it (along with the top-level `reasoning`, the `test_case.evaluators` echo, and an optional `scaleByEvaluatorUuid` fallback map) to **both** `EvaluationCriteriaPanel` (the third / right column on desktop) **and** `TestDetailView` (which renders a mobile-only `JudgeResultsList` via `md:hidden` so small screens don't lose the data). Field naming: `TestRunResult.judgeResults` (camel) and `BenchmarkTestResult.judge_results` (snake to match the API). Tool-call tests have `judge_results: null` — the right column renders the expected tool calls + the top-level `reasoning` (success/failure summary), and the middle panel's tool-call output renders without an inline reasoning block (the right column already covers it). The right column dropped the visible "Type" badge — section structure (`Evaluators` heading vs `Expected Tool Calls` heading) makes the test type self-evident. Each per-evaluator card renders the evaluator name as a `next/link` to `/evaluators/{evaluator_uuid}` (legacy rows with `evaluator_uuid: null` render plain text — see `EvaluatorNameLink` in `shared.tsx`); the evaluator's one-line description is intentionally **not** rendered on the card — the link is the affordance. Per-test variable values and the rating scale are read inline from each `JudgeResult` (`result.variable_values`, `result.scale_max`); the panel keeps a single fallback to `test_case.evaluators[i].variable_values` and the caller-supplied `scaleByEvaluatorUuid` map for older snapshots that pre-date the inline-fields backend rollout. Neither dialog currently populates `scaleByEvaluatorUuid`, so rating chips for legacy snapshots fall through to amber `Score: N`; new snapshots colour green / red because `scale_max` is on the entry itself.
+    - **Per-evaluator verdicts** (response tests): both dialogs thread the `judge_results: JudgeResult[] | null` field straight through from the API to `TestRunOutputsPanel` / `BenchmarkOutputsPanel`, which in turn pass it (along with the top-level `reasoning`, the `test_case.evaluators` echo, and an optional `scaleByEvaluatorUuid` fallback map) to **both** `EvaluationCriteriaPanel` (the third / right column on desktop) **and** `TestDetailView` (which renders a mobile-only `JudgeResultsList` via `md:hidden` so small screens don't lose the data). Field naming: `TestRunResult.judgeResults` (camel) and `BenchmarkTestResult.judge_results` (snake to match the API). Tool-call tests have `judge_results: null` — the right column renders the expected tool calls + the top-level `reasoning` (success/failure summary; **`CollapsibleReasoningStrip`** expands it — hidden by default), and the middle panel's tool-call output renders without an inline reasoning block (the right column already covers it). The right column dropped the visible "Type" badge — section structure (`Evaluators` heading vs `Expected Tool Calls` heading) makes the test type self-evident. Each per-evaluator card links the evaluator name to `/evaluators/{evaluator_uuid}` when the UUID is present (`EvaluatorNameLink` in `shared.tsx`; legacy `evaluator_uuid: null` → plain text). A snapshotted one-line **description** may appear under the name on both the desktop panel cards and the mobile `JudgeResultCard` list when the API provides it. Per-test variable values and the rating scale are read inline from each `JudgeResult` (`result.variable_values`, `result.scale_max`); the panel keeps a single fallback to `test_case.evaluators[i].variable_values` and the caller-supplied `scaleByEvaluatorUuid` map for older snapshots that pre-date the inline-fields backend rollout. Neither dialog currently populates `scaleByEvaluatorUuid`, so rating chips for legacy snapshots fall through to amber `Score: N`; new snapshots colour green / red because `scale_max` is on the entry itself. See **Reasoning disclosure** under Test Results Components for the collapsible UI pattern.
     - Used for: clicking past run rows in Tests tab to view historical results
 
 ### Data Fetching Pattern
@@ -3926,14 +3935,16 @@ const { toolName, args } = normalizeToolCall(rawToolCallFromApi);
 
 // Full test conversation view (fully responsive)
 // - Padding: `p-4 md:p-6`
-// - Message bubbles: `w-[70%] md:w-1/2` (70% width on mobile for visual differentiation, half on desktop)
+// - Message bubbles: `w-[88%] md:w-3/4` (runner/benchmark middle column — ~88% on small screens, 75% from `md` up)
 // - User messages aligned right, agent messages aligned left for clear visual distinction
 // - Status indicators: responsive padding `pl-2 md:pl-3`
 // - `reasoning` (optional): top-level reasoning string. For tool-call tests this is the deterministic
-//   diff/match summary and is rendered inline next to the tool-call output. For RESPONSE tests, the
+//   diff/match summary — shown in `EvaluationCriteriaPanel` behind **See reasoning** (collapsed by default),
+//   same as per-evaluator rows. For RESPONSE tests, the
 //   inline reasoning is suppressed when `judgeResults` is populated (the per-evaluator panel below
 //   already covers it; the top-level string is just the first failing evaluator's reasoning anyway).
-//   Legacy response rows that pre-date judge_results capture still fall back to inline reasoning.
+//   Legacy response rows that pre-date judge_results capture still fall back to inline reasoning
+//   (also **See reasoning**, italic body when expanded).
 // - `judgeResults` (optional, response tests only): array of per-evaluator verdicts. When present
 //   and non-empty, renders a `JudgeResultsList` panel below the agent response with one card per
 //   evaluator. Tool-call tests always pass `null` here; the legacy single-reasoning UI handles them.
@@ -3956,8 +3967,13 @@ const { toolName, args } = normalizeToolCall(rawToolCallFromApi);
 // `EvaluatorNameLink` when uuid is non-null; plain text for legacy snapshots) + verdict
 // badge. Binary → Pass/Fail. Rating → `score / max` (or `Score: N` when no scale) coloured
 // **green** only when `score === scale_max`, **red** only when `score === scale_min`,
-// otherwise **amber** (anything in between, or either bound unknown). + per-evaluator
-// reasoning underneath.
+// otherwise **amber** (anything in between, or either bound unknown). Per-evaluator
+// **reasoning** is collapsed by default: internal **`ReasoningToggleIconButton`** + **`ReasoningExpandedContent`**
+// in `shared.tsx` (**See reasoning** / **Hide reasoning** text, cyan vs fuchsia by state). The right-column
+// **`EvaluatorPanelCard`** nests **`{{variable}}` values and reasoning in one collapsible block** (expand
+// shows variables first, then reasoning when present; variables-only evaluators still use the same toggle).
+// **`JudgeResultCard`** (mobile `JudgeResultsList`) shares the toggle + verdict-tinted card surfaces; clicking
+// the card toggles reasoning except on links, verdict chips, the toggle button, or inside the expanded body.
 <JudgeResultsList results={judgeResults} scaleByEvaluatorUuid={scaleByEvaluatorUuid} />
 
 // Stats bar - shows passed/failed counts
@@ -3965,7 +3981,8 @@ const { toolName, args } = normalizeToolCall(rawToolCallFromApi);
 <TestStats passedCount={5} failedCount={2} />
 
 // Evaluation criteria panel - third column in test/benchmark runner dialogs
-// Shows test type badge ("Next Reply Text" blue / "Tool Call" purple), criteria text, expected tool calls
+// Shows expected tool calls (tool-call tests) or per-evaluator cards (response tests). Tool-call
+// top-level `reasoning` uses **`CollapsibleReasoningStrip`** in `shared.tsx` (same See/Hide control).
 // Desktop only (hidden on mobile), w-72, border-l
 // IMPORTANT: Both TestRunnerDialog and BenchmarkResultsDialog import this from shared — no local copies
 // IMPORTANT: Only rendered after test completes (status "passed" or "failed"). During running/pending/queued,
@@ -4003,7 +4020,9 @@ type JudgeResult = {
 - `name` is refreshed server-side on every read of the run, so a rename in the evaluator settings UI surfaces on the next poll without a re-run. **Don't cache `name` long-term** — store `evaluator_uuid` as the stable key.
 - `evaluator_uuid` may be `null` for legacy runs that pre-date snapshot capture; treat as "no canonical link, just display the name" (no clickable evaluator link). When non-null, the cards render the name as a `next/link` to `/evaluators/{uuid}` via the shared `EvaluatorNameLink` helper in `shared.tsx`.
 - A test passes only when **all** judge entries pass: binary entries pass when `match === true`, rating entries pass when `score === scale_max`. The frontend can rely on the top-level `result.passed` for this — no need to recompute. Rating cards resolve `scale_max` inline from `result.scale_max` first (newer snapshots), falling back to the caller's `scaleByEvaluatorUuid` map; without either, they render a neutral amber `Score: N` chip.
-- `variable_values` shown on the right-column card resolve in the same priority order: inline `result.variable_values` first, then `test_case.evaluators[i].variable_values` matched by `evaluator_uuid` for older snapshots. Empty objects are normalised to `null` server-side, so an evaluator with zero variables simply renders no variables section.
+- `variable_values` shown on the right-column card resolve in the same priority order: inline `result.variable_values` first, then `test_case.evaluators[i].variable_values` matched by `evaluator_uuid` for older snapshots. Empty objects are normalised to `null` server-side. On **`EvaluatorPanelCard`**, variable rows render **inside the same collapsible region as reasoning** (not above the header); expand when either variables or reasoning exist.
+
+**Reasoning disclosure** (`src/components/test-results/shared.tsx`, not exported): Reasoning is **collapsed by default**. **`ReasoningToggleIconButton`** shows **See reasoning** / **Hide reasoning** plus a chevron; closed state uses **cyan** accents, open state **fuchsia** (not gray-only chrome). **`ReasoningExpandedContent`** renders the paragraph; **`showReasoningLabel`** adds the small uppercase **Reasoning** label (used in the right-column panel when expanded). **`CollapsibleReasoningStrip`** (tool-call / some strips) is a bordered row with a leading label + the same toggle, expanded body below. **Per-evaluator cards** (`JudgeResultCard`, `EvaluatorPanelCard`): local `useState` per card; **`getEvaluatorVerdictTone`** + **`evaluatorVerdictCardSurfaceClass`** apply **green / red / amber / neutral** tinted backgrounds, borders, and a **left accent stripe** from the verdict (not flat `bg-muted` only). **Card click** toggles the collapsible when the card has expandable content (`hasReasoning` on mobile cards; **`hasCollapsibleBody`** = reasoning **or** variables on **`EvaluatorPanelCard`**): ignored targets include **`button`**, **`a[href]`**, **`[data-evaluator-verdict-chips]`** (Pass/Fail/score chips), **`[data-reasoning-body]`** (expanded copy — avoids collapsing while selecting text), and the toggle uses **`stopPropagation`** so it does not double-fire. **Legacy** single `reasoning` under the agent bubble (no `judge_results`): toggle sits on the **Agent** header row (`justify-between`); **`italic`** + muted body on the expanded line. **Tool-call** top-level `reasoning` in **`EvaluationCriteriaPanel`**: **`CollapsibleReasoningStrip`**. Empty **`reasoning`** on **`JudgeResultCard`** (no text) hides the collapsible; **`EvaluatorPanelCard`** can still expand when only **`variable_values`** exist (**`hasCollapsibleBody`**). **`aria-expanded`** is set on the toggle **button**.
 
 ---
 
@@ -4214,7 +4233,7 @@ This prevents infinite polling when the backend is unreachable and gives users i
 - `src/app/stt/[uuid]/page.tsx` - STT evaluation detail page
 - `src/app/tts/[uuid]/page.tsx` - TTS evaluation detail page
 - `src/app/simulations/[uuid]/runs/[runId]/page.tsx` - Simulation run detail page
-- `src/components/agent-tabs/TestsTabContent.tsx` - Background polling for past runs
+- `src/components/agent-tabs/TestsTabContent.tsx` - Past runs (`pastRunsPanel`, polling, empty vs split layout, wrapped display names)
 - `src/components/TestRunnerDialog.tsx` - Test run polling
 - `src/components/BenchmarkResultsDialog.tsx` - Benchmark polling
 
@@ -4782,7 +4801,7 @@ Set `MAINTENANCE_MODE=true` in `.env.local` to show a maintenance page. When ena
 - **Checkboxes need visible borders**: Use `border-muted-foreground` (not `border-border`) and `border-2` for custom checkbox buttons to ensure visibility in both light and dark modes
 - **Spinners in flex containers**: Always add `flex-shrink-0` to spinner SVGs to prevent them from shrinking. Standard spinner class: `w-5 h-5 flex-shrink-0 animate-spin`
 - **Icon action buttons** (play, edit, etc.): Use `bg-foreground/90 text-background hover:bg-foreground` for solid icon buttons that need to be visible in both light and dark modes. Never use `text-white` alone as icons become invisible on light backgrounds. **Avoid `hover:opacity-*`** on buttons with child tooltips - opacity affects all children including tooltips, making them translucent. Use `bg-foreground/90 hover:bg-foreground` instead to only affect the background
-- **Chat message bubbles**: Consistent styling across AddTestDialog and TestDetailView (test results). User messages use `bg-muted border border-border text-foreground` (gray background, right-aligned). Agent messages use `bg-background border border-border text-foreground` (white/light background, left-aligned). Tool call cards use `bg-muted border border-border`. All use `rounded-xl` corners. **Width pattern**: `w-[70%] md:w-1/2` (70% width on mobile for better visual differentiation between user/agent messages, 50% on desktop). This prevents full-width message bubbles on mobile that look monotonous. See `@/components/test-results/shared.tsx` for the pattern
+- **Chat message bubbles (test results)**: **`TestDetailView`** (`@/components/test-results/shared.tsx`) drives the middle column in **TestRunnerDialog**, **BenchmarkOutputsPanel**, and public test/benchmark pages. User, assistant, history tool-call, and final output bubbles share **`w-[88%] md:w-3/4`** so the transcript uses most of the column without going edge-to-edge. Alignment: user right (`items-end`), agent left. Colors: user `bg-muted border border-border`, agent `bg-background border border-border`, tool output matches tool-call card styling; **`rounded-xl`**. **`AddTestDialog`** preview rows use **`w-1/2`** in the editor — different layout from result view; update docs in both places if you change width conventions.
 - **Info banners (colored text on tinted bg)**: When using colored text on a semi-transparent background (e.g., blue info notices, yellow warnings), always provide separate light and dark mode classes. Light mode needs darker shades for readability. Pattern: `text-blue-600 dark:text-blue-300/90` for text, `text-blue-500 dark:text-blue-400` for icons. Never use only a light shade like `text-blue-300` — it's invisible on light backgrounds. **Yellow/cream warning strips** (e.g., `bg-yellow-500/10`): prefer **`text-foreground`** for the banner body so contrast holds on the pale tint; pair with a darker icon in light mode, e.g. **`text-amber-900 dark:text-amber-400`**, instead of mid yellow on yellow (`text-yellow-500` on `bg-yellow-500/10` fails WCAG in light mode)
 
 ### Forms

--- a/src/app/datasets/[id]/page.tsx
+++ b/src/app/datasets/[id]/page.tsx
@@ -21,6 +21,7 @@ import {
   TTSDatasetEditorHandle,
 } from "@/components/evaluations/TTSDatasetEditor";
 import { toast } from "sonner";
+import { Tooltip } from "@/components/Tooltip";
 
 export default function DatasetDetailPage() {
   const router = useRouter();
@@ -89,9 +90,16 @@ export default function DatasetDetailPage() {
     const isStt = dataset.dataset_type === "stt";
     const editorRef = isStt ? sttEditorRef : ttsEditorRef;
 
+    if (isStt && sttEditorRef.current && !sttEditorRef.current.validate()) {
+      toast.error(
+        "Enter reference transcription for every row with uploaded audio.",
+      );
+      return;
+    }
+
     const dirtyUpdates = editorRef.current?.getDirtyUpdates() ?? [];
-    const newRows = editorRef.current?.getNewRows() ?? [];
-    if (dirtyUpdates.length === 0 && newRows.length === 0) return;
+    const newRowsPayload = editorRef.current?.getNewRows() ?? [];
+    if (dirtyUpdates.length === 0 && newRowsPayload.length === 0) return;
 
     setIsSaving(true);
     try {
@@ -100,8 +108,8 @@ export default function DatasetDetailPage() {
           updateDatasetItem(accessToken, dataset.uuid, u.uuid, u.text),
         ),
       );
-      if (newRows.length > 0) {
-        await addDatasetItems(accessToken, dataset.uuid, newRows);
+      if (newRowsPayload.length > 0) {
+        await addDatasetItems(accessToken, dataset.uuid, newRowsPayload);
       }
       editorRef.current?.clearDirtyUpdates();
       editorRef.current?.clearNewRows();
@@ -111,9 +119,9 @@ export default function DatasetDetailPage() {
         parts.push(
           `${dirtyUpdates.length} item${dirtyUpdates.length !== 1 ? "s" : ""} updated`,
         );
-      if (newRows.length > 0)
+      if (newRowsPayload.length > 0)
         parts.push(
-          `${newRows.length} item${newRows.length !== 1 ? "s" : ""} added`,
+          `${newRowsPayload.length} item${newRowsPayload.length !== 1 ? "s" : ""} added`,
         );
       toast.success(parts.join(", ") + ".");
     } catch (err) {
@@ -194,21 +202,46 @@ export default function DatasetDetailPage() {
                   <button
                     onClick={handleSave}
                     disabled={isSaving}
-                    className="h-9 px-4 rounded-md text-sm font-medium border border-border hover:bg-muted/50 transition-colors cursor-pointer flex-shrink-0 disabled:opacity-50 disabled:cursor-not-allowed"
+                    className="h-9 px-4 rounded-md text-sm font-semibold bg-foreground text-background hover:opacity-90 transition-opacity cursor-pointer flex-shrink-0 disabled:opacity-50 disabled:cursor-not-allowed shadow-sm"
                   >
                     {isSaving ? "Saving..." : "Save"}
                   </button>
                 )}
-                <button
-                  onClick={() =>
-                    router.push(
-                      `/${dataset.dataset_type}/new?dataset=${dataset.uuid}`,
-                    )
-                  }
-                  className="h-9 px-4 rounded-md text-sm font-medium bg-foreground text-background hover:opacity-90 transition-opacity cursor-pointer flex-shrink-0"
-                >
-                  New evaluation
-                </button>
+                {dataset.item_count > 0 && !hasPendingChanges ? (
+                  <button
+                    type="button"
+                    onClick={() =>
+                      router.push(
+                        `/${dataset.dataset_type}/new?dataset=${dataset.uuid}`,
+                      )
+                    }
+                    className="h-9 px-4 rounded-md text-sm font-medium flex-shrink-0 bg-foreground text-background hover:opacity-90 transition-opacity cursor-pointer shadow-sm"
+                  >
+                    New evaluation
+                  </button>
+                ) : (
+                  <Tooltip
+                    content={
+                      hasPendingChanges
+                        ? "Save your changes before starting an evaluation."
+                        : "Add at least one row to run an evaluation."
+                    }
+                    position="top"
+                    className="flex-shrink-0"
+                  >
+                    <div className="inline-flex flex-shrink-0">
+                      <button
+                        type="button"
+                        disabled
+                        tabIndex={-1}
+                        aria-disabled="true"
+                        className="h-9 px-4 rounded-md text-sm font-medium flex-shrink-0 border border-border bg-background text-foreground opacity-60 cursor-not-allowed pointer-events-none"
+                      >
+                        New evaluation
+                      </button>
+                    </div>
+                  </Tooltip>
+                )}
               </div>
             </div>
 

--- a/src/components/BenchmarkResultsDialog.tsx
+++ b/src/components/BenchmarkResultsDialog.tsx
@@ -98,6 +98,8 @@ export function BenchmarkResultsDialog({
     useState<DefaultEvaluatorSummary | null>(null);
   const backendAccessToken = useAccessToken();
   const pollingIntervalRef = useRef<NodeJS.Timeout | null>(null);
+  /** Once per dialog open: select first test of `models[0]` when its row exists. */
+  const hasAutoSelectedFirstBenchmarkTestRef = useRef(false);
 
   const isDone =
     taskStatus === "completed" ||
@@ -139,6 +141,7 @@ export function BenchmarkResultsDialog({
       setError(null);
       setExpandedProviders(new Set(models.length > 0 ? [models[0]] : []));
       setSelectedTest(null);
+      hasAutoSelectedFirstBenchmarkTestRef.current = false;
       setActiveTab("outputs");
       setIsPublic(false);
       setShareToken(null);
@@ -179,6 +182,52 @@ export function BenchmarkResultsDialog({
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isOpen, taskId]);
+
+  // Default selection: first test (index 0) of the first model that has
+  // `test_results`. When `models` is populated (new run), prefer that order
+  // and match by `model` id. When `models` is empty (e.g. past run opened
+  // with only `taskId`), use the first API row that has results — the parent
+  // often passes `models={[]}` in that case.
+  useEffect(() => {
+    if (!isOpen || hasAutoSelectedFirstBenchmarkTestRef.current) return;
+    if (modelResults.length === 0) return;
+
+    const pickDefaultSelection = (): {
+      model: string;
+      testIndex: number;
+    } | null => {
+      if (models.length > 0) {
+        for (const modelId of models) {
+          const mr = modelResults.find((m) => m.model === modelId);
+          if (mr?.test_results && mr.test_results.length > 0) {
+            return { model: modelId, testIndex: 0 };
+          }
+        }
+        // Config order vs API label mismatch — first row with results
+        const firstWith = modelResults.find(
+          (m) => m.test_results && m.test_results.length > 0,
+        );
+        if (firstWith) return { model: firstWith.model, testIndex: 0 };
+        return null;
+      }
+      const firstWith = modelResults.find(
+        (m) => m.test_results && m.test_results.length > 0,
+      );
+      if (firstWith) return { model: firstWith.model, testIndex: 0 };
+      return null;
+    };
+
+    const sel = pickDefaultSelection();
+    if (!sel) return;
+
+    hasAutoSelectedFirstBenchmarkTestRef.current = true;
+    setSelectedTest(sel);
+    setExpandedProviders((prev) => {
+      const next = new Set(prev);
+      next.add(sel.model);
+      return next;
+    });
+  }, [isOpen, models, modelResults]);
 
   const pollBenchmarkStatus = async (taskId: string, backendUrl: string) => {
     try {

--- a/src/components/ExportResultsButton.tsx
+++ b/src/components/ExportResultsButton.tsx
@@ -72,7 +72,7 @@ export function ExportResultsButton({
       onClick={handleClick}
       disabled={disabled}
       title="Export results as CSV"
-      className={`flex items-center gap-2 h-8 px-2 md:px-3 rounded-md text-xs md:text-sm font-medium border border-border hover:bg-muted/50 transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed ${className ?? ""}`}
+      className={`flex items-center gap-2 h-8 px-2 md:px-3 rounded-lg text-xs md:text-sm font-medium border cursor-pointer transition-colors disabled:opacity-50 disabled:cursor-not-allowed bg-teal-500/12 border-teal-500/45 text-teal-950 dark:text-teal-100 hover:bg-teal-500/22 dark:hover:bg-teal-500/18 ${className ?? ""}`}
     >
       <svg
         className="w-4 h-4"

--- a/src/components/ShareButton.tsx
+++ b/src/components/ShareButton.tsx
@@ -131,8 +131,8 @@ export function ShareButton({
           disabled={isLoading}
           className={`flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-[13px] font-medium transition-colors border cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed ${
             isPublic
-              ? "bg-blue-500/10 border-blue-500/30 text-blue-600 dark:text-blue-400 hover:bg-blue-500/20"
-              : "bg-muted border-border text-muted-foreground hover:text-foreground hover:bg-muted/70"
+              ? "bg-sky-500/18 border-sky-500/50 text-sky-900 dark:text-sky-100 hover:bg-sky-500/30 dark:hover:bg-sky-500/25"
+              : "bg-violet-500/14 border-violet-500/45 text-violet-900 dark:text-violet-200 hover:bg-violet-500/26 dark:hover:bg-violet-500/20"
           }`}
         >
           {isLoading ? (
@@ -194,13 +194,17 @@ export function ShareButton({
       {isPublic && publicUrl && (
         <button
           onClick={copyLink}
-          className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-[13px] font-medium bg-muted border border-border text-muted-foreground hover:text-foreground hover:bg-muted/70 transition-colors cursor-pointer dark:bg-accent/20 dark:border-accent/40 dark:text-accent-foreground dark:hover:bg-accent/30"
+          className={`flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-[13px] font-medium border transition-colors cursor-pointer ${
+            copied
+              ? "bg-rose-500/16 border-rose-500/48 text-rose-950 dark:text-rose-50 hover:bg-rose-500/24 dark:hover:bg-rose-500/22"
+              : "bg-amber-500/16 border-amber-500/50 text-amber-950 dark:text-amber-100 hover:bg-amber-500/28 dark:hover:bg-amber-500/22"
+          }`}
           title="Copy public link"
         >
           {copied ? (
             <>
               <svg
-                className="w-3.5 h-3.5 text-green-500"
+                className="w-3.5 h-3.5 text-rose-600 dark:text-rose-300"
                 fill="none"
                 viewBox="0 0 24 24"
                 stroke="currentColor"
@@ -212,7 +216,7 @@ export function ShareButton({
                   d="M4.5 12.75l6 6 9-13.5"
                 />
               </svg>
-              <span className="text-green-600 dark:text-green-400">Copied</span>
+              <span>Copied</span>
             </>
           ) : (
             <>

--- a/src/components/agent-tabs/TestsTabContent.tsx
+++ b/src/components/agent-tabs/TestsTabContent.tsx
@@ -156,7 +156,7 @@ export function TestsTabContent({
 
   // Selection state for bulk operations
   const [selectedTestUuids, setSelectedTestUuids] = useState<Set<string>>(
-    new Set()
+    new Set(),
   );
 
   // Delete confirmation state
@@ -173,8 +173,10 @@ export function TestsTabContent({
   // Benchmark dialog state
   const [benchmarkDialogOpen, setBenchmarkDialogOpen] = useState(false);
 
-  const isConnectionUnverified = agentType === "connection" && connectionVerified === false;
-  const isBenchmarkDisabled = agentType === "connection" && supportsBenchmark !== true;
+  const isConnectionUnverified =
+    agentType === "connection" && connectionVerified === false;
+  const isBenchmarkDisabled =
+    agentType === "connection" && supportsBenchmark !== true;
 
   // Past test runs state
   const [pastRuns, setPastRuns] = useState<TestRun[]>([]);
@@ -233,7 +235,7 @@ export function TestsTabContent({
               "ngrok-skip-browser-warning": "true",
               Authorization: `Bearer ${backendAccessToken}`,
             },
-          }
+          },
         );
 
         if (response.status === 401) {
@@ -250,7 +252,7 @@ export function TestsTabContent({
       } catch (err) {
         console.error("Error fetching agent tests:", err);
         setAgentTestsError(
-          err instanceof Error ? err.message : "Failed to load agent tests"
+          err instanceof Error ? err.message : "Failed to load agent tests",
         );
       } finally {
         setAgentTestsLoading(false);
@@ -346,7 +348,7 @@ export function TestsTabContent({
               "ngrok-skip-browser-warning": "true",
               Authorization: `Bearer ${backendAccessToken}`,
             },
-          }
+          },
         );
 
         if (response.status === 401) {
@@ -400,7 +402,7 @@ export function TestsTabContent({
           (run.status === "pending" ||
             run.status === "queued" ||
             run.status === "in_progress") &&
-          run.uuid !== viewingRunId
+          run.uuid !== viewingRunId,
       );
 
       // If no pending runs to poll, skip this poll cycle
@@ -458,7 +460,7 @@ export function TestsTabContent({
                   updated_at: new Date().toISOString(),
                 };
               }
-            })
+            }),
           );
         } catch (err) {
           console.error(`Error polling run ${run.uuid}:`, err);
@@ -471,8 +473,8 @@ export function TestsTabContent({
                     status: "failed",
                     updated_at: new Date().toISOString(),
                   }
-                : r
-            )
+                : r,
+            ),
           );
         }
       }
@@ -482,7 +484,7 @@ export function TestsTabContent({
     pollPendingRuns(); // Poll immediately on mount/dependency change
     pendingRunsPollingRef.current = setInterval(
       pollPendingRuns,
-      POLLING_INTERVAL_MS
+      POLLING_INTERVAL_MS,
     );
 
     return () => {
@@ -501,7 +503,7 @@ export function TestsTabContent({
   // Filter out tests already attached to the agent
   const agentTestUuids = new Set(agentTests.map((t) => t.uuid));
   const availableTests = allTests.filter(
-    (test) => !agentTestUuids.has(test.uuid)
+    (test) => !agentTestUuids.has(test.uuid),
   );
 
   // Filter available tests based on search query
@@ -509,7 +511,7 @@ export function TestsTabContent({
     (test) =>
       test.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
       (test.description &&
-        test.description.toLowerCase().includes(searchQuery.toLowerCase()))
+        test.description.toLowerCase().includes(searchQuery.toLowerCase())),
   );
 
   // Filter agent tests based on search query
@@ -517,7 +519,9 @@ export function TestsTabContent({
     (test) =>
       test.name.toLowerCase().includes(testsSearchQuery.toLowerCase()) ||
       (test.description &&
-        test.description.toLowerCase().includes(testsSearchQuery.toLowerCase()))
+        test.description
+          .toLowerCase()
+          .includes(testsSearchQuery.toLowerCase())),
   );
 
   // Add test to agent
@@ -664,7 +668,7 @@ export function TestsTabContent({
       status: string,
       results?: TestRunResult[],
       passed?: number | null,
-      failed?: number | null
+      failed?: number | null,
     ) => {
       setPastRuns((prev) =>
         prev.map((run) => {
@@ -677,10 +681,10 @@ export function TestsTabContent({
             failed: failed ?? run.failed,
             updated_at: new Date().toISOString(),
           };
-        })
+        }),
       );
     },
-    []
+    [],
   );
 
   // Remove test(s) from agent
@@ -689,8 +693,8 @@ export function TestsTabContent({
       testsToDeleteBulk.length > 0
         ? testsToDeleteBulk
         : testToDelete
-        ? [testToDelete.uuid]
-        : [];
+          ? [testToDelete.uuid]
+          : [];
     if (uuidsToRemove.length === 0) return;
 
     try {
@@ -736,11 +740,16 @@ export function TestsTabContent({
     }
   };
 
-  const renderAddTestOutlineControl = () => (
+  const renderAddTestControl = (variant: "outline" | "primary" = "outline") => (
     <div className="relative" ref={dropdownRef}>
       <button
         onClick={() => setShowTestDropdown(!showTestDropdown)}
-        className="h-9 md:h-10 px-3 md:px-4 rounded-md text-sm md:text-base font-medium border border-border bg-background hover:bg-muted/50 transition-colors cursor-pointer"
+        type="button"
+        className={
+          variant === "primary"
+            ? "h-9 md:h-10 px-4 md:px-5 rounded-md text-sm md:text-base font-medium bg-foreground text-background hover:opacity-90 transition-opacity cursor-pointer shadow-sm"
+            : "h-9 md:h-10 px-3 md:px-4 rounded-md text-sm md:text-base font-medium border border-border bg-background hover:bg-muted/50 transition-colors cursor-pointer"
+        }
       >
         Add test
       </button>
@@ -799,9 +808,7 @@ export function TestsTabContent({
             ) : filteredAvailableTests.length === 0 ? (
               <div className="py-8 text-center">
                 <p className="text-sm text-muted-foreground">
-                  {searchQuery
-                    ? "No tests found"
-                    : "No tests available"}
+                  {searchQuery ? "No tests found" : "No tests available"}
                 </p>
               </div>
             ) : (
@@ -820,9 +827,7 @@ export function TestsTabContent({
                     </p>
                   )}
                   <span className="inline-block mt-1 px-2 py-0.5 text-xs rounded-full bg-muted text-muted-foreground">
-                    {test.type === "tool_call"
-                      ? "Tool Call"
-                      : "Next Reply"}
+                    {test.type === "tool_call" ? "Tool Call" : "Next Reply"}
                   </span>
                 </button>
               ))
@@ -1076,7 +1081,9 @@ export function TestsTabContent({
                 onClick={() => {
                   if (isConnectionUnverified) return;
                   if (agentTests.length > maxRowsPerEval) {
-                    showLimitToast(`You can only run up to ${maxRowsPerEval} tests at a time.`);
+                    showLimitToast(
+                      `You can only run up to ${maxRowsPerEval} tests at a time.`,
+                    );
                     return;
                   }
                   setTestsToRun(agentTests);
@@ -1150,7 +1157,8 @@ export function TestsTabContent({
               )}
               {!isConnectionUnverified && isBenchmarkDisabled && (
                 <div className="absolute left-1/2 -translate-x-1/2 bottom-full mb-2 px-3 py-1.5 bg-foreground text-background text-xs rounded-lg shadow-lg opacity-0 group-hover/compare:opacity-100 pointer-events-none transition-opacity whitespace-nowrap z-50">
-                  You have turned off benchmarking models in connection settings — turn it on to enable this
+                  You have turned off benchmarking models in connection settings
+                  — turn it on to enable this
                 </div>
               )}
             </div>
@@ -1196,8 +1204,8 @@ export function TestsTabContent({
           </button>
         </div>
       ) : agentTests.length === 0 &&
-          !pastRunsLoading &&
-          pastRuns.length === 0 ? (
+        !pastRunsLoading &&
+        pastRuns.length === 0 ? (
         <div className="flex-1 border border-border rounded-xl p-6 md:p-12 flex flex-col items-center justify-center bg-muted/20">
           <div className="w-12 md:w-14 h-12 md:h-14 rounded-xl bg-muted flex items-center justify-center mb-3 md:mb-4">
             <svg
@@ -1215,13 +1223,12 @@ export function TestsTabContent({
             This agent doesn&apos;t have any tests attached to it.
           </p>
           <div className="flex items-center gap-2 md:gap-3">
-            {renderAddTestOutlineControl()}
+            {renderAddTestControl("primary")}
           </div>
         </div>
       ) : agentTests.length === 0 ? (
         <div className="flex-1 flex flex-col lg:flex-row gap-4 md:gap-6">
           <div className="flex-1 flex flex-col min-w-0">
-            <div className="mb-3 md:mb-4">{renderAddTestOutlineControl()}</div>
             <div className="flex-1 border border-border rounded-xl p-6 md:p-10 flex flex-col items-center justify-center bg-muted/20 min-h-[220px] md:min-h-[280px]">
               <div className="w-12 md:w-14 h-12 md:h-14 rounded-xl bg-muted flex items-center justify-center mb-3 md:mb-4">
                 <svg
@@ -1235,11 +1242,12 @@ export function TestsTabContent({
               <h3 className="text-base md:text-lg font-semibold text-foreground mb-1 text-center">
                 No tests attached
               </h3>
-              <p className="text-sm md:text-base text-muted-foreground text-center max-w-md">
-                This agent doesn&apos;t have any tests linked right now. Past runs
-                from earlier sessions are on the right — add a test here to run new
-                ones from this tab.
+              <p className="text-sm md:text-base text-muted-foreground text-center max-w-md mb-0">
+                This agent doesn&apos;t have any tests linked right now
               </p>
+              <div className="flex justify-center mt-3 md:mt-4 w-full">
+                {renderAddTestControl("primary")}
+              </div>
             </div>
           </div>
           {pastRunsPanel}
@@ -1296,7 +1304,8 @@ export function TestsTabContent({
                         type="button"
                         onClick={toggleSelectAll}
                         className={`w-5 h-5 rounded border flex-shrink-0 flex items-center justify-center transition-colors cursor-pointer ${
-                          selectedTestUuids.size === filteredAgentTests.length &&
+                          selectedTestUuids.size ===
+                            filteredAgentTests.length &&
                           filteredAgentTests.length > 0
                             ? "bg-foreground border-foreground"
                             : "border-border hover:border-muted-foreground"
@@ -1582,7 +1591,9 @@ export function TestsTabContent({
 
       {/* Delete Confirmation Dialog */}
       <DeleteConfirmationDialog
-        isOpen={deleteDialogOpen && (!!testToDelete || testsToDeleteBulk.length > 0)}
+        isOpen={
+          deleteDialogOpen && (!!testToDelete || testsToDeleteBulk.length > 0)
+        }
         onClose={closeDeleteDialog}
         onConfirm={handleRemoveTest}
         title={testsToDeleteBulk.length > 0 ? "Remove tests" : "Remove test"}

--- a/src/components/agent-tabs/TestsTabContent.tsx
+++ b/src/components/agent-tabs/TestsTabContent.tsx
@@ -736,6 +736,223 @@ export function TestsTabContent({
     }
   };
 
+  const renderAddTestOutlineControl = () => (
+    <div className="relative" ref={dropdownRef}>
+      <button
+        onClick={() => setShowTestDropdown(!showTestDropdown)}
+        className="h-9 md:h-10 px-3 md:px-4 rounded-md text-sm md:text-base font-medium border border-border bg-background hover:bg-muted/50 transition-colors cursor-pointer"
+      >
+        Add test
+      </button>
+      {showTestDropdown && (
+        <div className="absolute top-full left-0 mt-2 w-80 bg-background border border-border rounded-lg shadow-lg z-50">
+          <div className="p-3 border-b border-border">
+            <div className="relative">
+              <div className="absolute inset-y-0 left-0 flex items-center pl-3 pointer-events-none">
+                <svg
+                  className="w-4 h-4 text-muted-foreground"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                  strokeWidth={2}
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    d="M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 5.196a7.5 7.5 0 0010.607 10.607z"
+                  />
+                </svg>
+              </div>
+              <input
+                type="text"
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.target.value)}
+                placeholder="Search tests"
+                className="w-full h-9 pl-9 pr-3 rounded-md text-sm border border-border bg-background text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-accent focus:border-transparent"
+                autoFocus
+              />
+            </div>
+          </div>
+          <div className="max-h-64 overflow-y-auto">
+            {allTestsLoading ? (
+              <div className="flex items-center justify-center py-8">
+                <svg
+                  className="w-5 h-5 animate-spin text-muted-foreground"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                >
+                  <circle
+                    className="opacity-25"
+                    cx="12"
+                    cy="12"
+                    r="10"
+                    stroke="currentColor"
+                    strokeWidth="4"
+                  ></circle>
+                  <path
+                    className="opacity-75"
+                    fill="currentColor"
+                    d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+                  ></path>
+                </svg>
+              </div>
+            ) : filteredAvailableTests.length === 0 ? (
+              <div className="py-8 text-center">
+                <p className="text-sm text-muted-foreground">
+                  {searchQuery
+                    ? "No tests found"
+                    : "No tests available"}
+                </p>
+              </div>
+            ) : (
+              filteredAvailableTests.map((test) => (
+                <button
+                  key={test.uuid}
+                  onClick={() => handleSelectTest(test)}
+                  className="w-full px-4 py-3 text-left hover:bg-muted/50 transition-colors cursor-pointer border-b border-border last:border-b-0"
+                >
+                  <p className="text-sm font-medium text-foreground truncate">
+                    {test.name}
+                  </p>
+                  {test.description && (
+                    <p className="text-xs text-muted-foreground mt-0.5 line-clamp-2">
+                      {test.description}
+                    </p>
+                  )}
+                  <span className="inline-block mt-1 px-2 py-0.5 text-xs rounded-full bg-muted text-muted-foreground">
+                    {test.type === "tool_call"
+                      ? "Tool Call"
+                      : "Next Reply"}
+                  </span>
+                </button>
+              ))
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+
+  const pastRunsPanel = (
+    <div className="w-full lg:w-[400px] xl:w-[560px] flex-shrink-0 border border-border rounded-xl overflow-hidden bg-muted/30">
+      <div className="px-3 md:px-4 py-2 md:py-3">
+        <h3 className="text-sm md:text-base font-semibold text-foreground">
+          Past runs
+        </h3>
+      </div>
+
+      <div className="overflow-y-auto max-h-[300px] lg:max-h-[500px]">
+        {pastRunsLoading ? (
+          <div className="flex items-center justify-center py-6 md:py-8">
+            <svg
+              className="w-5 h-5 animate-spin text-muted-foreground"
+              fill="none"
+              viewBox="0 0 24 24"
+            >
+              <circle
+                className="opacity-25"
+                cx="12"
+                cy="12"
+                r="10"
+                stroke="currentColor"
+                strokeWidth="4"
+              ></circle>
+              <path
+                className="opacity-75"
+                fill="currentColor"
+                d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+              ></path>
+            </svg>
+          </div>
+        ) : pastRuns.length === 0 ? (
+          <div className="py-6 md:py-8 text-center">
+            <p className="text-xs md:text-sm text-muted-foreground">
+              No test runs yet
+            </p>
+          </div>
+        ) : (
+          pastRuns.map((run) => (
+            <div
+              key={run.uuid}
+              onClick={() => handlePastRunClick(run)}
+              className="flex flex-col sm:grid sm:grid-cols-[minmax(0,1fr)_5.75rem_5rem_9.25rem] sm:items-start sm:justify-items-stretch gap-2 sm:gap-2 xl:grid-cols-[minmax(0,1fr)_6.25rem_5.75rem_11.5rem] xl:gap-3 px-3 md:px-4 py-2 md:py-2 border-b border-border last:border-b-0 hover:bg-muted/20 transition-colors cursor-pointer"
+            >
+              <div className="flex items-start justify-between gap-2 sm:block min-w-0">
+                <span className="text-xs md:text-sm font-medium text-foreground block min-w-0 break-words">
+                  {getTestRunDisplayName(run)}
+                </span>
+                <span className="sm:hidden text-xs text-muted-foreground">
+                  {formatRelativeTime(run.updated_at)}
+                </span>
+              </div>
+              <span
+                className={`hidden sm:flex sm:w-full sm:min-w-0 sm:items-center sm:justify-center px-2 py-0.5 rounded text-xs font-medium ${
+                  run.type === "llm-unit-test"
+                    ? "bg-blue-500/20 text-blue-400"
+                    : "bg-purple-500/20 text-purple-400"
+                }`}
+              >
+                {run.type === "llm-unit-test" ? "Test" : "Benchmark"}
+              </span>
+              <span className="hidden sm:block sm:w-full sm:min-w-0 text-sm text-muted-foreground text-right tabular-nums">
+                {formatRelativeTime(run.updated_at)}
+              </span>
+              <div className="flex flex-wrap items-center sm:justify-end gap-2 sm:flex-nowrap sm:justify-self-end">
+                {run.status === "pending" ||
+                run.status === "queued" ||
+                run.status === "in_progress" ? (
+                  <span className="inline-flex items-center whitespace-nowrap px-2 py-0.5 rounded text-xs font-medium bg-yellow-500/20 text-yellow-500">
+                    <svg
+                      className="w-3 h-3 animate-spin mr-1"
+                      fill="none"
+                      viewBox="0 0 24 24"
+                    >
+                      <circle
+                        className="opacity-25"
+                        cx="12"
+                        cy="12"
+                        r="10"
+                        stroke="currentColor"
+                        strokeWidth="4"
+                      ></circle>
+                      <path
+                        className="opacity-75"
+                        fill="currentColor"
+                        d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+                      ></path>
+                    </svg>
+                    Running
+                  </span>
+                ) : run.status === "failed" ? (
+                  <span className="inline-flex items-center whitespace-nowrap px-2 py-0.5 rounded text-xs font-medium bg-red-100 text-red-700 dark:bg-red-500/20 dark:text-red-500">
+                    Error
+                  </span>
+                ) : run.type === "llm-unit-test" ? (
+                  <>
+                    {run.passed !== null && run.passed > 0 && (
+                      <span className="inline-flex items-center whitespace-nowrap px-2 py-0.5 rounded text-xs font-medium bg-green-100 text-green-700 dark:bg-green-500/20 dark:text-green-500">
+                        {run.passed} Success
+                      </span>
+                    )}
+                    {run.failed !== null && run.failed > 0 && (
+                      <span className="inline-flex items-center whitespace-nowrap px-2 py-0.5 rounded text-xs font-medium bg-red-100 text-red-700 dark:bg-red-500/20 dark:text-red-500">
+                        {run.failed} Fail
+                      </span>
+                    )}
+                  </>
+                ) : (
+                  <span className="inline-flex items-center whitespace-nowrap px-2 py-0.5 rounded text-xs font-medium bg-green-100 text-green-700 dark:bg-green-500/20 dark:text-green-500">
+                    Complete
+                  </span>
+                )}
+              </div>
+            </div>
+          ))
+        )}
+      </div>
+    </div>
+  );
+
   return (
     <div className="flex flex-col">
       {/* Header with Add button - only show when there are tests */}
@@ -978,7 +1195,9 @@ export function TestsTabContent({
             Retry
           </button>
         </div>
-      ) : agentTests.length === 0 ? (
+      ) : agentTests.length === 0 &&
+          !pastRunsLoading &&
+          pastRuns.length === 0 ? (
         <div className="flex-1 border border-border rounded-xl p-6 md:p-12 flex flex-col items-center justify-center bg-muted/20">
           <div className="w-12 md:w-14 h-12 md:h-14 rounded-xl bg-muted flex items-center justify-center mb-3 md:mb-4">
             <svg
@@ -996,106 +1215,34 @@ export function TestsTabContent({
             This agent doesn&apos;t have any tests attached to it.
           </p>
           <div className="flex items-center gap-2 md:gap-3">
-            <div className="relative" ref={dropdownRef}>
-              <button
-                onClick={() => setShowTestDropdown(!showTestDropdown)}
-                className="h-9 md:h-10 px-3 md:px-4 rounded-md text-sm md:text-base font-medium border border-border bg-background hover:bg-muted/50 transition-colors cursor-pointer"
-              >
-                Add test
-              </button>
-
-              {/* Test Selection Dropdown */}
-              {showTestDropdown && (
-                <div className="absolute top-full left-0 mt-2 w-80 bg-background border border-border rounded-lg shadow-lg z-50">
-                  {/* Search Input */}
-                  <div className="p-3 border-b border-border">
-                    <div className="relative">
-                      <div className="absolute inset-y-0 left-0 flex items-center pl-3 pointer-events-none">
-                        <svg
-                          className="w-4 h-4 text-muted-foreground"
-                          fill="none"
-                          viewBox="0 0 24 24"
-                          stroke="currentColor"
-                          strokeWidth={2}
-                        >
-                          <path
-                            strokeLinecap="round"
-                            strokeLinejoin="round"
-                            d="M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 5.196a7.5 7.5 0 0010.607 10.607z"
-                          />
-                        </svg>
-                      </div>
-                      <input
-                        type="text"
-                        value={searchQuery}
-                        onChange={(e) => setSearchQuery(e.target.value)}
-                        placeholder="Search tests"
-                        className="w-full h-9 pl-9 pr-3 rounded-md text-sm border border-border bg-background text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-accent focus:border-transparent"
-                        autoFocus
-                      />
-                    </div>
-                  </div>
-
-                  {/* Tests List */}
-                  <div className="max-h-64 overflow-y-auto">
-                    {allTestsLoading ? (
-                      <div className="flex items-center justify-center py-8">
-                        <svg
-                          className="w-5 h-5 animate-spin text-muted-foreground"
-                          fill="none"
-                          viewBox="0 0 24 24"
-                        >
-                          <circle
-                            className="opacity-25"
-                            cx="12"
-                            cy="12"
-                            r="10"
-                            stroke="currentColor"
-                            strokeWidth="4"
-                          ></circle>
-                          <path
-                            className="opacity-75"
-                            fill="currentColor"
-                            d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
-                          ></path>
-                        </svg>
-                      </div>
-                    ) : filteredAvailableTests.length === 0 ? (
-                      <div className="py-8 text-center">
-                        <p className="text-sm text-muted-foreground">
-                          {searchQuery
-                            ? "No tests found"
-                            : "No tests available"}
-                        </p>
-                      </div>
-                    ) : (
-                      filteredAvailableTests.map((test) => (
-                        <button
-                          key={test.uuid}
-                          onClick={() => handleSelectTest(test)}
-                          className="w-full px-4 py-3 text-left hover:bg-muted/50 transition-colors cursor-pointer border-b border-border last:border-b-0"
-                        >
-                          <p className="text-sm font-medium text-foreground truncate">
-                            {test.name}
-                          </p>
-                          {test.description && (
-                            <p className="text-xs text-muted-foreground mt-0.5 line-clamp-2">
-                              {test.description}
-                            </p>
-                          )}
-                          <span className="inline-block mt-1 px-2 py-0.5 text-xs rounded-full bg-muted text-muted-foreground">
-                            {test.type === "tool_call"
-                              ? "Tool Call"
-                              : "Next Reply"}
-                          </span>
-                        </button>
-                      ))
-                    )}
-                  </div>
-                </div>
-              )}
+            {renderAddTestOutlineControl()}
+          </div>
+        </div>
+      ) : agentTests.length === 0 ? (
+        <div className="flex-1 flex flex-col lg:flex-row gap-4 md:gap-6">
+          <div className="flex-1 flex flex-col min-w-0">
+            <div className="mb-3 md:mb-4">{renderAddTestOutlineControl()}</div>
+            <div className="flex-1 border border-border rounded-xl p-6 md:p-10 flex flex-col items-center justify-center bg-muted/20 min-h-[220px] md:min-h-[280px]">
+              <div className="w-12 md:w-14 h-12 md:h-14 rounded-xl bg-muted flex items-center justify-center mb-3 md:mb-4">
+                <svg
+                  className="w-7 h-7 text-muted-foreground"
+                  viewBox="0 0 24 24"
+                  fill="currentColor"
+                >
+                  <path d="M9 3h6v2h-1v4.5l4.5 7.5c.5.83.5 1.5-.17 2.17-.67.67-1.34.83-2.33.83H8c-1 0-1.67-.17-2.33-.83-.67-.67-.67-1.34-.17-2.17L10 9.5V5H9V3zm3 8.5L8.5 17h7L12 11.5z" />
+                </svg>
+              </div>
+              <h3 className="text-base md:text-lg font-semibold text-foreground mb-1 text-center">
+                No tests attached
+              </h3>
+              <p className="text-sm md:text-base text-muted-foreground text-center max-w-md">
+                This agent doesn&apos;t have any tests linked right now. Past runs
+                from earlier sessions are on the right — add a test here to run new
+                ones from this tab.
+              </p>
             </div>
           </div>
+          {pastRunsPanel}
         </div>
       ) : (
         <div className="flex-1 flex flex-col lg:flex-row gap-4 md:gap-6">
@@ -1429,126 +1576,7 @@ export function TestsTabContent({
             )}
           </div>
 
-          {/* Right Panel - Past Runs */}
-          <div className="w-full lg:w-[400px] xl:w-[560px] flex-shrink-0 border border-border rounded-xl overflow-hidden bg-muted/30">
-            {/* Past Runs Title */}
-            <div className="px-3 md:px-4 py-2 md:py-3">
-              <h3 className="text-sm md:text-base font-semibold text-foreground">
-                Past runs
-              </h3>
-            </div>
-
-            {/* Past Runs List */}
-            <div className="overflow-y-auto max-h-[300px] lg:max-h-[500px]">
-              {pastRunsLoading ? (
-                <div className="flex items-center justify-center py-6 md:py-8">
-                  <svg
-                    className="w-5 h-5 animate-spin text-muted-foreground"
-                    fill="none"
-                    viewBox="0 0 24 24"
-                  >
-                    <circle
-                      className="opacity-25"
-                      cx="12"
-                      cy="12"
-                      r="10"
-                      stroke="currentColor"
-                      strokeWidth="4"
-                    ></circle>
-                    <path
-                      className="opacity-75"
-                      fill="currentColor"
-                      d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
-                    ></path>
-                  </svg>
-                </div>
-              ) : pastRuns.length === 0 ? (
-                <div className="py-6 md:py-8 text-center">
-                  <p className="text-xs md:text-sm text-muted-foreground">
-                    No test runs yet
-                  </p>
-                </div>
-              ) : (
-                pastRuns.map((run) => (
-                  <div
-                    key={run.uuid}
-                    onClick={() => handlePastRunClick(run)}
-                    className="flex flex-col sm:grid sm:grid-cols-[minmax(0,1fr)_auto_auto_auto] gap-2 sm:gap-4 px-3 md:px-4 py-2 md:py-2 border-b border-border last:border-b-0 hover:bg-muted/20 transition-colors cursor-pointer"
-                  >
-                    <div className="flex items-center justify-between sm:block min-w-0">
-                      <span className="text-xs md:text-sm font-medium text-foreground truncate block">
-                        {getTestRunDisplayName(run)}
-                      </span>
-                      <span className="sm:hidden text-xs text-muted-foreground">
-                        {formatRelativeTime(run.updated_at)}
-                      </span>
-                    </div>
-                    <span
-                      className={`hidden sm:inline-flex items-center px-2 py-0.5 rounded text-xs font-medium ${
-                        run.type === "llm-unit-test"
-                          ? "bg-blue-500/20 text-blue-400"
-                          : "bg-purple-500/20 text-purple-400"
-                      }`}
-                    >
-                      {run.type === "llm-unit-test" ? "Test" : "Benchmark"}
-                    </span>
-                    <span className="hidden sm:block text-sm text-muted-foreground w-24 text-right">
-                      {formatRelativeTime(run.updated_at)}
-                    </span>
-                    <div className="flex items-center sm:justify-end gap-2 sm:w-32">
-                      {run.status === "pending" ||
-                      run.status === "queued" ||
-                      run.status === "in_progress" ? (
-                        <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-yellow-500/20 text-yellow-500">
-                          <svg
-                            className="w-3 h-3 animate-spin mr-1"
-                            fill="none"
-                            viewBox="0 0 24 24"
-                          >
-                            <circle
-                              className="opacity-25"
-                              cx="12"
-                              cy="12"
-                              r="10"
-                              stroke="currentColor"
-                              strokeWidth="4"
-                            ></circle>
-                            <path
-                              className="opacity-75"
-                              fill="currentColor"
-                              d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
-                            ></path>
-                          </svg>
-                          Running
-                        </span>
-                      ) : run.status === "failed" ? (
-                        <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-red-100 text-red-700 dark:bg-red-500/20 dark:text-red-500">
-                          Error
-                        </span>
-                      ) : run.type === "llm-unit-test" ? (
-                        <>
-                          {run.passed !== null && run.passed > 0 && (
-                            <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-green-100 text-green-700 dark:bg-green-500/20 dark:text-green-500">
-                              {run.passed} Success
-                            </span>
-                          )}
-                          {run.failed !== null && run.failed > 0 && (
-                            <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-red-100 text-red-700 dark:bg-red-500/20 dark:text-red-500">
-                              {run.failed} Fail
-                            </span>
-                          )}
-                        </>
-                      ) : (
-                        <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-green-100 text-green-700 dark:bg-green-500/20 dark:text-green-500">
-                          Complete
-                        </span>
-                      )}
-                    </div>
-                  </div>
-                ))
-              )}
-            </div>
-          </div>
+          {pastRunsPanel}
         </div>
       )}
 

--- a/src/components/evaluations/DatasetPicker.tsx
+++ b/src/components/evaluations/DatasetPicker.tsx
@@ -2,6 +2,10 @@
 
 import { useState } from "react";
 import { Dataset } from "@/lib/datasets";
+import { Tooltip } from "@/components/Tooltip";
+
+const EMPTY_DATASET_TOOLTIP =
+  "This dataset has no items. Add a few rows to it before running an evaluation.";
 
 function formatDate(dateStr: string) {
   return new Date(dateStr).toLocaleDateString("en-US", {
@@ -74,21 +78,24 @@ export function DatasetPicker({ datasets, selectedId, onSelect }: Props) {
           </div>
         ) : (
           filtered.map((ds, i) => {
-            const isSelected = ds.uuid === selectedId;
-            return (
-              <button
-                key={ds.uuid}
-                type="button"
-                onClick={() => onSelect(ds.uuid)}
-                className={`w-full grid grid-cols-[2fr_70px_1fr] items-center px-4 py-3 text-left transition-colors cursor-pointer ${
-                  i < filtered.length - 1 ? "border-b border-border" : ""
-                } ${isSelected ? "bg-foreground/5" : "hover:bg-muted/40"}`}
-              >
-                {/* Name + checkmark */}
-                <div className="flex items-center gap-2 min-w-0">
-                  {isSelected ? (
+            const hasItems = (ds.item_count ?? 0) > 0;
+            const isSelected = hasItems && ds.uuid === selectedId;
+            const rowClass = `w-full grid grid-cols-[2fr_70px_1fr] items-start px-4 py-3 text-left transition-colors ${
+              i < filtered.length - 1 ? "border-b border-border" : ""
+            } ${
+              !hasItems
+                ? "cursor-not-allowed bg-muted/25 opacity-[0.65] hover:bg-muted/25"
+                : `cursor-pointer ${
+                    isSelected ? "bg-foreground/5" : "hover:bg-muted/40"
+                  }`
+            }`;
+
+            const rowBody = (
+              <>
+                <div className="flex items-start gap-2 min-w-0">
+                  {hasItems && isSelected ? (
                     <svg
-                      className="w-3.5 h-3.5 text-foreground shrink-0"
+                      className="w-3.5 h-3.5 text-foreground shrink-0 mt-0.5"
                       fill="none"
                       viewBox="0 0 24 24"
                       stroke="currentColor"
@@ -101,29 +108,77 @@ export function DatasetPicker({ datasets, selectedId, onSelect }: Props) {
                       />
                     </svg>
                   ) : (
-                    <div className="w-3.5 h-3.5 shrink-0" />
+                    <div className="w-3.5 h-3.5 shrink-0 mt-0.5" aria-hidden />
                   )}
-                  <span
-                    className={`text-sm truncate ${
-                      isSelected
-                        ? "font-medium text-foreground"
-                        : "text-foreground"
-                    }`}
-                  >
-                    {ds.name}
-                  </span>
+                  <div className="flex flex-col min-w-0 text-left">
+                    <span
+                      className={`text-sm truncate ${
+                        isSelected
+                          ? "font-medium text-foreground"
+                          : hasItems
+                            ? "text-foreground"
+                            : "text-muted-foreground"
+                      }`}
+                    >
+                      {ds.name}
+                    </span>
+                  </div>
                 </div>
 
-                {/* Item count */}
-                <span className="text-sm text-muted-foreground text-right">
+                <span
+                  className={`text-sm text-right tabular-nums ${
+                    hasItems
+                      ? "text-muted-foreground"
+                      : "text-muted-foreground/70"
+                  }`}
+                >
                   {ds.item_count}
                 </span>
 
-                {/* Updated date */}
-                <span className="text-sm text-muted-foreground text-right">
+                <span
+                  className={`text-sm text-right ${
+                    hasItems
+                      ? "text-muted-foreground"
+                      : "text-muted-foreground/70"
+                  }`}
+                >
                   {formatDate(ds.updated_at)}
                 </span>
-              </button>
+              </>
+            );
+
+            if (hasItems) {
+              return (
+                <button
+                  key={ds.uuid}
+                  type="button"
+                  onClick={() => onSelect(ds.uuid)}
+                  className={rowClass}
+                >
+                  {rowBody}
+                </button>
+              );
+            }
+
+            return (
+              <Tooltip
+                key={ds.uuid}
+                content={EMPTY_DATASET_TOOLTIP}
+                position="top"
+                className="w-full block"
+              >
+                <div className="w-full">
+                  <button
+                    type="button"
+                    disabled
+                    tabIndex={-1}
+                    aria-disabled="true"
+                    className={`${rowClass} pointer-events-none`}
+                  >
+                    {rowBody}
+                  </button>
+                </div>
+              </Tooltip>
             );
           })
         )}

--- a/src/components/evaluations/STTDatasetEditor.tsx
+++ b/src/components/evaluations/STTDatasetEditor.tsx
@@ -111,11 +111,15 @@ export const STTDatasetEditor = forwardRef<STTDatasetEditorHandle, Props>(
 
     // Notify parent when there are pending changes (new rows or dirty transcripts)
     useEffect(() => {
-      const hasNewRows = newRows.some((r) => r.s3Path && r.text.trim());
       const hasDirty = savedItems.some(
-        (item) => editedTexts[item.uuid] !== undefined && editedTexts[item.uuid] !== item.text,
+        (item) =>
+          editedTexts[item.uuid] !== undefined &&
+          editedTexts[item.uuid] !== item.text,
       );
-      onHasPendingChangesChange?.(hasNewRows || hasDirty);
+      const hasNewWork = newRows.some(
+        (r) => r.s3Path || r.audioFile || r.text.trim(),
+      );
+      onHasPendingChangesChange?.(hasDirty || hasNewWork);
     }, [newRows, editedTexts, savedItems, onHasPendingChangesChange]);
 
     // ── Imperative handle ──────────────────────────────────────────────────
@@ -124,9 +128,11 @@ export const STTDatasetEditor = forwardRef<STTDatasetEditorHandle, Props>(
       validate() {
         const invalid = new Set<string>();
         newRows.forEach((row) => {
-          if (!row.audioFile || !row.text.trim() || !row.s3Path) {
-            invalid.add(row.id);
-          }
+          const isBlank =
+            !row.audioFile && !row.text.trim() && !row.s3Path;
+          if (isBlank) return;
+          const complete = !!(row.s3Path && row.text.trim());
+          if (!complete) invalid.add(row.id);
         });
         setInvalidRowIds(invalid);
         return invalid.size === 0;
@@ -208,10 +214,16 @@ export const STTDatasetEditor = forwardRef<STTDatasetEditorHandle, Props>(
       }
       const invalid = new Set<string>();
       newRows.forEach((row) => {
-        if (!row.audioFile || !row.text.trim() || !row.s3Path) invalid.add(row.id);
+        const isBlank =
+          !row.audioFile && !row.text.trim() && !row.s3Path;
+        if (isBlank) return;
+        const complete = !!(row.s3Path && row.text.trim());
+        if (!complete) invalid.add(row.id);
       });
       if (invalid.size > 0) {
-        setInvalidRowIds(invalid);
+        toast.error(
+          "Finish or clear incomplete rows before adding another sample.",
+        );
         return;
       }
       setInvalidRowIds(new Set());
@@ -221,11 +233,28 @@ export const STTDatasetEditor = forwardRef<STTDatasetEditorHandle, Props>(
       ]);
     };
 
-    const deleteNewRow = (id: string) => {
-      if (newRows.length === 1) return;
+    const clearNewRowContents = (id: string) => {
       const row = newRows.find((r) => r.id === id);
       if (row?.audioUrl) URL.revokeObjectURL(row.audioUrl);
-      setNewRows((prev) => prev.filter((r) => r.id !== id));
+      const input = fileInputRefs.current[id];
+      if (input) input.value = "";
+      setNewRows((prev) =>
+        prev.map((r) =>
+          r.id === id
+            ? { ...r, audioFile: null, audioUrl: null, text: "", s3Path: null }
+            : r,
+        ),
+      );
+      setUploadStatus((prev) => {
+        const n = { ...prev };
+        delete n[id];
+        return n;
+      });
+      setInvalidRowIds((prev) => {
+        const n = new Set(prev);
+        n.delete(id);
+        return n;
+      });
       setDeleteNewRowId(null);
     };
 
@@ -237,6 +266,11 @@ export const STTDatasetEditor = forwardRef<STTDatasetEditorHandle, Props>(
           prev.map((r) => (r.id === id ? { ...r, audioFile: null, audioUrl: null, s3Path: null } : r)),
         );
         setUploadStatus((prev) => { const n = { ...prev }; delete n[id]; return n; });
+        setInvalidRowIds((prev) => {
+          const n = new Set(prev);
+          n.delete(id);
+          return n;
+        });
         return;
       }
 
@@ -263,12 +297,20 @@ export const STTDatasetEditor = forwardRef<STTDatasetEditorHandle, Props>(
       const s3Path = await uploadFileToS3(file);
 
       if (s3Path) {
+        const prevRow = newRows.find((r) => r.id === id);
+        const hadText = !!prevRow?.text.trim();
         const audioUrl = URL.createObjectURL(file);
         setNewRows((prev) =>
           prev.map((r) => (r.id === id ? { ...r, audioFile: file, audioUrl, s3Path } : r)),
         );
         setUploadStatus((prev) => ({ ...prev, [id]: "success" }));
-        setInvalidRowIds((prev) => { const n = new Set(prev); n.delete(id); return n; });
+        if (hadText) {
+          setInvalidRowIds((prev) => {
+            const n = new Set(prev);
+            n.delete(id);
+            return n;
+          });
+        }
       } else {
         setUploadStatus((prev) => ({ ...prev, [id]: "error" }));
       }
@@ -277,7 +319,11 @@ export const STTDatasetEditor = forwardRef<STTDatasetEditorHandle, Props>(
     const handleTextChange = (id: string, text: string) => {
       setNewRows((prev) => prev.map((r) => (r.id === id ? { ...r, text } : r)));
       if (text.trim()) {
-        setInvalidRowIds((prev) => { const n = new Set(prev); n.delete(id); return n; });
+        setInvalidRowIds((prevInv) => {
+          const n = new Set(prevInv);
+          n.delete(id);
+          return n;
+        });
       }
     };
 
@@ -453,7 +499,6 @@ export const STTDatasetEditor = forwardRef<STTDatasetEditorHandle, Props>(
     // ── Render ─────────────────────────────────────────────────────────────
 
     const savedCount = savedItems.length;
-    const startIndex = savedCount + 1;
 
     return (
       <div className="space-y-4">
@@ -570,8 +615,14 @@ export const STTDatasetEditor = forwardRef<STTDatasetEditorHandle, Props>(
             const rowNumber = savedCount + index + 1;
 
             const handleDelete = () => {
-              if (!row.audioFile && !row.text.trim()) deleteNewRow(row.id);
-              else setDeleteNewRowId(row.id);
+              const hasContent =
+                !!row.s3Path ||
+                !!row.audioFile ||
+                !!row.text.trim() ||
+                uploadStatus[row.id] === "uploading" ||
+                uploadStatus[row.id] === "error";
+              if (!hasContent) return;
+              setDeleteNewRowId(row.id);
             };
 
             const triggerFileInput = () => fileInputRefs.current[row.id]?.click();
@@ -619,13 +670,20 @@ export const STTDatasetEditor = forwardRef<STTDatasetEditorHandle, Props>(
               </button>
             );
 
+            const referenceTextMissing =
+              invalidRowIds.has(row.id) && !!row.s3Path && !row.text.trim();
+
             const textInput = (
               <input
                 type="text"
                 value={row.text}
                 onChange={(e) => handleTextChange(row.id, e.target.value)}
                 placeholder="Enter reference transcription"
-                className="w-full h-8 px-2 rounded text-[13px] border border-border bg-background focus:outline-none focus:ring-2 focus:ring-accent focus:border-transparent"
+                className={`w-full h-8 px-2 rounded text-[13px] border bg-background focus:outline-none focus:ring-2 focus:ring-accent focus:border-transparent ${
+                  referenceTextMissing
+                    ? "border-red-500 ring-1 ring-red-500/30"
+                    : "border-border"
+                }`}
               />
             );
 
@@ -782,14 +840,16 @@ export const STTDatasetEditor = forwardRef<STTDatasetEditorHandle, Props>(
           </div>
         </div>
 
-        {/* Delete new row dialog */}
+        {/* Clear unsaved new row (no API — resets audio + text in place) */}
         <DeleteConfirmationDialog
           isOpen={deleteNewRowId !== null}
           onClose={() => setDeleteNewRowId(null)}
-          onConfirm={() => { if (deleteNewRowId) deleteNewRow(deleteNewRowId); }}
-          title="Delete row"
-          message="Are you sure you want to delete this row?"
-          confirmText="Delete"
+          onConfirm={() => {
+            if (deleteNewRowId) clearNewRowContents(deleteNewRowId);
+          }}
+          title="Clear row"
+          message="Remove the uploaded audio and reference text from this row? Nothing is saved to the server until you choose Save."
+          confirmText="Clear"
         />
 
         {/* Delete saved item dialog */}

--- a/src/components/evaluations/SpeechToTextEvaluation.tsx
+++ b/src/components/evaluations/SpeechToTextEvaluation.tsx
@@ -134,6 +134,14 @@ export function SpeechToTextEvaluation({
   }, [backendAccessToken]);
 
   useEffect(() => {
+    if (!selectedDatasetId) return;
+    const sel = availableDatasets.find((d) => d.uuid === selectedDatasetId);
+    if (sel && (sel.item_count ?? 0) === 0) {
+      setSelectedDatasetId("");
+    }
+  }, [availableDatasets, selectedDatasetId]);
+
+  useEffect(() => {
     const fetchEvaluators = async () => {
       if (!backendAccessToken) return;
       try {

--- a/src/components/evaluations/TextToSpeechEvaluation.tsx
+++ b/src/components/evaluations/TextToSpeechEvaluation.tsx
@@ -121,6 +121,14 @@ export function TextToSpeechEvaluation({ evaluateRef, onEvaluatingChange, initia
   }, [backendAccessToken]);
 
   useEffect(() => {
+    if (!selectedDatasetId) return;
+    const sel = availableDatasets.find((d) => d.uuid === selectedDatasetId);
+    if (sel && (sel.item_count ?? 0) === 0) {
+      setSelectedDatasetId("");
+    }
+  }, [availableDatasets, selectedDatasetId]);
+
+  useEffect(() => {
     const fetchEvaluators = async () => {
       if (!backendAccessToken) return;
       try {

--- a/src/components/test-results/shared.tsx
+++ b/src/components/test-results/shared.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React from "react";
+import React, { useState } from "react";
 import Link from "next/link";
 import {
   CheckIcon,
@@ -9,6 +9,7 @@ import {
   ToolIcon,
   DocumentIcon,
   CloseIcon,
+  ChevronDownIcon,
 } from "@/components/icons";
 import type { DefaultEvaluatorSummary } from "@/lib/defaultEvaluators";
 
@@ -320,6 +321,158 @@ export function ToolCallCard({
   );
 }
 
+/** Text + chevron toggle for evaluator / tool-call reasoning (compact header control). */
+function ReasoningToggleIconButton({
+  open,
+  onToggle,
+}: {
+  open: boolean;
+  onToggle: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={(e) => {
+        e.stopPropagation();
+        onToggle();
+      }}
+      aria-expanded={open}
+      className={`inline-flex items-center gap-1.5 max-w-[min(100%,14rem)] rounded-md border px-2 py-1 text-[11px] font-medium transition-colors cursor-pointer shrink-0 ${
+        open
+          ? "border-fuchsia-500/50 bg-fuchsia-500/16 text-fuchsia-950 dark:border-fuchsia-500/45 dark:bg-fuchsia-500/18 dark:text-fuchsia-100 hover:bg-fuchsia-500/26 dark:hover:bg-fuchsia-500/28"
+          : "border-cyan-500/50 bg-cyan-500/14 text-cyan-950 dark:border-cyan-500/45 dark:bg-cyan-500/16 dark:text-cyan-100 hover:bg-cyan-500/24 dark:hover:bg-cyan-500/22"
+      }`}
+    >
+      <span className="truncate">
+        {open ? "Hide reasoning" : "See reasoning"}
+      </span>
+      <ChevronDownIcon
+        className={`w-3.5 h-3.5 shrink-0 transition-transform duration-200 ${open ? "rotate-180" : ""}`}
+      />
+    </button>
+  );
+}
+
+function ReasoningExpandedContent({
+  text,
+  showReasoningLabel = false,
+  mutedBody = true,
+  italic = false,
+}: {
+  text: string;
+  showReasoningLabel?: boolean;
+  mutedBody?: boolean;
+  italic?: boolean;
+}) {
+  return (
+    <div className="space-y-1">
+      {showReasoningLabel && (
+        <span className="text-[10px] font-medium text-muted-foreground uppercase tracking-wide block">
+          Reasoning
+        </span>
+      )}
+      <p
+        className={`${
+          mutedBody
+            ? "text-xs text-muted-foreground whitespace-pre-wrap break-words"
+            : "text-xs text-foreground whitespace-pre-wrap break-words"
+        }${italic ? " italic" : ""}`}
+      >
+        {text}
+      </p>
+    </div>
+  );
+}
+
+/** Tool-call verdict: one header row (label + chevron), body when expanded. */
+function CollapsibleReasoningStrip({
+  text,
+  mutedBody = true,
+  italic = false,
+  leadingLabel = "Reasoning",
+}: {
+  text?: string | null;
+  mutedBody?: boolean;
+  italic?: boolean;
+  leadingLabel?: string;
+}) {
+  const [open, setOpen] = useState(false);
+  if (!text?.trim()) return null;
+  return (
+    <div className="rounded-lg border border-border bg-muted/25 shadow-sm dark:bg-muted/35 dark:shadow-md dark:shadow-black/30 p-3">
+      <div className="flex items-center justify-between gap-2 min-h-7">
+        <span className="text-[10px] font-medium text-muted-foreground uppercase tracking-wide">
+          {leadingLabel}
+        </span>
+        <ReasoningToggleIconButton
+          open={open}
+          onToggle={() => setOpen((o) => !o)}
+        />
+      </div>
+      {open && (
+        <div className="mt-2 pt-2 border-t border-border/60">
+          <ReasoningExpandedContent
+            text={text}
+            showReasoningLabel={false}
+            mutedBody={mutedBody}
+            italic={italic}
+          />
+        </div>
+      )}
+    </div>
+  );
+}
+
+/** Surface styles for per-evaluator cards: tinted fill + border + left stripe by outcome. */
+type EvaluatorVerdictTone = "green" | "red" | "amber" | "neutral";
+
+function getEvaluatorVerdictTone(
+  result: JudgeResult,
+  scaleMax?: number
+): EvaluatorVerdictTone {
+  const isRating = result.score !== null && result.score !== undefined;
+  const isBinary = result.match !== null && result.match !== undefined;
+  const effectiveScaleMax =
+    typeof result.scale_max === "number" ? result.scale_max : scaleMax;
+  const effectiveScaleMin =
+    typeof result.scale_min === "number" ? result.scale_min : undefined;
+
+  if (isBinary) {
+    return result.match ? "green" : "red";
+  }
+  if (isRating) {
+    if (
+      effectiveScaleMax !== undefined &&
+      result.score === effectiveScaleMax
+    ) {
+      return "green";
+    }
+    if (
+      effectiveScaleMin !== undefined &&
+      result.score === effectiveScaleMin
+    ) {
+      return "red";
+    }
+    return "amber";
+  }
+  return "neutral";
+}
+
+function evaluatorVerdictCardSurfaceClass(tone: EvaluatorVerdictTone): string {
+  const base =
+    "rounded-lg border shadow-md dark:shadow-lg transition-colors";
+  switch (tone) {
+    case "green":
+      return `${base} border-green-500/40 bg-green-500/[0.14] border-l-4 border-l-green-600 dark:border-green-500/45 dark:bg-green-500/[0.16] dark:shadow-green-950/35`;
+    case "red":
+      return `${base} border-red-500/40 bg-red-500/[0.12] border-l-4 border-l-red-600 dark:border-red-500/45 dark:bg-red-500/[0.14] dark:shadow-red-950/30`;
+    case "amber":
+      return `${base} border-amber-500/40 bg-amber-500/[0.12] border-l-4 border-l-amber-600 dark:border-amber-500/45 dark:bg-amber-500/[0.13] dark:shadow-amber-950/30`;
+    default:
+      return `${base} border-border bg-muted/30 border-l-4 border-l-muted-foreground/40 dark:bg-muted/40 dark:border-border dark:shadow-black/25`;
+  }
+}
+
 // Per-evaluator verdict card. Binary evaluators render a ✓/✗ badge; rating
 // evaluators render `score / scale_max` when the scale is known.
 //
@@ -339,6 +492,8 @@ function JudgeResultCard({
   scaleMax?: number;
   enableEvaluatorLinks: boolean;
 }) {
+  const [reasoningOpen, setReasoningOpen] = useState(false);
+  const hasReasoning = !!result.reasoning?.trim();
   const isRating = result.score !== null && result.score !== undefined;
   const isBinary = result.match !== null && result.match !== undefined;
   const effectiveScaleMax =
@@ -352,16 +507,29 @@ function JudgeResultCard({
       : effectiveScaleMin !== undefined && result.score === effectiveScaleMin
         ? "red"
         : "amber";
+  const verdictTone = getEvaluatorVerdictTone(result, scaleMax);
+
+  const onCardClick = (e: React.MouseEvent) => {
+    if (!hasReasoning) return;
+    const el = e.target as HTMLElement;
+    if (el.closest("button") || el.closest("a[href]")) return;
+    if (el.closest("[data-reasoning-body]")) return;
+    if (el.closest("[data-evaluator-verdict-chips]")) return;
+    setReasoningOpen((o) => !o);
+  };
 
   return (
-    <div className="rounded-lg border border-border bg-background px-3 py-2.5 space-y-1.5">
+    <div
+      onClick={hasReasoning ? onCardClick : undefined}
+      className={`${evaluatorVerdictCardSurfaceClass(verdictTone)} px-3 py-2.5 space-y-1.5${hasReasoning ? " cursor-pointer" : ""}`}
+    >
       <div className="flex items-center justify-between gap-2">
         <div className="flex items-center gap-2 min-w-0">
           <div className="min-w-0">
             <EvaluatorNameLink
               uuid={result.evaluator_uuid}
               name={result.name}
-              className="text-sm font-medium text-foreground truncate block"
+              className="text-sm font-medium text-foreground truncate inline-block max-w-full align-top"
               enableLink={enableEvaluatorLinks}
             />
             {result.description && (
@@ -371,44 +539,58 @@ function JudgeResultCard({
             )}
           </div>
         </div>
-        <div className="flex-shrink-0">
-          {isBinary && (
-            <span
-              className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-md text-[11px] font-medium ${
-                result.match
-                  ? "bg-green-500/15 text-green-600 dark:text-green-400"
-                  : "bg-red-500/15 text-red-600 dark:text-red-400"
-              }`}
-            >
-              {result.match ? (
-                <CheckIcon className="w-3 h-3" />
-              ) : (
-                <XIcon className="w-3 h-3" />
-              )}
-              {result.match ? "Pass" : "Fail"}
-            </span>
-          )}
-          {isRating && (
-            <span
-              className={`inline-flex items-center px-2 py-0.5 rounded-md text-[11px] font-medium ${
-                ratingTone === "green"
-                  ? "bg-green-500/15 text-green-600 dark:text-green-400"
-                  : ratingTone === "red"
-                    ? "bg-red-500/15 text-red-600 dark:text-red-400"
-                    : "bg-amber-500/15 text-amber-600 dark:text-amber-400"
-              }`}
-            >
-              {effectiveScaleMax !== undefined
-                ? `${result.score} / ${effectiveScaleMax}`
-                : `Score: ${result.score}`}
-            </span>
+        <div className="flex-shrink-0 flex items-center gap-1.5">
+          <div
+            className="flex items-center gap-1.5"
+            data-evaluator-verdict-chips
+          >
+            {isBinary && (
+              <span
+                className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-md text-[11px] font-medium ${
+                  result.match
+                    ? "bg-green-500/15 text-green-600 dark:text-green-400"
+                    : "bg-red-500/15 text-red-600 dark:text-red-400"
+                }`}
+              >
+                {result.match ? (
+                  <CheckIcon className="w-3 h-3" />
+                ) : (
+                  <XIcon className="w-3 h-3" />
+                )}
+                {result.match ? "Pass" : "Fail"}
+              </span>
+            )}
+            {isRating && (
+              <span
+                className={`inline-flex items-center px-2 py-0.5 rounded-md text-[11px] font-medium ${
+                  ratingTone === "green"
+                    ? "bg-green-500/15 text-green-600 dark:text-green-400"
+                    : ratingTone === "red"
+                      ? "bg-red-500/15 text-red-600 dark:text-red-400"
+                      : "bg-amber-500/15 text-amber-600 dark:text-amber-400"
+                }`}
+              >
+                {effectiveScaleMax !== undefined
+                  ? `${result.score} / ${effectiveScaleMax}`
+                  : `Score: ${result.score}`}
+              </span>
+            )}
+          </div>
+          {hasReasoning && (
+            <ReasoningToggleIconButton
+              open={reasoningOpen}
+              onToggle={() => setReasoningOpen((o) => !o)}
+            />
           )}
         </div>
       </div>
-      {result.reasoning && (
-        <p className="text-xs text-muted-foreground whitespace-pre-wrap">
-          {result.reasoning}
-        </p>
+      {hasReasoning && reasoningOpen && (
+        <div
+          data-reasoning-body
+          className="mt-1.5 pt-1.5 border-t border-border/60"
+        >
+          <ReasoningExpandedContent text={result.reasoning!} mutedBody />
+        </div>
       )}
     </div>
   );
@@ -490,6 +672,9 @@ export function TestDetailView({
         });
   const hasJudgeResults =
     Array.isArray(effectiveJudgeResults) && effectiveJudgeResults.length > 0;
+  const [legacyReasoningOpen, setLegacyReasoningOpen] = useState(false);
+  const showLegacyReasoningToggle =
+    !hasJudgeResults && !!reasoning?.trim();
   return (
     <div className="p-4 md:p-6 space-y-4 md:space-y-6">
       {/* Chat History from test_case.history */}
@@ -505,7 +690,7 @@ export function TestDetailView({
               >
                 {/* User Message */}
                 {message.role === "user" && (
-                  <div className="w-[70%] md:w-1/2">
+                  <div className="w-[88%] md:w-3/4">
                     <div className="px-3 md:px-4 py-2.5 md:py-3 rounded-xl bg-muted border border-border">
                       <p className="text-sm text-foreground whitespace-pre-wrap">
                         {message.content}
@@ -522,7 +707,7 @@ export function TestDetailView({
                         Agent
                       </span>
                     </div>
-                    <div className="w-[70%] md:w-1/2">
+                    <div className="w-[88%] md:w-3/4">
                       <div className="px-3 md:px-4 py-2.5 md:py-3 rounded-xl bg-background border border-border">
                         <p className="text-sm text-foreground whitespace-pre-wrap">
                           {message.content}
@@ -542,7 +727,7 @@ export function TestDetailView({
                           Agent Tool Call
                         </span>
                       </div>
-                      <div className="w-[70%] md:w-1/2">
+                      <div className="w-[88%] md:w-3/4">
                         {message.tool_calls.map((toolCall, tcIndex) => {
                           const { toolName, args } =
                             normalizeToolCall(toolCall);
@@ -575,22 +760,31 @@ export function TestDetailView({
                   : "border-l-4 border-l-red-500 pl-2 md:pl-3"
               }`}
             >
-              <div className="flex items-center gap-2 mb-1">
-                <span className="text-sm font-medium text-foreground">
-                  Agent
-                </span>
-                <SmallStatusBadge passed={passed} />
+              <div className="flex items-center justify-between gap-2 mb-1">
+                <div className="flex items-center gap-2">
+                  <span className="text-sm font-medium text-foreground">
+                    Agent
+                  </span>
+                  <SmallStatusBadge passed={passed} />
+                </div>
+                {showLegacyReasoningToggle && (
+                  <ReasoningToggleIconButton
+                    open={legacyReasoningOpen}
+                    onToggle={() => setLegacyReasoningOpen((o) => !o)}
+                  />
+                )}
               </div>
-              {/* Legacy single-reasoning fallback — only when judge_results
-                  isn't populated (tool-call tests, or pre-snapshot response
-                  rows). New response rows render the per-evaluator panel
-                  at the bottom instead. */}
-              {!hasJudgeResults && reasoning && (
-                <p className="text-xs text-muted-foreground italic mb-2">
-                  {reasoning}
-                </p>
+              {showLegacyReasoningToggle && legacyReasoningOpen && (
+                <div className="mb-2">
+                  <ReasoningExpandedContent
+                    text={reasoning!}
+                    showReasoningLabel={false}
+                    mutedBody
+                    italic
+                  />
+                </div>
               )}
-              <div className="w-[70%] md:w-1/2">
+              <div className="w-[88%] md:w-3/4">
                 <div className="px-3 md:px-4 py-2.5 md:py-3 rounded-xl bg-background border border-border">
                   <p className="text-sm text-foreground whitespace-pre-wrap">
                     {output.response}
@@ -619,7 +813,7 @@ export function TestDetailView({
                 {output.tool_calls.map((toolCall, index) => {
                   const { toolName, args } = normalizeToolCall(toolCall);
                   return (
-                    <div key={index} className="w-[70%] md:w-1/2">
+                    <div key={index} className="w-[88%] md:w-3/4">
                       <ToolCallCard toolName={toolName} args={args} />
                     </div>
                   );
@@ -674,8 +868,8 @@ export function EmptyStateView({ message }: { message: string }) {
 
 // Per-evaluator card for the right-column panel of the test runner. Larger
 // and richer than `JudgeResultCard` (which is the inline mobile fallback) —
-// shows the per-test variable values configured for this evaluator above
-// the evaluator's reasoning.
+// per-test variable values and reasoning share one collapsible block below
+// the header.
 //
 // Data resolution order for variables / scale_max:
 //   1. Inline on the `JudgeResult` itself (`result.variable_values`,
@@ -696,6 +890,8 @@ function EvaluatorPanelCard({
   scaleMax?: number;
   enableEvaluatorLinks: boolean;
 }) {
+  const [reasoningOpen, setReasoningOpen] = useState(false);
+  const hasReasoning = !!result.reasoning?.trim();
   const isRating = result.score !== null && result.score !== undefined;
   const isBinary = result.match !== null && result.match !== undefined;
   const effectiveScaleMax =
@@ -722,16 +918,30 @@ function EvaluatorPanelCard({
     effectiveVariables &&
     typeof effectiveVariables === "object" &&
     Object.keys(effectiveVariables).length > 0;
+  const hasCollapsibleBody = hasReasoning || !!hasVariables;
+  const verdictTone = getEvaluatorVerdictTone(result, scaleMax);
+
+  const onCardClick = (e: React.MouseEvent) => {
+    if (!hasCollapsibleBody) return;
+    const el = e.target as HTMLElement;
+    if (el.closest("button") || el.closest("a[href]")) return;
+    if (el.closest("[data-reasoning-body]")) return;
+    if (el.closest("[data-evaluator-verdict-chips]")) return;
+    setReasoningOpen((o) => !o);
+  };
 
   return (
-    <div className="rounded-lg border border-border bg-background p-3 space-y-2.5">
+    <div
+      onClick={hasCollapsibleBody ? onCardClick : undefined}
+      className={`${evaluatorVerdictCardSurfaceClass(verdictTone)} p-3 space-y-2.5${hasCollapsibleBody ? " cursor-pointer" : ""}`}
+    >
       {/* Name + verdict header */}
       <div className="flex items-start justify-between gap-2">
         <div className="min-w-0">
           <EvaluatorNameLink
             uuid={result.evaluator_uuid}
             name={result.name}
-            className="text-sm font-medium text-foreground break-words block"
+            className="text-sm font-medium text-foreground break-words inline-block max-w-full align-top"
             enableLink={enableEvaluatorLinks}
           />
           {result.description && (
@@ -740,68 +950,86 @@ function EvaluatorPanelCard({
             </p>
           )}
         </div>
-        <div className="flex-shrink-0">
-          {isBinary && (
-            <span
-              className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-md text-[11px] font-medium ${
-                result.match
-                  ? "bg-green-500/15 text-green-600 dark:text-green-400"
-                  : "bg-red-500/15 text-red-600 dark:text-red-400"
-              }`}
-            >
-              {result.match ? (
-                <CheckIcon className="w-3 h-3" />
-              ) : (
-                <XIcon className="w-3 h-3" />
-              )}
-              {result.match ? "Pass" : "Fail"}
-            </span>
-          )}
-          {isRating && (
-            <span
-              className={`inline-flex items-center px-2 py-0.5 rounded-md text-[11px] font-medium ${
-                ratingTone === "green"
-                  ? "bg-green-500/15 text-green-600 dark:text-green-400"
-                  : ratingTone === "red"
-                    ? "bg-red-500/15 text-red-600 dark:text-red-400"
-                    : "bg-amber-500/15 text-amber-600 dark:text-amber-400"
-              }`}
-            >
-              {effectiveScaleMax !== undefined
-                ? `${result.score} / ${effectiveScaleMax}`
-                : `Score: ${result.score}`}
-            </span>
+        <div className="flex-shrink-0 flex items-center gap-1.5">
+          <div
+            className="flex items-center gap-1.5"
+            data-evaluator-verdict-chips
+          >
+            {isBinary && (
+              <span
+                className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-md text-[11px] font-medium ${
+                  result.match
+                    ? "bg-green-500/15 text-green-600 dark:text-green-400"
+                    : "bg-red-500/15 text-red-600 dark:text-red-400"
+                }`}
+              >
+                {result.match ? (
+                  <CheckIcon className="w-3 h-3" />
+                ) : (
+                  <XIcon className="w-3 h-3" />
+                )}
+                {result.match ? "Pass" : "Fail"}
+              </span>
+            )}
+            {isRating && (
+              <span
+                className={`inline-flex items-center px-2 py-0.5 rounded-md text-[11px] font-medium ${
+                  ratingTone === "green"
+                    ? "bg-green-500/15 text-green-600 dark:text-green-400"
+                    : ratingTone === "red"
+                      ? "bg-red-500/15 text-red-600 dark:text-red-400"
+                      : "bg-amber-500/15 text-amber-600 dark:text-amber-400"
+                }`}
+              >
+                {effectiveScaleMax !== undefined
+                  ? `${result.score} / ${effectiveScaleMax}`
+                  : `Score: ${result.score}`}
+              </span>
+            )}
+          </div>
+          {hasCollapsibleBody && (
+            <ReasoningToggleIconButton
+              open={reasoningOpen}
+              onToggle={() => setReasoningOpen((o) => !o)}
+            />
           )}
         </div>
       </div>
 
-      {/* Per-test variable values (one labeled row per variable). Skipped
-          when the evaluator has no variables or the test_case payload
-          didn't echo evaluator attachments. */}
-      {hasVariables && (
-        <div className="space-y-2">
-          {Object.entries(effectiveVariables!).map(([name, value]) => (
-            <div key={name}>
-              <span className="font-mono text-[10px] text-muted-foreground">
-                {`{{${name}}}`}
-              </span>
-              <p className="text-xs text-foreground whitespace-pre-wrap break-words mt-0.5">
-                {String(value)}
-              </p>
+      {reasoningOpen && hasCollapsibleBody && (
+        <div
+          data-reasoning-body
+          className="mt-1.5 pt-1.5 border-t border-border/60 space-y-3"
+        >
+          {hasVariables && (
+            <div className="space-y-2">
+              {Object.entries(effectiveVariables!).map(([name, value]) => (
+                <div key={name}>
+                  <span className="font-mono text-[10px] text-muted-foreground">
+                    {`{{${name}}}`}
+                  </span>
+                  <p className="text-xs text-foreground whitespace-pre-wrap break-words mt-0.5">
+                    {String(value)}
+                  </p>
+                </div>
+              ))}
             </div>
-          ))}
-        </div>
-      )}
-
-      {/* Per-evaluator reasoning */}
-      {result.reasoning && (
-        <div>
-          <label className="text-[10px] font-medium text-muted-foreground uppercase tracking-wide mb-1 block">
-            Reasoning
-          </label>
-          <p className="text-xs text-foreground whitespace-pre-wrap break-words">
-            {result.reasoning}
-          </p>
+          )}
+          {hasReasoning && (
+            <div
+              className={
+                hasVariables
+                  ? "pt-3 border-t border-border/60"
+                  : undefined
+              }
+            >
+              <ReasoningExpandedContent
+                text={result.reasoning!}
+                showReasoningLabel
+                mutedBody={false}
+              />
+            </div>
+          )}
         </div>
       )}
     </div>
@@ -919,16 +1147,11 @@ export function EvaluationCriteriaPanel({
               No expected tool calls specified
             </p>
           )}
-          {reasoning && (
-            <div>
-              <label className="text-[10px] font-medium text-muted-foreground uppercase tracking-wide mb-1 block">
-                Reasoning
-              </label>
-              <p className="text-xs text-foreground whitespace-pre-wrap break-words">
-                {reasoning}
-              </p>
-            </div>
-          )}
+          <CollapsibleReasoningStrip
+            text={reasoning}
+            mutedBody={false}
+            leadingLabel="Reasoning"
+          />
         </>
       )}
 


### PR DESCRIPTION
- **Datasets (STT/TTS detail):** Primary **Save**; **New evaluation** gated on saved rows + no pending edits; tooltips on disabled **New evaluation**; STT **Save** validates rows before API.
- **`STTDatasetEditor`:** Pending when any new work exists; errors only after **Save**/**Evaluate**; **Clear** unsaved rows in place (no API); add-row blocked with toast; shared with **`/stt/new`**.
- **`DatasetPicker`:** Empty datasets disabled + **Tooltip**; STT/TTS clear selection when dataset has 0 items.
- **Agent Tests tab:** Primary **Add test**; single control in empty card when past runs exist.
- **Benchmark / test-run UI:** Updates to benchmark dialog, shared test-result panels, share/export chrome (`3c182a5` scope).
