### PR TITLE
Human labelling: bulk upload, evaluator runs, verdict colors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,10 @@
       "dependencies": {
         "@next/third-parties": "^16.1.4",
         "@sentry/nextjs": "^10.36.0",
+        "@types/canvas-confetti": "^1.9.0",
         "@types/jszip": "^3.4.0",
         "@vercel/analytics": "^1.6.1",
+        "canvas-confetti": "^1.9.4",
         "jszip": "^3.10.1",
         "next": "16.1.1",
         "next-auth": "^5.0.0-beta.30",
@@ -4185,6 +4187,12 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/canvas-confetti": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@types/canvas-confetti/-/canvas-confetti-1.9.0.tgz",
+      "integrity": "sha512-aBGj/dULrimR1XDZLtG9JwxX1b4HPRF6CX9Yfwh3NvstZEm1ZL7RBnel4keCPSqs1ANRu1u2Aoz9R+VmtjYuTg==",
+      "license": "MIT"
+    },
     "node_modules/@types/connect": {
       "version": "3.4.38",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
@@ -6024,6 +6032,16 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/canvas-confetti": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/canvas-confetti/-/canvas-confetti-1.9.4.tgz",
+      "integrity": "sha512-yxQbJkAVrFXWNbTUjPqjF7G+g6pDotOUHGbkZq2NELZUMDpiJ85rIEazVb8GTaAptNW2miJAXbs1BtioA251Pw==",
+      "license": "ISC",
+      "funding": {
+        "type": "donate",
+        "url": "https://www.paypal.me/kirilvatev"
+      }
     },
     "node_modules/chalk": {
       "version": "4.1.2",

--- a/package.json
+++ b/package.json
@@ -14,8 +14,10 @@
   "dependencies": {
     "@next/third-parties": "^16.1.4",
     "@sentry/nextjs": "^10.36.0",
+    "@types/canvas-confetti": "^1.9.0",
     "@types/jszip": "^3.4.0",
     "@vercel/analytics": "^1.6.1",
+    "canvas-confetti": "^1.9.4",
     "jszip": "^3.10.1",
     "next": "16.1.1",
     "next-auth": "^5.0.0-beta.30",

--- a/src/app/annotate-job/[token]/layout.tsx
+++ b/src/app/annotate-job/[token]/layout.tsx
@@ -1,0 +1,13 @@
+import { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Annotate | Calibrate",
+};
+
+export default function AnnotateJobLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return children;
+}

--- a/src/app/annotate-job/[token]/page.tsx
+++ b/src/app/annotate-job/[token]/page.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import { useEffect } from "react";
+import { useParams } from "next/navigation";
+import { AnnotationJobView } from "@/components/human-labelling/AnnotationJobView";
+
+export default function AnnotateJobPage() {
+  const params = useParams();
+  const token =
+    typeof params?.token === "string"
+      ? params.token
+      : Array.isArray(params?.token)
+        ? params.token[0]
+        : "";
+
+  useEffect(() => {
+    document.title = "Annotate | Calibrate";
+  }, []);
+
+  return <AnnotationJobView token={token} mode="public" />;
+}

--- a/src/app/human-labelling/annotators/[uuid]/layout.tsx
+++ b/src/app/human-labelling/annotators/[uuid]/layout.tsx
@@ -1,0 +1,13 @@
+import { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Annotator | Calibrate",
+};
+
+export default function AnnotatorDetailLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return children;
+}

--- a/src/app/human-labelling/annotators/[uuid]/page.tsx
+++ b/src/app/human-labelling/annotators/[uuid]/page.tsx
@@ -62,7 +62,7 @@ type AnnotatorJob = {
   created_at: string;
   completed_at: string | null;
   item_count: number;
-  annotation_count: number;
+  completed_item_count: number;
 };
 
 type AnnotatorDetailResponse = {
@@ -527,7 +527,7 @@ function AnnotatorJobsList({ jobs }: { jobs: AnnotatorJob[] }) {
               </span>
             </div>
             <div className="text-sm text-muted-foreground tabular-nums">
-              {job.annotation_count} / {job.item_count}
+              {job.completed_item_count} / {job.item_count}
             </div>
           </div>
         );

--- a/src/app/human-labelling/annotators/[uuid]/page.tsx
+++ b/src/app/human-labelling/annotators/[uuid]/page.tsx
@@ -1,0 +1,558 @@
+"use client";
+
+import { Suspense, useCallback, useEffect, useState } from "react";
+import { useParams, useRouter, useSearchParams } from "next/navigation";
+import {
+  CartesianGrid,
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+import { AppLayout } from "@/components/AppLayout";
+import { EmptyState } from "@/components/ui/LoadingState";
+import { useAccessToken } from "@/hooks";
+import { apiClient } from "@/lib/api";
+import { useSidebarState } from "@/lib/sidebar";
+
+type Tab = "overview" | "jobs";
+
+const TABS: Tab[] = ["overview", "jobs"];
+
+function isTab(value: string | null): value is Tab {
+  return !!value && (TABS as string[]).includes(value);
+}
+
+type Annotator = {
+  uuid: string;
+  name: string;
+  created_at?: string;
+  updated_at?: string;
+};
+
+type AnnotatorStats = {
+  current_agreement: number | null;
+  pair_count: number;
+  jobs_count: number;
+};
+
+type Bucket = "week" | "month" | "year";
+
+type AgreementSeriesPoint = {
+  bucket_start: string;
+  bucket_end: string;
+  agreement: number | null;
+  pair_count: number;
+};
+
+type AnnotatorTrend = {
+  bucket: Bucket;
+  days: number;
+  series: AgreementSeriesPoint[];
+};
+
+type AnnotatorJob = {
+  uuid: string;
+  task_id: string;
+  task_name: string;
+  public_token: string;
+  status: "pending" | "in_progress" | "completed";
+  created_at: string;
+  completed_at: string | null;
+  item_count: number;
+  annotation_count: number;
+};
+
+type AnnotatorDetailResponse = {
+  annotator: Annotator;
+  stats: AnnotatorStats;
+  trend: AnnotatorTrend;
+  jobs: AnnotatorJob[];
+};
+
+const DEFAULT_BUCKET: Bucket = "month";
+const DEFAULT_DAYS = 365;
+
+function formatBucketLabel(iso: string, bucket: Bucket): string {
+  const d = new Date(iso.replace(" ", "T") + "Z");
+  if (Number.isNaN(d.getTime())) return iso;
+  if (bucket === "year") return d.getUTCFullYear().toString();
+  return d.toLocaleString("en-US", { month: "short", timeZone: "UTC" });
+}
+
+function parseApiError(err: unknown, fallback: string): string {
+  if (!(err instanceof Error)) return fallback;
+  const match = err.message.match(/Request failed: \d+ - (.+)$/);
+  if (match) {
+    try {
+      const parsed = JSON.parse(match[1]);
+      if (parsed && typeof parsed.detail === "string") return parsed.detail;
+    } catch {
+      // not JSON
+    }
+    return match[1];
+  }
+  return err.message || fallback;
+}
+
+export default function AnnotatorDetailPage() {
+  return (
+    <Suspense fallback={null}>
+      <AnnotatorDetailPageInner />
+    </Suspense>
+  );
+}
+
+function AnnotatorDetailPageInner() {
+  const router = useRouter();
+  const params = useParams();
+  const searchParams = useSearchParams();
+  const accessToken = useAccessToken();
+  const [sidebarOpen, setSidebarOpen] = useSidebarState();
+
+  const uuid = typeof params?.uuid === "string" ? params.uuid : "";
+
+  const initialTab = searchParams.get("tab");
+  const [activeTab, setActiveTab] = useState<Tab>(
+    isTab(initialTab) ? initialTab : "overview",
+  );
+
+  const handleTabChange = useCallback(
+    (tab: Tab) => {
+      setActiveTab(tab);
+      window.history.replaceState(
+        null,
+        "",
+        `/human-labelling/annotators/${uuid}?tab=${tab}`,
+      );
+    },
+    [uuid],
+  );
+
+  const [detail, setDetail] = useState<AnnotatorDetailResponse | null>(null);
+  const [detailLoading, setDetailLoading] = useState(false);
+  const [detailError, setDetailError] = useState<string | null>(null);
+
+  const annotator = detail?.annotator ?? null;
+  const stats = detail?.stats;
+  const trend = detail?.trend;
+  const jobs = detail?.jobs ?? [];
+
+  useEffect(() => {
+    if (annotator?.name) {
+      document.title = `${annotator.name} | Calibrate`;
+    }
+  }, [annotator?.name]);
+
+  const fetchDetail = useCallback(async () => {
+    if (!accessToken || !uuid) return;
+    setDetailLoading(true);
+    setDetailError(null);
+    try {
+      const query = `?bucket=${DEFAULT_BUCKET}&days=${DEFAULT_DAYS}`;
+      const data = await apiClient<AnnotatorDetailResponse>(
+        `/annotators/${uuid}${query}`,
+        accessToken,
+      );
+      setDetail(data);
+    } catch (err) {
+      setDetailError(parseApiError(err, "Failed to load annotator"));
+    } finally {
+      setDetailLoading(false);
+    }
+  }, [accessToken, uuid]);
+
+  useEffect(() => {
+    fetchDetail();
+  }, [fetchDetail]);
+
+  const formatPercent = (value: number | null | undefined): string => {
+    if (value == null) return "—";
+    return `${Math.round(value * 100)}%`;
+  };
+
+  const agreementColor = (value: number | null | undefined): string => {
+    if (value == null) return "";
+    const pct = value * 100;
+    if (pct >= 75) return "text-green-600 dark:text-green-400";
+    if (pct <= 50) return "text-red-600 dark:text-red-400";
+    return "text-yellow-600 dark:text-yellow-400";
+  };
+
+  const jobsCount = stats?.jobs_count ?? jobs.length;
+
+  return (
+    <AppLayout
+      activeItem="human-labelling"
+      onItemChange={(id) => router.push(`/${id}`)}
+      sidebarOpen={sidebarOpen}
+      onSidebarToggle={() => setSidebarOpen(!sidebarOpen)}
+    >
+      <div className="py-4 md:py-6 space-y-6">
+        <button
+          onClick={() => router.push("/human-labelling?tab=annotators")}
+          className="text-sm text-muted-foreground hover:text-foreground transition-colors cursor-pointer flex items-center gap-1.5"
+        >
+          <svg
+            className="w-4 h-4"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            strokeWidth={2}
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              d="M15.75 19.5L8.25 12l7.5-7.5"
+            />
+          </svg>
+          All annotators
+        </button>
+
+        {/* Header */}
+        <div>
+          <h1 className="text-2xl font-semibold">{annotator?.name ?? "—"}</h1>
+        </div>
+
+        {/* Tabs */}
+        <div className="border-b border-border flex items-center gap-1">
+          {[
+            { id: "overview" as Tab, label: "Overview" },
+            {
+              id: "jobs" as Tab,
+              label: jobsCount > 0 ? `Jobs (${jobsCount})` : "Jobs",
+            },
+          ].map((t) => (
+            <button
+              key={t.id}
+              onClick={() => handleTabChange(t.id)}
+              className={`px-3 py-2 text-sm font-medium -mb-px border-b-2 transition-colors cursor-pointer ${
+                activeTab === t.id
+                  ? "border-foreground text-foreground"
+                  : "border-transparent text-muted-foreground hover:text-foreground"
+              }`}
+            >
+              {t.label}
+            </button>
+          ))}
+        </div>
+
+        {activeTab === "overview" && (
+          <div className="space-y-4 md:space-y-6">
+            {detailError && (
+              <div className="rounded-md border border-border bg-muted/20 p-4 text-sm text-red-500">
+                {detailError}
+              </div>
+            )}
+
+            {/* Stat cards */}
+            <div className="flex flex-wrap items-stretch gap-3">
+              <StatCard
+                label="Latest agreement"
+                value={
+                  detailLoading ? "—" : formatPercent(stats?.current_agreement)
+                }
+                valueClassName={agreementColor(stats?.current_agreement)}
+              />
+              <StatCard
+                label="Jobs"
+                value={detailLoading ? "—" : String(jobsCount)}
+              />
+            </div>
+
+            {/* Trend chart */}
+            {(() => {
+              const series = trend?.series ?? [];
+              const hasTrend =
+                !detailLoading &&
+                series.length > 0 &&
+                series.some((p) => p.agreement != null);
+              return (
+                <div className="border border-border rounded-xl bg-background p-4 md:p-5">
+                  <div className="mb-4">
+                    <h3 className="text-sm font-semibold">
+                      Agreement with other annotators
+                    </h3>
+                    <p className="text-xs text-muted-foreground">
+                      Monthly % of overlapping rows where this annotator agreed
+                      with the others.
+                    </p>
+                  </div>
+
+                  {detailLoading ? (
+                    <div className="flex items-center justify-center gap-2 h-56 md:h-64 text-sm text-muted-foreground">
+                      <svg
+                        className="w-4 h-4 animate-spin"
+                        fill="none"
+                        viewBox="0 0 24 24"
+                      >
+                        <circle
+                          className="opacity-25"
+                          cx="12"
+                          cy="12"
+                          r="10"
+                          stroke="currentColor"
+                          strokeWidth="4"
+                        />
+                        <path
+                          className="opacity-75"
+                          fill="currentColor"
+                          d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+                        />
+                      </svg>
+                      Loading trend
+                    </div>
+                  ) : !hasTrend ? (
+                    <div className="flex flex-col items-center justify-center text-center h-56 md:h-64 px-6">
+                      <p className="text-sm font-medium text-foreground">
+                        Not enough overlap yet to compute agreement
+                      </p>
+                      <p className="text-xs text-muted-foreground mt-1.5 max-w-md">
+                        This chart will populate once this annotator and at
+                        least one other annotator label one or more of the same
+                        items
+                      </p>
+                    </div>
+                  ) : (
+                    <div className="w-full h-56 md:h-64">
+                      <ResponsiveContainer width="100%" height="100%">
+                        <LineChart
+                          data={series.map((p) => ({
+                            month: formatBucketLabel(
+                              p.bucket_end,
+                              trend?.bucket ?? DEFAULT_BUCKET,
+                            ),
+                            agreement:
+                              p.agreement == null
+                                ? null
+                                : Math.round(p.agreement * 100),
+                          }))}
+                        >
+                          <CartesianGrid
+                            strokeDasharray="3 3"
+                            stroke="rgba(125,125,125,0.15)"
+                          />
+                          <XAxis dataKey="month" fontSize={11} />
+                          <YAxis domain={[0, 100]} fontSize={11} unit="%" />
+                          <Tooltip
+                            contentStyle={{
+                              background: "var(--background, #fff)",
+                              border: "1px solid rgba(125,125,125,0.2)",
+                              borderRadius: 8,
+                              fontSize: 12,
+                            }}
+                          />
+                          <Line
+                            type="monotone"
+                            dataKey="agreement"
+                            name="Agreement %"
+                            stroke="#10b981"
+                            strokeWidth={2}
+                            dot={{ r: 3 }}
+                            connectNulls={false}
+                          />
+                        </LineChart>
+                      </ResponsiveContainer>
+                    </div>
+                  )}
+                </div>
+              );
+            })()}
+          </div>
+        )}
+
+        {activeTab === "jobs" &&
+          (jobs.length === 0 ? (
+            <EmptyState
+              icon={
+                <svg
+                  className="w-7 h-7 text-muted-foreground"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                  strokeWidth={1.5}
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    d="M20.25 14.15v4.25c0 1.094-.787 2.036-1.872 2.18-2.087.277-4.216.42-6.378.42s-4.291-.143-6.378-.42c-1.085-.144-1.872-1.086-1.872-2.18v-4.25m16.5 0a2.18 2.18 0 00.75-1.661V8.706c0-1.081-.768-2.015-1.837-2.175a48.114 48.114 0 00-3.413-.387m4.5 8.006c-.194.165-.42.295-.673.38A23.978 23.978 0 0112 15.75c-2.648 0-5.195-.429-7.577-1.22a2.16 2.16 0 01-.673-.38m0 0A2.18 2.18 0 013 12.489V8.706c0-1.081.768-2.015 1.837-2.175a48.111 48.111 0 013.413-.387m7.5 0V5.25A2.25 2.25 0 0013.5 3h-3a2.25 2.25 0 00-2.25 2.25v.894m7.5 0a48.667 48.667 0 00-7.5 0M12 12.75h.008v.008H12v-.008z"
+                  />
+                </svg>
+              }
+              title="No jobs assigned yet"
+              description="Jobs will appear here once this annotator is assigned to a labelling task"
+            />
+          ) : (
+            <AnnotatorJobsList jobs={jobs} />
+          ))}
+      </div>
+    </AppLayout>
+  );
+}
+
+function buildAnnotateUrl(token: string): string {
+  if (typeof window === "undefined") return `/annotate-job/${token}`;
+  return `${window.location.origin}/annotate-job/${token}`;
+}
+
+function statusPillClass(status: AnnotatorJob["status"]): string {
+  switch (status) {
+    case "completed":
+      return "border-green-200 bg-green-100 text-green-700 dark:border-green-500/30 dark:bg-green-500/20 dark:text-green-400";
+    case "in_progress":
+      return "border-yellow-200 bg-yellow-100 text-yellow-700 dark:border-yellow-500/30 dark:bg-yellow-500/20 dark:text-yellow-400";
+    default:
+      return "border-gray-200 bg-gray-100 text-gray-700 dark:border-gray-500/30 dark:bg-gray-500/20 dark:text-gray-300";
+  }
+}
+
+function statusLabel(status: AnnotatorJob["status"]): string {
+  if (status === "in_progress") return "In progress";
+  if (status === "completed") return "Completed";
+  return "Pending";
+}
+
+function AnnotatorJobsList({ jobs }: { jobs: AnnotatorJob[] }) {
+  const router = useRouter();
+  const [copiedToken, setCopiedToken] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!copiedToken) return;
+    const t = setTimeout(() => setCopiedToken(null), 1500);
+    return () => clearTimeout(t);
+  }, [copiedToken]);
+
+  const handleCopy = async (token: string) => {
+    try {
+      await navigator.clipboard.writeText(buildAnnotateUrl(token));
+      setCopiedToken(token);
+    } catch {
+      // ignore
+    }
+  };
+
+  return (
+    <div className="border border-border rounded-xl overflow-hidden">
+      <div className="grid grid-cols-[180px_minmax(0,1fr)_120px_120px] gap-4 [&>*:nth-child(3)]:pl-6 px-4 py-2 border-b border-border bg-muted/30 items-center">
+        <div className="text-sm font-medium text-muted-foreground">
+          Labelling task
+        </div>
+        <div className="text-sm font-medium text-muted-foreground">Link</div>
+        <div className="text-sm font-medium text-muted-foreground">Status</div>
+        <div className="text-sm font-medium text-muted-foreground">
+          Progress
+        </div>
+      </div>
+      {jobs.map((job) => {
+        const isImported = job.public_token.startsWith("import:");
+        const copied = copiedToken === job.public_token;
+        const url = buildAnnotateUrl(job.public_token);
+        return (
+          <div
+            key={job.uuid}
+            onClick={() => {
+              if (!isImported)
+                router.push(`/human-labelling/jobs/${job.public_token}`);
+            }}
+            className={`grid grid-cols-[180px_minmax(0,1fr)_120px_120px] gap-4 [&>*:nth-child(3)]:pl-6 px-4 py-3 border-b border-border last:border-b-0 items-center hover:bg-muted/20 transition-colors ${
+              isImported ? "" : "cursor-pointer"
+            }`}
+          >
+            <div className="text-sm font-medium truncate" title={job.task_name}>
+              {job.task_name}
+            </div>
+            <div className="flex items-center gap-2 min-w-0">
+              {isImported ? (
+                <span className="text-xs text-muted-foreground">Imported</span>
+              ) : (
+                <>
+                  <span className="text-xs font-mono text-muted-foreground truncate">
+                    {url}
+                  </span>
+                  <button
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      handleCopy(job.public_token);
+                    }}
+                    aria-label={copied ? "Copied" : "Copy link"}
+                    title={copied ? "Copied" : "Copy link"}
+                    className={`shrink-0 w-7 h-7 flex items-center justify-center rounded-md border transition-colors cursor-pointer ${
+                      copied
+                        ? "border-green-200 bg-green-100 text-green-700 dark:border-green-500/40 dark:bg-green-500/20 dark:text-green-400"
+                        : "border-border bg-background text-muted-foreground hover:bg-muted/50 hover:text-foreground"
+                    }`}
+                  >
+                    {copied ? (
+                      <svg
+                        className="w-3.5 h-3.5"
+                        fill="none"
+                        viewBox="0 0 24 24"
+                        stroke="currentColor"
+                        strokeWidth={2.5}
+                      >
+                        <path
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          d="M5 13l4 4L19 7"
+                        />
+                      </svg>
+                    ) : (
+                      <svg
+                        className="w-3.5 h-3.5"
+                        fill="none"
+                        viewBox="0 0 24 24"
+                        stroke="currentColor"
+                        strokeWidth={1.8}
+                      >
+                        <path
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2"
+                        />
+                      </svg>
+                    )}
+                  </button>
+                </>
+              )}
+            </div>
+            <div>
+              <span
+                className={`inline-block px-2 py-0.5 rounded-md text-xs font-medium border ${statusPillClass(
+                  job.status,
+                )}`}
+              >
+                {statusLabel(job.status)}
+              </span>
+            </div>
+            <div className="text-sm text-muted-foreground tabular-nums">
+              {job.annotation_count} / {job.item_count}
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+function StatCard({
+  label,
+  value,
+  valueClassName = "",
+}: {
+  label: string;
+  value: string;
+  valueClassName?: string;
+}) {
+  return (
+    <div className="border border-border rounded-lg px-4 py-3 bg-background min-w-[160px]">
+      <div className="text-[10px] uppercase tracking-wide text-muted-foreground">
+        {label}
+      </div>
+      <div className={`text-2xl font-semibold tabular-nums ${valueClassName}`}>
+        {value}
+      </div>
+    </div>
+  );
+}

--- a/src/app/human-labelling/annotators/[uuid]/page.tsx
+++ b/src/app/human-labelling/annotators/[uuid]/page.tsx
@@ -305,16 +305,32 @@ function AnnotatorDetailPageInner() {
                       Loading trend
                     </div>
                   ) : !hasTrend ? (
-                    <div className="flex flex-col items-center justify-center text-center h-56 md:h-64 px-6">
-                      <p className="text-sm font-medium text-foreground">
-                        Not enough overlap yet to compute agreement
-                      </p>
-                      <p className="text-xs text-muted-foreground mt-1.5 max-w-md">
-                        This chart will populate once this annotator and at
-                        least one other annotator label one or more of the same
-                        items
-                      </p>
-                    </div>
+                    <EmptyState
+                      icon={
+                        <svg
+                          className="w-7 h-7 text-muted-foreground"
+                          fill="none"
+                          viewBox="0 0 24 24"
+                          stroke="currentColor"
+                          strokeWidth={1.5}
+                        >
+                          <path
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                            d="M3 13.125C3 12.504 3.504 12 4.125 12h2.25c.621 0 1.125.504 1.125 1.125v6.75C7.5 20.496 6.996 21 6.375 21h-2.25A1.125 1.125 0 013 19.875v-6.75zM9.75 8.625c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125v11.25c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 01-1.125-1.125V8.625zM16.5 4.125c0-.621.504-1.125 1.125-1.125h2.25C20.496 3 21 3.504 21 4.125v15.75c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 01-1.125-1.125V4.125z"
+                          />
+                        </svg>
+                      }
+                      title="Not enough overlap yet"
+                      description={
+                        <>
+                          This chart will populate once this annotator and at
+                          <br />
+                          least one other annotator label one or more of the
+                          same items
+                        </>
+                      }
+                    />
                   ) : (
                     <div className="w-full h-56 md:h-64">
                       <ResponsiveContainer width="100%" height="100%">

--- a/src/app/human-labelling/jobs/[token]/page.tsx
+++ b/src/app/human-labelling/jobs/[token]/page.tsx
@@ -1,0 +1,160 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import Link from "next/link";
+import { useParams, useRouter } from "next/navigation";
+import { AppLayout } from "@/components/AppLayout";
+import {
+  AnnotationJobView,
+  type AnnotationJobMeta,
+} from "@/components/human-labelling/AnnotationJobView";
+import { useSidebarState } from "@/lib/sidebar";
+
+export default function AdminAnnotateJobPage() {
+  const router = useRouter();
+  const params = useParams();
+  const [sidebarOpen, setSidebarOpen] = useSidebarState();
+  const [meta, setMeta] = useState<AnnotationJobMeta | null>(null);
+
+  const token =
+    typeof params?.token === "string"
+      ? params.token
+      : Array.isArray(params?.token)
+        ? params.token[0]
+        : "";
+
+  useEffect(() => {
+    document.title = "Annotation job | Calibrate";
+  }, []);
+
+  const handleLoaded = useCallback((m: AnnotationJobMeta) => setMeta(m), []);
+
+  return (
+    <AppLayout
+      activeItem="human-labelling"
+      onItemChange={(id) => router.push(`/${id}`)}
+      sidebarOpen={sidebarOpen}
+      onSidebarToggle={() => setSidebarOpen(!sidebarOpen)}
+    >
+      <div className="py-4 md:py-6 space-y-4">
+        <button
+          onClick={() => router.back()}
+          className="text-sm text-muted-foreground hover:text-foreground transition-colors cursor-pointer flex items-center gap-1.5"
+        >
+          <svg
+            className="w-4 h-4"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            strokeWidth={2}
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              d="M15 19l-7-7 7-7"
+            />
+          </svg>
+          Back
+        </button>
+
+        {meta && (
+          <>
+            <div>
+              <span
+                className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium border ${jobStatusPillClass(
+                  meta.jobStatus,
+                )}`}
+              >
+                {jobStatusLabel(meta.jobStatus)}
+              </span>
+            </div>
+            <div className="flex flex-wrap gap-3">
+              <FieldRow label="Labelling task">
+                <Link
+                  href={`/human-labelling/tasks/${meta.task.uuid}`}
+                  className="text-sm font-medium text-foreground hover:underline underline-offset-2"
+                >
+                  {meta.task.name}
+                </Link>
+              </FieldRow>
+              <FieldRow label="Annotator">
+                <Link
+                  href={`/human-labelling/annotators/${meta.annotator.uuid}`}
+                  className="text-sm font-medium text-foreground hover:underline underline-offset-2"
+                >
+                  {meta.annotator.name}
+                </Link>
+              </FieldRow>
+            </div>
+
+            {meta.evaluators.length > 0 && (
+              <div className="space-y-2">
+                <div className="text-[10px] uppercase tracking-wide text-muted-foreground">
+                  Evaluators
+                </div>
+                <div className="flex flex-wrap gap-1.5">
+                  {meta.evaluators.map((ev) => (
+                    <Link
+                      key={ev.uuid}
+                      href={`/evaluators/${ev.uuid}`}
+                      title={`Open ${ev.name}`}
+                      className="inline-flex items-center px-2 py-0.5 rounded-md text-xs font-medium border border-border bg-muted/40 text-foreground hover:bg-muted hover:border-foreground/30 transition-colors cursor-pointer"
+                    >
+                      {ev.name}
+                    </Link>
+                  ))}
+                </div>
+              </div>
+            )}
+          </>
+        )}
+
+        <div className="border border-border rounded-xl overflow-hidden">
+          <AnnotationJobView
+            token={token}
+            mode="admin"
+            fillViewport={false}
+            onLoaded={handleLoaded}
+          />
+        </div>
+      </div>
+    </AppLayout>
+  );
+}
+
+function jobStatusPillClass(
+  status: AnnotationJobMeta["jobStatus"],
+): string {
+  switch (status) {
+    case "completed":
+      return "border-green-200 bg-green-100 text-green-700 dark:border-green-500/30 dark:bg-green-500/20 dark:text-green-400";
+    case "in_progress":
+      return "border-yellow-200 bg-yellow-100 text-yellow-700 dark:border-yellow-500/30 dark:bg-yellow-500/20 dark:text-yellow-400";
+    default:
+      return "border-gray-200 bg-gray-100 text-gray-700 dark:border-gray-500/30 dark:bg-gray-500/20 dark:text-gray-300";
+  }
+}
+
+function jobStatusLabel(status: AnnotationJobMeta["jobStatus"]): string {
+  if (status === "in_progress") return "In progress";
+  if (status === "completed") return "Completed";
+  return "Pending";
+}
+
+function FieldRow({
+  label,
+  children,
+}: {
+  label: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="border border-border rounded-lg px-4 py-3 bg-background">
+      <div className="text-[10px] uppercase tracking-wide text-muted-foreground mb-1">
+        {label}
+      </div>
+      <div>{children}</div>
+    </div>
+  );
+}
+

--- a/src/app/human-labelling/layout.tsx
+++ b/src/app/human-labelling/layout.tsx
@@ -1,0 +1,13 @@
+import { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Human Labelling | Calibrate",
+};
+
+export default function HumanLabellingLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return children;
+}

--- a/src/app/human-labelling/page.tsx
+++ b/src/app/human-labelling/page.tsx
@@ -1,0 +1,1415 @@
+"use client";
+
+import { Suspense, useEffect, useState, useCallback, FormEvent } from "react";
+import Link from "next/link";
+import { useRouter, useSearchParams } from "next/navigation";
+import {
+  CartesianGrid,
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+import { AppLayout } from "@/components/AppLayout";
+import { DeleteConfirmationDialog } from "@/components/DeleteConfirmationDialog";
+import { EvaluatorTypePill } from "@/components/EvaluatorPills";
+import { CreateLabellingTaskDialog } from "@/components/human-labelling/CreateLabellingTaskDialog";
+import { EmptyState } from "@/components/ui/LoadingState";
+import { Select } from "@/components/ui/Select";
+import { useAccessToken } from "@/hooks";
+import { apiClient } from "@/lib/api";
+import { useSidebarState } from "@/lib/sidebar";
+
+type Tab = "overview" | "tasks" | "annotators";
+
+type Annotator = {
+  uuid: string;
+  name: string;
+  created_at?: string;
+  updated_at?: string;
+  jobs_count?: number;
+  current_agreement?: number | null;
+  pair_count?: number | null;
+};
+
+function parseApiError(err: unknown, fallback: string): string {
+  if (!(err instanceof Error)) return fallback;
+  // apiClient throws "Request failed: {status} - {body}" where body is JSON
+  const match = err.message.match(/Request failed: \d+ - (.+)$/);
+  if (match) {
+    try {
+      const parsed = JSON.parse(match[1]);
+      if (parsed && typeof parsed.detail === "string") return parsed.detail;
+    } catch {
+      // not JSON, fall through
+    }
+    return match[1];
+  }
+  return err.message || fallback;
+}
+
+type LabellingTaskSummary = {
+  uuid: string;
+  name: string;
+};
+
+type LabellingTaskEvaluator = {
+  uuid: string;
+  name: string;
+  evaluator_type?: "llm" | "stt" | "tts" | "simulation";
+  output_type?: "binary" | "rating";
+  owner_user_id?: string | null;
+};
+
+type LabellingTask = {
+  uuid: string;
+  name: string;
+  type?: "llm" | "stt" | "tts" | "simulation";
+  description?: string;
+  created_at?: string;
+  updated_at?: string;
+  item_count?: number;
+  evaluators?: LabellingTaskEvaluator[];
+};
+
+type SortDirection = "asc" | "desc";
+
+type AgreementSeriesPoint = {
+  bucket_start: string;
+  bucket_end: string;
+  agreement: number | null;
+  pair_count: number;
+};
+
+type AgreementBlock = {
+  current: number | null;
+  pair_count: number;
+  series: AgreementSeriesPoint[];
+};
+
+type EvaluatorAgreementBlock = AgreementBlock & {
+  evaluator_id: string;
+  name: string;
+};
+
+type AgreementResponse = {
+  bucket: string;
+  days: number;
+  task_id?: string;
+  human_human: AgreementBlock;
+  evaluators: EvaluatorAgreementBlock[];
+};
+
+type Bucket = "week" | "month" | "year";
+
+const ALL_TASKS = "all";
+const DEFAULT_BUCKET: Bucket = "month";
+const DEFAULT_DAYS = 180;
+
+function agreementColor(fraction: number | null | undefined): string {
+  if (fraction == null) return "";
+  const pct = fraction * 100;
+  if (pct >= 75) return "text-green-600 dark:text-green-400";
+  if (pct <= 50) return "text-red-600 dark:text-red-400";
+  return "text-yellow-600 dark:text-yellow-400";
+}
+
+function formatBucketLabel(iso: string, bucket: Bucket): string {
+  // Backend returns "YYYY-MM-DD HH:MM:SS" UTC, no offset suffix.
+  const d = new Date(iso.replace(" ", "T") + "Z");
+  if (Number.isNaN(d.getTime())) return iso;
+  if (bucket === "year") return d.getUTCFullYear().toString();
+  return d.toLocaleString("en-US", {
+    month: "short",
+    timeZone: "UTC",
+  });
+}
+
+const TABS: Tab[] = ["overview", "tasks", "annotators"];
+
+function isTab(value: string | null): value is Tab {
+  return !!value && (TABS as string[]).includes(value);
+}
+
+export default function HumanLabellingPage() {
+  return (
+    <Suspense fallback={null}>
+      <HumanLabellingPageInner />
+    </Suspense>
+  );
+}
+
+function HumanLabellingPageInner() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const accessToken = useAccessToken();
+  const [sidebarOpen, setSidebarOpen] = useSidebarState();
+  const initialTab = searchParams.get("tab");
+  const [activeTab, setActiveTab] = useState<Tab>(
+    isTab(initialTab) ? initialTab : "overview",
+  );
+
+  const handleTabChange = useCallback((tab: Tab) => {
+    setActiveTab(tab);
+    window.history.replaceState(null, "", `/human-labelling?tab=${tab}`);
+  }, []);
+
+  const [annotators, setAnnotators] = useState<Annotator[]>([]);
+  const [annotatorsLoading, setAnnotatorsLoading] = useState(false);
+  const [annotatorsError, setAnnotatorsError] = useState<string | null>(null);
+
+  const [newAnnotatorName, setNewAnnotatorName] = useState("");
+  const [isAdding, setIsAdding] = useState(false);
+  const [addError, setAddError] = useState<string | null>(null);
+
+  const [annotatorToDelete, setAnnotatorToDelete] = useState<Annotator | null>(
+    null,
+  );
+  const [isDeleting, setIsDeleting] = useState(false);
+
+  const [taskToDelete, setTaskToDelete] = useState<LabellingTask | null>(null);
+  const [isDeletingTask, setIsDeletingTask] = useState(false);
+
+  const [agreement, setAgreement] = useState<AgreementResponse | null>(null);
+  const [agreementLoading, setAgreementLoading] = useState(false);
+  const [agreementError, setAgreementError] = useState<string | null>(null);
+
+  const [tasks, setTasks] = useState<LabellingTask[]>([]);
+  const [tasksLoading, setTasksLoading] = useState(false);
+  const [tasksError, setTasksError] = useState<string | null>(null);
+
+  const sortedTasks = [...tasks].sort((a, b) =>
+    a.name.localeCompare(b.name),
+  );
+
+  const [selectedTaskId, setSelectedTaskId] = useState<string>(ALL_TASKS);
+  const [bucket] = useState<Bucket>(DEFAULT_BUCKET);
+  const [days] = useState<number>(DEFAULT_DAYS);
+  // Task uuids that have any agreement data (human-human or any evaluator).
+  // Populated lazily after tasks load so the dropdown only lists tasks with
+  // at least one comparable pair.
+  const [tasksWithAgreement, setTasksWithAgreement] = useState<Set<string>>(
+    new Set(),
+  );
+
+  const taskOptions: LabellingTaskSummary[] = tasks
+    .filter((t) => tasksWithAgreement.has(t.uuid))
+    .map((t) => ({ uuid: t.uuid, name: t.name }));
+
+  useEffect(() => {
+    document.title = "Human Labelling | Calibrate";
+  }, []);
+
+  const fetchAnnotators = useCallback(async () => {
+    if (!accessToken) return;
+    setAnnotatorsLoading(true);
+    setAnnotatorsError(null);
+    try {
+      const data = await apiClient<Annotator[]>("/annotators", accessToken);
+      setAnnotators(Array.isArray(data) ? data : []);
+    } catch (err) {
+      setAnnotatorsError(parseApiError(err, "Failed to load annotators"));
+    } finally {
+      setAnnotatorsLoading(false);
+    }
+  }, [accessToken]);
+
+  useEffect(() => {
+    if (activeTab === "annotators") {
+      fetchAnnotators();
+    }
+  }, [activeTab, fetchAnnotators]);
+
+  const fetchTasks = useCallback(async () => {
+    if (!accessToken) return;
+    setTasksLoading(true);
+    setTasksError(null);
+    try {
+      const data = await apiClient<LabellingTask[]>(
+        "/annotation-tasks",
+        accessToken,
+      );
+      setTasks(Array.isArray(data) ? data : []);
+    } catch (err) {
+      setTasksError(parseApiError(err, "Failed to load labelling tasks"));
+    } finally {
+      setTasksLoading(false);
+    }
+  }, [accessToken]);
+
+  // Tasks list is needed on every tab — for the dropdown on overview, the
+  // list itself on tasks, and the Tasks (n) tab counter everywhere.
+  useEffect(() => {
+    fetchTasks();
+  }, [fetchTasks]);
+
+  const fetchAgreement = useCallback(async () => {
+    if (!accessToken) return;
+    setAgreementLoading(true);
+    setAgreementError(null);
+    try {
+      const query = `?bucket=${bucket}&days=${days}`;
+      const endpoint =
+        selectedTaskId === ALL_TASKS
+          ? `/annotation-agreement/trend${query}`
+          : `/annotation-tasks/${encodeURIComponent(selectedTaskId)}/agreement${query}`;
+      const data = await apiClient<AgreementResponse>(endpoint, accessToken);
+      setAgreement(data);
+    } catch (err) {
+      setAgreementError(parseApiError(err, "Failed to load agreement"));
+    } finally {
+      setAgreementLoading(false);
+    }
+  }, [accessToken, selectedTaskId, bucket, days]);
+
+  useEffect(() => {
+    if (activeTab === "overview") {
+      fetchAgreement();
+      // Annotators are needed for the count card; refetch is cheap.
+      fetchAnnotators();
+    }
+  }, [activeTab, fetchAgreement, fetchAnnotators]);
+
+  // Probe each task's agreement endpoint once so we can filter the
+  // task-selector dropdown to those that actually have comparable pairs.
+  useEffect(() => {
+    if (!accessToken || tasks.length === 0) return;
+    let cancelled = false;
+    (async () => {
+      const query = `?bucket=${bucket}&days=${days}`;
+      const results = await Promise.all(
+        tasks.map(async (t) => {
+          try {
+            const data = await apiClient<AgreementResponse>(
+              `/annotation-tasks/${encodeURIComponent(t.uuid)}/agreement${query}`,
+              accessToken,
+            );
+            const hh = (data.human_human?.pair_count ?? 0) > 0;
+            const anyEval = (data.evaluators ?? []).some(
+              (e) => (e.pair_count ?? 0) > 0,
+            );
+            return hh || anyEval ? t.uuid : null;
+          } catch {
+            return null;
+          }
+        }),
+      );
+      if (cancelled) return;
+      setTasksWithAgreement(
+        new Set(results.filter((u): u is string => !!u)),
+      );
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [tasks, accessToken, bucket, days]);
+
+  const [createDialogOpen, setCreateDialogOpen] = useState(false);
+
+  const handleCreateTask = () => {
+    setCreateDialogOpen(true);
+  };
+
+  const handleAddAnnotator = async (e: FormEvent) => {
+    e.preventDefault();
+    const name = newAnnotatorName.trim();
+    if (!name || !accessToken || isAdding) return;
+    setIsAdding(true);
+    setAddError(null);
+    try {
+      const { uuid } = await apiClient<{ uuid: string; message: string }>(
+        "/annotators",
+        accessToken,
+        { method: "POST", body: { name } },
+      );
+      setAnnotators((prev) =>
+        [...prev.filter((a) => a.uuid !== uuid), { uuid, name }].sort((a, b) =>
+          a.name.localeCompare(b.name),
+        ),
+      );
+      setNewAnnotatorName("");
+    } catch (err) {
+      setAddError(parseApiError(err, "Failed to add annotator"));
+    } finally {
+      setIsAdding(false);
+    }
+  };
+
+  const handleConfirmDelete = async () => {
+    if (!annotatorToDelete || !accessToken) return;
+    setIsDeleting(true);
+    try {
+      await apiClient<{ message: string }>(
+        `/annotators/${annotatorToDelete.uuid}`,
+        accessToken,
+        { method: "DELETE" },
+      );
+      setAnnotators((prev) =>
+        prev.filter((a) => a.uuid !== annotatorToDelete.uuid),
+      );
+      setAnnotatorToDelete(null);
+    } catch (err) {
+      setAddError(parseApiError(err, "Failed to remove annotator"));
+    } finally {
+      setIsDeleting(false);
+    }
+  };
+
+  const handleConfirmDeleteTask = async () => {
+    if (!taskToDelete || !accessToken) return;
+    setIsDeletingTask(true);
+    try {
+      await apiClient<{ message: string }>(
+        `/annotation-tasks/${taskToDelete.uuid}`,
+        accessToken,
+        { method: "DELETE" },
+      );
+      setTasks((prev) => prev.filter((t) => t.uuid !== taskToDelete.uuid));
+      setTaskToDelete(null);
+    } catch (err) {
+      setTasksError(parseApiError(err, "Failed to delete task"));
+    } finally {
+      setIsDeletingTask(false);
+    }
+  };
+
+  const tasksCount = tasks.length;
+  const annotatorsCount = annotators.length;
+
+  return (
+    <AppLayout
+      activeItem="human-labelling"
+      onItemChange={(id) => router.push(`/${id}`)}
+      sidebarOpen={sidebarOpen}
+      onSidebarToggle={() => setSidebarOpen(!sidebarOpen)}
+    >
+      <div className="space-y-4 md:space-y-6 py-4 md:py-6">
+        {/* Header */}
+        <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-3">
+          <div>
+            <h1 className="text-xl md:text-2xl font-semibold">
+              Human Labelling
+            </h1>
+            <p className="text-muted-foreground text-sm md:text-base leading-relaxed mt-1 max-w-3xl">
+              Manage labelling tasks and the annotators who review them. Use the
+              collected judgments to measure how well your evaluators agree with
+              human experts.
+            </p>
+          </div>
+          <button
+            onClick={handleCreateTask}
+            className="h-9 md:h-10 px-4 rounded-md text-sm md:text-base font-medium bg-foreground text-background hover:opacity-90 transition-opacity cursor-pointer flex-shrink-0"
+          >
+            Create new labelling task
+          </button>
+        </div>
+
+        {/* Tabs */}
+        <div className="border-b border-border flex items-center gap-1">
+          {[
+            { id: "overview" as Tab, label: "Overview" },
+            {
+              id: "tasks" as Tab,
+              label: tasksCount > 0 ? `Tasks (${tasksCount})` : "Tasks",
+            },
+            {
+              id: "annotators" as Tab,
+              label:
+                annotatorsCount > 0
+                  ? `Annotators (${annotatorsCount})`
+                  : "Annotators",
+            },
+          ].map((t) => (
+            <button
+              key={t.id}
+              onClick={() => handleTabChange(t.id)}
+              className={`px-3 py-2 text-sm font-medium -mb-px border-b-2 transition-colors cursor-pointer ${
+                activeTab === t.id
+                  ? "border-foreground text-foreground"
+                  : "border-transparent text-muted-foreground hover:text-foreground"
+              }`}
+            >
+              {t.label}
+            </button>
+          ))}
+        </div>
+
+        {/* Tab Content */}
+        {activeTab === "overview" && (
+          <AgreementOverview
+            agreement={agreement}
+            agreementLoading={agreementLoading}
+            agreementError={agreementError}
+            bucket={bucket}
+            selectedTaskId={selectedTaskId}
+            onSelectTask={setSelectedTaskId}
+            taskOptions={taskOptions}
+            tasks={tasks}
+          />
+        )}
+
+        {activeTab === "tasks" &&
+          (tasksLoading ? (
+            <div className="flex items-center justify-center gap-2 py-8 text-sm text-muted-foreground">
+              <svg
+                className="w-4 h-4 animate-spin"
+                fill="none"
+                viewBox="0 0 24 24"
+              >
+                <circle
+                  className="opacity-25"
+                  cx="12"
+                  cy="12"
+                  r="10"
+                  stroke="currentColor"
+                  strokeWidth="4"
+                />
+                <path
+                  className="opacity-75"
+                  fill="currentColor"
+                  d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+                />
+              </svg>
+              Loading tasks
+            </div>
+          ) : tasksError ? (
+            <div className="rounded-md border border-border bg-muted/20 p-4 text-sm text-red-500">
+              {tasksError}
+            </div>
+          ) : tasks.length === 0 ? (
+            <EmptyState
+              icon={
+                <svg
+                  className="w-7 h-7 text-muted-foreground"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                  strokeWidth={1.5}
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    d="M9 12h3.75M9 15h3.75M9 18h3.75m3 .75H18a2.25 2.25 0 002.25-2.25V6.108c0-1.135-.845-2.098-1.976-2.192a48.424 48.424 0 00-1.123-.08m-5.801 0c-.065.21-.1.433-.1.664 0 .414.336.75.75.75h4.5a.75.75 0 00.75-.75 2.25 2.25 0 00-.1-.664m-5.8 0A2.251 2.251 0 0113.5 2.25H15c1.012 0 1.867.668 2.15 1.586m-5.8 0c-.376.023-.75.05-1.124.08C9.095 4.01 8.25 4.973 8.25 6.108V8.25m0 0H4.875c-.621 0-1.125.504-1.125 1.125v11.25c0 .621.504 1.125 1.125 1.125h9.75c.621 0 1.125-.504 1.125-1.125V9.375c0-.621-.504-1.125-1.125-1.125H8.25zM6.75 12h.008v.008H6.75V12zm0 3h.008v.008H6.75V15zm0 3h.008v.008H6.75V18z"
+                  />
+                </svg>
+              }
+              title="No labelling tasks yet"
+              description="Create a task for gathering human feedback and aligning LLM evaluators to humans"
+              action={{
+                label: "Create new labelling task",
+                onClick: handleCreateTask,
+              }}
+            />
+          ) : (
+            <>
+              {/* Desktop table */}
+              <div className="hidden md:block border border-border rounded-xl overflow-hidden">
+                <div className="grid grid-cols-[minmax(0,1fr)_160px_100px_minmax(0,1.2fr)_40px] gap-4 [&>*:nth-child(3)]:pl-6 px-4 py-2 border-b border-border bg-muted/30">
+                  <div className="text-sm font-medium text-muted-foreground">
+                    Name
+                  </div>
+                  <div className="text-sm font-medium text-muted-foreground">
+                    Type
+                  </div>
+                  <div className="text-sm font-medium text-muted-foreground">
+                    Items
+                  </div>
+                  <div className="text-sm font-medium text-muted-foreground">
+                    Evaluators
+                  </div>
+                  <div />
+                </div>
+                {sortedTasks.map((task) => {
+                  const evaluators = task.evaluators ?? [];
+                  const evaluatorType =
+                    task.type ?? evaluators[0]?.evaluator_type;
+                  return (
+                    <div
+                      key={task.uuid}
+                      onClick={() =>
+                        router.push(`/human-labelling/tasks/${task.uuid}`)
+                      }
+                      className="grid grid-cols-[minmax(0,1fr)_160px_100px_minmax(0,1.2fr)_40px] gap-4 [&>*:nth-child(3)]:pl-6 px-4 py-3 border-b border-border last:border-b-0 hover:bg-muted/20 transition-colors cursor-pointer items-center"
+                    >
+                      <p className="text-sm font-medium text-foreground truncate">
+                        {task.name}
+                      </p>
+                      <div>
+                        {evaluatorType ? (
+                          <EvaluatorTypePill evaluatorType={evaluatorType} />
+                        ) : (
+                          <span className="text-sm text-muted-foreground">
+                            —
+                          </span>
+                        )}
+                      </div>
+                      <p className="text-sm text-muted-foreground tabular-nums">
+                        {task.item_count ?? 0}
+                      </p>
+                      <div className="flex flex-wrap gap-1">
+                        {evaluators.length === 0 ? (
+                          <span className="text-sm text-muted-foreground">
+                            —
+                          </span>
+                        ) : (
+                          evaluators.map((ev) => (
+                            <Link
+                              key={ev.uuid}
+                              href={`/evaluators/${ev.uuid}`}
+                              onClick={(e) => e.stopPropagation()}
+                              title={`Open ${ev.name}`}
+                              className="inline-flex items-center px-2 py-0.5 rounded-md text-xs font-medium border border-border bg-muted/40 text-foreground hover:bg-muted hover:border-foreground/30 transition-colors cursor-pointer max-w-full"
+                            >
+                              <span className="truncate">{ev.name}</span>
+                            </Link>
+                          ))
+                        )}
+                      </div>
+                      <button
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          setTaskToDelete(task);
+                        }}
+                        aria-label={`Delete ${task.name}`}
+                        title="Delete task"
+                        className="w-8 h-8 flex items-center justify-center rounded-md text-muted-foreground hover:text-red-500 hover:bg-red-500/10 transition-colors cursor-pointer"
+                      >
+                        <svg
+                          className="w-4 h-4"
+                          fill="none"
+                          viewBox="0 0 24 24"
+                          stroke="currentColor"
+                          strokeWidth={1.8}
+                        >
+                          <path
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                            d="M14.74 9l-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 01-2.244 2.077H8.084a2.25 2.25 0 01-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 00-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 013.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 00-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 00-7.5 0"
+                          />
+                        </svg>
+                      </button>
+                    </div>
+                  );
+                })}
+              </div>
+
+              {/* Mobile cards */}
+              <div className="md:hidden space-y-2">
+                {sortedTasks.map((task) => {
+                  const evaluators = task.evaluators ?? [];
+                  const evaluatorType =
+                    task.type ?? evaluators[0]?.evaluator_type;
+                  return (
+                    <div
+                      key={task.uuid}
+                      onClick={() =>
+                        router.push(`/human-labelling/tasks/${task.uuid}`)
+                      }
+                      className="border border-border rounded-xl p-4 hover:bg-muted/20 transition-colors cursor-pointer flex items-start gap-3"
+                    >
+                      <div className="flex-1 min-w-0">
+                        <div className="flex items-center gap-2 flex-wrap mb-1">
+                          <p className="text-sm font-medium text-foreground truncate">
+                            {task.name}
+                          </p>
+                          {evaluatorType && (
+                            <EvaluatorTypePill evaluatorType={evaluatorType} />
+                          )}
+                        </div>
+                        <p className="text-xs text-muted-foreground">
+                          {task.item_count ?? 0} item
+                          {(task.item_count ?? 0) === 1 ? "" : "s"}
+                        </p>
+                        {evaluators.length > 0 && (
+                          <div className="flex flex-wrap gap-1 mt-2">
+                            {evaluators.map((ev) => (
+                              <Link
+                                key={ev.uuid}
+                                href={`/evaluators/${ev.uuid}`}
+                                onClick={(e) => e.stopPropagation()}
+                                title={`Open ${ev.name}`}
+                                className="inline-flex items-center px-2 py-0.5 rounded-md text-xs font-medium border border-border bg-muted/40 text-foreground hover:bg-muted hover:border-foreground/30 transition-colors cursor-pointer max-w-full"
+                              >
+                                <span className="truncate">{ev.name}</span>
+                              </Link>
+                            ))}
+                          </div>
+                        )}
+                      </div>
+                      <button
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          setTaskToDelete(task);
+                        }}
+                        aria-label={`Delete ${task.name}`}
+                        className="w-8 h-8 flex items-center justify-center rounded-md text-muted-foreground hover:text-red-500 hover:bg-red-500/10 transition-colors cursor-pointer flex-shrink-0"
+                      >
+                        <svg
+                          className="w-4 h-4"
+                          fill="none"
+                          viewBox="0 0 24 24"
+                          stroke="currentColor"
+                          strokeWidth={1.8}
+                        >
+                          <path
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                            d="M14.74 9l-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 01-2.244 2.077H8.084a2.25 2.25 0 01-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 00-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 013.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 00-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 00-7.5 0"
+                          />
+                        </svg>
+                      </button>
+                    </div>
+                  );
+                })}
+              </div>
+            </>
+          ))}
+
+        {activeTab === "annotators" && (
+          <div className="space-y-4">
+            {/* Add annotator form */}
+            <form
+              onSubmit={handleAddAnnotator}
+              className="flex flex-col sm:flex-row gap-2 sm:gap-3"
+            >
+              <input
+                type="text"
+                value={newAnnotatorName}
+                onChange={(e) => {
+                  setNewAnnotatorName(e.target.value);
+                  if (addError) setAddError(null);
+                }}
+                placeholder="Annotator name"
+                disabled={isAdding}
+                className={`flex-1 max-w-md h-9 md:h-10 px-3 rounded-md text-sm md:text-base border bg-background text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-accent focus:border-transparent disabled:opacity-50 disabled:cursor-not-allowed ${
+                  addError ? "border-red-500" : "border-border"
+                }`}
+              />
+              <button
+                type="submit"
+                disabled={!newAnnotatorName.trim() || isAdding}
+                className="h-9 md:h-10 px-4 rounded-md text-sm md:text-base font-medium bg-foreground text-background hover:opacity-90 transition-opacity cursor-pointer flex-shrink-0 disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                {isAdding ? "Adding..." : "Add"}
+              </button>
+            </form>
+
+            {addError && <p className="text-sm text-red-500">{addError}</p>}
+
+            {/* Annotator list */}
+            {annotatorsLoading ? (
+              <div className="flex items-center justify-center gap-2 py-8 text-sm text-muted-foreground">
+                <svg
+                  className="w-4 h-4 animate-spin"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                >
+                  <circle
+                    className="opacity-25"
+                    cx="12"
+                    cy="12"
+                    r="10"
+                    stroke="currentColor"
+                    strokeWidth="4"
+                  />
+                  <path
+                    className="opacity-75"
+                    fill="currentColor"
+                    d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+                  />
+                </svg>
+                Loading annotators
+              </div>
+            ) : annotatorsError ? (
+              <div className="rounded-md border border-border bg-muted/20 p-4 text-sm text-red-500">
+                {annotatorsError}
+              </div>
+            ) : annotators.length === 0 ? (
+              <EmptyState
+                icon={
+                  <svg
+                    className="w-7 h-7 text-muted-foreground"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                    strokeWidth={1.5}
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      d="M15 19.128a9.38 9.38 0 002.625.372 9.337 9.337 0 004.121-.952 4.125 4.125 0 00-7.533-2.493M15 19.128v-.003c0-1.113-.285-2.16-.786-3.07M15 19.128v.106A12.318 12.318 0 018.624 21c-2.331 0-4.512-.645-6.374-1.766l-.001-.109a6.375 6.375 0 0111.964-3.07M12 6.375a3.375 3.375 0 11-6.75 0 3.375 3.375 0 016.75 0zm8.25 2.25a2.625 2.625 0 11-5.25 0 2.625 2.625 0 015.25 0z"
+                    />
+                  </svg>
+                }
+                title="No annotators yet"
+                description="Add annotators above so they can be assigned to labelling tasks"
+              />
+            ) : (
+              <>
+                {/* Desktop table */}
+                <div className="hidden md:block border border-border rounded-xl overflow-hidden">
+                  <div className="grid grid-cols-[minmax(0,1fr)_120px_180px_40px] gap-4 px-4 py-2 border-b border-border bg-muted/30">
+                    <div className="text-sm font-medium text-muted-foreground">
+                      Name
+                    </div>
+                    <div className="text-sm font-medium text-muted-foreground">
+                      Jobs
+                    </div>
+                    <div className="text-sm font-medium text-muted-foreground">
+                      Current agreement
+                    </div>
+                    <div />
+                  </div>
+                  {annotators.map((annotator) => {
+                    const agreement = annotator.current_agreement;
+                    return (
+                      <div
+                        key={annotator.uuid}
+                        onClick={() =>
+                          router.push(
+                            `/human-labelling/annotators/${annotator.uuid}`,
+                          )
+                        }
+                        className="grid grid-cols-[minmax(0,1fr)_120px_180px_40px] gap-4 px-4 py-3 border-b border-border last:border-b-0 hover:bg-muted/20 transition-colors cursor-pointer items-center"
+                      >
+                        <p className="text-sm font-medium text-foreground truncate">
+                          {annotator.name}
+                        </p>
+                        <p className="text-sm text-muted-foreground tabular-nums">
+                          {annotator.jobs_count ?? 0}
+                        </p>
+                        <p
+                          className={`text-sm font-semibold tabular-nums ${agreementColor(agreement)}`}
+                        >
+                          {agreement != null
+                            ? `${Math.round(agreement * 100)}%`
+                            : "—"}
+                        </p>
+                        <button
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            setAnnotatorToDelete(annotator);
+                          }}
+                          aria-label={`Remove ${annotator.name}`}
+                          title="Remove annotator"
+                          className="w-8 h-8 flex items-center justify-center rounded-md text-muted-foreground hover:text-red-500 hover:bg-red-500/10 transition-colors cursor-pointer"
+                        >
+                          <svg
+                            className="w-4 h-4"
+                            fill="none"
+                            viewBox="0 0 24 24"
+                            stroke="currentColor"
+                            strokeWidth={1.8}
+                          >
+                            <path
+                              strokeLinecap="round"
+                              strokeLinejoin="round"
+                              d="M14.74 9l-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 01-2.244 2.077H8.084a2.25 2.25 0 01-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 00-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 013.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 00-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 00-7.5 0"
+                            />
+                          </svg>
+                        </button>
+                      </div>
+                    );
+                  })}
+                </div>
+
+                {/* Mobile cards */}
+                <div className="md:hidden space-y-2">
+                  {annotators.map((annotator) => {
+                    const agreement = annotator.current_agreement;
+                    return (
+                      <div
+                        key={annotator.uuid}
+                        onClick={() =>
+                          router.push(
+                            `/human-labelling/annotators/${annotator.uuid}`,
+                          )
+                        }
+                        className="border border-border rounded-xl p-4 hover:bg-muted/20 transition-colors cursor-pointer flex items-start gap-3"
+                      >
+                        <div className="flex-1 min-w-0">
+                          <p className="text-sm font-medium text-foreground truncate mb-1">
+                            {annotator.name}
+                          </p>
+                          <p className="text-xs text-muted-foreground">
+                            {annotator.jobs_count ?? 0} job
+                            {(annotator.jobs_count ?? 0) === 1 ? "" : "s"}
+                            {" · "}
+                            <span
+                              className={`font-semibold tabular-nums ${agreementColor(agreement)}`}
+                            >
+                              {agreement != null
+                                ? `${Math.round(agreement * 100)}% agreement`
+                                : "No agreement yet"}
+                            </span>
+                          </p>
+                        </div>
+                        <button
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            setAnnotatorToDelete(annotator);
+                          }}
+                          aria-label={`Remove ${annotator.name}`}
+                          className="w-8 h-8 flex items-center justify-center rounded-md text-muted-foreground hover:text-red-500 hover:bg-red-500/10 transition-colors cursor-pointer flex-shrink-0"
+                        >
+                          <svg
+                            className="w-4 h-4"
+                            fill="none"
+                            viewBox="0 0 24 24"
+                            stroke="currentColor"
+                            strokeWidth={1.8}
+                          >
+                            <path
+                              strokeLinecap="round"
+                              strokeLinejoin="round"
+                              d="M14.74 9l-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 01-2.244 2.077H8.084a2.25 2.25 0 01-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 00-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 013.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 00-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 00-7.5 0"
+                            />
+                          </svg>
+                        </button>
+                      </div>
+                    );
+                  })}
+                </div>
+              </>
+            )}
+          </div>
+        )}
+      </div>
+
+      {createDialogOpen && accessToken && (
+        <CreateLabellingTaskDialog
+          accessToken={accessToken}
+          onClose={() => setCreateDialogOpen(false)}
+          onCreated={(taskUuid) => {
+            setCreateDialogOpen(false);
+            router.push(`/human-labelling/tasks/${taskUuid}`);
+          }}
+        />
+      )}
+
+      <DeleteConfirmationDialog
+        isOpen={!!taskToDelete}
+        onClose={() => {
+          if (!isDeletingTask) setTaskToDelete(null);
+        }}
+        onConfirm={handleConfirmDeleteTask}
+        title="Delete labelling task"
+        message={
+          taskToDelete
+            ? `Delete "${taskToDelete.name}"? All items, jobs, and annotations in this task will be lost. This cannot be undone.`
+            : ""
+        }
+        confirmText="Delete"
+        isDeleting={isDeletingTask}
+      />
+
+      <DeleteConfirmationDialog
+        isOpen={!!annotatorToDelete}
+        onClose={() => {
+          if (!isDeleting) setAnnotatorToDelete(null);
+        }}
+        onConfirm={handleConfirmDelete}
+        title="Remove annotator"
+        message={
+          annotatorToDelete
+            ? `Are you sure you want to remove "${annotatorToDelete.name}"?`
+            : ""
+        }
+        confirmText="Remove"
+        isDeleting={isDeleting}
+      />
+    </AppLayout>
+  );
+}
+
+type SeriesRow = {
+  key: string;
+  name: string;
+  color: string;
+  current: number | null;
+  pairCount: number;
+  series: AgreementSeriesPoint[];
+  evaluatorType?: "llm" | "stt" | "tts" | "simulation";
+  emptyTitle: string;
+  emptyDescription: string;
+};
+
+const EVAL_COLORS = [
+  "#3b82f6",
+  "#a855f7",
+  "#06b6d4",
+  "#ec4899",
+  "#f59e0b",
+  "#14b8a6",
+  "#6366f1",
+];
+
+type SortKey = "name" | "current";
+
+function AgreementOverview({
+  agreement,
+  agreementLoading,
+  agreementError,
+  bucket,
+  selectedTaskId,
+  onSelectTask,
+  taskOptions,
+  tasks,
+}: {
+  agreement: AgreementResponse | null;
+  agreementLoading: boolean;
+  agreementError: string | null;
+  bucket: Bucket;
+  selectedTaskId: string;
+  onSelectTask: (id: string) => void;
+  taskOptions: LabellingTaskSummary[];
+  tasks: LabellingTask[];
+}) {
+  const evaluatorTypeMap = (() => {
+    const m = new Map<string, "llm" | "stt" | "tts" | "simulation">();
+    for (const t of tasks) {
+      for (const ev of t.evaluators ?? []) {
+        const type = ev.evaluator_type ?? t.type;
+        if (type && !m.has(ev.uuid)) m.set(ev.uuid, type);
+      }
+    }
+    return m;
+  })();
+  const [sortKey, setSortKey] = useState<SortKey>("current");
+  const [sortDir, setSortDir] = useState<SortDirection>("desc");
+  const [expanded, setExpanded] = useState<Set<string>>(new Set());
+
+  const rows: SeriesRow[] = (() => {
+    if (!agreement) return [];
+    const out: SeriesRow[] = [];
+    const hh = agreement.human_human;
+    out.push({
+      key: "human_human",
+      name: "Annotator agreement",
+      color: "#10b981",
+      current: hh?.current ?? null,
+      pairCount: hh?.pair_count ?? 0,
+      series: hh?.series ?? [],
+      emptyTitle: "Not enough annotations yet to compute agreement",
+      emptyDescription:
+        "Inter-rater agreement will appear here once two or more annotators have labelled at least one of the same items",
+    });
+    (agreement.evaluators ?? []).forEach((ev, i) => {
+      out.push({
+        key: ev.evaluator_id,
+        name: ev.name,
+        color: EVAL_COLORS[i % EVAL_COLORS.length],
+        current: ev.current ?? null,
+        pairCount: ev.pair_count ?? 0,
+        series: ev.series ?? [],
+        evaluatorType: evaluatorTypeMap.get(ev.evaluator_id),
+        emptyTitle: "Not enough overlap yet to compute alignment",
+        emptyDescription: `This evaluator's alignment with humans will appear here once it's been run on items that humans have also labelled`,
+      });
+    });
+    return out;
+  })();
+
+  const sorted = [...rows].sort((a, b) => {
+    const dir = sortDir === "desc" ? -1 : 1;
+    const cmp = (x: number | null, y: number | null) => {
+      if (x == null && y == null) return 0;
+      if (x == null) return 1; // nulls last
+      if (y == null) return -1;
+      return x === y ? 0 : x < y ? -1 : 1;
+    };
+    if (sortKey === "name") return dir * a.name.localeCompare(b.name);
+    return dir * cmp(a.current, b.current);
+  });
+
+  const buildChartData = (series: AgreementSeriesPoint[]) =>
+    series.map((p) => ({
+      month: formatBucketLabel(p.bucket_end, bucket),
+      agreement:
+        p.agreement == null ? null : Math.round(p.agreement * 100),
+    }));
+
+  const toggleRow = (key: string) => {
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return next;
+    });
+  };
+
+  const handleSort = (key: SortKey) => {
+    if (sortKey === key) {
+      setSortDir((d) => (d === "desc" ? "asc" : "desc"));
+    } else {
+      setSortKey(key);
+      setSortDir(key === "name" ? "asc" : "desc");
+    }
+  };
+
+  return (
+    <div className="space-y-4 md:space-y-6">
+      {agreementError && (
+        <div className="rounded-md border border-border bg-muted/20 p-4 text-sm text-red-500">
+          {agreementError}
+        </div>
+      )}
+
+      <div className="flex items-center justify-between gap-3 flex-wrap">
+        <div>
+          <h2 className="text-sm font-semibold">Agreement summary</h2>
+          <p className="text-xs text-muted-foreground">
+            Agreement between annotators, and how closely each evaluator aligns
+            with the annotators
+          </p>
+        </div>
+        <Select
+          value={selectedTaskId}
+          onChange={(e) => onSelectTask(e.target.value)}
+          wrapperClassName="w-48"
+          className="h-9"
+        >
+          <option value={ALL_TASKS}>All tasks</option>
+          {taskOptions.map((task) => (
+            <option key={task.uuid} value={task.uuid}>
+              {task.name}
+            </option>
+          ))}
+        </Select>
+      </div>
+
+      {agreementLoading ? (
+        <div className="flex items-center justify-center gap-2 py-12 text-sm text-muted-foreground">
+          <svg
+            className="w-4 h-4 animate-spin"
+            fill="none"
+            viewBox="0 0 24 24"
+          >
+            <circle
+              className="opacity-25"
+              cx="12"
+              cy="12"
+              r="10"
+              stroke="currentColor"
+              strokeWidth="4"
+            />
+            <path
+              className="opacity-75"
+              fill="currentColor"
+              d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+            />
+          </svg>
+          Loading agreement
+        </div>
+      ) : rows.length === 0 ? (
+        <div className="flex flex-col items-center justify-center text-center border border-border rounded-xl py-12 px-6">
+          <p className="text-sm font-medium text-foreground">
+            No agreement data yet
+          </p>
+          <p className="text-xs text-muted-foreground mt-1.5 max-w-md">
+            Agreement will appear here once annotators have labelled overlapping items
+          </p>
+        </div>
+      ) : (
+        <>
+          {/* Desktop table */}
+          <div className="hidden md:block border border-border rounded-xl overflow-hidden">
+            <div className="grid grid-cols-[minmax(0,1fr)_minmax(0,1fr)_minmax(0,1fr)_32px] gap-4 px-4 py-2 border-b border-border bg-muted/30 items-center">
+              <SortHeader
+                label="Name"
+                active={sortKey === "name"}
+                dir={sortDir}
+                onClick={() => handleSort("name")}
+              />
+              <div className="text-sm font-medium text-muted-foreground">
+                Type
+              </div>
+              <SortHeader
+                label="Current agreement"
+                active={sortKey === "current"}
+                dir={sortDir}
+                onClick={() => handleSort("current")}
+              />
+              <div />
+            </div>
+            {sorted.map((row) => {
+              const isOpen = expanded.has(row.key);
+              const hasData =
+                row.series.length > 0 &&
+                row.pairCount > 0 &&
+                row.current != null;
+              return (
+                <div
+                  key={row.key}
+                  className="border-b border-border last:border-b-0"
+                >
+                  <div
+                    onClick={() => toggleRow(row.key)}
+                    className="grid grid-cols-[minmax(0,1fr)_minmax(0,1fr)_minmax(0,1fr)_32px] gap-4 px-4 py-3 hover:bg-muted/20 transition-colors cursor-pointer items-center"
+                  >
+                    <div className="flex items-center gap-2 min-w-0">
+                      {row.key === "human_human" ? (
+                        <p className="text-sm font-medium text-foreground truncate">
+                          {row.name}
+                        </p>
+                      ) : (
+                        <Link
+                          href={`/evaluators/${row.key}`}
+                          onClick={(e) => e.stopPropagation()}
+                          title={`Open ${row.name}`}
+                          className="inline-flex items-center px-2 py-0.5 rounded-md text-xs font-medium border border-border bg-muted/40 text-foreground hover:bg-muted hover:border-foreground/30 transition-colors cursor-pointer truncate max-w-full"
+                        >
+                          <span className="truncate">{row.name}</span>
+                        </Link>
+                      )}
+                    </div>
+                    <div>
+                      {row.key === "human_human" ? (
+                        <HumanTypePill />
+                      ) : row.evaluatorType ? (
+                        <EvaluatorTypePill
+                          evaluatorType={row.evaluatorType}
+                        />
+                      ) : (
+                        <span className="text-sm text-muted-foreground">
+                          —
+                        </span>
+                      )}
+                    </div>
+                    <div
+                      className={`text-sm font-semibold tabular-nums ${agreementColor(row.current)}`}
+                    >
+                      {row.current != null
+                        ? `${Math.round(row.current * 100)}%`
+                        : "—"}
+                    </div>
+                    <div className="flex justify-end">
+                      <svg
+                        className={`w-4 h-4 text-muted-foreground transition-transform ${isOpen ? "rotate-180" : ""}`}
+                        fill="none"
+                        viewBox="0 0 24 24"
+                        stroke="currentColor"
+                        strokeWidth={2}
+                      >
+                        <path
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          d="M19.5 8.25l-7.5 7.5-7.5-7.5"
+                        />
+                      </svg>
+                    </div>
+                  </div>
+                  {isOpen && (
+                    <div className="border-t border-border bg-muted/10 p-4">
+                      <ExpandedChart
+                        hasData={hasData}
+                        data={buildChartData(row.series)}
+                        color={row.color}
+                        seriesName={row.name}
+                        emptyTitle={row.emptyTitle}
+                        emptyDescription={row.emptyDescription}
+                      />
+                    </div>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+
+          {/* Mobile cards */}
+          <div className="md:hidden space-y-2">
+            {sorted.map((row) => {
+              const isOpen = expanded.has(row.key);
+              const hasData =
+                row.series.length > 0 &&
+                row.pairCount > 0 &&
+                row.current != null;
+              return (
+                <div
+                  key={row.key}
+                  className="border border-border rounded-xl overflow-hidden"
+                >
+                  <div
+                    onClick={() => toggleRow(row.key)}
+                    className="p-4 hover:bg-muted/20 transition-colors cursor-pointer"
+                  >
+                    <div className="flex items-center gap-2 mb-2">
+                      {row.key === "human_human" ? (
+                        <p className="text-sm font-medium text-foreground truncate flex-1">
+                          {row.name}
+                        </p>
+                      ) : (
+                        <Link
+                          href={`/evaluators/${row.key}`}
+                          onClick={(e) => e.stopPropagation()}
+                          title={`Open ${row.name}`}
+                          className="inline-flex items-center px-2 py-0.5 rounded-md text-xs font-medium border border-border bg-muted/40 text-foreground hover:bg-muted hover:border-foreground/30 transition-colors cursor-pointer truncate flex-1 min-w-0"
+                        >
+                          <span className="truncate">{row.name}</span>
+                        </Link>
+                      )}
+                      {row.key === "human_human" ? (
+                        <HumanTypePill />
+                      ) : (
+                        row.evaluatorType && (
+                          <EvaluatorTypePill
+                            evaluatorType={row.evaluatorType}
+                          />
+                        )
+                      )}
+                      <svg
+                        className={`w-4 h-4 text-muted-foreground transition-transform flex-shrink-0 ${isOpen ? "rotate-180" : ""}`}
+                        fill="none"
+                        viewBox="0 0 24 24"
+                        stroke="currentColor"
+                        strokeWidth={2}
+                      >
+                        <path
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          d="M19.5 8.25l-7.5 7.5-7.5-7.5"
+                        />
+                      </svg>
+                    </div>
+                    <div className="flex items-center gap-3 flex-wrap">
+                      <span
+                        className={`text-base font-semibold tabular-nums ${agreementColor(row.current)}`}
+                      >
+                        {row.current != null
+                          ? `${Math.round(row.current * 100)}%`
+                          : "—"}
+                      </span>
+                    </div>
+                  </div>
+                  {isOpen && (
+                    <div className="border-t border-border bg-muted/10 p-4">
+                      <ExpandedChart
+                        hasData={hasData}
+                        data={buildChartData(row.series)}
+                        color={row.color}
+                        seriesName={row.name}
+                        emptyTitle={row.emptyTitle}
+                        emptyDescription={row.emptyDescription}
+                      />
+                    </div>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
+function HumanTypePill() {
+  return (
+    <span className="inline-flex items-center px-2 py-0.5 rounded-md text-[10px] md:text-[11px] font-medium uppercase tracking-wide bg-green-500/10 text-green-600 dark:text-green-400">
+      Human
+    </span>
+  );
+}
+
+function SortHeader({
+  label,
+  active,
+  dir,
+  onClick,
+  align = "left",
+}: {
+  label: string;
+  active: boolean;
+  dir: SortDirection;
+  onClick: () => void;
+  align?: "left" | "right";
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`flex items-center gap-1 text-sm font-medium transition-colors cursor-pointer w-fit ${
+        active ? "text-foreground" : "text-muted-foreground hover:text-foreground"
+      } ${align === "right" ? "justify-self-end" : ""}`}
+    >
+      {label}
+      <svg
+        className={`w-3.5 h-3.5 ${active ? "opacity-100" : "opacity-40"}`}
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke="currentColor"
+        strokeWidth={2}
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          d={
+            dir === "desc"
+              ? "M19.5 8.25l-7.5 7.5-7.5-7.5"
+              : "M4.5 15.75l7.5-7.5 7.5 7.5"
+          }
+        />
+      </svg>
+    </button>
+  );
+}
+
+function ExpandedChart({
+  hasData,
+  data,
+  color,
+  seriesName,
+  emptyTitle,
+  emptyDescription,
+}: {
+  hasData: boolean;
+  data: Array<{ month: string; agreement: number | null }>;
+  color: string;
+  seriesName: string;
+  emptyTitle: string;
+  emptyDescription: string;
+}) {
+  if (!hasData) {
+    return (
+      <div className="flex flex-col items-center justify-center text-center h-48 px-6">
+        <p className="text-sm font-medium text-foreground">{emptyTitle}</p>
+        <p className="text-xs text-muted-foreground mt-1.5 max-w-md">
+          {emptyDescription}
+        </p>
+      </div>
+    );
+  }
+  return (
+    <div className="w-full h-56 md:h-64">
+      <ResponsiveContainer width="100%" height="100%">
+        <LineChart data={data}>
+          <CartesianGrid
+            strokeDasharray="3 3"
+            stroke="rgba(125,125,125,0.15)"
+          />
+          <XAxis dataKey="month" fontSize={11} />
+          <YAxis domain={[0, 100]} fontSize={11} unit="%" />
+          <Tooltip
+            contentStyle={{
+              background: "var(--background, #fff)",
+              border: "1px solid rgba(125,125,125,0.2)",
+              borderRadius: 8,
+              fontSize: 12,
+            }}
+          />
+          <Line
+            type="monotone"
+            dataKey="agreement"
+            name={seriesName}
+            stroke={color}
+            strokeWidth={2}
+            dot={{ r: 3 }}
+            connectNulls={false}
+          />
+        </LineChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}

--- a/src/app/human-labelling/page.tsx
+++ b/src/app/human-labelling/page.tsx
@@ -180,9 +180,7 @@ function HumanLabellingPageInner() {
   const [tasksLoading, setTasksLoading] = useState(false);
   const [tasksError, setTasksError] = useState<string | null>(null);
 
-  const sortedTasks = [...tasks].sort((a, b) =>
-    a.name.localeCompare(b.name),
-  );
+  const sortedTasks = [...tasks].sort((a, b) => a.name.localeCompare(b.name));
 
   const [selectedTaskId, setSelectedTaskId] = useState<string>(ALL_TASKS);
   const [bucket] = useState<Bucket>(DEFAULT_BUCKET);
@@ -297,9 +295,7 @@ function HumanLabellingPageInner() {
         }),
       );
       if (cancelled) return;
-      setTasksWithAgreement(
-        new Set(results.filter((u): u is string => !!u)),
-      );
+      setTasksWithAgreement(new Set(results.filter((u): u is string => !!u)));
     })();
     return () => {
       cancelled = true;
@@ -1013,6 +1009,22 @@ function AgreementOverview({
   })();
 
   const sorted = [...rows].sort((a, b) => {
+    // Pin the inter-rater (human ↔ human) row to the top regardless of
+    // sort — it's the baseline every evaluator row is compared against.
+    if (a.key === "human_human" && b.key !== "human_human") return -1;
+    if (b.key === "human_human" && a.key !== "human_human") return 1;
+
+    // Group evaluators by type so all of the same type sit together.
+    // Rows missing a type sort after typed groups; within a group the
+    // user's chosen sort applies.
+    const aType = a.evaluatorType ?? "";
+    const bType = b.evaluatorType ?? "";
+    if (aType !== bType) {
+      if (!aType) return 1;
+      if (!bType) return -1;
+      return aType.localeCompare(bType);
+    }
+
     const dir = sortDir === "desc" ? -1 : 1;
     const cmp = (x: number | null, y: number | null) => {
       if (x == null && y == null) return 0;
@@ -1027,8 +1039,7 @@ function AgreementOverview({
   const buildChartData = (series: AgreementSeriesPoint[]) =>
     series.map((p) => ({
       month: formatBucketLabel(p.bucket_end, bucket),
-      agreement:
-        p.agreement == null ? null : Math.round(p.agreement * 100),
+      agreement: p.agreement == null ? null : Math.round(p.agreement * 100),
     }));
 
   const toggleRow = (key: string) => {
@@ -1049,6 +1060,10 @@ function AgreementOverview({
     }
   };
 
+  const hasNoAgreementData =
+    rows.length === 0 ||
+    rows.every((r) => r.current == null && r.pairCount === 0);
+
   return (
     <div className="space-y-4 md:space-y-6">
       {agreementError && (
@@ -1057,36 +1072,34 @@ function AgreementOverview({
         </div>
       )}
 
-      <div className="flex items-center justify-between gap-3 flex-wrap">
-        <div>
-          <h2 className="text-sm font-semibold">Agreement summary</h2>
-          <p className="text-xs text-muted-foreground">
-            Agreement between annotators, and how closely each evaluator aligns
-            with the annotators
-          </p>
+      {!agreementLoading && !hasNoAgreementData && (
+        <div className="flex items-center justify-between gap-3 flex-wrap">
+          <div>
+            <h2 className="text-sm font-semibold">Agreement summary</h2>
+            <p className="text-xs text-muted-foreground">
+              Agreement between annotators, and how closely each evaluator
+              aligns with the annotators
+            </p>
+          </div>
+          <Select
+            value={selectedTaskId}
+            onChange={(e) => onSelectTask(e.target.value)}
+            wrapperClassName="w-48"
+            className="h-9"
+          >
+            <option value={ALL_TASKS}>All tasks</option>
+            {taskOptions.map((task) => (
+              <option key={task.uuid} value={task.uuid}>
+                {task.name}
+              </option>
+            ))}
+          </Select>
         </div>
-        <Select
-          value={selectedTaskId}
-          onChange={(e) => onSelectTask(e.target.value)}
-          wrapperClassName="w-48"
-          className="h-9"
-        >
-          <option value={ALL_TASKS}>All tasks</option>
-          {taskOptions.map((task) => (
-            <option key={task.uuid} value={task.uuid}>
-              {task.name}
-            </option>
-          ))}
-        </Select>
-      </div>
+      )}
 
       {agreementLoading ? (
         <div className="flex items-center justify-center gap-2 py-12 text-sm text-muted-foreground">
-          <svg
-            className="w-4 h-4 animate-spin"
-            fill="none"
-            viewBox="0 0 24 24"
-          >
+          <svg className="w-4 h-4 animate-spin" fill="none" viewBox="0 0 24 24">
             <circle
               className="opacity-25"
               cx="12"
@@ -1103,15 +1116,33 @@ function AgreementOverview({
           </svg>
           Loading agreement
         </div>
-      ) : rows.length === 0 ? (
-        <div className="flex flex-col items-center justify-center text-center border border-border rounded-xl py-12 px-6">
-          <p className="text-sm font-medium text-foreground">
-            No agreement data yet
-          </p>
-          <p className="text-xs text-muted-foreground mt-1.5 max-w-md">
-            Agreement will appear here once annotators have labelled overlapping items
-          </p>
-        </div>
+      ) : hasNoAgreementData ? (
+        <EmptyState
+          icon={
+            <svg
+              className="w-7 h-7 text-muted-foreground"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              strokeWidth={1.5}
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M3 13.125C3 12.504 3.504 12 4.125 12h2.25c.621 0 1.125.504 1.125 1.125v6.75C7.5 20.496 6.996 21 6.375 21h-2.25A1.125 1.125 0 013 19.875v-6.75zM9.75 8.625c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125v11.25c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 01-1.125-1.125V8.625zM16.5 4.125c0-.621.504-1.125 1.125-1.125h2.25C20.496 3 21 3.504 21 4.125v15.75c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 01-1.125-1.125V4.125z"
+              />
+            </svg>
+          }
+          title="No agreement data yet"
+          description={
+            <>
+              Agreement between annotators and evaluators will appear here
+              <br />
+              once annotators start labelling and evaluators are run on the
+              task items
+            </>
+          }
+        />
       ) : (
         <>
           {/* Desktop table */}
@@ -1169,13 +1200,9 @@ function AgreementOverview({
                       {row.key === "human_human" ? (
                         <HumanTypePill />
                       ) : row.evaluatorType ? (
-                        <EvaluatorTypePill
-                          evaluatorType={row.evaluatorType}
-                        />
+                        <EvaluatorTypePill evaluatorType={row.evaluatorType} />
                       ) : (
-                        <span className="text-sm text-muted-foreground">
-                          —
-                        </span>
+                        <span className="text-sm text-muted-foreground">—</span>
                       )}
                     </div>
                     <div
@@ -1331,7 +1358,9 @@ function SortHeader({
       type="button"
       onClick={onClick}
       className={`flex items-center gap-1 text-sm font-medium transition-colors cursor-pointer w-fit ${
-        active ? "text-foreground" : "text-muted-foreground hover:text-foreground"
+        active
+          ? "text-foreground"
+          : "text-muted-foreground hover:text-foreground"
       } ${align === "right" ? "justify-self-end" : ""}`}
     >
       {label}

--- a/src/app/human-labelling/tasks/[uuid]/evaluator-runs/[runUuid]/page.tsx
+++ b/src/app/human-labelling/tasks/[uuid]/evaluator-runs/[runUuid]/page.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import Link from "next/link";
 import { useParams, useRouter } from "next/navigation";
 import { AppLayout } from "@/components/AppLayout";
+import { EvaluatorVerdictCard } from "@/components/EvaluatorVerdictCard";
 import {
   ItemPane,
   type Item,
@@ -88,22 +89,6 @@ function statusLabel(status: EvaluatorRunJob["status"]): string {
   if (status === "completed") return "Completed";
   if (status === "failed") return "Failed";
   return status;
-}
-
-function formatValueDisplay(v: unknown): string {
-  if (v === true) return "Correct";
-  if (v === false) return "Wrong";
-  if (typeof v === "number") return String(v);
-  if (typeof v === "string") return v;
-  return "—";
-}
-
-function valuePillClass(v: unknown): string {
-  if (v === true)
-    return "border-green-200 bg-green-100 text-green-700 dark:border-green-500/30 dark:bg-green-500/20 dark:text-green-400";
-  if (v === false)
-    return "border-red-200 bg-red-100 text-red-700 dark:border-red-500/30 dark:bg-red-500/20 dark:text-red-400";
-  return "border-border bg-muted/40 text-foreground";
 }
 
 export default function EvaluatorRunDetailPage() {
@@ -201,18 +186,23 @@ export default function EvaluatorRunDetailPage() {
   }, [fetchJob]);
 
   // Lazily fetch version labels for evaluators referenced by the run.
+  // Keyed on the sorted list of evaluator IDs so the effect doesn't
+  // re-fire when the run polls — `job` changes every 2.5s while the
+  // job is in-progress, but the evaluator set is fixed at run creation.
+  const evaluatorIdsKey = (job?.details?.evaluators ?? [])
+    .map((e) => e.evaluator_id)
+    .filter(Boolean)
+    .slice()
+    .sort()
+    .join(",");
   useEffect(() => {
-    if (!accessToken || !job) return;
-    const evIds = new Set<string>();
-    for (const e of job.details?.evaluators ?? []) {
-      if (e.evaluator_id) evIds.add(e.evaluator_id);
-    }
-    if (evIds.size === 0) return;
+    if (!accessToken || !evaluatorIdsKey) return;
+    const evIds = evaluatorIdsKey.split(",");
     let cancelled = false;
     (async () => {
       const merged: Record<string, string> = {};
       await Promise.all(
-        Array.from(evIds).map(async (evaluatorId) => {
+        evIds.map(async (evaluatorId) => {
           try {
             const versions = await apiClient<
               Array<{ uuid: string; version_number: number }>
@@ -230,7 +220,7 @@ export default function EvaluatorRunDetailPage() {
     return () => {
       cancelled = true;
     };
-  }, [accessToken, job]);
+  }, [accessToken, evaluatorIdsKey]);
 
   // Limit the items displayed to those actually in this run.
   // Source of truth (in priority order):
@@ -514,18 +504,35 @@ function EvaluatorResultsPane({
             (!ev.evaluator_version_id ||
               x.evaluator_version_id === ev.evaluator_version_id),
         );
-        const value = r?.value?.value;
         const reasoning =
           typeof r?.value?.reasoning === "string"
             ? (r.value.reasoning as string)
-            : "";
-        return (
-          <div
-            key={`${ev.evaluator_id}-${ev.evaluator_version_id ?? ""}`}
-            className="border border-border rounded-xl p-4 space-y-3"
-          >
-            <div className="flex items-start justify-between gap-3 min-w-0">
-              <div className="min-w-0 flex items-center gap-2 flex-wrap">
+            : null;
+
+        let match: boolean | null = null;
+        let score: number | null = null;
+        let outputType: "binary" | "rating" = "binary";
+
+        if (r) {
+          const v = r.value?.value;
+          if (typeof v === "boolean") {
+            outputType = "binary";
+            match = v;
+          } else if (typeof v === "number") {
+            outputType = "rating";
+            score = v;
+          }
+        }
+
+        const stillRunning =
+          !r && (jobStatus === "in_progress" || jobStatus === "queued");
+        if (stillRunning) {
+          return (
+            <div
+              key={`${ev.evaluator_id}-${ev.evaluator_version_id ?? ""}`}
+              className="border border-border rounded-xl p-4 space-y-2"
+            >
+              <div className="flex items-center gap-2 flex-wrap min-w-0">
                 <h3 className="text-sm font-semibold truncate">
                   {ev.name || ev.evaluator_id.slice(0, 8)}
                 </h3>
@@ -535,32 +542,6 @@ function EvaluatorResultsPane({
                   </span>
                 )}
               </div>
-            </div>
-
-            {r ? (
-              <>
-                <div className="flex items-center gap-2">
-                  <span
-                    className={`inline-flex items-center px-2.5 py-1 rounded-md text-sm font-medium border ${valuePillClass(
-                      value,
-                    )}`}
-                  >
-                    {formatValueDisplay(value)}
-                  </span>
-                </div>
-                <div className="space-y-1.5">
-                  <div className="text-xs font-medium text-muted-foreground">
-                    Reasoning
-                  </div>
-                  <textarea
-                    value={reasoning}
-                    readOnly
-                    rows={2}
-                    className="w-full text-sm rounded-md border border-border bg-background px-3 py-2 resize-y focus:outline-none focus:ring-2 focus:ring-foreground/20"
-                  />
-                </div>
-              </>
-            ) : jobStatus === "in_progress" || jobStatus === "queued" ? (
               <div className="flex items-center gap-3 py-1">
                 <svg
                   className="w-5 h-5 animate-spin text-muted-foreground"
@@ -585,12 +566,50 @@ function EvaluatorResultsPane({
                   Running evaluator
                 </p>
               </div>
-            ) : (
-              <p className="text-xs text-muted-foreground">
-                No result for this item.
+            </div>
+          );
+        }
+
+        const evaluatorName = ev.name || ev.evaluator_id.slice(0, 8);
+
+        // Job is done (or failed) but no row exists for this item — that's
+        // a real error state now that the backend always populates runs[].
+        if (!r) {
+          return (
+            <div
+              key={`${ev.evaluator_id}-${ev.evaluator_version_id ?? ""}`}
+              className="border border-red-500/30 bg-red-500/5 rounded-xl p-4 space-y-1.5"
+            >
+              <div className="flex items-center gap-2 flex-wrap min-w-0">
+                <h3 className="text-sm font-semibold truncate">
+                  {evaluatorName}
+                </h3>
+                {versionLabel && (
+                  <span className="font-mono text-[10px] px-1.5 py-0.5 rounded-md border border-foreground/20 bg-background text-foreground">
+                    {versionLabel}
+                  </span>
+                )}
+              </div>
+              <p className="text-xs text-red-600 dark:text-red-400">
+                No result recorded for this item.
               </p>
-            )}
-          </div>
+            </div>
+          );
+        }
+
+        return (
+          <EvaluatorVerdictCard
+            key={`${ev.evaluator_id}-${ev.evaluator_version_id ?? ""}`}
+            mode="read"
+            name={evaluatorName}
+            versionLabel={versionLabel}
+            outputType={outputType}
+            evaluatorUuid={ev.evaluator_id}
+            enableLink
+            match={match}
+            score={score}
+            reasoning={reasoning}
+          />
         );
       })}
     </div>

--- a/src/app/human-labelling/tasks/[uuid]/evaluator-runs/[runUuid]/page.tsx
+++ b/src/app/human-labelling/tasks/[uuid]/evaluator-runs/[runUuid]/page.tsx
@@ -24,6 +24,14 @@ type EvaluatorRunRow = {
   status: string;
   created_at: string;
   completed_at: string | null;
+  // Backend now embeds the version's scale bounds (numeric min/max for
+  // rating evaluators, null for binary).
+  evaluator_version?: {
+    uuid?: string;
+    version_number?: number;
+    scale_min?: number | null;
+    scale_max?: number | null;
+  } | null;
 };
 
 type EvaluatorRunJob = {
@@ -608,6 +616,16 @@ function EvaluatorResultsPane({
             enableLink
             match={match}
             score={score}
+            scaleMin={
+              typeof r.evaluator_version?.scale_min === "number"
+                ? r.evaluator_version.scale_min
+                : undefined
+            }
+            scaleMax={
+              typeof r.evaluator_version?.scale_max === "number"
+                ? r.evaluator_version.scale_max
+                : undefined
+            }
             reasoning={reasoning}
           />
         );

--- a/src/app/human-labelling/tasks/[uuid]/evaluator-runs/[runUuid]/page.tsx
+++ b/src/app/human-labelling/tasks/[uuid]/evaluator-runs/[runUuid]/page.tsx
@@ -1,0 +1,598 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import Link from "next/link";
+import { useParams, useRouter } from "next/navigation";
+import { AppLayout } from "@/components/AppLayout";
+import {
+  ItemPane,
+  type Item,
+  type Task,
+} from "@/components/human-labelling/AnnotationJobView";
+import { useAccessToken } from "@/hooks";
+import { apiClient } from "@/lib/api";
+import { useSidebarState } from "@/lib/sidebar";
+
+type EvaluatorRunRow = {
+  uuid: string;
+  job_id: string;
+  item_id: string;
+  evaluator_id: string;
+  evaluator_version_id: string;
+  value: { value?: unknown; reasoning?: unknown } | null;
+  status: string;
+  created_at: string;
+  completed_at: string | null;
+};
+
+type EvaluatorRunJob = {
+  uuid: string;
+  task_id: string;
+  status: "queued" | "in_progress" | "completed" | "failed";
+  details: {
+    evaluators?: {
+      evaluator_id: string;
+      evaluator_version_id?: string;
+      name?: string;
+    }[];
+    item_count?: number;
+    s3_prefix?: string;
+    item_ids?: string[];
+  } | null;
+  error: string | null;
+  created_at: string;
+  updated_at: string;
+  completed_at: string | null;
+  runs: EvaluatorRunRow[];
+};
+
+type LabellingTaskFull = {
+  uuid: string;
+  name: string;
+  type: "llm" | "stt" | "tts" | "simulation";
+  description?: string | null;
+  items?: Item[];
+};
+
+function parseApiError(err: unknown, fallback: string): string {
+  if (!(err instanceof Error)) return fallback;
+  const m = err.message.match(/Request failed: \d+ - (.+)$/);
+  if (m) {
+    try {
+      const parsed = JSON.parse(m[1]);
+      if (parsed && typeof parsed.detail === "string") return parsed.detail;
+    } catch {
+      // ignore
+    }
+    return m[1];
+  }
+  return err.message || fallback;
+}
+
+function statusPillClass(status: EvaluatorRunJob["status"]): string {
+  switch (status) {
+    case "completed":
+      return "border-green-200 bg-green-100 text-green-700 dark:border-green-500/30 dark:bg-green-500/20 dark:text-green-400";
+    case "failed":
+      return "border-red-200 bg-red-100 text-red-700 dark:border-red-500/30 dark:bg-red-500/20 dark:text-red-400";
+    case "in_progress":
+      return "border-yellow-200 bg-yellow-100 text-yellow-700 dark:border-yellow-500/30 dark:bg-yellow-500/20 dark:text-yellow-400";
+    default:
+      return "border-gray-200 bg-gray-100 text-gray-700 dark:border-gray-500/30 dark:bg-gray-500/20 dark:text-gray-300";
+  }
+}
+
+function statusLabel(status: EvaluatorRunJob["status"]): string {
+  if (status === "queued") return "Queued";
+  if (status === "in_progress") return "In progress";
+  if (status === "completed") return "Completed";
+  if (status === "failed") return "Failed";
+  return status;
+}
+
+function formatValueDisplay(v: unknown): string {
+  if (v === true) return "Correct";
+  if (v === false) return "Wrong";
+  if (typeof v === "number") return String(v);
+  if (typeof v === "string") return v;
+  return "—";
+}
+
+function valuePillClass(v: unknown): string {
+  if (v === true)
+    return "border-green-200 bg-green-100 text-green-700 dark:border-green-500/30 dark:bg-green-500/20 dark:text-green-400";
+  if (v === false)
+    return "border-red-200 bg-red-100 text-red-700 dark:border-red-500/30 dark:bg-red-500/20 dark:text-red-400";
+  return "border-border bg-muted/40 text-foreground";
+}
+
+export default function EvaluatorRunDetailPage() {
+  const router = useRouter();
+  const params = useParams();
+  const accessToken = useAccessToken();
+  const [sidebarOpen, setSidebarOpen] = useSidebarState();
+
+  const taskUuid =
+    typeof params?.uuid === "string"
+      ? params.uuid
+      : Array.isArray(params?.uuid)
+        ? params.uuid[0]
+        : "";
+  const runUuid =
+    typeof params?.runUuid === "string"
+      ? params.runUuid
+      : Array.isArray(params?.runUuid)
+        ? params.runUuid[0]
+        : "";
+
+  const [job, setJob] = useState<EvaluatorRunJob | null>(null);
+  const [task, setTask] = useState<LabellingTaskFull | null>(null);
+  const [versionLabels, setVersionLabels] = useState<Record<string, string>>(
+    {},
+  );
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const startTime = useRef(Date.now());
+
+  useEffect(() => {
+    document.title = "Evaluation run | Calibrate";
+  }, []);
+
+  const fetchJob = useCallback(async () => {
+    if (!accessToken || !taskUuid || !runUuid) return null;
+    try {
+      const data = await apiClient<EvaluatorRunJob>(
+        `/annotation-tasks/${taskUuid}/evaluator-runs/${runUuid}`,
+        accessToken,
+      );
+      setJob(data);
+      setError(null);
+      setLoading(false);
+      return data;
+    } catch (err) {
+      setError(parseApiError(err, "Failed to load run"));
+      setLoading(false);
+      return null;
+    }
+  }, [accessToken, taskUuid, runUuid]);
+
+  // Fetch the task once for items.
+  useEffect(() => {
+    if (!accessToken || !taskUuid) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const data = await apiClient<LabellingTaskFull>(
+          `/annotation-tasks/${taskUuid}`,
+          accessToken,
+        );
+        if (!cancelled) setTask(data);
+      } catch {
+        // surfaced below
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [accessToken, taskUuid]);
+
+  // Poll the run.
+  useEffect(() => {
+    let cancelled = false;
+    let timer: ReturnType<typeof setTimeout> | null = null;
+    const tick = async () => {
+      if (cancelled) return;
+      const data = await fetchJob();
+      if (cancelled) return;
+      const isTerminal =
+        data && (data.status === "completed" || data.status === "failed");
+      if (!isTerminal) {
+        const elapsed = Date.now() - startTime.current;
+        const delay = elapsed < 30_000 ? 2500 : 5000;
+        timer = setTimeout(tick, delay);
+      }
+    };
+    tick();
+    return () => {
+      cancelled = true;
+      if (timer) clearTimeout(timer);
+    };
+  }, [fetchJob]);
+
+  // Lazily fetch version labels for evaluators referenced by the run.
+  useEffect(() => {
+    if (!accessToken || !job) return;
+    const evIds = new Set<string>();
+    for (const e of job.details?.evaluators ?? []) {
+      if (e.evaluator_id) evIds.add(e.evaluator_id);
+    }
+    if (evIds.size === 0) return;
+    let cancelled = false;
+    (async () => {
+      const merged: Record<string, string> = {};
+      await Promise.all(
+        Array.from(evIds).map(async (evaluatorId) => {
+          try {
+            const versions = await apiClient<
+              Array<{ uuid: string; version_number: number }>
+            >(`/evaluators/${evaluatorId}/versions`, accessToken);
+            for (const v of versions) {
+              merged[v.uuid] = `v${v.version_number}`;
+            }
+          } catch {
+            // ignore
+          }
+        }),
+      );
+      if (!cancelled) setVersionLabels((prev) => ({ ...prev, ...merged }));
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [accessToken, job]);
+
+  // Limit the items displayed to those actually in this run.
+  // Source of truth (in priority order):
+  //   1. details.item_ids — explicit subset persisted at run creation
+  //   2. unique item_ids from runs[] — once results land
+  //   3. fall back to all task items (only happens for in-progress full-task runs)
+  const itemsForRun: Item[] = (() => {
+    if (!task?.items) return [];
+    const subset = job?.details?.item_ids;
+    if (subset && subset.length > 0) {
+      const set = new Set(subset);
+      return task.items.filter((i) => set.has(i.uuid));
+    }
+    const fromRuns = new Set<string>();
+    for (const r of job?.runs ?? []) {
+      if (r.item_id) fromRuns.add(r.item_id);
+    }
+    if (fromRuns.size > 0) {
+      return task.items.filter((i) => fromRuns.has(i.uuid));
+    }
+    // Cap at item_count when known so an in-progress full-task run shows the
+    // right number even before any rows have been written.
+    const cap = job?.details?.item_count;
+    if (typeof cap === "number" && cap >= 0 && cap < task.items.length) {
+      return task.items.slice(0, cap);
+    }
+    return task.items;
+  })();
+
+  const total = itemsForRun.length;
+  const safeIndex = Math.min(Math.max(currentIndex, 0), Math.max(total - 1, 0));
+  const currentItem: Item | undefined = itemsForRun[safeIndex];
+
+  // Group runs by item_id for quick lookup.
+  const runsByItem = (() => {
+    const m: Record<string, EvaluatorRunRow[]> = {};
+    for (const r of job?.runs ?? []) {
+      (m[r.item_id] = m[r.item_id] ?? []).push(r);
+    }
+    return m;
+  })();
+
+  const itemDone = (itemId: string): boolean => {
+    if (!job || job.status !== "completed") return false;
+    const rs = runsByItem[itemId] ?? [];
+    const evaluators = job.details?.evaluators ?? [];
+    if (rs.length === 0 || evaluators.length === 0) return false;
+    return evaluators.every((e) =>
+      rs.some(
+        (r) =>
+          r.evaluator_id === e.evaluator_id &&
+          (!e.evaluator_version_id ||
+            r.evaluator_version_id === e.evaluator_version_id) &&
+          r.status === "completed",
+      ),
+    );
+  };
+
+  return (
+    <AppLayout
+      activeItem="human-labelling"
+      onItemChange={(id) => router.push(`/${id}`)}
+      sidebarOpen={sidebarOpen}
+      onSidebarToggle={() => setSidebarOpen(!sidebarOpen)}
+    >
+      <div className="py-4 md:py-6 space-y-4">
+        <button
+          onClick={() =>
+            router.push(`/human-labelling/tasks/${taskUuid}?tab=runs`)
+          }
+          className="text-sm text-muted-foreground hover:text-foreground transition-colors cursor-pointer flex items-center gap-1.5"
+        >
+          <svg
+            className="w-4 h-4"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            strokeWidth={2}
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              d="M15 19l-7-7 7-7"
+            />
+          </svg>
+          Back to evaluation runs
+        </button>
+
+        {loading && !job && (
+          <div className="flex items-center justify-center gap-2 py-8 text-sm text-muted-foreground">
+            <svg
+              className="w-4 h-4 animate-spin"
+              fill="none"
+              viewBox="0 0 24 24"
+            >
+              <circle
+                className="opacity-25"
+                cx="12"
+                cy="12"
+                r="10"
+                stroke="currentColor"
+                strokeWidth="4"
+              />
+              <path
+                className="opacity-75"
+                fill="currentColor"
+                d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+              />
+            </svg>
+            Loading run
+          </div>
+        )}
+
+        {error && (
+          <div className="rounded-md border border-red-500/30 bg-red-500/10 px-3 py-2 text-sm text-red-500">
+            {error}
+          </div>
+        )}
+
+        {job && task && (task.type === "stt" || task.type === "llm" || task.type === "simulation") ? (
+          <>
+            <div>
+              <span
+                className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium border ${statusPillClass(
+                  job.status,
+                )}`}
+              >
+                {statusLabel(job.status)}
+              </span>
+            </div>
+            <div className="flex items-center gap-2 flex-wrap min-w-0">
+              {(job.details?.evaluators ?? []).length === 0 ? (
+                <span className="text-sm text-muted-foreground">—</span>
+              ) : (
+                (job.details?.evaluators ?? []).map((e) => {
+                  const name = e.name || e.evaluator_id.slice(0, 8);
+                  const label = e.evaluator_version_id
+                    ? versionLabels[e.evaluator_version_id]
+                    : null;
+                  return (
+                    <Link
+                      key={`${e.evaluator_id}-${e.evaluator_version_id ?? ""}`}
+                      href={`/evaluators/${e.evaluator_id}`}
+                      title={`Open ${name}`}
+                      className="inline-flex items-center gap-1 px-2 py-0.5 rounded-md text-sm font-semibold border border-border bg-muted/40 text-foreground hover:bg-muted hover:border-foreground/30 transition-colors cursor-pointer"
+                    >
+                      <span className="truncate max-w-[200px]">{name}</span>
+                      {label && (
+                        <span className="font-mono text-[11px] text-muted-foreground">
+                          {label}
+                        </span>
+                      )}
+                    </Link>
+                  );
+                })
+              )}
+            </div>
+
+          <div className="border border-border rounded-xl overflow-hidden">
+            <div className="flex flex-col flex-1 min-h-0">
+              <header className="border-b border-border px-4 md:px-6 py-3 flex items-center justify-center gap-2">
+                <button
+                  onClick={() =>
+                    setCurrentIndex(Math.max(0, currentIndex - 1))
+                  }
+                  disabled={currentIndex === 0 || total === 0}
+                  className="h-9 px-3 rounded-md text-sm font-medium border border-border bg-background hover:bg-muted/50 transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+                >
+                  Previous
+                </button>
+                <span className="text-sm text-muted-foreground tabular-nums px-2">
+                  Item {Math.min(currentIndex + 1, Math.max(total, 1))} of{" "}
+                  {total}
+                </span>
+                <button
+                  onClick={() =>
+                    setCurrentIndex(Math.min(total - 1, currentIndex + 1))
+                  }
+                  disabled={currentIndex >= total - 1 || total === 0}
+                  className="h-9 px-3 rounded-md text-sm font-medium border border-border bg-background hover:bg-muted/50 transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+                >
+                  Next
+                </button>
+              </header>
+
+              <div className="flex flex-col md:flex-row min-h-0">
+                <aside className="w-full md:w-20 border-b md:border-b-0 md:border-r border-border bg-muted/20 overflow-y-auto">
+                  <div className="p-2 md:p-3 grid grid-cols-8 md:grid-cols-1 gap-2">
+                    {itemsForRun.map((it, i) => {
+                      const done = itemDone(it.uuid);
+                      const isCurrent = i === safeIndex;
+                      return (
+                        <button
+                          key={it.uuid}
+                          onClick={() => setCurrentIndex(i)}
+                          title={`Item ${i + 1}${done ? " (completed)" : ""}`}
+                          className={`h-10 w-full rounded-md border text-sm font-medium transition-colors cursor-pointer flex items-center justify-center ${
+                            isCurrent
+                              ? "border-foreground bg-foreground text-background"
+                              : done
+                                ? "border-blue-200 bg-blue-100 text-blue-700 dark:border-blue-500/30 dark:bg-blue-500/20 dark:text-blue-400"
+                                : "border-border bg-background text-foreground hover:bg-muted/50"
+                          }`}
+                        >
+                          {i + 1}
+                        </button>
+                      );
+                    })}
+                  </div>
+                </aside>
+
+                <main className="flex-1 overflow-y-auto">
+                  {!currentItem ? (
+                    <div className="flex items-center justify-center h-full p-8 text-sm text-muted-foreground">
+                      No items in this run.
+                    </div>
+                  ) : (
+                    <div className="p-4 md:p-6 grid grid-cols-1 md:grid-cols-2 gap-4 md:gap-6">
+                      <ItemPane item={currentItem} taskType={task.type} />
+                      <EvaluatorResultsPane
+                        evaluators={job.details?.evaluators ?? []}
+                        runs={runsByItem[currentItem.uuid] ?? []}
+                        versionLabels={versionLabels}
+                        jobStatus={job.status}
+                      />
+                    </div>
+                  )}
+                </main>
+              </div>
+            </div>
+          </div>
+          </>
+        ) : null}
+
+        {job && job.status === "failed" && job.error && (
+          <div className="border border-red-500/30 bg-red-500/10 rounded-xl p-4">
+            <h2 className="text-sm font-semibold text-red-600 dark:text-red-400 mb-2">
+              Run failed
+            </h2>
+            <pre className="text-xs font-mono text-red-700 dark:text-red-300 whitespace-pre-wrap break-words">
+              {job.error}
+            </pre>
+          </div>
+        )}
+      </div>
+    </AppLayout>
+  );
+}
+
+function EvaluatorResultsPane({
+  evaluators,
+  runs,
+  versionLabels,
+  jobStatus,
+}: {
+  evaluators: {
+    evaluator_id: string;
+    evaluator_version_id?: string;
+    name?: string;
+  }[];
+  runs: EvaluatorRunRow[];
+  versionLabels: Record<string, string>;
+  jobStatus: EvaluatorRunJob["status"];
+}) {
+  if (evaluators.length === 0) {
+    return (
+      <div className="border border-border rounded-xl p-4 text-sm text-muted-foreground">
+        No evaluators in this run.
+      </div>
+    );
+  }
+  return (
+    <div className="space-y-3">
+      {evaluators.map((ev) => {
+        const versionLabel = ev.evaluator_version_id
+          ? versionLabels[ev.evaluator_version_id]
+          : null;
+        const r = runs.find(
+          (x) =>
+            x.evaluator_id === ev.evaluator_id &&
+            (!ev.evaluator_version_id ||
+              x.evaluator_version_id === ev.evaluator_version_id),
+        );
+        const value = r?.value?.value;
+        const reasoning =
+          typeof r?.value?.reasoning === "string"
+            ? (r.value.reasoning as string)
+            : "";
+        return (
+          <div
+            key={`${ev.evaluator_id}-${ev.evaluator_version_id ?? ""}`}
+            className="border border-border rounded-xl p-4 space-y-3"
+          >
+            <div className="flex items-start justify-between gap-3 min-w-0">
+              <div className="min-w-0 flex items-center gap-2 flex-wrap">
+                <h3 className="text-sm font-semibold truncate">
+                  {ev.name || ev.evaluator_id.slice(0, 8)}
+                </h3>
+                {versionLabel && (
+                  <span className="font-mono text-[10px] px-1.5 py-0.5 rounded-md border border-border bg-muted/40 text-muted-foreground">
+                    {versionLabel}
+                  </span>
+                )}
+              </div>
+            </div>
+
+            {r ? (
+              <>
+                <div className="flex items-center gap-2">
+                  <span
+                    className={`inline-flex items-center px-2.5 py-1 rounded-md text-sm font-medium border ${valuePillClass(
+                      value,
+                    )}`}
+                  >
+                    {formatValueDisplay(value)}
+                  </span>
+                </div>
+                <div className="space-y-1.5">
+                  <div className="text-xs font-medium text-muted-foreground">
+                    Reasoning
+                  </div>
+                  <textarea
+                    value={reasoning}
+                    readOnly
+                    rows={2}
+                    className="w-full text-sm rounded-md border border-border bg-background px-3 py-2 resize-y focus:outline-none focus:ring-2 focus:ring-foreground/20"
+                  />
+                </div>
+              </>
+            ) : jobStatus === "in_progress" || jobStatus === "queued" ? (
+              <div className="flex items-center gap-3 py-1">
+                <svg
+                  className="w-5 h-5 animate-spin text-muted-foreground"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                >
+                  <circle
+                    className="opacity-25"
+                    cx="12"
+                    cy="12"
+                    r="10"
+                    stroke="currentColor"
+                    strokeWidth="4"
+                  />
+                  <path
+                    className="opacity-75"
+                    fill="currentColor"
+                    d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+                  />
+                </svg>
+                <p className="text-sm text-muted-foreground">
+                  Running evaluator
+                </p>
+              </div>
+            ) : (
+              <p className="text-xs text-muted-foreground">
+                No result for this item.
+              </p>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/app/human-labelling/tasks/[uuid]/layout.tsx
+++ b/src/app/human-labelling/tasks/[uuid]/layout.tsx
@@ -1,0 +1,13 @@
+import { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Labelling task | Calibrate",
+};
+
+export default function LabellingTaskLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return children;
+}

--- a/src/app/human-labelling/tasks/[uuid]/page.tsx
+++ b/src/app/human-labelling/tasks/[uuid]/page.tsx
@@ -938,7 +938,13 @@ function LabellingTaskPageInner() {
     setTaskSummaryLoading(true);
     setTaskSummaryError(null);
     try {
-      const qs = summaryLiveOnly ? "?live_only=true" : "";
+      // `live_only` only constrains the *overview* table; the items tab
+      // uses the same summary to decide which rows can show results, and
+      // there it should reflect every version — otherwise toggling the
+      // overview filter would also disable "View results" buttons on the
+      // items tab.
+      const useLiveOnly = activeTab === "overview" && summaryLiveOnly;
+      const qs = useLiveOnly ? "?live_only=true" : "";
       const data = await apiClient<TaskSummaryResponse>(
         `/annotation-tasks/${uuid}/summary${qs}`,
         accessToken,
@@ -949,7 +955,7 @@ function LabellingTaskPageInner() {
     } finally {
       setTaskSummaryLoading(false);
     }
-  }, [accessToken, uuid, summaryLiveOnly]);
+  }, [accessToken, uuid, activeTab, summaryLiveOnly]);
 
   useEffect(() => {
     if (activeTab === "overview" || activeTab === "items") fetchTaskSummary();
@@ -1754,35 +1760,59 @@ function LabellingTaskPageInner() {
                 </svg>
                 {taskType === "stt" ? "Add items" : "Add item"}
               </button>
-              <button
-                onClick={() => {
-                  if (taskType === "stt") {
-                    setBulkUploadSttOpen(true);
-                  } else if (taskType === "simulation") {
-                    setBulkUploadSimulationOpen(true);
-                  } else if (taskType === "llm") {
-                    setBulkUploadLlmOpen(true);
-                  } else {
-                    toast.info("CSV upload isn't supported yet — coming soon.");
-                  }
-                }}
-                className="h-9 px-3 rounded-md text-sm font-medium bg-foreground text-background hover:opacity-90 transition-opacity cursor-pointer flex items-center gap-1.5"
-              >
-                <svg
-                  className="w-4 h-4"
-                  fill="none"
-                  viewBox="0 0 24 24"
-                  stroke="currentColor"
-                  strokeWidth={2}
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5m-13.5-9L12 3m0 0l4.5 4.5M12 3v13.5"
-                  />
-                </svg>
-                Bulk upload
-              </button>
+              {(() => {
+                // LLM bulk upload references evaluators by name in the
+                // CSV; without any linked evaluators the validator will
+                // reject every row. Disable the button instead.
+                const llmNoEvaluators =
+                  taskType === "llm" && (task?.evaluators?.length ?? 0) === 0;
+                const buttonEl = (
+                  <button
+                    onClick={() => {
+                      if (llmNoEvaluators) return;
+                      if (taskType === "stt") {
+                        setBulkUploadSttOpen(true);
+                      } else if (taskType === "simulation") {
+                        setBulkUploadSimulationOpen(true);
+                      } else if (taskType === "llm") {
+                        setBulkUploadLlmOpen(true);
+                      } else {
+                        toast.info(
+                          "CSV upload isn't supported yet — coming soon.",
+                        );
+                      }
+                    }}
+                    disabled={llmNoEvaluators}
+                    className={`h-9 px-3 rounded-md text-sm font-medium bg-foreground text-background flex items-center gap-1.5 transition-opacity ${
+                      llmNoEvaluators
+                        ? "opacity-50 cursor-not-allowed"
+                        : "hover:opacity-90 cursor-pointer"
+                    }`}
+                  >
+                    <svg
+                      className="w-4 h-4"
+                      fill="none"
+                      viewBox="0 0 24 24"
+                      stroke="currentColor"
+                      strokeWidth={2}
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5m-13.5-9L12 3m0 0l4.5 4.5M12 3v13.5"
+                      />
+                    </svg>
+                    Bulk upload
+                  </button>
+                );
+                return llmNoEvaluators ? (
+                  <Tooltip content="Link at least one evaluator to this task before bulk uploading">
+                    {buttonEl}
+                  </Tooltip>
+                ) : (
+                  buttonEl
+                );
+              })()}
             </div>
           )}
         </div>

--- a/src/app/human-labelling/tasks/[uuid]/page.tsx
+++ b/src/app/human-labelling/tasks/[uuid]/page.tsx
@@ -1,6 +1,13 @@
 "use client";
 
-import { Suspense, useCallback, useEffect, useState } from "react";
+import {
+  Fragment,
+  Suspense,
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
 import Link from "next/link";
 import { useParams, useRouter, useSearchParams } from "next/navigation";
 import { toast } from "sonner";
@@ -16,16 +23,17 @@ import { EvaluatorTypePill } from "@/components/EvaluatorPills";
 import { Tooltip } from "@/components/Tooltip";
 import { DeleteConfirmationDialog } from "@/components/DeleteConfirmationDialog";
 import { AddSttItemsDialog } from "@/components/human-labelling/AddSttItemsDialog";
+import { BulkUploadSttItemsDialog } from "@/components/human-labelling/BulkUploadSttItemsDialog";
+import { BulkUploadSimulationItemsDialog } from "@/components/human-labelling/BulkUploadSimulationItemsDialog";
+import { BulkUploadLlmItemsDialog } from "@/components/human-labelling/BulkUploadLlmItemsDialog";
 import { AssignAnnotatorsDialog } from "@/components/human-labelling/AssignAnnotatorsDialog";
 import { EditTaskDialog } from "@/components/human-labelling/EditTaskDialog";
-import {
-  ItemResultsDialog,
-} from "@/components/human-labelling/ItemResultsDialog";
 import {
   JobsCreatedDialog,
   type CreatedJob,
 } from "@/components/human-labelling/JobsCreatedDialog";
 import { ManageEvaluatorsDialog } from "@/components/human-labelling/ManageEvaluatorsDialog";
+import { RunEvaluatorsDialog } from "@/components/human-labelling/RunEvaluatorsDialog";
 import { EmptyState } from "@/components/ui/LoadingState";
 import {
   MultiSelectPicker,
@@ -87,18 +95,26 @@ type TaskSummaryResponse = {
   rows: SummaryRow[];
 };
 
-function formatVerdictValue(
-  v: boolean | number | null | undefined,
-): string {
+// A summary row is "empty" when no value column has anything to show:
+// no evaluator value, no agreement scores, and no annotator label.
+function summaryRowHasAnyValue(r: SummaryRow): boolean {
+  if (r.evaluator_value !== null) return true;
+  if (r.human_agreement !== null) return true;
+  if (r.evaluator_agreement !== null) return true;
+  for (const v of Object.values(r.annotations ?? {})) {
+    if (v && v.value !== null && v.value !== undefined) return true;
+  }
+  return false;
+}
+
+function formatVerdictValue(v: boolean | number | null | undefined): string {
   if (v === null || v === undefined) return "—";
   if (typeof v === "boolean") return v ? "Correct" : "Wrong";
   if (typeof v === "number") return String(v);
   return "—";
 }
 
-function verdictTextClass(
-  v: boolean | number | null | undefined,
-): string {
+function verdictTextClass(v: boolean | number | null | undefined): string {
   if (v === null || v === undefined) return "text-muted-foreground";
   if (v === true) return "text-green-600 dark:text-green-400";
   if (v === false) return "text-red-600 dark:text-red-400";
@@ -127,9 +143,7 @@ function AgreementStatCard({
       <div className="text-[10px] uppercase tracking-wide text-muted-foreground">
         {label}
       </div>
-      <div
-        className={`text-2xl font-semibold tabular-nums ${valueClassName}`}
-      >
+      <div className={`text-2xl font-semibold tabular-nums ${valueClassName}`}>
         {value}
       </div>
     </div>
@@ -330,11 +344,7 @@ function EvaluatorRunsList({
   if (loading) {
     return (
       <div className="flex items-center justify-center gap-2 py-8 text-sm text-muted-foreground">
-        <svg
-          className="w-4 h-4 animate-spin"
-          fill="none"
-          viewBox="0 0 24 24"
-        >
+        <svg className="w-4 h-4 animate-spin" fill="none" viewBox="0 0 24 24">
           <circle
             className="opacity-25"
             cx="12"
@@ -411,7 +421,10 @@ function EvaluatorRunsList({
         const evaluatorTitle = evaluators
           .map((e) => {
             const name = e.name || e.evaluator_id.slice(0, 8);
-            const label = versionLabelFor(e.evaluator_id, e.evaluator_version_id);
+            const label = versionLabelFor(
+              e.evaluator_id,
+              e.evaluator_version_id,
+            );
             return label ? `${name} (${label})` : name;
           })
           .join(", ");
@@ -508,6 +521,9 @@ function ItemRowActions({
   onLabel,
   playDisabled,
   playLoadingForUuid,
+  isResultsOpen,
+  viewResultsDisabled,
+  viewResultsDisabledTooltip,
 }: {
   itemUuid: string;
   onDelete: (uuid: string) => void | Promise<void>;
@@ -516,6 +532,9 @@ function ItemRowActions({
   onLabel?: (uuid: string) => void;
   playDisabled?: boolean;
   playLoadingForUuid?: string | null;
+  isResultsOpen?: boolean;
+  viewResultsDisabled?: boolean;
+  viewResultsDisabledTooltip?: string;
 }) {
   const isLoading = playLoadingForUuid === itemUuid;
   return (
@@ -533,33 +552,79 @@ function ItemRowActions({
           Label
         </button>
       )}
-      {/* View results (analytics) */}
-      <button
-        type="button"
-        onClick={() => onViewResults(itemUuid)}
-        aria-label="View results"
-        className="h-8 px-3 inline-flex items-center gap-1.5 rounded-md text-sm font-semibold border border-fuchsia-500/40 bg-fuchsia-500/10 text-fuchsia-600 dark:text-fuchsia-400 hover:bg-fuchsia-500/20 hover:border-fuchsia-500/60 transition-colors cursor-pointer"
-      >
-        <svg
-          className="w-4 h-4"
-          fill="none"
-          viewBox="0 0 24 24"
-          stroke="currentColor"
-          strokeWidth={1.8}
+      {/* View / Hide results (toggle) */}
+      {viewResultsDisabled ? (
+        <Tooltip
+          content={
+            viewResultsDisabledTooltip ??
+            "Results can be seen once annotators label the data or evaluator is run for this item"
+          }
         >
-          <path
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            d="M2.036 12.322a1.012 1.012 0 010-.639C3.423 7.51 7.36 4.5 12 4.5c4.638 0 8.573 3.007 9.963 7.178.07.207.07.431 0 .639C20.577 16.49 16.64 19.5 12 19.5c-4.638 0-8.573-3.007-9.963-7.178z"
-          />
-          <path
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
-          />
-        </svg>
-        View results
-      </button>
+          <button
+            type="button"
+            disabled
+            aria-label="View results"
+            className="h-8 px-3 inline-flex items-center gap-1.5 rounded-md text-sm font-semibold border border-fuchsia-500/40 bg-fuchsia-500/10 text-fuchsia-600 dark:text-fuchsia-400 transition-colors disabled:opacity-50 cursor-not-allowed"
+          >
+            <svg
+              className="w-4 h-4"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              strokeWidth={1.8}
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M2.036 12.322a1.012 1.012 0 010-.639C3.423 7.51 7.36 4.5 12 4.5c4.638 0 8.573 3.007 9.963 7.178.07.207.07.431 0 .639C20.577 16.49 16.64 19.5 12 19.5c-4.638 0-8.573-3.007-9.963-7.178z"
+              />
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
+              />
+            </svg>
+            View results
+          </button>
+        </Tooltip>
+      ) : (
+        <button
+          type="button"
+          onClick={() => onViewResults(itemUuid)}
+          aria-label={isResultsOpen ? "Hide results" : "View results"}
+          className="h-8 px-3 inline-flex items-center gap-1.5 rounded-md text-sm font-semibold border border-fuchsia-500/40 bg-fuchsia-500/10 text-fuchsia-600 dark:text-fuchsia-400 hover:bg-fuchsia-500/20 hover:border-fuchsia-500/60 transition-colors cursor-pointer"
+        >
+          <svg
+            className="w-4 h-4"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            strokeWidth={1.8}
+          >
+            {isResultsOpen ? (
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M3.98 8.223A10.477 10.477 0 001.934 12C3.226 16.338 7.244 19.5 12 19.5c.993 0 1.953-.138 2.863-.395M6.228 6.228A10.45 10.45 0 0112 4.5c4.756 0 8.773 3.162 10.065 7.498a10.523 10.523 0 01-4.293 5.774M6.228 6.228L3 3m3.228 3.228l3.65 3.65m7.894 7.894L21 21m-3.228-3.228l-3.65-3.65m0 0a3 3 0 10-4.243-4.243m4.242 4.242L9.88 9.88"
+              />
+            ) : (
+              <>
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M2.036 12.322a1.012 1.012 0 010-.639C3.423 7.51 7.36 4.5 12 4.5c4.638 0 8.573 3.007 9.963 7.178.07.207.07.431 0 .639C20.577 16.49 16.64 19.5 12 19.5c-4.638 0-8.573-3.007-9.963-7.178z"
+                />
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
+                />
+              </>
+            )}
+          </svg>
+          {isResultsOpen ? "Hide results" : "View results"}
+        </button>
+      )}
       {/* Run evaluators */}
       <button
         type="button"
@@ -853,9 +918,7 @@ function LabellingTaskPageInner() {
     null,
   );
   const [taskSummaryLoading, setTaskSummaryLoading] = useState(false);
-  const [taskSummaryError, setTaskSummaryError] = useState<string | null>(
-    null,
-  );
+  const [taskSummaryError, setTaskSummaryError] = useState<string | null>(null);
   const [summaryEvaluatorFilter, setSummaryEvaluatorFilter] = useState<
     PickerItem[]
   >([]);
@@ -864,17 +927,20 @@ function LabellingTaskPageInner() {
   const [summarySortColKey, setSummarySortColKey] = useState<string | null>(
     null,
   );
-  const [summarySortDir, setSummarySortDir] = useState<"asc" | "desc">(
-    "desc",
-  );
+  const [summarySortDir, setSummarySortDir] = useState<"asc" | "desc">("desc");
+  // Toggle next to the evaluator filter that constrains the summary table
+  // to each evaluator's live version. Sent as ?live_only=true on the
+  // /summary endpoint when checked.
+  const [summaryLiveOnly, setSummaryLiveOnly] = useState(true);
 
   const fetchTaskSummary = useCallback(async () => {
     if (!accessToken || !uuid) return;
     setTaskSummaryLoading(true);
     setTaskSummaryError(null);
     try {
+      const qs = summaryLiveOnly ? "?live_only=true" : "";
       const data = await apiClient<TaskSummaryResponse>(
-        `/annotation-tasks/${uuid}/summary`,
+        `/annotation-tasks/${uuid}/summary${qs}`,
         accessToken,
       );
       setTaskSummary(data);
@@ -883,11 +949,23 @@ function LabellingTaskPageInner() {
     } finally {
       setTaskSummaryLoading(false);
     }
-  }, [accessToken, uuid]);
+  }, [accessToken, uuid, summaryLiveOnly]);
 
   useEffect(() => {
-    if (activeTab === "overview") fetchTaskSummary();
+    if (activeTab === "overview" || activeTab === "items") fetchTaskSummary();
   }, [activeTab, fetchTaskSummary]);
+
+  // Set of item uuids that have at least one summary row with a value
+  // worth displaying. Used to disable the per-item "View results" button
+  // when there's nothing to show.
+  const itemsWithResults = useMemo(() => {
+    const set = new Set<string>();
+    if (!taskSummary) return set;
+    for (const row of taskSummary.rows) {
+      if (summaryRowHasAnyValue(row)) set.add(row.item_id);
+    }
+    return set;
+  }, [taskSummary]);
   // Map evaluator_id -> { version_id: "v1" }, populated on demand from
   // /evaluators/{uuid}/versions so we can label runs by version number.
   const [versionLabels, setVersionLabels] = useState<
@@ -1003,9 +1081,17 @@ function LabellingTaskPageInner() {
   const [startingRunForItem, setStartingRunForItem] = useState<string | null>(
     null,
   );
-  const handleRunEvaluators = async (
-    itemUuids?: string[] | string,
-  ) => {
+  // Run evaluators dialog state. itemUuids: null = all items in task,
+  // []/non-empty = the specific items to run for.
+  const [runDialogOpen, setRunDialogOpen] = useState(false);
+  const [runDialogItemUuids, setRunDialogItemUuids] = useState<string[] | null>(
+    null,
+  );
+  const [runDialogSubmitError, setRunDialogSubmitError] = useState<
+    string | null
+  >(null);
+
+  const handleRunEvaluators = (itemUuids?: string[] | string) => {
     if (!accessToken || !uuid || startingRun) return;
     const linked = task?.evaluators ?? [];
     if (linked.length === 0) {
@@ -1017,14 +1103,21 @@ function LabellingTaskPageInner() {
       : itemUuids
         ? [itemUuids]
         : null;
+    setRunDialogItemUuids(ids);
+    setRunDialogSubmitError(null);
+    setRunDialogOpen(true);
+  };
+
+  const submitRunEvaluators = async (
+    selections: { evaluator_id: string; evaluator_version_id: string }[],
+  ) => {
+    if (!accessToken || !uuid || startingRun) return;
+    const ids = runDialogItemUuids;
     setStartingRun(true);
-    setStartingRunForItem(
-      ids && ids.length === 1 ? ids[0] : null,
-    );
+    setStartingRunForItem(ids && ids.length === 1 ? ids[0] : null);
+    setRunDialogSubmitError(null);
     try {
-      const body: Record<string, unknown> = {
-        evaluators: linked.map((e) => ({ evaluator_id: e.uuid })),
-      };
+      const body: Record<string, unknown> = { evaluators: selections };
       if (ids && ids.length > 0) body.item_ids = ids;
       const result = await apiClient<{
         job_uuid: string;
@@ -1035,11 +1128,14 @@ function LabellingTaskPageInner() {
         method: "POST",
         body,
       });
+      setRunDialogOpen(false);
       router.push(
         `/human-labelling/tasks/${uuid}/evaluator-runs/${result.job_uuid}`,
       );
     } catch (err) {
-      toast.error(parseApiError(err, "Failed to start evaluation run"));
+      const msg = parseApiError(err, "Failed to start evaluation run");
+      setRunDialogSubmitError(msg);
+      toast.error(msg);
       setStartingRun(false);
       setStartingRunForItem(null);
     }
@@ -1307,8 +1403,175 @@ function LabellingTaskPageInner() {
 
   const [createdJobs, setCreatedJobs] = useState<CreatedJob[]>([]);
   const [jobsCreatedOpen, setJobsCreatedOpen] = useState(false);
-  const [resultsForItemUuid, setResultsForItemUuid] = useState<string | null>(
-    null,
+  // Inline expanded "results" panel below an item row. Backed by a
+  // per-item GET /summary?item_id=<uuid> fetch, cached by item uuid so
+  // toggling open the same row twice doesn't re-fetch.
+  const [expandedResultsItemId, setExpandedResultsItemId] = useState<
+    string | null
+  >(null);
+  const [itemSummaryByUuid, setItemSummaryByUuid] = useState<
+    Record<string, TaskSummaryResponse>
+  >({});
+  const [itemSummaryLoadingId, setItemSummaryLoadingId] = useState<
+    string | null
+  >(null);
+  const [itemSummaryError, setItemSummaryError] = useState<string | null>(null);
+
+  const renderItemResultsExpansion = (itemUuid: string) => {
+    const summary = itemSummaryByUuid[itemUuid];
+    if (itemSummaryLoadingId === itemUuid && !summary) {
+      return (
+        <div className="flex items-center gap-2 text-sm text-muted-foreground py-2">
+          <svg className="w-4 h-4 animate-spin" fill="none" viewBox="0 0 24 24">
+            <circle
+              className="opacity-25"
+              cx="12"
+              cy="12"
+              r="10"
+              stroke="currentColor"
+              strokeWidth="4"
+            />
+            <path
+              className="opacity-75"
+              fill="currentColor"
+              d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+            />
+          </svg>
+          Loading results
+        </div>
+      );
+    }
+    if (itemSummaryError && !summary) {
+      return <p className="text-sm text-red-500">{itemSummaryError}</p>;
+    }
+    const visibleRows = summary?.rows.filter(summaryRowHasAnyValue) ?? [];
+    if (!summary || visibleRows.length === 0) {
+      return (
+        <p className="text-sm text-muted-foreground">
+          No results recorded for this item yet.
+        </p>
+      );
+    }
+    const annotators = summary.annotators ?? [];
+    const evalColTpl = "minmax(180px,1fr) 170px 170px 140px";
+    const annotatorColTpl =
+      annotators.length > 0 ? annotators.map(() => "120px").join(" ") : "";
+    const gridTemplate = [evalColTpl, annotatorColTpl]
+      .filter(Boolean)
+      .join(" ");
+    return (
+      <div className="border border-border rounded-xl overflow-hidden bg-background">
+        <div
+          className="grid gap-4 px-4 py-2 border-b border-border bg-muted/30 items-center min-w-fit"
+          style={{ gridTemplateColumns: gridTemplate }}
+        >
+          <div className="text-sm font-medium text-muted-foreground">
+            Evaluator
+          </div>
+          <div className="text-sm font-medium text-muted-foreground whitespace-nowrap">
+            Annotator agreement
+          </div>
+          <div className="text-sm font-medium text-muted-foreground whitespace-nowrap">
+            Evaluator agreement
+          </div>
+          <div className="text-sm font-medium text-muted-foreground">
+            Evaluator value
+          </div>
+          {annotators.map((a) => (
+            <div
+              key={a.uuid}
+              className="text-sm font-medium text-muted-foreground truncate"
+              title={a.name}
+            >
+              {a.name}
+            </div>
+          ))}
+        </div>
+        {visibleRows.map((row, idx) => {
+          const versionLabel =
+            typeof row.evaluator_version_number === "number"
+              ? `v${row.evaluator_version_number}`
+              : null;
+          return (
+            <div
+              key={`${row.evaluator_id}-${row.evaluator_version_id ?? ""}-${idx}`}
+              className="grid gap-4 px-4 py-3 border-b border-border last:border-b-0 items-center min-w-fit"
+              style={{ gridTemplateColumns: gridTemplate }}
+            >
+              <div className="flex items-center gap-2 min-w-0">
+                <Link
+                  href={`/evaluators/${row.evaluator_id}`}
+                  title={`Open ${row.evaluator_name}`}
+                  className="inline-flex items-center px-2 py-0.5 rounded-md text-xs font-medium border border-border bg-muted/40 text-foreground hover:bg-muted hover:border-foreground/30 transition-colors cursor-pointer truncate max-w-full"
+                >
+                  <span className="truncate">{row.evaluator_name}</span>
+                </Link>
+                {versionLabel && (
+                  <span className="font-mono text-[10px] px-1.5 py-0.5 rounded-md border border-foreground/20 bg-background text-foreground flex-shrink-0">
+                    {versionLabel}
+                  </span>
+                )}
+              </div>
+              <div
+                className={`text-sm font-semibold tabular-nums ${agreementColor(row.human_agreement)}`}
+              >
+                {row.human_agreement != null
+                  ? `${Math.round(row.human_agreement * 100)}%`
+                  : "—"}
+              </div>
+              <div
+                className={`text-sm font-semibold tabular-nums ${agreementColor(row.evaluator_agreement)}`}
+              >
+                {row.evaluator_agreement != null
+                  ? `${Math.round(row.evaluator_agreement * 100)}%`
+                  : "—"}
+              </div>
+              <div
+                className={`text-sm font-medium tabular-nums ${verdictTextClass(row.evaluator_value)}`}
+              >
+                {formatVerdictValue(row.evaluator_value)}
+              </div>
+              {annotators.map((a) => {
+                const v = row.annotations?.[a.uuid] ?? null;
+                return (
+                  <div
+                    key={a.uuid}
+                    className={`text-sm font-medium tabular-nums ${verdictTextClass(v?.value ?? null)}`}
+                  >
+                    {formatVerdictValue(v?.value ?? null)}
+                  </div>
+                );
+              })}
+            </div>
+          );
+        })}
+      </div>
+    );
+  };
+
+  const toggleItemResults = useCallback(
+    async (itemUuid: string) => {
+      if (expandedResultsItemId === itemUuid) {
+        setExpandedResultsItemId(null);
+        return;
+      }
+      setExpandedResultsItemId(itemUuid);
+      setItemSummaryError(null);
+      if (itemSummaryByUuid[itemUuid] || !accessToken || !uuid) return;
+      setItemSummaryLoadingId(itemUuid);
+      try {
+        const data = await apiClient<TaskSummaryResponse>(
+          `/annotation-tasks/${uuid}/summary?item_id=${encodeURIComponent(itemUuid)}`,
+          accessToken,
+        );
+        setItemSummaryByUuid((prev) => ({ ...prev, [itemUuid]: data }));
+      } catch (err) {
+        setItemSummaryError(parseApiError(err, "Failed to load results"));
+      } finally {
+        setItemSummaryLoadingId((id) => (id === itemUuid ? null : id));
+      }
+    },
+    [expandedResultsItemId, itemSummaryByUuid, accessToken, uuid],
   );
 
   const handleAssignAnnotators = async (annotatorIds: string[]) => {
@@ -1336,6 +1599,10 @@ function LabellingTaskPageInner() {
   const [editOpen, setEditOpen] = useState(false);
   const [addItemOpen, setAddItemOpen] = useState(false);
   const [addSttItemsOpen, setAddSttItemsOpen] = useState(false);
+  const [bulkUploadSttOpen, setBulkUploadSttOpen] = useState(false);
+  const [bulkUploadSimulationOpen, setBulkUploadSimulationOpen] =
+    useState(false);
+  const [bulkUploadLlmOpen, setBulkUploadLlmOpen] = useState(false);
   const [newItemName, setNewItemName] = useState("");
   const [creatingItem, setCreatingItem] = useState(false);
   const [createItemError, setCreateItemError] = useState<string | null>(null);
@@ -1392,30 +1659,30 @@ function LabellingTaskPageInner() {
             {task && (
               <div className="flex flex-wrap items-center gap-1.5 mt-3">
                 <Tooltip content="Manage evaluators" position="top">
-                <button
-                  onClick={() => setManageOpen(true)}
-                  aria-label="Manage evaluators"
-                  className="inline-flex items-center justify-center px-1.5 py-0.5 rounded-md border border-border bg-muted/40 text-foreground hover:bg-muted hover:border-foreground/30 transition-colors cursor-pointer"
-                >
-                  <svg
-                    className="w-3 h-3"
-                    fill="none"
-                    viewBox="0 0 24 24"
-                    stroke="currentColor"
-                    strokeWidth={2}
+                  <button
+                    onClick={() => setManageOpen(true)}
+                    aria-label="Manage evaluators"
+                    className="inline-flex items-center justify-center px-1.5 py-0.5 rounded-md border border-border bg-muted/40 text-foreground hover:bg-muted hover:border-foreground/30 transition-colors cursor-pointer"
                   >
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      d="M10.343 3.94c.09-.542.56-.94 1.11-.94h1.093c.55 0 1.02.398 1.11.94l.149.894c.07.424.384.764.78.93.398.164.855.142 1.205-.108l.737-.527a1.125 1.125 0 011.45.12l.773.774c.39.389.44 1.002.12 1.45l-.527.737c-.25.35-.272.806-.107 1.204.165.397.505.71.93.78l.893.15c.543.09.94.56.94 1.109v1.094c0 .55-.397 1.02-.94 1.11l-.893.149c-.425.07-.765.383-.93.78-.165.398-.143.854.107 1.204l.527.738c.32.447.269 1.06-.12 1.45l-.774.773a1.125 1.125 0 01-1.449.12l-.738-.527c-.35-.25-.806-.272-1.203-.107-.397.165-.71.505-.781.929l-.149.894c-.09.542-.56.94-1.11.94h-1.094c-.55 0-1.019-.398-1.11-.94l-.148-.894c-.071-.424-.384-.764-.781-.93-.398-.164-.854-.142-1.204.108l-.738.527c-.447.32-1.06.269-1.45-.12l-.773-.774a1.125 1.125 0 01-.12-1.45l.527-.737c.25-.35.273-.806.108-1.204-.165-.397-.505-.71-.93-.78l-.894-.15c-.542-.09-.94-.56-.94-1.109v-1.094c0-.55.398-1.02.94-1.11l.894-.149c.424-.07.764-.383.929-.78.165-.398.143-.854-.107-1.204l-.527-.738a1.125 1.125 0 01.12-1.45l.773-.773a1.125 1.125 0 011.45-.12l.737.527c.35.25.807.272 1.204.107.397-.165.71-.505.78-.929l.15-.894z"
-                    />
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
-                    />
-                  </svg>
-                </button>
+                    <svg
+                      className="w-3 h-3"
+                      fill="none"
+                      viewBox="0 0 24 24"
+                      stroke="currentColor"
+                      strokeWidth={2}
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        d="M10.343 3.94c.09-.542.56-.94 1.11-.94h1.093c.55 0 1.02.398 1.11.94l.149.894c.07.424.384.764.78.93.398.164.855.142 1.205-.108l.737-.527a1.125 1.125 0 011.45.12l.773.774c.39.389.44 1.002.12 1.45l-.527.737c-.25.35-.272.806-.107 1.204.165.397.505.71.93.78l.893.15c.543.09.94.56.94 1.109v1.094c0 .55-.397 1.02-.94 1.11l-.893.149c-.425.07-.765.383-.93.78-.165.398-.143.854.107 1.204l.527.738c.32.447.269 1.06-.12 1.45l-.774.773a1.125 1.125 0 01-1.449.12l-.738-.527c-.35-.25-.806-.272-1.203-.107-.397.165-.71.505-.781.929l-.149.894c-.09.542-.56.94-1.11.94h-1.094c-.55 0-1.019-.398-1.11-.94l-.148-.894c-.071-.424-.384-.764-.781-.93-.398-.164-.854-.142-1.204.108l-.738.527c-.447.32-1.06.269-1.45-.12l-.773-.774a1.125 1.125 0 01-.12-1.45l.527-.737c.25-.35.273-.806.108-1.204-.165-.397-.505-.71-.93-.78l-.894-.15c-.542-.09-.94-.56-.94-1.109v-1.094c0-.55.398-1.02.94-1.11l.894-.149c.424-.07.764-.383.929-.78.165-.398.143-.854-.107-1.204l-.527-.738a1.125 1.125 0 01.12-1.45l.773-.773a1.125 1.125 0 011.45-.12l.737.527c.35.25.807.272 1.204.107.397-.165.71-.505.78-.929l.15-.894z"
+                      />
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
+                      />
+                    </svg>
+                  </button>
                 </Tooltip>
                 {(task.evaluators ?? []).map((ev) => (
                   <Link
@@ -1489,7 +1756,15 @@ function LabellingTaskPageInner() {
               </button>
               <button
                 onClick={() => {
-                  toast.info("CSV upload isn't supported yet — coming soon.");
+                  if (taskType === "stt") {
+                    setBulkUploadSttOpen(true);
+                  } else if (taskType === "simulation") {
+                    setBulkUploadSimulationOpen(true);
+                  } else if (taskType === "llm") {
+                    setBulkUploadLlmOpen(true);
+                  } else {
+                    toast.info("CSV upload isn't supported yet — coming soon.");
+                  }
                 }}
                 className="h-9 px-3 rounded-md text-sm font-medium bg-foreground text-background hover:opacity-90 transition-opacity cursor-pointer flex items-center gap-1.5"
               >
@@ -1506,7 +1781,7 @@ function LabellingTaskPageInner() {
                     d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5m-13.5-9L12 3m0 0l4.5 4.5M12 3v13.5"
                   />
                 </svg>
-                Upload CSV
+                Bulk upload
               </button>
             </div>
           )}
@@ -1604,9 +1879,10 @@ function LabellingTaskPageInner() {
                 title="No agreement data yet"
                 description={
                   <>
-                    Agreement will appear here once annotators
+                    Agreement between annotators and evaluators will appear here
+                    once annotators
                     <br />
-                    have labelled overlapping items
+                    start labelling and evaluators are run on the task items
                   </>
                 }
               />
@@ -1667,33 +1943,7 @@ function LabellingTaskPageInner() {
                 </svg>
                 Loading labels
               </div>
-            ) : !taskSummary || taskSummary.rows.length === 0 ? (
-              <EmptyState
-                icon={
-                  <svg
-                    className="w-7 h-7 text-muted-foreground"
-                    fill="none"
-                    viewBox="0 0 24 24"
-                    stroke="currentColor"
-                    strokeWidth={1.5}
-                  >
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      d="M9 12h3.75M9 15h3.75M9 18h3.75m3 .75H18a2.25 2.25 0 002.25-2.25V6.108c0-1.135-.845-2.098-1.976-2.192a48.424 48.424 0 00-1.123-.08m-5.801 0c-.065.21-.1.433-.1.664 0 .414.336.75.75.75h4.5a.75.75 0 00.75-.75 2.25 2.25 0 00-.1-.664m-5.8 0A2.251 2.251 0 0113.5 2.25H15c1.012 0 1.867.668 2.15 1.586m-5.8 0c-.376.023-.75.05-1.124.08C9.095 4.01 8.25 4.973 8.25 6.108V8.25m0 0H4.875c-.621 0-1.125.504-1.125 1.125v11.25c0 .621.504 1.125 1.125 1.125h9.75c.621 0 1.125-.504 1.125-1.125V9.375c0-.621-.504-1.125-1.125-1.125H8.25zM6.75 12h.008v.008H6.75V12zm0 3h.008v.008H6.75V15zm0 3h.008v.008H6.75V18z"
-                    />
-                  </svg>
-                }
-                title="No labels yet"
-                description={
-                  <>
-                    Detailed labels will appear here
-                    <br />
-                    once items have been evaluated and annotated
-                  </>
-                }
-              />
-            ) : (
+            ) : !taskSummary ? null : (
               (() => {
                 const annotators = taskSummary.annotators ?? [];
                 const evaluators = taskSummary.evaluators ?? [];
@@ -1743,10 +1993,14 @@ function LabellingTaskPageInner() {
                 const selectedEvaluatorIds = new Set(
                   summaryEvaluatorFilter.map((i) => i.uuid),
                 );
+                // Skip rows where everything is null — no evaluator run, no
+                // agreement signal, and no annotator has labelled yet.
+                const baseRows = taskSummary.rows.filter(summaryRowHasAnyValue);
+                if (baseRows.length === 0) return null;
                 const filteredRows =
                   selectedEvaluatorIds.size === 0
-                    ? taskSummary.rows
-                    : taskSummary.rows.filter((r) =>
+                    ? baseRows
+                    : baseRows.filter((r) =>
                         selectedEvaluatorIds.has(r.evaluator_id),
                       );
 
@@ -1784,9 +2038,7 @@ function LabellingTaskPageInner() {
 
                 const onSortClick = (key: string) => {
                   if (summarySortColKey === key) {
-                    setSummarySortDir((d) =>
-                      d === "desc" ? "asc" : "desc",
-                    );
+                    setSummarySortDir((d) => (d === "desc" ? "asc" : "desc"));
                   } else {
                     setSummarySortColKey(key);
                     setSummarySortDir("desc");
@@ -1834,156 +2086,192 @@ function LabellingTaskPageInner() {
 
                 return (
                   <>
-                    <div className="w-64">
-                      <MultiSelectPicker
-                        items={evaluators.map((ev) => ({
-                          uuid: ev.evaluator_id,
-                          name: ev.name,
-                        }))}
-                        selectedItems={summaryEvaluatorFilter}
-                        onSelectionChange={setSummaryEvaluatorFilter}
-                        placeholder="All evaluators"
-                        searchPlaceholder="Search evaluators..."
-                      />
+                    <div className="flex flex-wrap items-center gap-3">
+                      <div className="w-64">
+                        <MultiSelectPicker
+                          items={evaluators.map((ev) => ({
+                            uuid: ev.evaluator_id,
+                            name: ev.name,
+                          }))}
+                          selectedItems={summaryEvaluatorFilter}
+                          onSelectionChange={setSummaryEvaluatorFilter}
+                          placeholder="All evaluators"
+                          searchPlaceholder="Search evaluators..."
+                        />
+                      </div>
+                      <Tooltip content="Show results for only the live versions of each evaluator">
+                        <button
+                          type="button"
+                          onClick={() => setSummaryLiveOnly((v) => !v)}
+                          aria-pressed={summaryLiveOnly}
+                          className={`h-9 px-3 inline-flex items-center gap-1.5 rounded-md text-sm font-medium border transition-colors cursor-pointer ${
+                            summaryLiveOnly
+                              ? "bg-foreground text-background border-foreground"
+                              : "bg-transparent text-muted-foreground border-border hover:border-muted-foreground hover:text-foreground"
+                          }`}
+                        >
+                          {summaryLiveOnly ? (
+                            <svg
+                              className="w-3.5 h-3.5"
+                              fill="none"
+                              viewBox="0 0 24 24"
+                              stroke="currentColor"
+                              strokeWidth={2.5}
+                            >
+                              <path
+                                strokeLinecap="round"
+                                strokeLinejoin="round"
+                                d="M4.5 12.75l6 6 9-13.5"
+                              />
+                            </svg>
+                          ) : (
+                            <span
+                              className="inline-block w-1.5 h-1.5 rounded-full bg-muted-foreground"
+                              aria-hidden
+                            />
+                          )}
+                          Live versions only
+                        </button>
+                      </Tooltip>
                     </div>
                     <div className="border border-border rounded-xl overflow-x-auto">
-                    <div
-                      className="grid gap-4 px-4 py-2 border-b border-border bg-muted/30 items-center min-w-fit"
-                      style={{ gridTemplateColumns: gridTemplate }}
-                    >
-                      {itemColumns.map((c) => (
-                        <div
-                          key={c.key}
-                          className="text-sm font-medium text-muted-foreground truncate"
-                        >
-                          {c.label}
+                      <div
+                        className="grid gap-4 px-4 py-2 border-b border-border bg-muted/30 items-center min-w-fit"
+                        style={{ gridTemplateColumns: gridTemplate }}
+                      >
+                        {itemColumns.map((c) => (
+                          <div
+                            key={c.key}
+                            className="text-sm font-medium text-muted-foreground truncate"
+                          >
+                            {c.label}
+                          </div>
+                        ))}
+                        <div className="text-sm font-medium text-muted-foreground">
+                          Evaluator
                         </div>
-                      ))}
-                      <div className="text-sm font-medium text-muted-foreground">
-                        Evaluator
-                      </div>
-                      <button
-                        type="button"
-                        onClick={() => onSortClick("human_agreement")}
-                        className={`flex items-center gap-1 text-sm font-medium transition-colors cursor-pointer w-fit whitespace-nowrap ${
-                          summarySortColKey === "human_agreement"
-                            ? "text-foreground"
-                            : "text-muted-foreground hover:text-foreground"
-                        }`}
-                      >
-                        Annotator agreement
-                        {sortIndicator("human_agreement")}
-                      </button>
-                      <button
-                        type="button"
-                        onClick={() => onSortClick("evaluator_agreement")}
-                        className={`flex items-center gap-1 text-sm font-medium transition-colors cursor-pointer w-fit whitespace-nowrap ${
-                          summarySortColKey === "evaluator_agreement"
-                            ? "text-foreground"
-                            : "text-muted-foreground hover:text-foreground"
-                        }`}
-                      >
-                        Evaluator agreement
-                        {sortIndicator("evaluator_agreement")}
-                      </button>
-                      <button
-                        type="button"
-                        onClick={() => onSortClick("evaluator")}
-                        className={`flex items-center gap-1 text-sm font-medium transition-colors cursor-pointer w-fit ${
-                          summarySortColKey === "evaluator"
-                            ? "text-foreground"
-                            : "text-muted-foreground hover:text-foreground"
-                        }`}
-                      >
-                        Evaluator value
-                        {sortIndicator("evaluator")}
-                      </button>
-                      {annotators.map((a) => (
                         <button
-                          key={a.uuid}
                           type="button"
-                          onClick={() => onSortClick(a.uuid)}
-                          title={a.name}
-                          className={`flex items-center gap-1 text-sm font-medium transition-colors cursor-pointer w-fit truncate ${
-                            summarySortColKey === a.uuid
+                          onClick={() => onSortClick("human_agreement")}
+                          className={`flex items-center gap-1 text-sm font-medium transition-colors cursor-pointer w-fit whitespace-nowrap ${
+                            summarySortColKey === "human_agreement"
                               ? "text-foreground"
                               : "text-muted-foreground hover:text-foreground"
                           }`}
                         >
-                          <span className="truncate">{a.name}</span>
-                          {sortIndicator(a.uuid)}
+                          Annotator agreement
+                          {sortIndicator("human_agreement")}
                         </button>
-                      ))}
-                    </div>
-                    {sortedRows.map((row, idx) => {
-                      const cells = itemCellValues(row.payload);
-                      const versionLabel =
-                        typeof row.evaluator_version_number === "number"
-                          ? `v${row.evaluator_version_number}`
-                          : null;
-                      return (
-                        <div
-                          key={`${row.item_id}-${row.evaluator_id}-${row.evaluator_version_id ?? ""}-${idx}`}
-                          className="grid gap-4 px-4 py-3 border-b border-border last:border-b-0 items-center min-w-fit"
-                          style={{ gridTemplateColumns: gridTemplate }}
+                        <button
+                          type="button"
+                          onClick={() => onSortClick("evaluator_agreement")}
+                          className={`flex items-center gap-1 text-sm font-medium transition-colors cursor-pointer w-fit whitespace-nowrap ${
+                            summarySortColKey === "evaluator_agreement"
+                              ? "text-foreground"
+                              : "text-muted-foreground hover:text-foreground"
+                          }`}
                         >
-                          {cells.map((c, i) => (
-                            <p
-                              key={`item-${i}`}
-                              className="text-sm text-foreground line-clamp-2"
-                            >
-                              {c}
-                            </p>
-                          ))}
-                          <div className="flex items-center gap-2 min-w-0">
-                            <Link
-                              href={`/evaluators/${row.evaluator_id}`}
-                              title={`Open ${row.evaluator_name}`}
-                              className="inline-flex items-center px-2 py-0.5 rounded-md text-xs font-medium border border-border bg-muted/40 text-foreground hover:bg-muted hover:border-foreground/30 transition-colors cursor-pointer truncate max-w-full"
-                            >
-                              <span className="truncate">
-                                {row.evaluator_name}
-                              </span>
-                            </Link>
-                            {versionLabel && (
-                              <span className="font-mono text-[10px] px-1.5 py-0.5 rounded-md border border-foreground/20 bg-background text-foreground flex-shrink-0">
-                                {versionLabel}
-                              </span>
-                            )}
-                          </div>
-                          <div
-                            className={`text-sm font-semibold tabular-nums ${agreementColor(row.human_agreement)}`}
+                          Evaluator agreement
+                          {sortIndicator("evaluator_agreement")}
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => onSortClick("evaluator")}
+                          className={`flex items-center gap-1 text-sm font-medium transition-colors cursor-pointer w-fit ${
+                            summarySortColKey === "evaluator"
+                              ? "text-foreground"
+                              : "text-muted-foreground hover:text-foreground"
+                          }`}
+                        >
+                          Evaluator value
+                          {sortIndicator("evaluator")}
+                        </button>
+                        {annotators.map((a) => (
+                          <button
+                            key={a.uuid}
+                            type="button"
+                            onClick={() => onSortClick(a.uuid)}
+                            title={a.name}
+                            className={`flex items-center gap-1 text-sm font-medium transition-colors cursor-pointer w-fit truncate ${
+                              summarySortColKey === a.uuid
+                                ? "text-foreground"
+                                : "text-muted-foreground hover:text-foreground"
+                            }`}
                           >
-                            {row.human_agreement != null
-                              ? `${Math.round(row.human_agreement * 100)}%`
-                              : "—"}
-                          </div>
+                            <span className="truncate">{a.name}</span>
+                            {sortIndicator(a.uuid)}
+                          </button>
+                        ))}
+                      </div>
+                      {sortedRows.map((row, idx) => {
+                        const cells = itemCellValues(row.payload);
+                        const versionLabel =
+                          typeof row.evaluator_version_number === "number"
+                            ? `v${row.evaluator_version_number}`
+                            : null;
+                        return (
                           <div
-                            className={`text-sm font-semibold tabular-nums ${agreementColor(row.evaluator_agreement)}`}
+                            key={`${row.item_id}-${row.evaluator_id}-${row.evaluator_version_id ?? ""}-${idx}`}
+                            className="grid gap-4 px-4 py-3 border-b border-border last:border-b-0 items-center min-w-fit"
+                            style={{ gridTemplateColumns: gridTemplate }}
                           >
-                            {row.evaluator_agreement != null
-                              ? `${Math.round(row.evaluator_agreement * 100)}%`
-                              : "—"}
-                          </div>
-                          <div
-                            className={`text-sm font-medium tabular-nums ${verdictTextClass(row.evaluator_value)}`}
-                          >
-                            {formatVerdictValue(row.evaluator_value)}
-                          </div>
-                          {annotators.map((a) => {
-                            const v = row.annotations?.[a.uuid] ?? null;
-                            return (
-                              <div
-                                key={a.uuid}
-                                className={`text-sm font-medium tabular-nums ${verdictTextClass(v?.value ?? null)}`}
+                            {cells.map((c, i) => (
+                              <p
+                                key={`item-${i}`}
+                                className="text-sm text-foreground line-clamp-2"
                               >
-                                {formatVerdictValue(v?.value ?? null)}
-                              </div>
-                            );
-                          })}
-                        </div>
-                      );
-                    })}
+                                {c}
+                              </p>
+                            ))}
+                            <div className="flex items-center gap-2 min-w-0">
+                              <Link
+                                href={`/evaluators/${row.evaluator_id}`}
+                                title={`Open ${row.evaluator_name}`}
+                                className="inline-flex items-center px-2 py-0.5 rounded-md text-xs font-medium border border-border bg-muted/40 text-foreground hover:bg-muted hover:border-foreground/30 transition-colors cursor-pointer truncate max-w-full"
+                              >
+                                <span className="truncate">
+                                  {row.evaluator_name}
+                                </span>
+                              </Link>
+                              {versionLabel && (
+                                <span className="font-mono text-[10px] px-1.5 py-0.5 rounded-md border border-foreground/20 bg-background text-foreground flex-shrink-0">
+                                  {versionLabel}
+                                </span>
+                              )}
+                            </div>
+                            <div
+                              className={`text-sm font-semibold tabular-nums ${agreementColor(row.human_agreement)}`}
+                            >
+                              {row.human_agreement != null
+                                ? `${Math.round(row.human_agreement * 100)}%`
+                                : "—"}
+                            </div>
+                            <div
+                              className={`text-sm font-semibold tabular-nums ${agreementColor(row.evaluator_agreement)}`}
+                            >
+                              {row.evaluator_agreement != null
+                                ? `${Math.round(row.evaluator_agreement * 100)}%`
+                                : "—"}
+                            </div>
+                            <div
+                              className={`text-sm font-medium tabular-nums ${verdictTextClass(row.evaluator_value)}`}
+                            >
+                              {formatVerdictValue(row.evaluator_value)}
+                            </div>
+                            {annotators.map((a) => {
+                              const v = row.annotations?.[a.uuid] ?? null;
+                              return (
+                                <div
+                                  key={a.uuid}
+                                  className={`text-sm font-medium tabular-nums ${verdictTextClass(v?.value ?? null)}`}
+                                >
+                                  {formatVerdictValue(v?.value ?? null)}
+                                </div>
+                              );
+                            })}
+                          </div>
+                        );
+                      })}
                     </div>
                   </>
                 );
@@ -2076,10 +2364,7 @@ function LabellingTaskPageInner() {
                         const selected = Array.from(selectedItemIds);
                         // Omit item_ids when every item is selected; otherwise
                         // send the explicit subset.
-                        if (
-                          totalItems > 0 &&
-                          selected.length === totalItems
-                        ) {
+                        if (totalItems > 0 && selected.length === totalItems) {
                           handleRunEvaluators();
                         } else {
                           handleRunEvaluators(selected);
@@ -2163,36 +2448,47 @@ function LabellingTaskPageInner() {
                         ? p.predicted_transcript
                         : "";
                     const isSelected = selectedItemIds.has(item.uuid);
+                    const isResultsOpen = expandedResultsItemId === item.uuid;
                     return (
-                      <div
-                        key={item.uuid}
-                        className={`grid grid-cols-[40px_minmax(0,1fr)_minmax(0,1fr)_440px] gap-4 px-4 py-3 border-b border-border last:border-b-0 transition-colors items-center ${
-                          isSelected ? "bg-muted/30" : "hover:bg-muted/20"
-                        }`}
-                      >
-                        <input
-                          type="checkbox"
-                          checked={isSelected}
-                          onChange={() => toggleItem(item.uuid)}
-                          aria-label={`Select item ${item.id}`}
-                          className="w-4 h-4 cursor-pointer accent-foreground"
-                        />
-                        <p className="text-sm text-foreground line-clamp-2">
-                          {ref || "—"}
-                        </p>
-                        <p className="text-sm text-foreground line-clamp-2">
-                          {pred || "—"}
-                        </p>
-                        <ItemRowActions
-                          itemUuid={item.uuid}
-                          onDelete={requestDeleteOneItem}
-                          onPlay={handleRunEvaluators}
-                          onViewResults={setResultsForItemUuid}
-                          onLabel={toggleItem}
-                          playDisabled={startingRun}
-                          playLoadingForUuid={startingRunForItem}
-                        />
-                      </div>
+                      <Fragment key={item.uuid}>
+                        <div
+                          className={`grid grid-cols-[40px_minmax(0,1fr)_minmax(0,1fr)_440px] gap-4 px-4 py-3 border-b border-border last:border-b-0 transition-colors items-center ${
+                            isSelected ? "bg-muted/30" : "hover:bg-muted/20"
+                          }`}
+                        >
+                          <input
+                            type="checkbox"
+                            checked={isSelected}
+                            onChange={() => toggleItem(item.uuid)}
+                            aria-label={`Select item ${item.id}`}
+                            className="w-4 h-4 cursor-pointer accent-foreground"
+                          />
+                          <p className="text-sm text-foreground line-clamp-2">
+                            {ref || "—"}
+                          </p>
+                          <p className="text-sm text-foreground line-clamp-2">
+                            {pred || "—"}
+                          </p>
+                          <ItemRowActions
+                            itemUuid={item.uuid}
+                            onDelete={requestDeleteOneItem}
+                            onPlay={handleRunEvaluators}
+                            onViewResults={toggleItemResults}
+                            onLabel={toggleItem}
+                            playDisabled={startingRun}
+                            playLoadingForUuid={startingRunForItem}
+                            isResultsOpen={isResultsOpen}
+                            viewResultsDisabled={
+                              !!taskSummary && !itemsWithResults.has(item.uuid)
+                            }
+                          />
+                        </div>
+                        {isResultsOpen && (
+                          <div className="border-b border-border last:border-b-0 bg-muted/10 p-4">
+                            {renderItemResultsExpansion(item.uuid)}
+                          </div>
+                        )}
+                      </Fragment>
                     );
                   })}
                 </div>
@@ -2218,35 +2514,49 @@ function LabellingTaskPageInner() {
                   </div>
                   {items.map((item) => {
                     const isSelected = selectedItemIds.has(item.uuid);
+                    const isResultsOpen = expandedResultsItemId === item.uuid;
                     return (
-                      <div
-                        key={item.uuid}
-                        onClick={() => setEditLlmItemUuid(item.uuid)}
-                        className={`grid grid-cols-[40px_minmax(0,1fr)_440px] gap-4 px-4 py-3 border-b border-border last:border-b-0 transition-colors items-center cursor-pointer ${
-                          isSelected ? "bg-muted/30" : "hover:bg-muted/20"
-                        }`}
-                      >
-                        <input
-                          type="checkbox"
-                          checked={isSelected}
-                          onChange={() => toggleItem(item.uuid)}
-                          onClick={(e) => e.stopPropagation()}
-                          aria-label={`Select item ${item.id}`}
-                          className="w-4 h-4 cursor-pointer accent-foreground"
-                        />
-                        <p className="text-sm text-foreground line-clamp-1">
-                          {previewItemPayload(item.payload, taskType)}
-                        </p>
-                        <ItemRowActions
-                          itemUuid={item.uuid}
-                          onDelete={requestDeleteOneItem}
-                          onPlay={handleRunEvaluators}
-                          onViewResults={setResultsForItemUuid}
-                          onLabel={toggleItem}
-                          playDisabled={startingRun}
-                          playLoadingForUuid={startingRunForItem}
-                        />
-                      </div>
+                      <Fragment key={item.uuid}>
+                        <div
+                          onClick={() => setEditLlmItemUuid(item.uuid)}
+                          className={`grid grid-cols-[40px_minmax(0,1fr)_440px] gap-4 px-4 py-3 border-b border-border last:border-b-0 transition-colors items-center cursor-pointer ${
+                            isSelected ? "bg-muted/30" : "hover:bg-muted/20"
+                          }`}
+                        >
+                          <input
+                            type="checkbox"
+                            checked={isSelected}
+                            onChange={() => toggleItem(item.uuid)}
+                            onClick={(e) => e.stopPropagation()}
+                            aria-label={`Select item ${item.id}`}
+                            className="w-4 h-4 cursor-pointer accent-foreground"
+                          />
+                          <p className="text-sm text-foreground line-clamp-1">
+                            {previewItemPayload(item.payload, taskType)}
+                          </p>
+                          <ItemRowActions
+                            itemUuid={item.uuid}
+                            onDelete={requestDeleteOneItem}
+                            onPlay={handleRunEvaluators}
+                            onViewResults={toggleItemResults}
+                            onLabel={toggleItem}
+                            playDisabled={startingRun}
+                            playLoadingForUuid={startingRunForItem}
+                            isResultsOpen={isResultsOpen}
+                            viewResultsDisabled={
+                              !!taskSummary && !itemsWithResults.has(item.uuid)
+                            }
+                          />
+                        </div>
+                        {isResultsOpen && (
+                          <div
+                            className="border-b border-border last:border-b-0 bg-muted/10 p-4"
+                            onClick={(e) => e.stopPropagation()}
+                          >
+                            {renderItemResultsExpansion(item.uuid)}
+                          </div>
+                        )}
+                      </Fragment>
                     );
                   })}
                 </div>
@@ -2295,208 +2605,237 @@ function LabellingTaskPageInner() {
         )}
       </div>
 
+      {accessToken && (
+        <RunEvaluatorsDialog
+          isOpen={runDialogOpen}
+          accessToken={accessToken}
+          evaluators={(task?.evaluators ?? []).map((e) => ({
+            uuid: e.uuid,
+            name: e.name,
+          }))}
+          submitting={startingRun}
+          submitError={runDialogSubmitError}
+          onClose={() => {
+            if (!startingRun) {
+              setRunDialogOpen(false);
+              setRunDialogSubmitError(null);
+            }
+          }}
+          onConfirm={submitRunEvaluators}
+        />
+      )}
+
       {addItemOpen && (
-      <AddTestDialog
-        isOpen={addItemOpen}
-        onClose={() => {
-          if (!creatingItem) setAddItemOpen(false);
-        }}
-        isEditing={false}
-        isLoading={false}
-        isCreating={creatingItem}
-        createError={createItemError}
-        testName={newItemName}
-        setTestName={setNewItemName}
-        validationAttempted={validationAttempted}
-        mode="labelItem"
-        allowAgentLastMessage={taskType === "simulation"}
-        requireAssistantLastMessage={taskType === "llm"}
-        initialEvaluators={newItemInitialEvaluators}
-        onSubmit={async (
-          config: TestConfig,
-          evaluators: EvaluatorRefPayload[],
-        ) => {
-          setValidationAttempted(true);
-          if (!newItemName.trim()) return;
-          if (!accessToken) return;
+        <AddTestDialog
+          isOpen={addItemOpen}
+          onClose={() => {
+            if (!creatingItem) setAddItemOpen(false);
+          }}
+          isEditing={false}
+          isLoading={false}
+          isCreating={creatingItem}
+          createError={createItemError}
+          testName={newItemName}
+          setTestName={setNewItemName}
+          validationAttempted={validationAttempted}
+          mode="labelItem"
+          allowAgentLastMessage={taskType === "simulation"}
+          requireAssistantLastMessage={taskType === "llm"}
+          initialEvaluators={newItemInitialEvaluators}
+          onSubmit={async (
+            config: TestConfig,
+            evaluators: EvaluatorRefPayload[],
+          ) => {
+            setValidationAttempted(true);
+            if (!newItemName.trim()) return;
+            if (!accessToken) return;
 
-          // Preserve the rich TestConfig.history shape — assistant
-          // messages with `tool_calls`, and `tool` messages with their
-          // `tool_call_id` — the same shape tests are saved with. Drop
-          // only entries that have neither content nor tool_calls.
-          const history = (config.history ?? []).filter((h) => {
-            if (h.role === "assistant") {
-              if (Array.isArray(h.tool_calls) && h.tool_calls.length > 0)
-                return true;
-              return typeof h.content === "string" && h.content.length > 0;
-            }
-            if (h.role === "user") {
-              return typeof h.content === "string" && h.content.length > 0;
-            }
-            if (h.role === "tool") {
-              return typeof h.content === "string";
-            }
-            return false;
-          });
-
-          // Capture per-evaluator variable values entered in the dialog,
-          // keyed by evaluator uuid for easy lookup on edit.
-          const evaluator_variables: Record<
-            string,
-            Record<string, string>
-          > = {};
-          for (const e of evaluators) {
-            if (e.variable_values) {
-              evaluator_variables[e.evaluator_uuid] = { ...e.variable_values };
-            }
-          }
-
-          let payload: Record<string, unknown>;
-          if (taskType === "simulation") {
-            payload = {
-              name: newItemName.trim(),
-              transcript: history,
-              evaluator_variables,
-            };
-          } else {
-            // LLM: split the trailing plain agent reply (no tool_calls)
-            // out as `agent_response`. Tool-call assistant messages stay
-            // in `chat_history` since they aren't a graded reply.
-            let chat_history = history;
-            let agent_response = "";
-            const last = history[history.length - 1];
-            if (
-              last &&
-              last.role === "assistant" &&
-              !(Array.isArray(last.tool_calls) && last.tool_calls.length > 0) &&
-              typeof last.content === "string"
-            ) {
-              chat_history = history.slice(0, -1);
-              agent_response = last.content;
-            }
-            payload = {
-              name: newItemName.trim(),
-              chat_history,
-              agent_response,
-              evaluator_variables,
-            };
-          }
-
-          setCreatingItem(true);
-          setCreateItemError(null);
-          try {
-            await apiClient(`/annotation-tasks/${uuid}/items`, accessToken, {
-              method: "POST",
-              body: { items: [{ payload }] },
+            // Preserve the rich TestConfig.history shape — assistant
+            // messages with `tool_calls`, and `tool` messages with their
+            // `tool_call_id` — the same shape tests are saved with. Drop
+            // only entries that have neither content nor tool_calls.
+            const history = (config.history ?? []).filter((h) => {
+              if (h.role === "assistant") {
+                if (Array.isArray(h.tool_calls) && h.tool_calls.length > 0)
+                  return true;
+                return typeof h.content === "string" && h.content.length > 0;
+              }
+              if (h.role === "user") {
+                return typeof h.content === "string" && h.content.length > 0;
+              }
+              if (h.role === "tool") {
+                return typeof h.content === "string";
+              }
+              return false;
             });
-            setAddItemOpen(false);
-            await fetchTask();
-          } catch (err) {
-            setCreateItemError(parseApiError(err, "Failed to create item"));
-          } finally {
-            setCreatingItem(false);
-          }
-        }}
-      />
+
+            // Capture per-evaluator variable values entered in the dialog,
+            // keyed by evaluator uuid for easy lookup on edit.
+            const evaluator_variables: Record<
+              string,
+              Record<string, string>
+            > = {};
+            for (const e of evaluators) {
+              if (e.variable_values) {
+                evaluator_variables[e.evaluator_uuid] = {
+                  ...e.variable_values,
+                };
+              }
+            }
+
+            let payload: Record<string, unknown>;
+            if (taskType === "simulation") {
+              payload = {
+                name: newItemName.trim(),
+                transcript: history,
+                evaluator_variables,
+              };
+            } else {
+              // LLM: split the trailing plain agent reply (no tool_calls)
+              // out as `agent_response`. Tool-call assistant messages stay
+              // in `chat_history` since they aren't a graded reply.
+              let chat_history = history;
+              let agent_response = "";
+              const last = history[history.length - 1];
+              if (
+                last &&
+                last.role === "assistant" &&
+                !(
+                  Array.isArray(last.tool_calls) && last.tool_calls.length > 0
+                ) &&
+                typeof last.content === "string"
+              ) {
+                chat_history = history.slice(0, -1);
+                agent_response = last.content;
+              }
+              payload = {
+                name: newItemName.trim(),
+                chat_history,
+                agent_response,
+                evaluator_variables,
+              };
+            }
+
+            setCreatingItem(true);
+            setCreateItemError(null);
+            try {
+              await apiClient(`/annotation-tasks/${uuid}/items`, accessToken, {
+                method: "POST",
+                body: { items: [{ payload }] },
+              });
+              setAddItemOpen(false);
+              handleTabChange("items");
+              await fetchTask();
+            } catch (err) {
+              setCreateItemError(parseApiError(err, "Failed to create item"));
+            } finally {
+              setCreatingItem(false);
+            }
+          }}
+        />
       )}
 
       {!!editLlmItemUuid && taskType !== "stt" && (
-      <AddTestDialog
-        key={editLlmItemUuid}
-        isOpen={true}
-        onClose={() => {
-          if (!savingLlmItem) setEditLlmItemUuid(null);
-        }}
-        isEditing={true}
-        isLoading={false}
-        isCreating={savingLlmItem}
-        createError={editLlmError}
-        testName={editLlmItemName}
-        setTestName={setEditLlmItemName}
-        validationAttempted={false}
-        mode="labelItem"
-        allowAgentLastMessage={taskType === "simulation"}
-        requireAssistantLastMessage={taskType === "llm"}
-        initialConfig={editingInitialConfig}
-        initialEvaluators={editingInitialEvaluators}
-        onSubmit={async (
-          config: TestConfig,
-          evaluators: EvaluatorRefPayload[],
-        ) => {
-          if (!editLlmItemUuid || !editLlmItemName.trim() || !accessToken)
-            return;
-          const history = (config.history ?? []).filter((h) => {
-            if (h.role === "assistant") {
-              if (Array.isArray(h.tool_calls) && h.tool_calls.length > 0)
-                return true;
-              return typeof h.content === "string" && h.content.length > 0;
+        <AddTestDialog
+          key={editLlmItemUuid}
+          isOpen={true}
+          onClose={() => {
+            if (!savingLlmItem) setEditLlmItemUuid(null);
+          }}
+          isEditing={true}
+          isLoading={false}
+          isCreating={savingLlmItem}
+          createError={editLlmError}
+          testName={editLlmItemName}
+          setTestName={setEditLlmItemName}
+          validationAttempted={false}
+          mode="labelItem"
+          allowAgentLastMessage={taskType === "simulation"}
+          requireAssistantLastMessage={taskType === "llm"}
+          initialConfig={editingInitialConfig}
+          initialEvaluators={editingInitialEvaluators}
+          onSubmit={async (
+            config: TestConfig,
+            evaluators: EvaluatorRefPayload[],
+          ) => {
+            if (!editLlmItemUuid || !editLlmItemName.trim() || !accessToken)
+              return;
+            const history = (config.history ?? []).filter((h) => {
+              if (h.role === "assistant") {
+                if (Array.isArray(h.tool_calls) && h.tool_calls.length > 0)
+                  return true;
+                return typeof h.content === "string" && h.content.length > 0;
+              }
+              if (h.role === "user") {
+                return typeof h.content === "string" && h.content.length > 0;
+              }
+              if (h.role === "tool") {
+                return typeof h.content === "string";
+              }
+              return false;
+            });
+            const evaluator_variables: Record<
+              string,
+              Record<string, string>
+            > = {};
+            for (const e of evaluators) {
+              if (e.variable_values) {
+                evaluator_variables[e.evaluator_uuid] = {
+                  ...e.variable_values,
+                };
+              }
             }
-            if (h.role === "user") {
-              return typeof h.content === "string" && h.content.length > 0;
+            let payload: Record<string, unknown>;
+            if (taskType === "simulation") {
+              payload = {
+                name: editLlmItemName.trim(),
+                transcript: history,
+                evaluator_variables,
+              };
+            } else {
+              let chat_history = history;
+              let agent_response = "";
+              const last = history[history.length - 1];
+              if (
+                last &&
+                last.role === "assistant" &&
+                !(
+                  Array.isArray(last.tool_calls) && last.tool_calls.length > 0
+                ) &&
+                typeof last.content === "string"
+              ) {
+                chat_history = history.slice(0, -1);
+                agent_response = last.content;
+              }
+              payload = {
+                name: editLlmItemName.trim(),
+                chat_history,
+                agent_response,
+                evaluator_variables,
+              };
             }
-            if (h.role === "tool") {
-              return typeof h.content === "string";
-            }
-            return false;
-          });
-          const evaluator_variables: Record<
-            string,
-            Record<string, string>
-          > = {};
-          for (const e of evaluators) {
-            if (e.variable_values) {
-              evaluator_variables[e.evaluator_uuid] = { ...e.variable_values };
-            }
-          }
-          let payload: Record<string, unknown>;
-          if (taskType === "simulation") {
-            payload = {
-              name: editLlmItemName.trim(),
-              transcript: history,
-              evaluator_variables,
-            };
-          } else {
-            let chat_history = history;
-            let agent_response = "";
-            const last = history[history.length - 1];
-            if (
-              last &&
-              last.role === "assistant" &&
-              !(Array.isArray(last.tool_calls) && last.tool_calls.length > 0) &&
-              typeof last.content === "string"
-            ) {
-              chat_history = history.slice(0, -1);
-              agent_response = last.content;
-            }
-            payload = {
-              name: editLlmItemName.trim(),
-              chat_history,
-              agent_response,
-              evaluator_variables,
-            };
-          }
-          setSavingLlmItem(true);
-          setEditLlmError(null);
-          try {
-            await apiClient<{ updated_count: number }>(
-              `/annotation-tasks/${uuid}/items`,
-              accessToken,
-              {
-                method: "PUT",
-                body: {
-                  updates: [{ uuid: editLlmItemUuid, payload }],
+            setSavingLlmItem(true);
+            setEditLlmError(null);
+            try {
+              await apiClient<{ updated_count: number }>(
+                `/annotation-tasks/${uuid}/items`,
+                accessToken,
+                {
+                  method: "PUT",
+                  body: {
+                    updates: [{ uuid: editLlmItemUuid, payload }],
+                  },
                 },
-              },
-            );
-            setEditLlmItemUuid(null);
-            await fetchTask();
-          } catch (err) {
-            setEditLlmError(parseApiError(err, "Failed to save item"));
-          } finally {
-            setSavingLlmItem(false);
-          }
-        }}
-      />
+              );
+              setEditLlmItemUuid(null);
+              await fetchTask();
+            } catch (err) {
+              setEditLlmError(parseApiError(err, "Failed to save item"));
+            } finally {
+              setSavingLlmItem(false);
+            }
+          }}
+        />
       )}
 
       {accessToken && task && (
@@ -2510,6 +2849,66 @@ function LabellingTaskPageInner() {
           onSaved={() => {
             setEditOpen(false);
             fetchTask();
+          }}
+        />
+      )}
+
+      {accessToken && (
+        <BulkUploadSttItemsDialog
+          isOpen={bulkUploadSttOpen}
+          accessToken={accessToken}
+          taskUuid={uuid}
+          onClose={() => setBulkUploadSttOpen(false)}
+          onSuccess={async (count) => {
+            setBulkUploadSttOpen(false);
+            handleTabChange("items");
+            await fetchTask();
+            toast.success(
+              `Added ${count} ${count === 1 ? "item" : "items"}`,
+            );
+          }}
+        />
+      )}
+
+      {accessToken && (
+        <BulkUploadSimulationItemsDialog
+          isOpen={bulkUploadSimulationOpen}
+          accessToken={accessToken}
+          taskUuid={uuid}
+          onClose={() => setBulkUploadSimulationOpen(false)}
+          onSuccess={async (count) => {
+            setBulkUploadSimulationOpen(false);
+            handleTabChange("items");
+            await fetchTask();
+            toast.success(
+              `Added ${count} ${count === 1 ? "item" : "items"}`,
+            );
+          }}
+        />
+      )}
+
+      {accessToken && (
+        <BulkUploadLlmItemsDialog
+          isOpen={bulkUploadLlmOpen}
+          accessToken={accessToken}
+          taskUuid={uuid}
+          linkedEvaluators={(task?.evaluators ?? []).map((e) => {
+            const hydrated = evaluatorCatalogue[e.uuid];
+            return {
+              uuid: e.uuid,
+              name: hydrated?.name ?? e.name,
+              slug: hydrated?.slug ?? null,
+              variables: hydrated?.variables ?? [],
+            };
+          })}
+          onClose={() => setBulkUploadLlmOpen(false)}
+          onSuccess={async (count) => {
+            setBulkUploadLlmOpen(false);
+            handleTabChange("items");
+            await fetchTask();
+            toast.success(
+              `Added ${count} ${count === 1 ? "item" : "items"}`,
+            );
           }}
         />
       )}
@@ -2530,6 +2929,7 @@ function LabellingTaskPageInner() {
               })),
             },
           });
+          handleTabChange("items");
           await fetchTask();
           setAddSttItemsOpen(false);
         }}
@@ -2595,22 +2995,6 @@ function LabellingTaskPageInner() {
         isOpen={jobsCreatedOpen}
         jobs={createdJobs}
         onClose={() => setJobsCreatedOpen(false)}
-      />
-
-      <ItemResultsDialog
-        isOpen={!!resultsForItemUuid}
-        onClose={() => setResultsForItemUuid(null)}
-        itemName={(() => {
-          const it = items.find((i) => i.uuid === resultsForItemUuid);
-          if (!it) return "";
-          const p = (it.payload ?? {}) as Record<string, unknown>;
-          if (typeof p.name === "string" && p.name) return p.name;
-          return `Item ${it.id}`;
-        })()}
-        evaluators={(task?.evaluators ?? []).map((e) => ({
-          uuid: e.uuid,
-          name: e.name,
-        }))}
       />
 
       <DeleteConfirmationDialog

--- a/src/app/human-labelling/tasks/[uuid]/page.tsx
+++ b/src/app/human-labelling/tasks/[uuid]/page.tsx
@@ -1,0 +1,2053 @@
+"use client";
+
+import { Suspense, useCallback, useEffect, useState } from "react";
+import Link from "next/link";
+import { useParams, useRouter, useSearchParams } from "next/navigation";
+import { toast } from "sonner";
+import {
+  AddTestDialog,
+  type AttachedEvaluatorInit,
+  type EvaluatorRefPayload,
+  type EvaluatorVariableDef,
+  type TestConfig,
+} from "@/components/AddTestDialog";
+import { AppLayout } from "@/components/AppLayout";
+import { EvaluatorTypePill } from "@/components/EvaluatorPills";
+import { Tooltip } from "@/components/Tooltip";
+import { DeleteConfirmationDialog } from "@/components/DeleteConfirmationDialog";
+import { AddSttItemsDialog } from "@/components/human-labelling/AddSttItemsDialog";
+import { AssignAnnotatorsDialog } from "@/components/human-labelling/AssignAnnotatorsDialog";
+import { EditTaskDialog } from "@/components/human-labelling/EditTaskDialog";
+import {
+  ItemResultsDialog,
+} from "@/components/human-labelling/ItemResultsDialog";
+import {
+  JobsCreatedDialog,
+  type CreatedJob,
+} from "@/components/human-labelling/JobsCreatedDialog";
+import { ManageEvaluatorsDialog } from "@/components/human-labelling/ManageEvaluatorsDialog";
+import { EmptyState } from "@/components/ui/LoadingState";
+import { useAccessToken } from "@/hooks";
+import { apiClient } from "@/lib/api";
+import { useSidebarState } from "@/lib/sidebar";
+
+type Tab = "items" | "jobs" | "runs";
+
+const TABS: Tab[] = ["items", "jobs", "runs"];
+
+type EvaluatorRunMetricEntry = number | { type?: string; mean?: number | null };
+
+type EvaluatorRunJob = {
+  uuid: string;
+  task_id: string;
+  status: "queued" | "in_progress" | "completed" | "failed";
+  details: {
+    evaluators?: {
+      evaluator_id: string;
+      evaluator_version_id?: string;
+      name?: string;
+    }[];
+    item_count?: number;
+    s3_prefix?: string;
+    metrics?: Record<string, EvaluatorRunMetricEntry>;
+  } | null;
+  error: string | null;
+  created_at: string;
+  updated_at: string;
+  completed_at: string | null;
+};
+
+function isTab(value: string | null): value is Tab {
+  return !!value && (TABS as string[]).includes(value);
+}
+
+type ItemAgreement = {
+  human_human: { agreement: number | null; pair_count: number };
+  evaluators: {
+    evaluator_id: string;
+    agreement: number | null;
+    pair_count: number;
+  }[];
+};
+
+type LabellingItem = {
+  id: number;
+  uuid: string;
+  task_id: string;
+  payload: unknown;
+  created_at: string;
+  deleted_at: string | null;
+  agreement?: ItemAgreement;
+};
+
+type LabellingJob = {
+  uuid: string;
+  task_id: string;
+  annotator_id: string;
+  annotator_name: string;
+  public_token: string;
+  status: "pending" | "in_progress" | "completed";
+  created_at: string;
+  completed_at: string | null;
+  item_count: number;
+  annotation_count: number;
+};
+
+type LabellingTask = {
+  uuid: string;
+  name: string;
+  type?: "llm" | "stt" | "tts" | "simulation";
+  description?: string;
+  created_at?: string;
+  updated_at?: string;
+  evaluators?: {
+    uuid: string;
+    name: string;
+    evaluator_type?: "llm" | "stt" | "tts" | "simulation";
+  }[];
+  items?: LabellingItem[];
+  jobs?: LabellingJob[];
+  // item_count is still returned by the list endpoint; on the detail
+  // endpoint we prefer items.length.
+  item_count?: number;
+};
+
+type TaskKind = "llm" | "stt" | "tts" | "simulation" | undefined;
+
+function previewItemPayload(payload: unknown, kind: TaskKind): string {
+  if (payload == null || typeof payload !== "object") {
+    return typeof payload === "string" ? payload : "—";
+  }
+  const p = payload as Record<string, unknown>;
+  if (typeof p.name === "string" && p.name) return p.name;
+  if (kind === "stt") {
+    const ref =
+      typeof p.reference_transcript === "string" ? p.reference_transcript : "";
+    const pred =
+      typeof p.predicted_transcript === "string" ? p.predicted_transcript : "";
+    if (ref || pred) return `${ref} → ${pred}`;
+  }
+  if (kind === "llm") {
+    if (typeof p.agent_response === "string" && p.agent_response) {
+      return p.agent_response;
+    }
+    if (Array.isArray(p.chat_history) && p.chat_history.length > 0) {
+      const last = p.chat_history[p.chat_history.length - 1] as {
+        content?: unknown;
+      };
+      if (typeof last?.content === "string") return last.content;
+    }
+  }
+  if (kind === "simulation") {
+    if (Array.isArray(p.transcript) && p.transcript.length > 0) {
+      const first = p.transcript[0] as { content?: unknown };
+      if (typeof first?.content === "string") return first.content;
+    }
+  }
+  try {
+    return JSON.stringify(payload);
+  } catch {
+    return "—";
+  }
+}
+
+function parseApiError(err: unknown, fallback: string): string {
+  if (!(err instanceof Error)) return fallback;
+  const match = err.message.match(/Request failed: \d+ - (.+)$/);
+  if (match) {
+    try {
+      const parsed = JSON.parse(match[1]);
+      if (parsed && typeof parsed.detail === "string") return parsed.detail;
+    } catch {
+      // not JSON
+    }
+    return match[1];
+  }
+  return err.message || fallback;
+}
+
+function buildAnnotateUrl(token: string): string {
+  if (typeof window === "undefined") return `/annotate-job/${token}`;
+  return `${window.location.origin}/annotate-job/${token}`;
+}
+
+function statusPillClass(status: LabellingJob["status"]): string {
+  switch (status) {
+    case "completed":
+      return "border-green-200 bg-green-100 text-green-700 dark:border-green-500/30 dark:bg-green-500/20 dark:text-green-400";
+    case "in_progress":
+      return "border-yellow-200 bg-yellow-100 text-yellow-700 dark:border-yellow-500/30 dark:bg-yellow-500/20 dark:text-yellow-400";
+    default:
+      return "border-gray-200 bg-gray-100 text-gray-700 dark:border-gray-500/30 dark:bg-gray-500/20 dark:text-gray-300";
+  }
+}
+
+function statusLabel(status: LabellingJob["status"]): string {
+  if (status === "in_progress") return "In progress";
+  if (status === "completed") return "Completed";
+  return "Pending";
+}
+
+function runStatusPillClass(status: EvaluatorRunJob["status"]): string {
+  switch (status) {
+    case "completed":
+      return "border-green-200 bg-green-100 text-green-700 dark:border-green-500/30 dark:bg-green-500/20 dark:text-green-400";
+    case "failed":
+      return "border-red-200 bg-red-100 text-red-700 dark:border-red-500/30 dark:bg-red-500/20 dark:text-red-400";
+    case "in_progress":
+      return "border-yellow-200 bg-yellow-100 text-yellow-700 dark:border-yellow-500/30 dark:bg-yellow-500/20 dark:text-yellow-400";
+    default:
+      return "border-gray-200 bg-gray-100 text-gray-700 dark:border-gray-500/30 dark:bg-gray-500/20 dark:text-gray-300";
+  }
+}
+
+function runStatusLabel(status: EvaluatorRunJob["status"]): string {
+  if (status === "queued") return "Queued";
+  if (status === "in_progress") return "In progress";
+  if (status === "completed") return "Completed";
+  if (status === "failed") return "Failed";
+  return status;
+}
+
+function EvaluatorRunsList({
+  runs,
+  loading,
+  error,
+  versionLabels,
+  onRequestDelete,
+  onOpen,
+}: {
+  runs: EvaluatorRunJob[];
+  loading: boolean;
+  error: string | null;
+  versionLabels: Record<string, Record<string, string>>;
+  onRequestDelete: (runUuid: string) => void;
+  onOpen: (runUuid: string) => void;
+}) {
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center gap-2 py-8 text-sm text-muted-foreground">
+        <svg
+          className="w-4 h-4 animate-spin"
+          fill="none"
+          viewBox="0 0 24 24"
+        >
+          <circle
+            className="opacity-25"
+            cx="12"
+            cy="12"
+            r="10"
+            stroke="currentColor"
+            strokeWidth="4"
+          />
+          <path
+            className="opacity-75"
+            fill="currentColor"
+            d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+          />
+        </svg>
+        Loading runs
+      </div>
+    );
+  }
+  if (error) {
+    return (
+      <div className="rounded-md border border-border bg-muted/20 p-4 text-sm text-red-500">
+        {error}
+      </div>
+    );
+  }
+  if (runs.length === 0) {
+    return (
+      <EmptyState
+        icon={
+          <svg
+            className="w-7 h-7 text-muted-foreground"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            strokeWidth={1.5}
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              d="M9 17v-2a4 4 0 014-4h6m0 0l-3-3m3 3l-3 3M5 7h6a4 4 0 014 4v2"
+            />
+          </svg>
+        }
+        title="No evaluation runs yet"
+        description="The results of running the linked evaluators on every item in this task will appear here"
+      />
+    );
+  }
+
+  return (
+    <div className="border border-border rounded-xl overflow-hidden">
+      <div className="grid grid-cols-[minmax(0,1.5fr)_100px_140px_minmax(0,1fr)_60px] gap-4 px-4 py-2 border-b border-border bg-muted/30 items-center">
+        <div className="text-sm font-medium text-muted-foreground">
+          Evaluators
+        </div>
+        <div className="text-sm font-medium text-muted-foreground">Items</div>
+        <div className="text-sm font-medium text-muted-foreground">Status</div>
+        <div className="text-sm font-medium text-muted-foreground">
+          Last updated
+        </div>
+        <div />
+      </div>
+      {runs.map((run) => {
+        const itemCount = run.details?.item_count ?? 0;
+        const lastUpdated = run.updated_at || run.created_at;
+        const evaluators = run.details?.evaluators ?? [];
+        const versionLabelFor = (
+          evaluatorId: string,
+          versionId: string | undefined,
+        ): string | null => {
+          if (!versionId) return null;
+          return versionLabels[evaluatorId]?.[versionId] ?? null;
+        };
+        const evaluatorTitle = evaluators
+          .map((e) => {
+            const name = e.name || e.evaluator_id.slice(0, 8);
+            const label = versionLabelFor(e.evaluator_id, e.evaluator_version_id);
+            return label ? `${name} (${label})` : name;
+          })
+          .join(", ");
+        return (
+          <div
+            key={run.uuid}
+            onClick={() => onOpen(run.uuid)}
+            className="grid grid-cols-[minmax(0,1.5fr)_100px_140px_minmax(0,1fr)_60px] gap-4 px-4 py-3 border-b border-border last:border-b-0 items-center hover:bg-muted/20 transition-colors cursor-pointer"
+          >
+            <div
+              className="flex flex-wrap gap-1.5 min-w-0"
+              title={evaluatorTitle}
+            >
+              {evaluators.length === 0 ? (
+                <span className="text-sm text-muted-foreground">—</span>
+              ) : (
+                evaluators.map((e) => {
+                  const name = e.name || e.evaluator_id.slice(0, 8);
+                  const label = versionLabelFor(
+                    e.evaluator_id,
+                    e.evaluator_version_id,
+                  );
+                  return (
+                    <span
+                      key={`${e.evaluator_id}-${e.evaluator_version_id ?? ""}`}
+                      className="inline-flex items-center gap-1 px-2 py-0.5 rounded-md text-xs font-medium border border-border bg-muted/40 text-foreground"
+                    >
+                      <span className="truncate max-w-[140px]">{name}</span>
+                      {label && (
+                        <span className="font-mono text-[10px] text-muted-foreground">
+                          {label}
+                        </span>
+                      )}
+                    </span>
+                  );
+                })
+              )}
+            </div>
+            <div className="text-sm text-muted-foreground tabular-nums">
+              {itemCount}
+            </div>
+            <div>
+              <span
+                className={`inline-block px-2 py-0.5 rounded-md text-xs font-medium border ${runStatusPillClass(
+                  run.status,
+                )}`}
+              >
+                {runStatusLabel(run.status)}
+              </span>
+            </div>
+            <div className="text-sm text-muted-foreground">
+              {new Date(lastUpdated.replace(" ", "T") + "Z").toLocaleString()}
+            </div>
+            <div className="flex justify-end">
+              {(run.status === "completed" || run.status === "failed") && (
+                <button
+                  type="button"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onRequestDelete(run.uuid);
+                  }}
+                  aria-label="Delete run"
+                  title="Delete run"
+                  className="w-8 h-8 flex items-center justify-center rounded-md text-muted-foreground hover:text-foreground hover:bg-muted transition-colors cursor-pointer"
+                >
+                  <svg
+                    className="w-4 h-4"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                    strokeWidth={2}
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      d="M14.74 9l-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 01-2.244 2.077H8.084a2.25 2.25 0 01-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 00-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 013.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 00-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 00-7.5 0"
+                    />
+                  </svg>
+                </button>
+              )}
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+function ItemRowActions({
+  itemUuid,
+  onDelete,
+  onPlay,
+  onViewResults,
+  onLabel,
+  playDisabled,
+  playLoadingForUuid,
+}: {
+  itemUuid: string;
+  onDelete: (uuid: string) => void | Promise<void>;
+  onPlay: (uuid: string) => void | Promise<void>;
+  onViewResults: (uuid: string) => void;
+  onLabel?: (uuid: string) => void;
+  playDisabled?: boolean;
+  playLoadingForUuid?: string | null;
+}) {
+  const isLoading = playLoadingForUuid === itemUuid;
+  return (
+    <div
+      className="flex items-center justify-center gap-2"
+      onClick={(e) => e.stopPropagation()}
+    >
+      {onLabel && (
+        <button
+          type="button"
+          onClick={() => onLabel(itemUuid)}
+          aria-label="Label"
+          className="h-8 px-3 rounded-md text-sm font-medium bg-foreground text-background hover:opacity-90 transition-opacity cursor-pointer"
+        >
+          Label
+        </button>
+      )}
+      {/* View results (analytics) */}
+      <button
+        type="button"
+        onClick={() => onViewResults(itemUuid)}
+        aria-label="View results"
+        className="h-8 px-3 inline-flex items-center gap-1.5 rounded-md text-sm font-semibold border border-fuchsia-500/40 bg-fuchsia-500/10 text-fuchsia-600 dark:text-fuchsia-400 hover:bg-fuchsia-500/20 hover:border-fuchsia-500/60 transition-colors cursor-pointer"
+      >
+        <svg
+          className="w-4 h-4"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+          strokeWidth={1.8}
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M2.036 12.322a1.012 1.012 0 010-.639C3.423 7.51 7.36 4.5 12 4.5c4.638 0 8.573 3.007 9.963 7.178.07.207.07.431 0 .639C20.577 16.49 16.64 19.5 12 19.5c-4.638 0-8.573-3.007-9.963-7.178z"
+          />
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
+          />
+        </svg>
+        View results
+      </button>
+      {/* Run evaluators */}
+      <button
+        type="button"
+        onClick={() => onPlay(itemUuid)}
+        disabled={playDisabled || isLoading}
+        aria-label="Run evaluators"
+        className="h-8 px-3 inline-flex items-center gap-1.5 rounded-md text-sm font-medium border border-indigo-500/30 bg-indigo-500/10 text-indigo-600 dark:text-indigo-300 hover:bg-indigo-500/20 transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+      >
+        {isLoading ? (
+          <svg
+            className="w-3.5 h-3.5 animate-spin"
+            viewBox="0 0 24 24"
+            fill="none"
+          >
+            <circle
+              className="opacity-25"
+              cx="12"
+              cy="12"
+              r="10"
+              stroke="currentColor"
+              strokeWidth="4"
+            />
+            <path
+              className="opacity-75"
+              fill="currentColor"
+              d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z"
+            />
+          </svg>
+        ) : (
+          <svg className="w-3.5 h-3.5" fill="currentColor" viewBox="0 0 24 24">
+            <path d="M8 5v14l11-7z" />
+          </svg>
+        )}
+        Run evaluators
+      </button>
+      {/* Delete Button */}
+      <button
+        type="button"
+        onClick={() => onDelete(itemUuid)}
+        aria-label="Delete item"
+        className="w-8 h-8 flex items-center justify-center rounded-md text-muted-foreground hover:text-foreground hover:bg-muted transition-colors cursor-pointer"
+      >
+        <svg
+          className="w-4 h-4"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+          strokeWidth={2}
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M14.74 9l-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 01-2.244 2.077H8.084a2.25 2.25 0 01-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 00-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 013.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 00-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 00-7.5 0"
+          />
+        </svg>
+      </button>
+    </div>
+  );
+}
+
+function JobsList({ jobs }: { jobs: LabellingJob[] }) {
+  const router = useRouter();
+  const [copiedToken, setCopiedToken] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!copiedToken) return;
+    const t = setTimeout(() => setCopiedToken(null), 1500);
+    return () => clearTimeout(t);
+  }, [copiedToken]);
+
+  const handleCopy = async (token: string) => {
+    try {
+      await navigator.clipboard.writeText(buildAnnotateUrl(token));
+      setCopiedToken(token);
+    } catch {
+      // ignore
+    }
+  };
+
+  return (
+    <div className="border border-border rounded-xl overflow-hidden">
+      <div className="grid grid-cols-[180px_minmax(0,1fr)_120px_120px] gap-4 [&>*:nth-child(3)]:pl-6 px-4 py-2 border-b border-border bg-muted/30 items-center">
+        <div className="text-sm font-medium text-muted-foreground">
+          Annotator
+        </div>
+        <div className="text-sm font-medium text-muted-foreground">Link</div>
+        <div className="text-sm font-medium text-muted-foreground">Status</div>
+        <div className="text-sm font-medium text-muted-foreground">
+          Progress
+        </div>
+      </div>
+      {jobs.map((job) => {
+        const isImported = job.public_token.startsWith("import:");
+        const copied = copiedToken === job.public_token;
+        const url = buildAnnotateUrl(job.public_token);
+        return (
+          <div
+            key={job.uuid}
+            onClick={() => {
+              if (!isImported)
+                router.push(`/human-labelling/jobs/${job.public_token}`);
+            }}
+            className={`grid grid-cols-[180px_minmax(0,1fr)_120px_120px] gap-4 [&>*:nth-child(3)]:pl-6 px-4 py-3 border-b border-border last:border-b-0 items-center hover:bg-muted/20 transition-colors ${
+              isImported ? "" : "cursor-pointer"
+            }`}
+          >
+            <div className="text-sm font-medium truncate">
+              {job.annotator_name}
+            </div>
+            <div className="flex items-center gap-2 min-w-0">
+              {isImported ? (
+                <span className="text-xs text-muted-foreground">Imported</span>
+              ) : (
+                <>
+                  <span className="text-xs font-mono text-muted-foreground truncate">
+                    {url}
+                  </span>
+                  <button
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      handleCopy(job.public_token);
+                    }}
+                    aria-label={copied ? "Copied" : "Copy link"}
+                    title={copied ? "Copied" : "Copy link"}
+                    className={`shrink-0 w-7 h-7 flex items-center justify-center rounded-md border transition-colors cursor-pointer ${
+                      copied
+                        ? "border-green-200 bg-green-100 text-green-700 dark:border-green-500/40 dark:bg-green-500/20 dark:text-green-400"
+                        : "border-border bg-background text-muted-foreground hover:bg-muted/50 hover:text-foreground"
+                    }`}
+                  >
+                    {copied ? (
+                      <svg
+                        className="w-3.5 h-3.5"
+                        fill="none"
+                        viewBox="0 0 24 24"
+                        stroke="currentColor"
+                        strokeWidth={2.5}
+                      >
+                        <path
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          d="M5 13l4 4L19 7"
+                        />
+                      </svg>
+                    ) : (
+                      <svg
+                        className="w-3.5 h-3.5"
+                        fill="none"
+                        viewBox="0 0 24 24"
+                        stroke="currentColor"
+                        strokeWidth={1.8}
+                      >
+                        <path
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2"
+                        />
+                      </svg>
+                    )}
+                  </button>
+                </>
+              )}
+            </div>
+            <div>
+              <span
+                className={`inline-block px-2 py-0.5 rounded-md text-xs font-medium border ${statusPillClass(
+                  job.status,
+                )}`}
+              >
+                {statusLabel(job.status)}
+              </span>
+            </div>
+            <div className="text-sm text-muted-foreground tabular-nums">
+              {job.annotation_count} / {job.item_count}
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+export default function LabellingTaskPage() {
+  return (
+    <Suspense fallback={null}>
+      <LabellingTaskPageInner />
+    </Suspense>
+  );
+}
+
+function LabellingTaskPageInner() {
+  const router = useRouter();
+  const params = useParams();
+  const searchParams = useSearchParams();
+  const accessToken = useAccessToken();
+  const [sidebarOpen, setSidebarOpen] = useSidebarState();
+
+  const uuid = typeof params?.uuid === "string" ? params.uuid : "";
+
+  const initialTab = searchParams.get("tab");
+  const [activeTab, setActiveTab] = useState<Tab>(
+    isTab(initialTab) ? initialTab : "items",
+  );
+
+  const handleTabChange = useCallback(
+    (tab: Tab) => {
+      setActiveTab(tab);
+      window.history.replaceState(
+        null,
+        "",
+        `/human-labelling/tasks/${uuid}?tab=${tab}`,
+      );
+    },
+    [uuid],
+  );
+
+  const [task, setTask] = useState<LabellingTask | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const [selectedItemIds, setSelectedItemIds] = useState<Set<string>>(
+    new Set(),
+  );
+  const [assignOpen, setAssignOpen] = useState(false);
+  const [deleteSelectedOpen, setDeleteSelectedOpen] = useState(false);
+  const [deletingSelected, setDeletingSelected] = useState(false);
+  const [editSttItemsOpen, setEditSttItemsOpen] = useState(false);
+  const [editLlmItemUuid, setEditLlmItemUuid] = useState<string | null>(null);
+  const [editLlmItemName, setEditLlmItemName] = useState("");
+  const [savingLlmItem, setSavingLlmItem] = useState(false);
+  const [editLlmError, setEditLlmError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (task?.name) document.title = `${task.name} | Calibrate`;
+  }, [task?.name]);
+
+  const fetchTask = useCallback(async () => {
+    if (!accessToken || !uuid) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const data = await apiClient<LabellingTask>(
+        `/annotation-tasks/${uuid}`,
+        accessToken,
+      );
+      setTask(data);
+    } catch (err) {
+      setError(parseApiError(err, "Failed to load task"));
+    } finally {
+      setLoading(false);
+    }
+  }, [accessToken, uuid]);
+
+  useEffect(() => {
+    fetchTask();
+  }, [fetchTask]);
+
+  // Evaluator runs.
+  const [runs, setRuns] = useState<EvaluatorRunJob[]>([]);
+  const [runsLoading, setRunsLoading] = useState(false);
+  const [runsError, setRunsError] = useState<string | null>(null);
+  // Map evaluator_id -> { version_id: "v1" }, populated on demand from
+  // /evaluators/{uuid}/versions so we can label runs by version number.
+  const [versionLabels, setVersionLabels] = useState<
+    Record<string, Record<string, string>>
+  >({});
+
+  const fetchRuns = useCallback(async () => {
+    if (!accessToken || !uuid) return;
+    setRunsLoading(true);
+    setRunsError(null);
+    try {
+      const data = await apiClient<EvaluatorRunJob[]>(
+        `/annotation-tasks/${uuid}/evaluator-runs`,
+        accessToken,
+      );
+      setRuns(Array.isArray(data) ? data : []);
+    } catch (err) {
+      setRunsError(parseApiError(err, "Failed to load evaluator runs"));
+    } finally {
+      setRunsLoading(false);
+    }
+  }, [accessToken, uuid]);
+
+  useEffect(() => {
+    fetchRuns();
+  }, [fetchRuns]);
+  void activeTab;
+
+  // Fetch evaluator versions for any evaluator referenced by a run that we
+  // haven't already loaded.
+  useEffect(() => {
+    if (!accessToken) return;
+    const needed = new Set<string>();
+    for (const r of runs) {
+      for (const ev of r.details?.evaluators ?? []) {
+        if (ev.evaluator_id && !versionLabels[ev.evaluator_id]) {
+          needed.add(ev.evaluator_id);
+        }
+      }
+    }
+    if (needed.size === 0) return;
+    let cancelled = false;
+    (async () => {
+      const updates: Record<string, Record<string, string>> = {};
+      await Promise.all(
+        Array.from(needed).map(async (evaluatorId) => {
+          try {
+            const versions = await apiClient<
+              Array<{ uuid: string; version_number: number }>
+            >(`/evaluators/${evaluatorId}/versions`, accessToken);
+            const map: Record<string, string> = {};
+            for (const v of versions) {
+              map[v.uuid] = `v${v.version_number}`;
+            }
+            updates[evaluatorId] = map;
+          } catch {
+            updates[evaluatorId] = {};
+          }
+        }),
+      );
+      if (!cancelled) {
+        setVersionLabels((prev) => ({ ...prev, ...updates }));
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [runs, accessToken, versionLabels]);
+
+  const items = task?.items ?? [];
+  const jobs = task?.jobs ?? [];
+  const itemsLoading = loading && !task;
+  const itemsError = error;
+  const itemsCount = items.length || task?.item_count || 0;
+  const jobsCount = jobs.length;
+  const taskType = task?.type ?? task?.evaluators?.[0]?.evaluator_type;
+  const canAddItem =
+    taskType === "llm" || taskType === "simulation" || taskType === "stt";
+
+  const toggleItem = (uuid: string) => {
+    setSelectedItemIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(uuid)) next.delete(uuid);
+      else next.add(uuid);
+      return next;
+    });
+  };
+
+  const allSelected = items.length > 0 && selectedItemIds.size === items.length;
+  const someSelected = selectedItemIds.size > 0 && !allSelected;
+  const toggleSelectAll = () => {
+    setSelectedItemIds((prev) =>
+      prev.size === items.length
+        ? new Set()
+        : new Set(items.map((i) => i.uuid)),
+    );
+  };
+
+  // Drop selections that no longer exist in the items list (after delete or refetch).
+  useEffect(() => {
+    setSelectedItemIds((prev) => {
+      if (prev.size === 0) return prev;
+      const ids = new Set(items.map((i) => i.uuid));
+      const next = new Set<string>();
+      prev.forEach((id) => {
+        if (ids.has(id)) next.add(id);
+      });
+      return next.size === prev.size ? prev : next;
+    });
+  }, [items]);
+
+  const [startingRun, setStartingRun] = useState(false);
+  const [startingRunForItem, setStartingRunForItem] = useState<string | null>(
+    null,
+  );
+  const handleRunEvaluators = async (
+    itemUuids?: string[] | string,
+  ) => {
+    if (!accessToken || !uuid || startingRun) return;
+    const linked = task?.evaluators ?? [];
+    if (linked.length === 0) {
+      toast.error("Link at least one evaluator before running.");
+      return;
+    }
+    const ids = Array.isArray(itemUuids)
+      ? itemUuids
+      : itemUuids
+        ? [itemUuids]
+        : null;
+    setStartingRun(true);
+    setStartingRunForItem(
+      ids && ids.length === 1 ? ids[0] : null,
+    );
+    try {
+      const body: Record<string, unknown> = {
+        evaluators: linked.map((e) => ({ evaluator_id: e.uuid })),
+      };
+      if (ids && ids.length > 0) body.item_ids = ids;
+      const result = await apiClient<{
+        job_uuid: string;
+        status: string;
+        evaluator_count: number;
+        item_count: number;
+      }>(`/annotation-tasks/${uuid}/evaluator-runs`, accessToken, {
+        method: "POST",
+        body,
+      });
+      router.push(
+        `/human-labelling/tasks/${uuid}/evaluator-runs/${result.job_uuid}`,
+      );
+    } catch (err) {
+      toast.error(parseApiError(err, "Failed to start evaluation run"));
+      setStartingRun(false);
+      setStartingRunForItem(null);
+    }
+    // Note: we intentionally keep the spinner state on the success path until
+    // the navigation completes (page unmounts), so the row's play button stays
+    // as a spinner up to the redirect.
+  };
+
+  const [deletingRunUuid, setDeletingRunUuid] = useState<string | null>(null);
+  const [deletingRunInFlight, setDeletingRunInFlight] = useState(false);
+
+  const confirmDeleteRun = async () => {
+    if (!accessToken || !deletingRunUuid) return;
+    const runUuid = deletingRunUuid;
+    setDeletingRunInFlight(true);
+    try {
+      await apiClient<{ deleted_runs: number }>(
+        `/annotation-tasks/${uuid}/evaluator-runs/${runUuid}`,
+        accessToken,
+        { method: "DELETE" },
+      );
+      // Optimistic update.
+      setRuns((prev) => prev.filter((r) => r.uuid !== runUuid));
+      setDeletingRunUuid(null);
+    } catch (err) {
+      toast.error(parseApiError(err, "Failed to delete evaluation run"));
+    } finally {
+      setDeletingRunInFlight(false);
+    }
+  };
+
+  const [deletingOneUuid, setDeletingOneUuid] = useState<string | null>(null);
+  const [deletingOneInFlight, setDeletingOneInFlight] = useState(false);
+
+  const requestDeleteOneItem = (itemUuid: string) => {
+    setDeletingOneUuid(itemUuid);
+  };
+
+  const confirmDeleteOneItem = async () => {
+    if (!accessToken || !deletingOneUuid) return;
+    setDeletingOneInFlight(true);
+    try {
+      await apiClient<{ deleted_count: number }>(
+        `/annotation-tasks/${uuid}/items`,
+        accessToken,
+        {
+          method: "DELETE",
+          body: { item_ids: [deletingOneUuid] },
+        },
+      );
+      setSelectedItemIds((prev) => {
+        const next = new Set(prev);
+        next.delete(deletingOneUuid);
+        return next;
+      });
+      setDeletingOneUuid(null);
+      await fetchTask();
+    } catch (err) {
+      setError(parseApiError(err, "Failed to delete item"));
+    } finally {
+      setDeletingOneInFlight(false);
+    }
+  };
+
+  const handleDeleteSelected = async () => {
+    if (selectedItemIds.size === 0 || !accessToken) return;
+    setDeletingSelected(true);
+    try {
+      await apiClient<{ deleted_count: number }>(
+        `/annotation-tasks/${uuid}/items`,
+        accessToken,
+        {
+          method: "DELETE",
+          body: { item_ids: Array.from(selectedItemIds) },
+        },
+      );
+      setDeleteSelectedOpen(false);
+      setSelectedItemIds(new Set());
+      await fetchTask();
+    } catch (err) {
+      setError(parseApiError(err, "Failed to delete items"));
+    } finally {
+      setDeletingSelected(false);
+    }
+  };
+
+  // Hydrated evaluator catalogue (with live_version.variables) used to
+  // pre-fill the AddTestDialog's evaluators section for label items.
+  type HydratedEvaluator = {
+    uuid: string;
+    name: string;
+    description?: string | null;
+    slug: string | null;
+    variables: EvaluatorVariableDef[];
+  };
+  const [evaluatorCatalogue, setEvaluatorCatalogue] = useState<
+    Record<string, HydratedEvaluator>
+  >({});
+
+  useEffect(() => {
+    if (!accessToken) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const data = await apiClient<
+          Array<{
+            uuid: string;
+            name: string;
+            description?: string | null;
+            slug: string | null;
+            evaluator_type?: string;
+            live_version?: { variables?: EvaluatorVariableDef[] | null } | null;
+          }>
+        >("/evaluators?include_defaults=true", accessToken);
+        if (cancelled) return;
+        const next: Record<string, HydratedEvaluator> = {};
+        for (const e of Array.isArray(data) ? data : []) {
+          next[e.uuid] = {
+            uuid: e.uuid,
+            name: e.name,
+            description: e.description ?? null,
+            slug: e.slug,
+            variables: Array.isArray(e.live_version?.variables)
+              ? (e.live_version!.variables as EvaluatorVariableDef[])
+              : [],
+          };
+        }
+        setEvaluatorCatalogue(next);
+      } catch {
+        // best-effort hydration; dialog will fall back to defaults
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [accessToken]);
+
+  const editingItem = items.find((i) => i.uuid === editLlmItemUuid) ?? null;
+  const editingPayload = (editingItem?.payload ?? null) as Record<
+    string,
+    unknown
+  > | null;
+
+  // Read saved evaluator variable values from an item payload, indexed by
+  // evaluator uuid → { var: value }.
+  const readEvaluatorVariables = (
+    payload: Record<string, unknown> | null,
+  ): Record<string, Record<string, string>> => {
+    if (!payload) return {};
+    const ev = payload.evaluator_variables;
+    if (!ev || typeof ev !== "object" || Array.isArray(ev)) return {};
+    const out: Record<string, Record<string, string>> = {};
+    for (const [k, v] of Object.entries(ev as Record<string, unknown>)) {
+      if (v && typeof v === "object" && !Array.isArray(v)) {
+        const inner: Record<string, string> = {};
+        for (const [vk, vv] of Object.entries(v as Record<string, unknown>)) {
+          if (typeof vv === "string") inner[vk] = vv;
+        }
+        out[k] = inner;
+      }
+    }
+    return out;
+  };
+
+  // Build initialEvaluators[] from the task's linked evaluators using the
+  // catalogue for variable definitions, optionally seeded with saved values.
+  // If the catalogue hasn't hydrated this evaluator yet but we have saved
+  // values, fall back to inferring variable defs from the saved keys so the
+  // dialog can still render and pre-fill them.
+  const buildInitialEvaluators = (
+    savedValues: Record<string, Record<string, string>>,
+  ): AttachedEvaluatorInit[] => {
+    const linked = task?.evaluators ?? [];
+    return linked.map((ev) => {
+      const hydrated = evaluatorCatalogue[ev.uuid];
+      const saved = savedValues[ev.uuid] ?? null;
+      let variables: EvaluatorVariableDef[] = hydrated?.variables ?? [];
+      if (variables.length === 0 && saved && Object.keys(saved).length > 0) {
+        variables = Object.keys(saved).map((name) => ({ name }));
+      }
+      return {
+        evaluator_uuid: ev.uuid,
+        name: hydrated?.name ?? ev.name,
+        description: hydrated?.description ?? null,
+        slug: hydrated?.slug ?? null,
+        variables,
+        variable_values: saved,
+      };
+    });
+  };
+
+  const editingInitialEvaluators = buildInitialEvaluators(
+    readEvaluatorVariables(editingPayload),
+  );
+  const newItemInitialEvaluators = buildInitialEvaluators({});
+
+  const editingInitialConfig = (() => {
+    if (!editingPayload) return undefined;
+    type HistoryItem = TestConfig["history"][number];
+    const parseHistory = (raw: unknown): HistoryItem[] => {
+      if (!Array.isArray(raw)) return [];
+      const out: HistoryItem[] = [];
+      for (const m of raw) {
+        if (!m || typeof m !== "object") continue;
+        const obj = m as Record<string, unknown>;
+        const role = obj.role;
+        const content =
+          typeof obj.content === "string" ? obj.content : undefined;
+        const toolCalls = obj.tool_calls;
+        const toolCallId =
+          typeof obj.tool_call_id === "string" ? obj.tool_call_id : undefined;
+        if (role === "assistant") {
+          if (Array.isArray(toolCalls) && toolCalls.length > 0) {
+            out.push({
+              role: "assistant",
+              ...(content != null ? { content } : {}),
+              tool_calls: toolCalls as HistoryItem["tool_calls"],
+            });
+          } else if (content != null) {
+            out.push({ role: "assistant", content });
+          }
+        } else if (role === "user" && content != null) {
+          out.push({ role: "user", content });
+        } else if (role === "tool" && content != null) {
+          out.push({
+            role: "tool",
+            content,
+            ...(toolCallId ? { tool_call_id: toolCallId } : {}),
+          });
+        }
+      }
+      return out;
+    };
+
+    let history: HistoryItem[];
+    if (taskType === "simulation") {
+      history = parseHistory(editingPayload.transcript);
+    } else {
+      // LLM: chat_history (may include tool calls + tool responses) +
+      // optional trailing agent_response (the regular text reply being
+      // graded).
+      history = parseHistory(editingPayload.chat_history);
+      const ar = editingPayload.agent_response;
+      if (typeof ar === "string" && ar.length > 0) {
+        history.push({ role: "assistant", content: ar });
+      }
+    }
+    return {
+      history,
+      evaluation: { type: "response" as const, criteria: "" },
+    };
+  })();
+
+  // Sync the name field whenever a different item is opened for edit.
+  useEffect(() => {
+    if (editingItem) {
+      const n =
+        typeof editingPayload?.name === "string"
+          ? (editingPayload.name as string)
+          : `Item ${editingItem.id}`;
+      setEditLlmItemName(n);
+      setEditLlmError(null);
+    }
+  }, [editingItem?.uuid, editingPayload]);
+
+  const [createdJobs, setCreatedJobs] = useState<CreatedJob[]>([]);
+  const [jobsCreatedOpen, setJobsCreatedOpen] = useState(false);
+  const [resultsForItemUuid, setResultsForItemUuid] = useState<string | null>(
+    null,
+  );
+
+  const handleAssignAnnotators = async (annotatorIds: string[]) => {
+    if (selectedItemIds.size === 0 || annotatorIds.length === 0 || !accessToken)
+      return;
+    const result = await apiClient<{ count: number; jobs: CreatedJob[] }>(
+      `/annotation-tasks/${uuid}/jobs`,
+      accessToken,
+      {
+        method: "POST",
+        body: {
+          annotator_ids: annotatorIds,
+          item_ids: Array.from(selectedItemIds),
+        },
+      },
+    );
+    setAssignOpen(false);
+    setSelectedItemIds(new Set());
+    setCreatedJobs(result.jobs ?? []);
+    setJobsCreatedOpen(true);
+    fetchTask();
+  };
+
+  const [manageOpen, setManageOpen] = useState(false);
+  const [editOpen, setEditOpen] = useState(false);
+  const [addItemOpen, setAddItemOpen] = useState(false);
+  const [addSttItemsOpen, setAddSttItemsOpen] = useState(false);
+  const [newItemName, setNewItemName] = useState("");
+  const [creatingItem, setCreatingItem] = useState(false);
+  const [createItemError, setCreateItemError] = useState<string | null>(null);
+  const [validationAttempted, setValidationAttempted] = useState(false);
+
+  return (
+    <AppLayout
+      activeItem="human-labelling"
+      onItemChange={(id) => router.push(`/${id}`)}
+      sidebarOpen={sidebarOpen}
+      onSidebarToggle={() => setSidebarOpen(!sidebarOpen)}
+    >
+      <div className="py-4 md:py-6 space-y-6">
+        <button
+          onClick={() => router.push("/human-labelling?tab=tasks")}
+          className="text-sm text-muted-foreground hover:text-foreground transition-colors cursor-pointer flex items-center gap-1.5"
+        >
+          <svg
+            className="w-4 h-4"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            strokeWidth={2}
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              d="M15.75 19.5L8.25 12l7.5-7.5"
+            />
+          </svg>
+          All labelling tasks
+        </button>
+
+        {error && (
+          <div className="rounded-md border border-border bg-muted/20 p-4 text-sm text-red-500">
+            {error}
+          </div>
+        )}
+
+        {/* Header */}
+        <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-3">
+          <div className="min-w-0">
+            <div className="flex items-center gap-2 flex-wrap">
+              <h1 className="text-2xl font-semibold">
+                {loading && !task ? "Loading..." : (task?.name ?? "—")}
+              </h1>
+              {taskType && <EvaluatorTypePill evaluatorType={taskType} />}
+            </div>
+            {task?.description && (
+              <p className="text-muted-foreground text-sm md:text-base leading-relaxed mt-1 max-w-3xl">
+                {task.description}
+              </p>
+            )}
+            {task && (
+              <div className="flex flex-wrap items-center gap-1.5 mt-3">
+                <Tooltip content="Manage evaluators" position="top">
+                <button
+                  onClick={() => setManageOpen(true)}
+                  aria-label="Manage evaluators"
+                  className="inline-flex items-center justify-center px-1.5 py-0.5 rounded-md border border-border bg-muted/40 text-foreground hover:bg-muted hover:border-foreground/30 transition-colors cursor-pointer"
+                >
+                  <svg
+                    className="w-3 h-3"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                    strokeWidth={2}
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      d="M10.343 3.94c.09-.542.56-.94 1.11-.94h1.093c.55 0 1.02.398 1.11.94l.149.894c.07.424.384.764.78.93.398.164.855.142 1.205-.108l.737-.527a1.125 1.125 0 011.45.12l.773.774c.39.389.44 1.002.12 1.45l-.527.737c-.25.35-.272.806-.107 1.204.165.397.505.71.93.78l.893.15c.543.09.94.56.94 1.109v1.094c0 .55-.397 1.02-.94 1.11l-.893.149c-.425.07-.765.383-.93.78-.165.398-.143.854.107 1.204l.527.738c.32.447.269 1.06-.12 1.45l-.774.773a1.125 1.125 0 01-1.449.12l-.738-.527c-.35-.25-.806-.272-1.203-.107-.397.165-.71.505-.781.929l-.149.894c-.09.542-.56.94-1.11.94h-1.094c-.55 0-1.019-.398-1.11-.94l-.148-.894c-.071-.424-.384-.764-.781-.93-.398-.164-.854-.142-1.204.108l-.738.527c-.447.32-1.06.269-1.45-.12l-.773-.774a1.125 1.125 0 01-.12-1.45l.527-.737c.25-.35.273-.806.108-1.204-.165-.397-.505-.71-.93-.78l-.894-.15c-.542-.09-.94-.56-.94-1.109v-1.094c0-.55.398-1.02.94-1.11l.894-.149c.424-.07.764-.383.929-.78.165-.398.143-.854-.107-1.204l-.527-.738a1.125 1.125 0 01.12-1.45l.773-.773a1.125 1.125 0 011.45-.12l.737.527c.35.25.807.272 1.204.107.397-.165.71-.505.78-.929l.15-.894z"
+                    />
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
+                    />
+                  </svg>
+                </button>
+                </Tooltip>
+                {(task.evaluators ?? []).map((ev) => (
+                  <Link
+                    key={ev.uuid}
+                    href={`/evaluators/${ev.uuid}`}
+                    className="inline-flex items-center px-2 py-0.5 rounded-md text-xs font-medium border border-border bg-muted/40 text-foreground hover:bg-muted hover:border-foreground/30 transition-colors cursor-pointer"
+                    title={`Open ${ev.name}`}
+                  >
+                    {ev.name}
+                  </Link>
+                ))}
+              </div>
+            )}
+          </div>
+          {task && (
+            <div className="flex items-center gap-2 flex-shrink-0">
+              <button
+                onClick={() => setEditOpen(true)}
+                className="h-9 px-3 rounded-md text-sm font-medium bg-amber-500/15 text-amber-700 dark:text-amber-300 hover:bg-amber-500/25 border border-amber-500/30 transition-colors cursor-pointer flex items-center gap-1.5"
+                title="Edit name and description"
+                aria-label="Edit task"
+              >
+                <svg
+                  className="w-4 h-4"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                  strokeWidth={1.8}
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    d="M16.862 4.487l1.687-1.688a1.875 1.875 0 112.652 2.652L10.582 16.07a4.5 4.5 0 01-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 011.13-1.897l8.932-8.931zm0 0L19.5 7.125M18 14v4.75A2.25 2.25 0 0115.75 21H5.25A2.25 2.25 0 013 18.75V8.25A2.25 2.25 0 015.25 6H10"
+                  />
+                </svg>
+                Edit
+              </button>
+              <button
+                onClick={() => {
+                  if (taskType === "llm" || taskType === "simulation") {
+                    setNewItemName("");
+                    setCreateItemError(null);
+                    setValidationAttempted(false);
+                    setAddItemOpen(true);
+                  } else if (taskType === "stt") {
+                    setAddSttItemsOpen(true);
+                  }
+                }}
+                disabled={!canAddItem}
+                title={
+                  !canAddItem
+                    ? "Manual item entry isn't supported for this task type yet"
+                    : undefined
+                }
+                className="h-9 px-3 rounded-md text-sm font-medium bg-teal-500/15 text-teal-700 dark:text-teal-300 hover:bg-teal-500/25 border border-teal-500/30 transition-colors cursor-pointer flex items-center gap-1.5 disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                <svg
+                  className="w-4 h-4"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                  strokeWidth={2}
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    d="M12 4.5v15m7.5-7.5h-15"
+                  />
+                </svg>
+                {taskType === "stt" ? "Add items" : "Add item"}
+              </button>
+              <button
+                onClick={() => {
+                  toast.info("CSV upload isn't supported yet — coming soon.");
+                }}
+                className="h-9 px-3 rounded-md text-sm font-medium bg-foreground text-background hover:opacity-90 transition-opacity cursor-pointer flex items-center gap-1.5"
+              >
+                <svg
+                  className="w-4 h-4"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                  strokeWidth={2}
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5m-13.5-9L12 3m0 0l4.5 4.5M12 3v13.5"
+                  />
+                </svg>
+                Upload CSV
+              </button>
+            </div>
+          )}
+        </div>
+
+        {/* Tabs */}
+        <div className="border-b border-border flex items-center gap-1">
+          {[
+            {
+              id: "items" as Tab,
+              label: itemsCount > 0 ? `Items (${itemsCount})` : "Items",
+            },
+            {
+              id: "jobs" as Tab,
+              label:
+                jobsCount > 0
+                  ? `Labelling jobs (${jobsCount})`
+                  : "Labelling jobs",
+            },
+            {
+              id: "runs" as Tab,
+              label:
+                runs.length > 0
+                  ? `Evaluation runs (${runs.length})`
+                  : "Evaluation runs",
+            },
+          ].map((t) => (
+            <button
+              key={t.id}
+              onClick={() => handleTabChange(t.id)}
+              className={`px-3 py-2 text-sm font-medium -mb-px border-b-2 transition-colors cursor-pointer ${
+                activeTab === t.id
+                  ? "border-foreground text-foreground"
+                  : "border-transparent text-muted-foreground hover:text-foreground"
+              }`}
+            >
+              {t.label}
+            </button>
+          ))}
+        </div>
+
+        {activeTab === "items" &&
+          (itemsLoading ? (
+            <div className="flex items-center justify-center gap-2 py-8 text-sm text-muted-foreground">
+              <svg
+                className="w-4 h-4 animate-spin"
+                fill="none"
+                viewBox="0 0 24 24"
+              >
+                <circle
+                  className="opacity-25"
+                  cx="12"
+                  cy="12"
+                  r="10"
+                  stroke="currentColor"
+                  strokeWidth="4"
+                />
+                <path
+                  className="opacity-75"
+                  fill="currentColor"
+                  d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+                />
+              </svg>
+              Loading items
+            </div>
+          ) : itemsError ? (
+            <div className="rounded-md border border-border bg-muted/20 p-4 text-sm text-red-500">
+              {itemsError}
+            </div>
+          ) : items.length === 0 ? (
+            <EmptyState
+              icon={
+                <svg
+                  className="w-7 h-7 text-muted-foreground"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                  strokeWidth={1.5}
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    d="M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25h16.5"
+                  />
+                </svg>
+              }
+              title="No items yet"
+              description="Add items for humans to label or load existing human labelled items"
+            />
+          ) : (
+            <div className="space-y-3">
+              {/* Bulk-action toolbar (shown when at least one row is selected) */}
+              {selectedItemIds.size > 0 && (
+                <div className="flex items-center justify-between gap-3 rounded-md border border-border bg-muted/30 px-3 py-2">
+                  <span className="text-sm">
+                    <span className="font-medium">{selectedItemIds.size}</span>{" "}
+                    item{selectedItemIds.size === 1 ? "" : "s"} selected
+                  </span>
+                  <div className="flex items-center gap-2">
+                    <button
+                      onClick={() => setSelectedItemIds(new Set())}
+                      className="h-8 px-3 rounded-md text-sm font-medium text-muted-foreground hover:text-foreground hover:bg-muted transition-colors cursor-pointer"
+                    >
+                      Clear
+                    </button>
+                    {taskType === "stt" && (
+                      <button
+                        onClick={() => setEditSttItemsOpen(true)}
+                        className="h-8 px-3 rounded-md text-sm font-medium border border-border bg-background hover:bg-muted/50 transition-colors cursor-pointer"
+                      >
+                        Edit
+                      </button>
+                    )}
+                    <button
+                      onClick={() => setDeleteSelectedOpen(true)}
+                      className="h-8 px-3 rounded-md text-sm font-medium border border-red-500/30 bg-red-500/10 text-red-500 hover:bg-red-500/20 transition-colors cursor-pointer"
+                    >
+                      Delete
+                    </button>
+                    <button
+                      onClick={() => {
+                        const totalItems = items.length;
+                        const selected = Array.from(selectedItemIds);
+                        // Omit item_ids when every item is selected; otherwise
+                        // send the explicit subset.
+                        if (
+                          totalItems > 0 &&
+                          selected.length === totalItems
+                        ) {
+                          handleRunEvaluators();
+                        } else {
+                          handleRunEvaluators(selected);
+                        }
+                      }}
+                      disabled={startingRun}
+                      className="h-8 px-3 rounded-md text-sm font-medium border border-indigo-500/30 bg-indigo-500/10 text-indigo-600 dark:text-indigo-300 hover:bg-indigo-500/20 transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed inline-flex items-center gap-1.5"
+                    >
+                      {startingRun && startingRunForItem === null ? (
+                        <svg
+                          className="w-3.5 h-3.5 animate-spin"
+                          viewBox="0 0 24 24"
+                          fill="none"
+                        >
+                          <circle
+                            className="opacity-25"
+                            cx="12"
+                            cy="12"
+                            r="10"
+                            stroke="currentColor"
+                            strokeWidth="4"
+                          />
+                          <path
+                            className="opacity-75"
+                            fill="currentColor"
+                            d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z"
+                          />
+                        </svg>
+                      ) : (
+                        <svg
+                          className="w-3.5 h-3.5"
+                          fill="currentColor"
+                          viewBox="0 0 24 24"
+                        >
+                          <path d="M8 5v14l11-7z" />
+                        </svg>
+                      )}
+                      Run evaluators
+                    </button>
+                    <button
+                      onClick={() => setAssignOpen(true)}
+                      className="h-8 px-3 rounded-md text-sm font-medium bg-foreground text-background hover:opacity-90 transition-opacity cursor-pointer"
+                    >
+                      Label all
+                    </button>
+                  </div>
+                </div>
+              )}
+
+              {taskType === "stt" ? (
+                <div className="border border-border rounded-xl overflow-hidden">
+                  <div className="grid grid-cols-[40px_minmax(0,1fr)_minmax(0,1fr)_440px] gap-4 px-4 py-2 border-b border-border bg-muted/30 items-center">
+                    <input
+                      type="checkbox"
+                      checked={allSelected}
+                      ref={(el) => {
+                        if (el) el.indeterminate = someSelected;
+                      }}
+                      onChange={toggleSelectAll}
+                      aria-label="Select all"
+                      className="w-4 h-4 cursor-pointer accent-foreground"
+                    />
+                    <div className="text-sm font-medium text-muted-foreground">
+                      Reference transcript
+                    </div>
+                    <div className="text-sm font-medium text-muted-foreground">
+                      Predicted transcript
+                    </div>
+                    <div className="text-sm font-medium text-muted-foreground text-center">
+                      Actions
+                    </div>
+                  </div>
+                  {items.map((item) => {
+                    const p = (item.payload ?? {}) as Record<string, unknown>;
+                    const ref =
+                      typeof p.reference_transcript === "string"
+                        ? p.reference_transcript
+                        : "";
+                    const pred =
+                      typeof p.predicted_transcript === "string"
+                        ? p.predicted_transcript
+                        : "";
+                    const isSelected = selectedItemIds.has(item.uuid);
+                    return (
+                      <div
+                        key={item.uuid}
+                        className={`grid grid-cols-[40px_minmax(0,1fr)_minmax(0,1fr)_440px] gap-4 px-4 py-3 border-b border-border last:border-b-0 transition-colors items-center ${
+                          isSelected ? "bg-muted/30" : "hover:bg-muted/20"
+                        }`}
+                      >
+                        <input
+                          type="checkbox"
+                          checked={isSelected}
+                          onChange={() => toggleItem(item.uuid)}
+                          aria-label={`Select item ${item.id}`}
+                          className="w-4 h-4 cursor-pointer accent-foreground"
+                        />
+                        <p className="text-sm text-foreground line-clamp-2">
+                          {ref || "—"}
+                        </p>
+                        <p className="text-sm text-foreground line-clamp-2">
+                          {pred || "—"}
+                        </p>
+                        <ItemRowActions
+                          itemUuid={item.uuid}
+                          onDelete={requestDeleteOneItem}
+                          onPlay={handleRunEvaluators}
+                          onViewResults={setResultsForItemUuid}
+                          onLabel={toggleItem}
+                          playDisabled={startingRun}
+                          playLoadingForUuid={startingRunForItem}
+                        />
+                      </div>
+                    );
+                  })}
+                </div>
+              ) : (
+                <div className="border border-border rounded-xl overflow-hidden">
+                  <div className="grid grid-cols-[40px_minmax(0,1fr)_440px] gap-4 px-4 py-2 border-b border-border bg-muted/30 items-center">
+                    <input
+                      type="checkbox"
+                      checked={allSelected}
+                      ref={(el) => {
+                        if (el) el.indeterminate = someSelected;
+                      }}
+                      onChange={toggleSelectAll}
+                      aria-label="Select all"
+                      className="w-4 h-4 cursor-pointer accent-foreground"
+                    />
+                    <div className="text-sm font-medium text-muted-foreground">
+                      Name
+                    </div>
+                    <div className="text-sm font-medium text-muted-foreground text-center">
+                      Actions
+                    </div>
+                  </div>
+                  {items.map((item) => {
+                    const isSelected = selectedItemIds.has(item.uuid);
+                    return (
+                      <div
+                        key={item.uuid}
+                        onClick={() => setEditLlmItemUuid(item.uuid)}
+                        className={`grid grid-cols-[40px_minmax(0,1fr)_440px] gap-4 px-4 py-3 border-b border-border last:border-b-0 transition-colors items-center cursor-pointer ${
+                          isSelected ? "bg-muted/30" : "hover:bg-muted/20"
+                        }`}
+                      >
+                        <input
+                          type="checkbox"
+                          checked={isSelected}
+                          onChange={() => toggleItem(item.uuid)}
+                          onClick={(e) => e.stopPropagation()}
+                          aria-label={`Select item ${item.id}`}
+                          className="w-4 h-4 cursor-pointer accent-foreground"
+                        />
+                        <p className="text-sm text-foreground line-clamp-1">
+                          {previewItemPayload(item.payload, taskType)}
+                        </p>
+                        <ItemRowActions
+                          itemUuid={item.uuid}
+                          onDelete={requestDeleteOneItem}
+                          onPlay={handleRunEvaluators}
+                          onViewResults={setResultsForItemUuid}
+                          onLabel={toggleItem}
+                          playDisabled={startingRun}
+                          playLoadingForUuid={startingRunForItem}
+                        />
+                      </div>
+                    );
+                  })}
+                </div>
+              )}
+            </div>
+          ))}
+
+        {activeTab === "jobs" &&
+          (jobs.length === 0 ? (
+            <EmptyState
+              icon={
+                <svg
+                  className="w-7 h-7 text-muted-foreground"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                  strokeWidth={1.5}
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    d="M20.25 14.15v4.25c0 1.094-.787 2.036-1.872 2.18-2.087.277-4.216.42-6.378.42s-4.291-.143-6.378-.42c-1.085-.144-1.872-1.086-1.872-2.18v-4.25m16.5 0a2.18 2.18 0 00.75-1.661V8.706c0-1.081-.768-2.015-1.837-2.175a48.114 48.114 0 00-3.413-.387m4.5 8.006c-.194.165-.42.295-.673.38A23.978 23.978 0 0112 15.75c-2.648 0-5.195-.429-7.577-1.22a2.16 2.16 0 01-.673-.38m0 0A2.18 2.18 0 013 12.489V8.706c0-1.081.768-2.015 1.837-2.175a48.111 48.111 0 013.413-.387m7.5 0V5.25A2.25 2.25 0 0013.5 3h-3a2.25 2.25 0 00-2.25 2.25v.894m7.5 0a48.667 48.667 0 00-7.5 0M12 12.75h.008v.008H12v-.008z"
+                  />
+                </svg>
+              }
+              title="No labelling jobs yet"
+              description="Assigning items to annotators creates a job they need to complete"
+            />
+          ) : (
+            <JobsList jobs={jobs} />
+          ))}
+
+        {activeTab === "runs" && (
+          <EvaluatorRunsList
+            runs={runs}
+            loading={runsLoading}
+            error={runsError}
+            versionLabels={versionLabels}
+            onRequestDelete={(runUuid) => setDeletingRunUuid(runUuid)}
+            onOpen={(runUuid) =>
+              router.push(
+                `/human-labelling/tasks/${uuid}/evaluator-runs/${runUuid}`,
+              )
+            }
+          />
+        )}
+      </div>
+
+      {addItemOpen && (
+      <AddTestDialog
+        isOpen={addItemOpen}
+        onClose={() => {
+          if (!creatingItem) setAddItemOpen(false);
+        }}
+        isEditing={false}
+        isLoading={false}
+        isCreating={creatingItem}
+        createError={createItemError}
+        testName={newItemName}
+        setTestName={setNewItemName}
+        validationAttempted={validationAttempted}
+        mode="labelItem"
+        allowAgentLastMessage={taskType === "simulation"}
+        requireAssistantLastMessage={taskType === "llm"}
+        initialEvaluators={newItemInitialEvaluators}
+        onSubmit={async (
+          config: TestConfig,
+          evaluators: EvaluatorRefPayload[],
+        ) => {
+          setValidationAttempted(true);
+          if (!newItemName.trim()) return;
+          if (!accessToken) return;
+
+          // Preserve the rich TestConfig.history shape — assistant
+          // messages with `tool_calls`, and `tool` messages with their
+          // `tool_call_id` — the same shape tests are saved with. Drop
+          // only entries that have neither content nor tool_calls.
+          const history = (config.history ?? []).filter((h) => {
+            if (h.role === "assistant") {
+              if (Array.isArray(h.tool_calls) && h.tool_calls.length > 0)
+                return true;
+              return typeof h.content === "string" && h.content.length > 0;
+            }
+            if (h.role === "user") {
+              return typeof h.content === "string" && h.content.length > 0;
+            }
+            if (h.role === "tool") {
+              return typeof h.content === "string";
+            }
+            return false;
+          });
+
+          // Capture per-evaluator variable values entered in the dialog,
+          // keyed by evaluator uuid for easy lookup on edit.
+          const evaluator_variables: Record<
+            string,
+            Record<string, string>
+          > = {};
+          for (const e of evaluators) {
+            if (e.variable_values) {
+              evaluator_variables[e.evaluator_uuid] = { ...e.variable_values };
+            }
+          }
+
+          let payload: Record<string, unknown>;
+          if (taskType === "simulation") {
+            payload = {
+              name: newItemName.trim(),
+              transcript: history,
+              evaluator_variables,
+            };
+          } else {
+            // LLM: split the trailing plain agent reply (no tool_calls)
+            // out as `agent_response`. Tool-call assistant messages stay
+            // in `chat_history` since they aren't a graded reply.
+            let chat_history = history;
+            let agent_response = "";
+            const last = history[history.length - 1];
+            if (
+              last &&
+              last.role === "assistant" &&
+              !(Array.isArray(last.tool_calls) && last.tool_calls.length > 0) &&
+              typeof last.content === "string"
+            ) {
+              chat_history = history.slice(0, -1);
+              agent_response = last.content;
+            }
+            payload = {
+              name: newItemName.trim(),
+              chat_history,
+              agent_response,
+              evaluator_variables,
+            };
+          }
+
+          setCreatingItem(true);
+          setCreateItemError(null);
+          try {
+            await apiClient(`/annotation-tasks/${uuid}/items`, accessToken, {
+              method: "POST",
+              body: { items: [{ payload }] },
+            });
+            setAddItemOpen(false);
+            await fetchTask();
+          } catch (err) {
+            setCreateItemError(parseApiError(err, "Failed to create item"));
+          } finally {
+            setCreatingItem(false);
+          }
+        }}
+      />
+      )}
+
+      {!!editLlmItemUuid && taskType !== "stt" && (
+      <AddTestDialog
+        key={editLlmItemUuid}
+        isOpen={true}
+        onClose={() => {
+          if (!savingLlmItem) setEditLlmItemUuid(null);
+        }}
+        isEditing={true}
+        isLoading={false}
+        isCreating={savingLlmItem}
+        createError={editLlmError}
+        testName={editLlmItemName}
+        setTestName={setEditLlmItemName}
+        validationAttempted={false}
+        mode="labelItem"
+        allowAgentLastMessage={taskType === "simulation"}
+        requireAssistantLastMessage={taskType === "llm"}
+        initialConfig={editingInitialConfig}
+        initialEvaluators={editingInitialEvaluators}
+        onSubmit={async (
+          config: TestConfig,
+          evaluators: EvaluatorRefPayload[],
+        ) => {
+          if (!editLlmItemUuid || !editLlmItemName.trim() || !accessToken)
+            return;
+          const history = (config.history ?? []).filter((h) => {
+            if (h.role === "assistant") {
+              if (Array.isArray(h.tool_calls) && h.tool_calls.length > 0)
+                return true;
+              return typeof h.content === "string" && h.content.length > 0;
+            }
+            if (h.role === "user") {
+              return typeof h.content === "string" && h.content.length > 0;
+            }
+            if (h.role === "tool") {
+              return typeof h.content === "string";
+            }
+            return false;
+          });
+          const evaluator_variables: Record<
+            string,
+            Record<string, string>
+          > = {};
+          for (const e of evaluators) {
+            if (e.variable_values) {
+              evaluator_variables[e.evaluator_uuid] = { ...e.variable_values };
+            }
+          }
+          let payload: Record<string, unknown>;
+          if (taskType === "simulation") {
+            payload = {
+              name: editLlmItemName.trim(),
+              transcript: history,
+              evaluator_variables,
+            };
+          } else {
+            let chat_history = history;
+            let agent_response = "";
+            const last = history[history.length - 1];
+            if (
+              last &&
+              last.role === "assistant" &&
+              !(Array.isArray(last.tool_calls) && last.tool_calls.length > 0) &&
+              typeof last.content === "string"
+            ) {
+              chat_history = history.slice(0, -1);
+              agent_response = last.content;
+            }
+            payload = {
+              name: editLlmItemName.trim(),
+              chat_history,
+              agent_response,
+              evaluator_variables,
+            };
+          }
+          setSavingLlmItem(true);
+          setEditLlmError(null);
+          try {
+            await apiClient<{ updated_count: number }>(
+              `/annotation-tasks/${uuid}/items`,
+              accessToken,
+              {
+                method: "PUT",
+                body: {
+                  updates: [{ uuid: editLlmItemUuid, payload }],
+                },
+              },
+            );
+            setEditLlmItemUuid(null);
+            await fetchTask();
+          } catch (err) {
+            setEditLlmError(parseApiError(err, "Failed to save item"));
+          } finally {
+            setSavingLlmItem(false);
+          }
+        }}
+      />
+      )}
+
+      {accessToken && task && (
+        <EditTaskDialog
+          isOpen={editOpen}
+          accessToken={accessToken}
+          taskUuid={task.uuid}
+          initialName={task.name}
+          initialDescription={task.description ?? ""}
+          onClose={() => setEditOpen(false)}
+          onSaved={() => {
+            setEditOpen(false);
+            fetchTask();
+          }}
+        />
+      )}
+
+      <AddSttItemsDialog
+        isOpen={addSttItemsOpen}
+        onClose={() => setAddSttItemsOpen(false)}
+        onSubmit={async (rows) => {
+          if (!accessToken) return;
+          await apiClient(`/annotation-tasks/${uuid}/items`, accessToken, {
+            method: "POST",
+            body: {
+              items: rows.map((r) => ({
+                payload: {
+                  reference_transcript: r.actual_transcript,
+                  predicted_transcript: r.predicted_transcript,
+                },
+              })),
+            },
+          });
+          await fetchTask();
+          setAddSttItemsOpen(false);
+        }}
+      />
+
+      <AddSttItemsDialog
+        isOpen={editSttItemsOpen}
+        mode="edit"
+        initialRows={items
+          .filter((it) => selectedItemIds.has(it.uuid))
+          .map((it) => {
+            const p = (it.payload ?? {}) as Record<string, unknown>;
+            return {
+              uuid: it.uuid,
+              actual:
+                typeof p.reference_transcript === "string"
+                  ? p.reference_transcript
+                  : "",
+              predicted:
+                typeof p.predicted_transcript === "string"
+                  ? p.predicted_transcript
+                  : "",
+            };
+          })}
+        onClose={() => setEditSttItemsOpen(false)}
+        onSubmit={async (rows) => {
+          if (!accessToken) return;
+          await apiClient<{ updated_count: number }>(
+            `/annotation-tasks/${uuid}/items`,
+            accessToken,
+            {
+              method: "PUT",
+              body: {
+                updates: rows
+                  .filter((r) => !!r.uuid)
+                  .map((r) => ({
+                    uuid: r.uuid,
+                    payload: {
+                      reference_transcript: r.actual_transcript,
+                      predicted_transcript: r.predicted_transcript,
+                    },
+                  })),
+              },
+            },
+          );
+          await fetchTask();
+          setEditSttItemsOpen(false);
+          setSelectedItemIds(new Set());
+        }}
+      />
+
+      {accessToken && (
+        <AssignAnnotatorsDialog
+          isOpen={assignOpen}
+          accessToken={accessToken}
+          selectedItemCount={selectedItemIds.size}
+          onClose={() => setAssignOpen(false)}
+          onConfirm={handleAssignAnnotators}
+        />
+      )}
+
+      <JobsCreatedDialog
+        isOpen={jobsCreatedOpen}
+        jobs={createdJobs}
+        onClose={() => setJobsCreatedOpen(false)}
+      />
+
+      <ItemResultsDialog
+        isOpen={!!resultsForItemUuid}
+        onClose={() => setResultsForItemUuid(null)}
+        itemName={(() => {
+          const it = items.find((i) => i.uuid === resultsForItemUuid);
+          if (!it) return "";
+          const p = (it.payload ?? {}) as Record<string, unknown>;
+          if (typeof p.name === "string" && p.name) return p.name;
+          return `Item ${it.id}`;
+        })()}
+        evaluators={(task?.evaluators ?? []).map((e) => ({
+          uuid: e.uuid,
+          name: e.name,
+        }))}
+      />
+
+      <DeleteConfirmationDialog
+        isOpen={deleteSelectedOpen}
+        onClose={() => {
+          if (!deletingSelected) setDeleteSelectedOpen(false);
+        }}
+        onConfirm={handleDeleteSelected}
+        title="Delete items"
+        message={`Delete ${selectedItemIds.size} item${selectedItemIds.size === 1 ? "" : "s"}? Any annotations on ${selectedItemIds.size === 1 ? "this item" : "these items"} will also be lost. This cannot be undone.`}
+        confirmText="Delete"
+        isDeleting={deletingSelected}
+      />
+
+      <DeleteConfirmationDialog
+        isOpen={!!deletingOneUuid}
+        onClose={() => {
+          if (!deletingOneInFlight) setDeletingOneUuid(null);
+        }}
+        onConfirm={confirmDeleteOneItem}
+        title="Delete item"
+        message="Delete this item? Any annotations on it will also be lost. This cannot be undone."
+        confirmText="Delete"
+        isDeleting={deletingOneInFlight}
+      />
+
+      <DeleteConfirmationDialog
+        isOpen={!!deletingRunUuid}
+        onClose={() => {
+          if (!deletingRunInFlight) setDeletingRunUuid(null);
+        }}
+        onConfirm={confirmDeleteRun}
+        title="Delete evaluation run"
+        message="Delete this evaluation run? Per-item results from this run will no longer be visible. This cannot be undone."
+        confirmText="Delete"
+        isDeleting={deletingRunInFlight}
+      />
+
+      {manageOpen && accessToken && task && (
+        <ManageEvaluatorsDialog
+          accessToken={accessToken}
+          taskUuid={task.uuid}
+          taskType={task.type ?? task.evaluators?.[0]?.evaluator_type}
+          currentEvaluatorIds={(task.evaluators ?? []).map((e) => e.uuid)}
+          onClose={() => setManageOpen(false)}
+          onSaved={() => {
+            setManageOpen(false);
+            fetchTask();
+          }}
+        />
+      )}
+    </AppLayout>
+  );
+}

--- a/src/app/human-labelling/tasks/[uuid]/page.tsx
+++ b/src/app/human-labelling/tasks/[uuid]/page.tsx
@@ -6,6 +6,7 @@ import {
   useCallback,
   useEffect,
   useMemo,
+  useRef,
   useState,
 } from "react";
 import Link from "next/link";
@@ -516,27 +517,22 @@ function EvaluatorRunsList({
 function ItemRowActions({
   itemUuid,
   onDelete,
-  onPlay,
   onViewResults,
   onLabel,
-  playDisabled,
-  playLoadingForUuid,
+  onEvaluate,
   isResultsOpen,
   viewResultsDisabled,
   viewResultsDisabledTooltip,
 }: {
   itemUuid: string;
   onDelete: (uuid: string) => void | Promise<void>;
-  onPlay: (uuid: string) => void | Promise<void>;
   onViewResults: (uuid: string) => void;
   onLabel?: (uuid: string) => void;
-  playDisabled?: boolean;
-  playLoadingForUuid?: string | null;
+  onEvaluate?: (uuid: string) => void;
   isResultsOpen?: boolean;
   viewResultsDisabled?: boolean;
   viewResultsDisabledTooltip?: string;
 }) {
-  const isLoading = playLoadingForUuid === itemUuid;
   return (
     <div
       className="flex items-center justify-center gap-2"
@@ -550,6 +546,16 @@ function ItemRowActions({
           className="h-8 px-3 rounded-md text-sm font-medium bg-foreground text-background hover:opacity-90 transition-opacity cursor-pointer"
         >
           Label
+        </button>
+      )}
+      {onEvaluate && (
+        <button
+          type="button"
+          onClick={() => onEvaluate(itemUuid)}
+          aria-label="Evaluate"
+          className="h-8 px-3 rounded-md text-sm font-medium border border-indigo-500/30 bg-indigo-500/10 text-indigo-600 dark:text-indigo-300 hover:bg-indigo-500/20 transition-colors cursor-pointer"
+        >
+          Evaluate
         </button>
       )}
       {/* View / Hide results (toggle) */}
@@ -625,41 +631,6 @@ function ItemRowActions({
           {isResultsOpen ? "Hide results" : "View results"}
         </button>
       )}
-      {/* Run evaluators */}
-      <button
-        type="button"
-        onClick={() => onPlay(itemUuid)}
-        disabled={playDisabled || isLoading}
-        aria-label="Run evaluators"
-        className="h-8 px-3 inline-flex items-center gap-1.5 rounded-md text-sm font-medium border border-indigo-500/30 bg-indigo-500/10 text-indigo-600 dark:text-indigo-300 hover:bg-indigo-500/20 transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
-      >
-        {isLoading ? (
-          <svg
-            className="w-3.5 h-3.5 animate-spin"
-            viewBox="0 0 24 24"
-            fill="none"
-          >
-            <circle
-              className="opacity-25"
-              cx="12"
-              cy="12"
-              r="10"
-              stroke="currentColor"
-              strokeWidth="4"
-            />
-            <path
-              className="opacity-75"
-              fill="currentColor"
-              d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z"
-            />
-          </svg>
-        ) : (
-          <svg className="w-3.5 h-3.5" fill="currentColor" viewBox="0 0 24 24">
-            <path d="M8 5v14l11-7z" />
-          </svg>
-        )}
-        Run evaluators
-      </button>
       {/* Delete Button */}
       <button
         type="button"
@@ -841,6 +812,12 @@ function LabellingTaskPageInner() {
     [uuid],
   );
 
+  // After landing on the task page for the first time, if the task has
+  // no items yet *and* the URL didn't pin a specific tab, drop the user
+  // straight onto the items tab — that's the next thing they need to
+  // do. Guarded by a ref so we don't fight the user's later tab choices.
+  const autoTabSwitchedRef = useRef(false);
+
   const [task, setTask] = useState<LabellingTask | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -882,6 +859,16 @@ function LabellingTaskPageInner() {
     fetchTask();
   }, [fetchTask]);
 
+  useEffect(() => {
+    if (autoTabSwitchedRef.current) return;
+    if (!task) return;
+    autoTabSwitchedRef.current = true;
+    if (isTab(initialTab)) return; // user pinned a tab via URL
+    if ((task.items?.length ?? 0) === 0) {
+      handleTabChange("items");
+    }
+  }, [task, initialTab, handleTabChange]);
+
   // Evaluator runs.
   const [runs, setRuns] = useState<EvaluatorRunJob[]>([]);
   const [runsLoading, setRunsLoading] = useState(false);
@@ -917,7 +904,10 @@ function LabellingTaskPageInner() {
   const [taskSummary, setTaskSummary] = useState<TaskSummaryResponse | null>(
     null,
   );
-  const [taskSummaryLoading, setTaskSummaryLoading] = useState(false);
+  // setter is kept; the boolean is no longer rendered (the agreement
+  // spinner above stands in for both fetches), but we still flip it so
+  // future code can subscribe if needed.
+  const [, setTaskSummaryLoading] = useState(false);
   const [taskSummaryError, setTaskSummaryError] = useState<string | null>(null);
   const [summaryEvaluatorFilter, setSummaryEvaluatorFilter] = useState<
     PickerItem[]
@@ -1084,9 +1074,6 @@ function LabellingTaskPageInner() {
   }, [items]);
 
   const [startingRun, setStartingRun] = useState(false);
-  const [startingRunForItem, setStartingRunForItem] = useState<string | null>(
-    null,
-  );
   // Run evaluators dialog state. itemUuids: null = all items in task,
   // []/non-empty = the specific items to run for.
   const [runDialogOpen, setRunDialogOpen] = useState(false);
@@ -1120,7 +1107,6 @@ function LabellingTaskPageInner() {
     if (!accessToken || !uuid || startingRun) return;
     const ids = runDialogItemUuids;
     setStartingRun(true);
-    setStartingRunForItem(ids && ids.length === 1 ? ids[0] : null);
     setRunDialogSubmitError(null);
     try {
       const body: Record<string, unknown> = { evaluators: selections };
@@ -1143,11 +1129,10 @@ function LabellingTaskPageInner() {
       setRunDialogSubmitError(msg);
       toast.error(msg);
       setStartingRun(false);
-      setStartingRunForItem(null);
     }
-    // Note: we intentionally keep the spinner state on the success path until
-    // the navigation completes (page unmounts), so the row's play button stays
-    // as a spinner up to the redirect.
+    // Note: we intentionally keep `startingRun=true` on the success path
+    // until the navigation completes (page unmounts), so the bulk
+    // "Evaluate all" button stays in its loading state up to the redirect.
   };
 
   const [deletingRunUuid, setDeletingRunUuid] = useState<string | null>(null);
@@ -1950,30 +1935,7 @@ function LabellingTaskPageInner() {
                 {taskSummaryError}
               </div>
             )}
-            {taskSummaryLoading && !taskSummary ? (
-              <div className="flex items-center justify-center gap-2 py-8 text-sm text-muted-foreground">
-                <svg
-                  className="w-4 h-4 animate-spin"
-                  fill="none"
-                  viewBox="0 0 24 24"
-                >
-                  <circle
-                    className="opacity-25"
-                    cx="12"
-                    cy="12"
-                    r="10"
-                    stroke="currentColor"
-                    strokeWidth="4"
-                  />
-                  <path
-                    className="opacity-75"
-                    fill="currentColor"
-                    d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
-                  />
-                </svg>
-                Loading labels
-              </div>
-            ) : !taskSummary ? null : (
+            {!taskSummary ? null : (
               (() => {
                 const annotators = taskSummary.annotators ?? [];
                 const evaluators = taskSummary.evaluators ?? [];
@@ -2403,7 +2365,7 @@ function LabellingTaskPageInner() {
                       disabled={startingRun}
                       className="h-8 px-3 rounded-md text-sm font-medium border border-indigo-500/30 bg-indigo-500/10 text-indigo-600 dark:text-indigo-300 hover:bg-indigo-500/20 transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed inline-flex items-center gap-1.5"
                     >
-                      {startingRun && startingRunForItem === null ? (
+                      {startingRun && (
                         <svg
                           className="w-3.5 h-3.5 animate-spin"
                           viewBox="0 0 24 24"
@@ -2423,22 +2385,14 @@ function LabellingTaskPageInner() {
                             d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z"
                           />
                         </svg>
-                      ) : (
-                        <svg
-                          className="w-3.5 h-3.5"
-                          fill="currentColor"
-                          viewBox="0 0 24 24"
-                        >
-                          <path d="M8 5v14l11-7z" />
-                        </svg>
                       )}
-                      Run evaluators
+                      Evaluate selected
                     </button>
                     <button
                       onClick={() => setAssignOpen(true)}
                       className="h-8 px-3 rounded-md text-sm font-medium bg-foreground text-background hover:opacity-90 transition-opacity cursor-pointer"
                     >
-                      Label all
+                      Label selected
                     </button>
                   </div>
                 </div>
@@ -2502,11 +2456,26 @@ function LabellingTaskPageInner() {
                           <ItemRowActions
                             itemUuid={item.uuid}
                             onDelete={requestDeleteOneItem}
-                            onPlay={handleRunEvaluators}
                             onViewResults={toggleItemResults}
-                            onLabel={toggleItem}
-                            playDisabled={startingRun}
-                            playLoadingForUuid={startingRunForItem}
+                            onLabel={(uuid) => {
+                              // Sole row → skip the select-then-bulk
+                              // dance and open the assign dialog
+                              // straight on this item.
+                              if (items.length === 1) {
+                                setSelectedItemIds(new Set([uuid]));
+                                setAssignOpen(true);
+                              } else {
+                                toggleItem(uuid);
+                              }
+                            }}
+                            onEvaluate={(uuid) => {
+                              if (items.length === 1) {
+                                setSelectedItemIds(new Set([uuid]));
+                                handleRunEvaluators([uuid]);
+                              } else {
+                                toggleItem(uuid);
+                              }
+                            }}
                             isResultsOpen={isResultsOpen}
                             viewResultsDisabled={
                               !!taskSummary && !itemsWithResults.has(item.uuid)
@@ -2567,11 +2536,26 @@ function LabellingTaskPageInner() {
                           <ItemRowActions
                             itemUuid={item.uuid}
                             onDelete={requestDeleteOneItem}
-                            onPlay={handleRunEvaluators}
                             onViewResults={toggleItemResults}
-                            onLabel={toggleItem}
-                            playDisabled={startingRun}
-                            playLoadingForUuid={startingRunForItem}
+                            onLabel={(uuid) => {
+                              // Sole row → skip the select-then-bulk
+                              // dance and open the assign dialog
+                              // straight on this item.
+                              if (items.length === 1) {
+                                setSelectedItemIds(new Set([uuid]));
+                                setAssignOpen(true);
+                              } else {
+                                toggleItem(uuid);
+                              }
+                            }}
+                            onEvaluate={(uuid) => {
+                              if (items.length === 1) {
+                                setSelectedItemIds(new Set([uuid]));
+                                handleRunEvaluators([uuid]);
+                              } else {
+                                toggleItem(uuid);
+                              }
+                            }}
                             isResultsOpen={isResultsOpen}
                             viewResultsDisabled={
                               !!taskSummary && !itemsWithResults.has(item.uuid)

--- a/src/app/human-labelling/tasks/[uuid]/page.tsx
+++ b/src/app/human-labelling/tasks/[uuid]/page.tsx
@@ -27,13 +27,116 @@ import {
 } from "@/components/human-labelling/JobsCreatedDialog";
 import { ManageEvaluatorsDialog } from "@/components/human-labelling/ManageEvaluatorsDialog";
 import { EmptyState } from "@/components/ui/LoadingState";
+import {
+  MultiSelectPicker,
+  type PickerItem,
+} from "@/components/MultiSelectPicker";
 import { useAccessToken } from "@/hooks";
 import { apiClient } from "@/lib/api";
 import { useSidebarState } from "@/lib/sidebar";
 
-type Tab = "items" | "jobs" | "runs";
+type Tab = "overview" | "items" | "jobs" | "runs";
 
-const TABS: Tab[] = ["items", "jobs", "runs"];
+type AgreementBlock = {
+  current: number | null;
+  pair_count: number;
+};
+
+type TaskAgreementResponse = {
+  human_human: AgreementBlock;
+  evaluators: (AgreementBlock & { evaluator_id: string; name: string })[];
+};
+
+// Denormalized one-row-per-(item × linked evaluator) view from
+// /annotation-tasks/{uuid}/summary. `annotators[]` provides the column
+// order (union of every annotator with ≥1 annotation on the task);
+// each `rows[i].annotations[annotator_uuid]` is that annotator's
+// latest annotation for the slot, or null when they didn't label it.
+type SummaryAnnotator = { uuid: string; name: string };
+type SummaryEvaluator = {
+  evaluator_id: string;
+  name: string;
+  output_type: "binary" | "rating";
+};
+type SummaryAnnotation = {
+  value: boolean | number | null;
+  reasoning?: string | null;
+};
+type SummaryRow = {
+  item_id: string;
+  payload: Record<string, unknown> | null;
+  evaluator_id: string;
+  evaluator_name: string;
+  output_type: "binary" | "rating";
+  evaluator_version_id?: string | null;
+  evaluator_version_number?: number | null;
+  evaluator_value: boolean | number | null;
+  evaluator_reasoning?: string | null;
+  // Aggregate agreement scores in [0, 1] for this (item, evaluator) slot.
+  // human_agreement: null when <2 annotators labelled the slot.
+  // evaluator_agreement: null when no evaluator run / no annotators / types incomparable.
+  human_agreement: number | null;
+  evaluator_agreement: number | null;
+  annotations: Record<string, SummaryAnnotation | null>;
+};
+type TaskSummaryResponse = {
+  task_id: string;
+  task_type: "stt" | "llm" | "simulation";
+  evaluators: SummaryEvaluator[];
+  annotators: SummaryAnnotator[];
+  rows: SummaryRow[];
+};
+
+function formatVerdictValue(
+  v: boolean | number | null | undefined,
+): string {
+  if (v === null || v === undefined) return "—";
+  if (typeof v === "boolean") return v ? "Correct" : "Wrong";
+  if (typeof v === "number") return String(v);
+  return "—";
+}
+
+function verdictTextClass(
+  v: boolean | number | null | undefined,
+): string {
+  if (v === null || v === undefined) return "text-muted-foreground";
+  if (v === true) return "text-green-600 dark:text-green-400";
+  if (v === false) return "text-red-600 dark:text-red-400";
+  return "text-foreground";
+}
+
+function agreementColor(v: number | null | undefined): string {
+  if (v == null) return "text-muted-foreground";
+  const pct = v * 100;
+  if (pct >= 75) return "text-green-600 dark:text-green-400";
+  if (pct <= 50) return "text-red-600 dark:text-red-400";
+  return "text-yellow-600 dark:text-yellow-400";
+}
+
+function AgreementStatCard({
+  label,
+  value,
+  valueClassName = "",
+}: {
+  label: string;
+  value: string;
+  valueClassName?: string;
+}) {
+  return (
+    <div className="border border-border rounded-lg px-4 py-3 bg-background min-w-[160px]">
+      <div className="text-[10px] uppercase tracking-wide text-muted-foreground">
+        {label}
+      </div>
+      <div
+        className={`text-2xl font-semibold tabular-nums ${valueClassName}`}
+      >
+        {value}
+      </div>
+    </div>
+  );
+}
+
+const TABS: Tab[] = ["overview", "items", "jobs", "runs"];
 
 type EvaluatorRunMetricEntry = number | { type?: string; mean?: number | null };
 
@@ -90,7 +193,7 @@ type LabellingJob = {
   created_at: string;
   completed_at: string | null;
   item_count: number;
-  annotation_count: number;
+  completed_item_count: number;
 };
 
 type LabellingTask = {
@@ -334,7 +437,7 @@ function EvaluatorRunsList({
                   return (
                     <span
                       key={`${e.evaluator_id}-${e.evaluator_version_id ?? ""}`}
-                      className="inline-flex items-center gap-1 px-2 py-0.5 rounded-md text-xs font-medium border border-border bg-muted/40 text-foreground"
+                      className="inline-flex items-center gap-1 px-2 py-0.5 rounded-md text-xs font-medium border border-border bg-background text-foreground"
                     >
                       <span className="truncate max-w-[140px]">{name}</span>
                       {label && (
@@ -630,7 +733,7 @@ function JobsList({ jobs }: { jobs: LabellingJob[] }) {
               </span>
             </div>
             <div className="text-sm text-muted-foreground tabular-nums">
-              {job.annotation_count} / {job.item_count}
+              {job.completed_item_count} / {job.item_count}
             </div>
           </div>
         );
@@ -658,7 +761,7 @@ function LabellingTaskPageInner() {
 
   const initialTab = searchParams.get("tab");
   const [activeTab, setActiveTab] = useState<Tab>(
-    isTab(initialTab) ? initialTab : "items",
+    isTab(initialTab) ? initialTab : "overview",
   );
 
   const handleTabChange = useCallback(
@@ -718,6 +821,73 @@ function LabellingTaskPageInner() {
   const [runs, setRuns] = useState<EvaluatorRunJob[]>([]);
   const [runsLoading, setRunsLoading] = useState(false);
   const [runsError, setRunsError] = useState<string | null>(null);
+
+  const [agreement, setAgreement] = useState<TaskAgreementResponse | null>(
+    null,
+  );
+  const [agreementLoading, setAgreementLoading] = useState(false);
+  const [agreementError, setAgreementError] = useState<string | null>(null);
+
+  const fetchAgreement = useCallback(async () => {
+    if (!accessToken || !uuid) return;
+    setAgreementLoading(true);
+    setAgreementError(null);
+    try {
+      const data = await apiClient<TaskAgreementResponse>(
+        `/annotation-tasks/${uuid}/agreement?bucket=month&days=180`,
+        accessToken,
+      );
+      setAgreement(data);
+    } catch (err) {
+      setAgreementError(parseApiError(err, "Failed to load agreement"));
+    } finally {
+      setAgreementLoading(false);
+    }
+  }, [accessToken, uuid]);
+
+  useEffect(() => {
+    if (activeTab === "overview") fetchAgreement();
+  }, [activeTab, fetchAgreement]);
+
+  const [taskSummary, setTaskSummary] = useState<TaskSummaryResponse | null>(
+    null,
+  );
+  const [taskSummaryLoading, setTaskSummaryLoading] = useState(false);
+  const [taskSummaryError, setTaskSummaryError] = useState<string | null>(
+    null,
+  );
+  const [summaryEvaluatorFilter, setSummaryEvaluatorFilter] = useState<
+    PickerItem[]
+  >([]);
+  // sortColKey: "evaluator" for the evaluator-value column, or an annotator
+  // uuid for that annotator's column. null → keep API order.
+  const [summarySortColKey, setSummarySortColKey] = useState<string | null>(
+    null,
+  );
+  const [summarySortDir, setSummarySortDir] = useState<"asc" | "desc">(
+    "desc",
+  );
+
+  const fetchTaskSummary = useCallback(async () => {
+    if (!accessToken || !uuid) return;
+    setTaskSummaryLoading(true);
+    setTaskSummaryError(null);
+    try {
+      const data = await apiClient<TaskSummaryResponse>(
+        `/annotation-tasks/${uuid}/summary`,
+        accessToken,
+      );
+      setTaskSummary(data);
+    } catch (err) {
+      setTaskSummaryError(parseApiError(err, "Failed to load task summary"));
+    } finally {
+      setTaskSummaryLoading(false);
+    }
+  }, [accessToken, uuid]);
+
+  useEffect(() => {
+    if (activeTab === "overview") fetchTaskSummary();
+  }, [activeTab, fetchTaskSummary]);
   // Map evaluator_id -> { version_id: "v1" }, populated on demand from
   // /evaluators/{uuid}/versions so we can label runs by version number.
   const [versionLabels, setVersionLabels] = useState<
@@ -1345,6 +1515,7 @@ function LabellingTaskPageInner() {
         {/* Tabs */}
         <div className="border-b border-border flex items-center gap-1">
           {[
+            { id: "overview" as Tab, label: "Overview" },
             {
               id: "items" as Tab,
               label: itemsCount > 0 ? `Items (${itemsCount})` : "Items",
@@ -1377,6 +1548,449 @@ function LabellingTaskPageInner() {
             </button>
           ))}
         </div>
+
+        {activeTab === "overview" && (
+          <div className="space-y-4 md:space-y-6">
+            {agreementError && (
+              <div className="rounded-md border border-border bg-muted/20 p-4 text-sm text-red-500">
+                {agreementError}
+              </div>
+            )}
+
+            {agreementLoading && !agreement ? (
+              <div className="flex items-center justify-center gap-2 py-8 text-sm text-muted-foreground">
+                <svg
+                  className="w-4 h-4 animate-spin"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                >
+                  <circle
+                    className="opacity-25"
+                    cx="12"
+                    cy="12"
+                    r="10"
+                    stroke="currentColor"
+                    strokeWidth="4"
+                  />
+                  <path
+                    className="opacity-75"
+                    fill="currentColor"
+                    d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+                  />
+                </svg>
+                Loading agreement
+              </div>
+            ) : !agreement ||
+              ((agreement.human_human?.pair_count ?? 0) === 0 &&
+                (agreement.evaluators ?? []).every(
+                  (e) => (e.pair_count ?? 0) === 0,
+                )) ? (
+              <EmptyState
+                icon={
+                  <svg
+                    className="w-7 h-7 text-muted-foreground"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                    strokeWidth={1.5}
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      d="M3 13.125C3 12.504 3.504 12 4.125 12h2.25c.621 0 1.125.504 1.125 1.125v6.75C7.5 20.496 6.996 21 6.375 21h-2.25A1.125 1.125 0 013 19.875v-6.75zM9.75 8.625c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125v11.25c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 01-1.125-1.125V8.625zM16.5 4.125c0-.621.504-1.125 1.125-1.125h2.25C20.496 3 21 3.504 21 4.125v15.75c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 01-1.125-1.125V4.125z"
+                    />
+                  </svg>
+                }
+                title="No agreement data yet"
+                description={
+                  <>
+                    Agreement will appear here once annotators
+                    <br />
+                    have labelled overlapping items
+                  </>
+                }
+              />
+            ) : (
+              <div className="flex flex-wrap items-stretch gap-3">
+                <AgreementStatCard
+                  label="Annotator agreement"
+                  value={
+                    agreement.human_human?.current != null
+                      ? `${Math.round(agreement.human_human.current * 100)}%`
+                      : "—"
+                  }
+                  valueClassName={agreementColor(
+                    agreement.human_human?.current,
+                  )}
+                />
+                {(agreement.evaluators ?? []).map((ev) => (
+                  <AgreementStatCard
+                    key={ev.evaluator_id}
+                    label={ev.name}
+                    value={
+                      ev.current != null
+                        ? `${Math.round(ev.current * 100)}%`
+                        : "—"
+                    }
+                    valueClassName={agreementColor(ev.current)}
+                  />
+                ))}
+              </div>
+            )}
+
+            {/* Per-item × per-evaluator summary table */}
+            {taskSummaryError && (
+              <div className="rounded-md border border-border bg-muted/20 p-4 text-sm text-red-500">
+                {taskSummaryError}
+              </div>
+            )}
+            {taskSummaryLoading && !taskSummary ? (
+              <div className="flex items-center justify-center gap-2 py-8 text-sm text-muted-foreground">
+                <svg
+                  className="w-4 h-4 animate-spin"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                >
+                  <circle
+                    className="opacity-25"
+                    cx="12"
+                    cy="12"
+                    r="10"
+                    stroke="currentColor"
+                    strokeWidth="4"
+                  />
+                  <path
+                    className="opacity-75"
+                    fill="currentColor"
+                    d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+                  />
+                </svg>
+                Loading labels
+              </div>
+            ) : !taskSummary || taskSummary.rows.length === 0 ? (
+              <EmptyState
+                icon={
+                  <svg
+                    className="w-7 h-7 text-muted-foreground"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                    strokeWidth={1.5}
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      d="M9 12h3.75M9 15h3.75M9 18h3.75m3 .75H18a2.25 2.25 0 002.25-2.25V6.108c0-1.135-.845-2.098-1.976-2.192a48.424 48.424 0 00-1.123-.08m-5.801 0c-.065.21-.1.433-.1.664 0 .414.336.75.75.75h4.5a.75.75 0 00.75-.75 2.25 2.25 0 00-.1-.664m-5.8 0A2.251 2.251 0 0113.5 2.25H15c1.012 0 1.867.668 2.15 1.586m-5.8 0c-.376.023-.75.05-1.124.08C9.095 4.01 8.25 4.973 8.25 6.108V8.25m0 0H4.875c-.621 0-1.125.504-1.125 1.125v11.25c0 .621.504 1.125 1.125 1.125h9.75c.621 0 1.125-.504 1.125-1.125V9.375c0-.621-.504-1.125-1.125-1.125H8.25zM6.75 12h.008v.008H6.75V12zm0 3h.008v.008H6.75V15zm0 3h.008v.008H6.75V18z"
+                    />
+                  </svg>
+                }
+                title="No labels yet"
+                description={
+                  <>
+                    Detailed labels will appear here
+                    <br />
+                    once items have been evaluated and annotated
+                  </>
+                }
+              />
+            ) : (
+              (() => {
+                const annotators = taskSummary.annotators ?? [];
+                const evaluators = taskSummary.evaluators ?? [];
+                const summaryTaskType = taskSummary.task_type;
+                const itemColumns =
+                  summaryTaskType === "stt"
+                    ? [
+                        { key: "ref", label: "Reference transcript" },
+                        { key: "pred", label: "Predicted transcript" },
+                      ]
+                    : [{ key: "name", label: "Name" }];
+                const itemColTpl = itemColumns
+                  .map(() => "minmax(180px,1.4fr)")
+                  .join(" ");
+                const evalColTpl = "minmax(180px,1fr) 170px 170px 140px";
+                const annotatorColTpl =
+                  annotators.length > 0
+                    ? annotators.map(() => "120px").join(" ")
+                    : "";
+                const gridTemplate = [itemColTpl, evalColTpl, annotatorColTpl]
+                  .filter(Boolean)
+                  .join(" ");
+
+                const itemCellValues = (
+                  payload: Record<string, unknown> | null,
+                ): string[] => {
+                  const p = payload ?? {};
+                  if (summaryTaskType === "stt") {
+                    const ref =
+                      typeof p.reference_transcript === "string"
+                        ? (p.reference_transcript as string)
+                        : "";
+                    const pred =
+                      typeof p.predicted_transcript === "string"
+                        ? (p.predicted_transcript as string)
+                        : "";
+                    return [ref || "—", pred || "—"];
+                  }
+                  const name =
+                    typeof p.name === "string" ? (p.name as string) : "";
+                  return [name || "—"];
+                };
+
+                // Filter rows by selected evaluator, then sort by the
+                // active value column. Null verdicts always sink to the
+                // bottom regardless of asc/desc; booleans sort false<true.
+                const selectedEvaluatorIds = new Set(
+                  summaryEvaluatorFilter.map((i) => i.uuid),
+                );
+                const filteredRows =
+                  selectedEvaluatorIds.size === 0
+                    ? taskSummary.rows
+                    : taskSummary.rows.filter((r) =>
+                        selectedEvaluatorIds.has(r.evaluator_id),
+                      );
+
+                const valueRank = (
+                  v: boolean | number | null | undefined,
+                ): number | null => {
+                  if (v === null || v === undefined) return null;
+                  if (typeof v === "boolean") return v ? 1 : 0;
+                  if (typeof v === "number") return v;
+                  return null;
+                };
+                const cellValueForSort = (
+                  row: SummaryRow,
+                ): boolean | number | null => {
+                  if (!summarySortColKey) return null;
+                  if (summarySortColKey === "evaluator")
+                    return row.evaluator_value;
+                  if (summarySortColKey === "human_agreement")
+                    return row.human_agreement;
+                  if (summarySortColKey === "evaluator_agreement")
+                    return row.evaluator_agreement;
+                  return row.annotations?.[summarySortColKey]?.value ?? null;
+                };
+                const sortedRows = summarySortColKey
+                  ? [...filteredRows].sort((a, b) => {
+                      const av = valueRank(cellValueForSort(a));
+                      const bv = valueRank(cellValueForSort(b));
+                      if (av === null && bv === null) return 0;
+                      if (av === null) return 1; // nulls last
+                      if (bv === null) return -1;
+                      const dir = summarySortDir === "desc" ? -1 : 1;
+                      return av === bv ? 0 : av < bv ? -1 * dir : 1 * dir;
+                    })
+                  : filteredRows;
+
+                const onSortClick = (key: string) => {
+                  if (summarySortColKey === key) {
+                    setSummarySortDir((d) =>
+                      d === "desc" ? "asc" : "desc",
+                    );
+                  } else {
+                    setSummarySortColKey(key);
+                    setSummarySortDir("desc");
+                  }
+                };
+
+                const sortIndicator = (key: string) => {
+                  if (summarySortColKey !== key) {
+                    return (
+                      <svg
+                        className="w-3 h-3 opacity-40"
+                        fill="none"
+                        viewBox="0 0 24 24"
+                        stroke="currentColor"
+                        strokeWidth={2}
+                      >
+                        <path
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          d="M8.25 15L12 18.75 15.75 15M8.25 9L12 5.25 15.75 9"
+                        />
+                      </svg>
+                    );
+                  }
+                  return (
+                    <svg
+                      className="w-3 h-3"
+                      fill="none"
+                      viewBox="0 0 24 24"
+                      stroke="currentColor"
+                      strokeWidth={2}
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        d={
+                          summarySortDir === "desc"
+                            ? "M19.5 8.25l-7.5 7.5-7.5-7.5"
+                            : "M4.5 15.75l7.5-7.5 7.5 7.5"
+                        }
+                      />
+                    </svg>
+                  );
+                };
+
+                return (
+                  <>
+                    <div className="w-64">
+                      <MultiSelectPicker
+                        items={evaluators.map((ev) => ({
+                          uuid: ev.evaluator_id,
+                          name: ev.name,
+                        }))}
+                        selectedItems={summaryEvaluatorFilter}
+                        onSelectionChange={setSummaryEvaluatorFilter}
+                        placeholder="All evaluators"
+                        searchPlaceholder="Search evaluators..."
+                      />
+                    </div>
+                    <div className="border border-border rounded-xl overflow-x-auto">
+                    <div
+                      className="grid gap-4 px-4 py-2 border-b border-border bg-muted/30 items-center min-w-fit"
+                      style={{ gridTemplateColumns: gridTemplate }}
+                    >
+                      {itemColumns.map((c) => (
+                        <div
+                          key={c.key}
+                          className="text-sm font-medium text-muted-foreground truncate"
+                        >
+                          {c.label}
+                        </div>
+                      ))}
+                      <div className="text-sm font-medium text-muted-foreground">
+                        Evaluator
+                      </div>
+                      <button
+                        type="button"
+                        onClick={() => onSortClick("human_agreement")}
+                        className={`flex items-center gap-1 text-sm font-medium transition-colors cursor-pointer w-fit whitespace-nowrap ${
+                          summarySortColKey === "human_agreement"
+                            ? "text-foreground"
+                            : "text-muted-foreground hover:text-foreground"
+                        }`}
+                      >
+                        Annotator agreement
+                        {sortIndicator("human_agreement")}
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => onSortClick("evaluator_agreement")}
+                        className={`flex items-center gap-1 text-sm font-medium transition-colors cursor-pointer w-fit whitespace-nowrap ${
+                          summarySortColKey === "evaluator_agreement"
+                            ? "text-foreground"
+                            : "text-muted-foreground hover:text-foreground"
+                        }`}
+                      >
+                        Evaluator agreement
+                        {sortIndicator("evaluator_agreement")}
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => onSortClick("evaluator")}
+                        className={`flex items-center gap-1 text-sm font-medium transition-colors cursor-pointer w-fit ${
+                          summarySortColKey === "evaluator"
+                            ? "text-foreground"
+                            : "text-muted-foreground hover:text-foreground"
+                        }`}
+                      >
+                        Evaluator value
+                        {sortIndicator("evaluator")}
+                      </button>
+                      {annotators.map((a) => (
+                        <button
+                          key={a.uuid}
+                          type="button"
+                          onClick={() => onSortClick(a.uuid)}
+                          title={a.name}
+                          className={`flex items-center gap-1 text-sm font-medium transition-colors cursor-pointer w-fit truncate ${
+                            summarySortColKey === a.uuid
+                              ? "text-foreground"
+                              : "text-muted-foreground hover:text-foreground"
+                          }`}
+                        >
+                          <span className="truncate">{a.name}</span>
+                          {sortIndicator(a.uuid)}
+                        </button>
+                      ))}
+                    </div>
+                    {sortedRows.map((row, idx) => {
+                      const cells = itemCellValues(row.payload);
+                      const versionLabel =
+                        typeof row.evaluator_version_number === "number"
+                          ? `v${row.evaluator_version_number}`
+                          : null;
+                      return (
+                        <div
+                          key={`${row.item_id}-${row.evaluator_id}-${row.evaluator_version_id ?? ""}-${idx}`}
+                          className="grid gap-4 px-4 py-3 border-b border-border last:border-b-0 items-center min-w-fit"
+                          style={{ gridTemplateColumns: gridTemplate }}
+                        >
+                          {cells.map((c, i) => (
+                            <p
+                              key={`item-${i}`}
+                              className="text-sm text-foreground line-clamp-2"
+                            >
+                              {c}
+                            </p>
+                          ))}
+                          <div className="flex items-center gap-2 min-w-0">
+                            <Link
+                              href={`/evaluators/${row.evaluator_id}`}
+                              title={`Open ${row.evaluator_name}`}
+                              className="inline-flex items-center px-2 py-0.5 rounded-md text-xs font-medium border border-border bg-muted/40 text-foreground hover:bg-muted hover:border-foreground/30 transition-colors cursor-pointer truncate max-w-full"
+                            >
+                              <span className="truncate">
+                                {row.evaluator_name}
+                              </span>
+                            </Link>
+                            {versionLabel && (
+                              <span className="font-mono text-[10px] px-1.5 py-0.5 rounded-md border border-foreground/20 bg-background text-foreground flex-shrink-0">
+                                {versionLabel}
+                              </span>
+                            )}
+                          </div>
+                          <div
+                            className={`text-sm font-semibold tabular-nums ${agreementColor(row.human_agreement)}`}
+                          >
+                            {row.human_agreement != null
+                              ? `${Math.round(row.human_agreement * 100)}%`
+                              : "—"}
+                          </div>
+                          <div
+                            className={`text-sm font-semibold tabular-nums ${agreementColor(row.evaluator_agreement)}`}
+                          >
+                            {row.evaluator_agreement != null
+                              ? `${Math.round(row.evaluator_agreement * 100)}%`
+                              : "—"}
+                          </div>
+                          <div
+                            className={`text-sm font-medium tabular-nums ${verdictTextClass(row.evaluator_value)}`}
+                          >
+                            {formatVerdictValue(row.evaluator_value)}
+                          </div>
+                          {annotators.map((a) => {
+                            const v = row.annotations?.[a.uuid] ?? null;
+                            return (
+                              <div
+                                key={a.uuid}
+                                className={`text-sm font-medium tabular-nums ${verdictTextClass(v?.value ?? null)}`}
+                              >
+                                {formatVerdictValue(v?.value ?? null)}
+                              </div>
+                            );
+                          })}
+                        </div>
+                      );
+                    })}
+                    </div>
+                  </>
+                );
+              })()
+            )}
+          </div>
+        )}
 
         {activeTab === "items" &&
           (itemsLoading ? (

--- a/src/app/simulations/[uuid]/runs/[runId]/page.tsx
+++ b/src/app/simulations/[uuid]/runs/[runId]/page.tsx
@@ -1174,7 +1174,7 @@ export default function SimulationRunPage() {
                     </div>
 
                     {/* Desktop Table View */}
-                    <div className="hidden md:block border border-border rounded-xl overflow-hidden bg-muted/20">
+                    <div className="hidden md:block border border-border rounded-xl overflow-hidden">
                       <div className="overflow-x-auto">
                         <table className="w-full table-fixed">
                           <thead className="bg-background border-t border-border">

--- a/src/components/AddTestDialog.tsx
+++ b/src/components/AddTestDialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState, useEffect, useRef } from "react";
+import React, { useState, useEffect, useRef, useCallback } from "react";
 import { signOut } from "next-auth/react";
 import { useAccessToken } from "@/hooks";
 import { ToolPicker, AvailableTool } from "@/components/ToolPicker";
@@ -104,6 +104,27 @@ type AddTestDialogProps = {
   initialTab?: "next-reply" | "tool-invocation";
   initialConfig?: TestConfig;
   initialEvaluators?: AttachedEvaluatorInit[];
+  /**
+   * "test" (default) — original behaviour with Next reply / Tool invocation
+   * tabs and "Test" labels.
+   * "labelItem" — used by the human-labelling task page. Hides the tabs
+   * (always next-reply view), and rewords any user-visible "Test" copy to
+   * "Item". The caller is responsible for hooking onSubmit up to the
+   * labelling-items API.
+   */
+  mode?: "test" | "labelItem";
+  /**
+   * If true, the last message in the conversation is allowed to be from the
+   * agent (or a tool call). Used for simulation labelling items, where the
+   * conversation is a static transcript rather than a prompt awaiting a reply.
+   */
+  allowAgentLastMessage?: boolean;
+  /**
+   * If true, REQUIRE the last message to be from the agent (assistant).
+   * Used for LLM labelling items, where the trailing assistant turn is the
+   * `agent_response` being judged. Takes precedence over `allowAgentLastMessage`.
+   */
+  requireAssistantLastMessage?: boolean;
 };
 
 export function AddTestDialog({
@@ -120,13 +141,20 @@ export function AddTestDialog({
   initialTab,
   initialConfig,
   initialEvaluators,
+  mode = "test",
+  allowAgentLastMessage = false,
+  requireAssistantLastMessage = false,
 }: AddTestDialogProps) {
   // Hide the floating "Talk to Us" button when this dialog is open
   useHideFloatingButton(isOpen);
 
+  const isLabelItem = mode === "labelItem";
+  const itemNoun = isLabelItem ? "item" : "test";
+  const ItemNoun = isLabelItem ? "Item" : "Test";
+
   const backendAccessToken = useAccessToken();
   const [activeTab, setActiveTab] = useState<"next-reply" | "tool-invocation">(
-    initialTab || "next-reply"
+    isLabelItem ? "next-reply" : initialTab || "next-reply",
   );
 
   // Available tools state - declared early so it's available for initialConfig parsing
@@ -194,7 +222,7 @@ export function AddTestDialog({
 
               // Look up the tool by name to check its actual config type
               const tool = availableTools.find(
-                (t) => t.name === toolCall.function.name
+                (t) => t.name === toolCall.function.name,
               );
               const isWebhook = tool?.config?.type === "webhook";
 
@@ -221,7 +249,7 @@ export function AddTestDialog({
                           value: formatValue(paramValue),
                           group: groupKey,
                         });
-                      }
+                      },
                     );
                   }
                 });
@@ -231,7 +259,7 @@ export function AddTestDialog({
                   ([name, value]) => ({
                     name,
                     value: formatValue(value),
-                  })
+                  }),
                 );
               }
 
@@ -268,7 +296,7 @@ export function AddTestDialog({
             const linkedToolCall = messages.find(
               (m) =>
                 m.role === "tool_call" &&
-                (m.toolId === linkedToolCallId || m.id === linkedToolCallId)
+                (m.toolId === linkedToolCallId || m.id === linkedToolCallId),
             );
             messages.push({
               id: `tool-response-${index}`,
@@ -314,13 +342,13 @@ export function AddTestDialog({
                           id: `param-${idx}-${paramIdx}`,
                           name,
                           value: String(value),
-                        })
+                        }),
                       )
                     : [];
 
                 // Check if this is an inbuilt tool by matching tool id or name
                 const inbuiltTool = INBUILT_TOOLS.find(
-                  (t) => t.id === toolCall.tool || t.name === toolCall.tool
+                  (t) => t.id === toolCall.tool || t.name === toolCall.tool,
                 );
 
                 return {
@@ -331,7 +359,7 @@ export function AddTestDialog({
                   isInbuilt: !!inbuiltTool,
                   expectedParameters: params,
                 };
-              }
+              },
             );
             setSelectedTools(tools);
           }
@@ -375,22 +403,44 @@ export function AddTestDialog({
       isWebhook?: boolean;
       linkedToolCallId?: string; // For tool_response to link back to tool_call
     }>
-  >([{ id: "1", role: "agent", content: "Hello, how can I help you today?" }]);
+  >(() => {
+    const u = (id: string) => ({
+      id,
+      role: "user" as const,
+      content: "",
+    });
+    const a = (id: string) => ({
+      id,
+      role: "agent" as const,
+      content: "",
+    });
+    if (requireAssistantLastMessage) {
+      // LLM task add-item: conversation must end with the agent's reply,
+      // since that's the message being graded.
+      return [u("1"), a("2")];
+    }
+    if (allowAgentLastMessage) {
+      // Simulation add-item: a short but complete conversation transcript.
+      return [u("1"), a("2"), u("3"), a("4"), u("5"), a("6")];
+    }
+    // Default test: user → agent → user (final user turn is what the agent
+    // will reply to when the test runs).
+    return [u("1"), a("2"), u("3")];
+  });
+
+  const [pendingFocusId, setPendingFocusId] = useState<string | null>(null);
 
   const addChatMessage = (role: "agent" | "user") => {
-    const defaultContent =
-      role === "agent" ? "Enter agent message" : "Enter user message";
-    setChatMessages([
-      ...chatMessages,
-      { id: Date.now().toString(), role, content: defaultContent },
-    ]);
+    const id = Date.now().toString();
+    setChatMessages([...chatMessages, { id, role, content: "" }]);
+    setPendingFocusId(id);
   };
 
   const addToolCallMessage = (
     toolId: string,
     toolName: string,
     params: Array<{ name: string; value: string; group?: string }>,
-    isWebhook: boolean = false
+    isWebhook: boolean = false,
   ) => {
     const toolCallId = Date.now().toString();
     const newMessages: typeof chatMessages = [
@@ -420,11 +470,14 @@ export function AddTestDialog({
     setChatMessages(newMessages);
     setToolCallDropdownOpen(false);
     setPendingToolCall(null);
+    if (params.length > 0) {
+      setPendingFocusId(toolCallId);
+    }
   };
 
   const updateChatMessage = (id: string, content: string) => {
     setChatMessages(
-      chatMessages.map((msg) => (msg.id === id ? { ...msg, content } : msg))
+      chatMessages.map((msg) => (msg.id === id ? { ...msg, content } : msg)),
     );
   };
 
@@ -432,7 +485,7 @@ export function AddTestDialog({
     messageId: string,
     paramName: string,
     value: string,
-    group?: string
+    group?: string,
   ) => {
     setChatMessages(
       chatMessages.map((msg) =>
@@ -440,11 +493,11 @@ export function AddTestDialog({
           ? {
               ...msg,
               toolParams: msg.toolParams.map((p) =>
-                p.name === paramName && p.group === group ? { ...p, value } : p
+                p.name === paramName && p.group === group ? { ...p, value } : p,
               ),
             }
-          : msg
-      )
+          : msg,
+      ),
     );
   };
 
@@ -455,8 +508,8 @@ export function AddTestDialog({
     if (messageToRemove?.role === "tool_call" && messageToRemove?.isWebhook) {
       setChatMessages(
         chatMessages.filter(
-          (msg) => msg.id !== id && msg.linkedToolCallId !== id
-        )
+          (msg) => msg.id !== id && msg.linkedToolCallId !== id,
+        ),
       );
     } else {
       setChatMessages(chatMessages.filter((msg) => msg.id !== id));
@@ -480,6 +533,45 @@ export function AddTestDialog({
       chatEndRef.current?.scrollIntoView({ behavior: "smooth" });
     }
   }, [chatMessages.length]);
+
+  // After a new chat message is added, focus its textarea so the user
+  // can start typing immediately. For a tool call, focus the first
+  // param input instead. We pass preventScroll so the browser doesn't
+  // bring the input into view at the top of the visible area — that
+  // would push the trailing + / delete buttons off-screen. Instead we
+  // explicitly scroll the chat sentinel into view so the action row
+  // below the new bubble stays visible.
+  useEffect(() => {
+    if (!pendingFocusId) return;
+    let focused: HTMLElement | null = null;
+    const textArea = document.querySelector(
+      `textarea[data-msg-id="${pendingFocusId}"]`,
+    );
+    if (textArea instanceof HTMLTextAreaElement) {
+      focused = textArea;
+    } else {
+      const firstParam = document.querySelector(
+        `input[data-tool-call-id="${pendingFocusId}"]`,
+      );
+      if (firstParam instanceof HTMLInputElement) focused = firstParam;
+    }
+    if (!focused) return;
+    focused.focus({ preventScroll: true });
+    chatEndRef.current?.scrollIntoView({ behavior: "smooth", block: "end" });
+    setPendingFocusId(null);
+  }, [pendingFocusId, chatMessages]);
+
+  // Stable ref callback for auto-resizing textareas on mount. Inline
+  // ref callbacks re-run on every parent re-render (toggling unrelated
+  // state like the add-message dropdown), which would reset every
+  // textarea's height to `auto` and back, causing the scroll container
+  // to thrash and jump to the top. A useCallback-memoised callback
+  // only runs on actual mount.
+  const autoSizeOnMount = useCallback((el: HTMLTextAreaElement | null) => {
+    if (!el) return;
+    el.style.height = "auto";
+    el.style.height = `${el.scrollHeight}px`;
+  }, []);
 
   // Fetch available tools when dialog opens
   useEffect(() => {
@@ -547,7 +639,7 @@ export function AddTestDialog({
               "ngrok-skip-browser-warning": "true",
               Authorization: `Bearer ${backendAccessToken}`,
             },
-          }
+          },
         );
 
         if (response.status === 401) {
@@ -597,7 +689,7 @@ export function AddTestDialog({
   // explicit values, then variable defaults, then empty string.
   const buildInitialVariableValues = (
     variables: EvaluatorVariableDef[],
-    explicit?: Record<string, string> | null
+    explicit?: Record<string, string> | null,
   ): Record<string, string> => {
     const values: Record<string, string> = {};
     for (const v of variables) {
@@ -637,16 +729,16 @@ export function AddTestDialog({
           variables: e.variables ?? [],
           variable_values: buildInitialVariableValues(
             e.variables ?? [],
-            e.variable_values ?? undefined
+            e.variable_values ?? undefined,
           ),
-        }))
+        })),
       );
       setAttachedEvaluatorsInitialized(true);
       return;
     }
 
     const correctness = availableLLMEvaluators.find(
-      (e) => e.slug === DEFAULT_NEXT_REPLY_EVALUATOR_SLUG
+      (e) => e.slug === DEFAULT_NEXT_REPLY_EVALUATOR_SLUG,
     );
 
     // Legacy edit: pre-fill criteria from the old free-text field.
@@ -707,7 +799,7 @@ export function AddTestDialog({
   const updateEvaluatorVariableValue = (
     evaluatorUuid: string,
     variableName: string,
-    value: string
+    value: string,
   ) => {
     setAttachedEvaluators((prev) =>
       prev.map((e) =>
@@ -716,14 +808,14 @@ export function AddTestDialog({
               ...e,
               variable_values: { ...e.variable_values, [variableName]: value },
             }
-          : e
-      )
+          : e,
+      ),
     );
   };
 
   const removeAttachedEvaluator = (evaluatorUuid: string) => {
     setAttachedEvaluators((prev) =>
-      prev.filter((e) => e.evaluator_uuid !== evaluatorUuid)
+      prev.filter((e) => e.evaluator_uuid !== evaluatorUuid),
     );
   };
 
@@ -813,7 +905,7 @@ export function AddTestDialog({
   // Helper function to get parameters from tool config for selected tool
   const getToolParamsForSelectedTool = (toolId: string, toolName: string) => {
     const tool = availableTools.find(
-      (t) => t.uuid === toolId || t.name === toolName
+      (t) => t.uuid === toolId || t.name === toolName,
     );
     if (!tool) return [];
 
@@ -845,7 +937,7 @@ export function AddTestDialog({
   // Update a specific tool's configuration
   const updateToolConfig = (
     toolId: string,
-    updates: Partial<SelectedToolConfig>
+    updates: Partial<SelectedToolConfig>,
   ) => {
     setSelectedTools(
       selectedTools.map((tool) => {
@@ -860,7 +952,7 @@ export function AddTestDialog({
         ) {
           updatedTool.expectedParameters = getToolParamsForSelectedTool(
             tool.id,
-            tool.name
+            tool.name,
           );
         }
 
@@ -873,12 +965,12 @@ export function AddTestDialog({
         ) {
           updatedTool.expectedParameters = getToolParamsForSelectedTool(
             tool.id,
-            tool.name
+            tool.name,
           );
         }
 
         return updatedTool;
-      })
+      }),
     );
   };
 
@@ -886,7 +978,7 @@ export function AddTestDialog({
   const updateToolParameterValue = (
     toolId: string,
     paramId: string,
-    value: string
+    value: string,
   ) => {
     setSelectedTools(
       selectedTools.map((tool) => {
@@ -894,17 +986,17 @@ export function AddTestDialog({
         return {
           ...tool,
           expectedParameters: tool.expectedParameters.map((param) =>
-            param.id === paramId ? { ...param, value } : param
+            param.id === paramId ? { ...param, value } : param,
           ),
         };
-      })
+      }),
     );
   };
 
   // Check if a tool has parameters in its original config
   const toolHasParams = (toolId: string, toolName: string) => {
     const tool = availableTools.find(
-      (t) => t.uuid === toolId || t.name === toolName
+      (t) => t.uuid === toolId || t.name === toolName,
     );
     if (!tool) return false;
 
@@ -994,7 +1086,7 @@ export function AddTestDialog({
         if (message.isWebhook) {
           const linkedResponse = chatMessages.find(
             (m) =>
-              m.role === "tool_response" && m.linkedToolCallId === message.id
+              m.role === "tool_response" && m.linkedToolCallId === message.id,
           );
           if (linkedResponse && linkedResponse.content) {
             history.push({
@@ -1118,6 +1210,14 @@ export function AddTestDialog({
       return; // Don't submit if any tool call has empty params
     }
 
+    // Every user/agent message must have non-empty content.
+    const hasEmptyChatMessage = chatMessages.some(
+      (m) => (m.role === "user" || m.role === "agent") && !m.content.trim(),
+    );
+    if (hasEmptyChatMessage) {
+      return;
+    }
+
     // Validate required fields based on test type
     if (activeTab === "next-reply") {
       if (!testName.trim()) {
@@ -1133,7 +1233,7 @@ export function AddTestDialog({
       }
       // Validate that all tool_response messages have valid JSON
       const toolResponses = chatMessages.filter(
-        (m) => m.role === "tool_response"
+        (m) => m.role === "tool_response",
       );
       for (const response of toolResponses) {
         try {
@@ -1155,7 +1255,7 @@ export function AddTestDialog({
           !tool.acceptAnyParameterValues
         ) {
           const hasEmptyParams = tool.expectedParameters.some(
-            (param) => !param.value.trim()
+            (param) => !param.value.trim(),
           );
           if (hasEmptyParams) {
             return;
@@ -1164,7 +1264,7 @@ export function AddTestDialog({
       }
       // Validate that all tool_response messages have valid JSON
       const toolResponses = chatMessages.filter(
-        (m) => m.role === "tool_response"
+        (m) => m.role === "tool_response",
       );
       for (const response of toolResponses) {
         try {
@@ -1240,29 +1340,31 @@ export function AddTestDialog({
       <div className="relative w-full max-w-7xl h-[95vh] md:h-[85vh] mx-2 md:mx-4 bg-background rounded-xl md:rounded-2xl shadow-2xl flex flex-col md:flex-row overflow-hidden border border-border">
         {/* Left Column - Form */}
         <div className="w-full md:w-2/5 flex flex-col border-b md:border-b-0 md:border-r border-border">
-          {/* Tabs */}
-          <div className="flex border-b border-border">
-            <button
-              onClick={() => setActiveTab("next-reply")}
-              className={`flex-1 py-3 md:py-4 text-sm md:text-base font-medium transition-colors cursor-pointer ${
-                activeTab === "next-reply"
-                  ? "text-foreground border-b-2 border-foreground"
-                  : "text-muted-foreground hover:text-foreground"
-              }`}
-            >
-              Next reply test
-            </button>
-            <button
-              onClick={() => setActiveTab("tool-invocation")}
-              className={`flex-1 py-3 md:py-4 text-sm md:text-base font-medium transition-colors cursor-pointer ${
-                activeTab === "tool-invocation"
-                  ? "text-foreground border-b-2 border-foreground"
-                  : "text-muted-foreground hover:text-foreground"
-              }`}
-            >
-              Tool invocation test
-            </button>
-          </div>
+          {/* Tabs — hidden in labelItem mode (always next-reply) */}
+          {!isLabelItem && (
+            <div className="flex border-b border-border">
+              <button
+                onClick={() => setActiveTab("next-reply")}
+                className={`flex-1 py-3 md:py-4 text-sm md:text-base font-medium transition-colors cursor-pointer ${
+                  activeTab === "next-reply"
+                    ? "text-foreground border-b-2 border-foreground"
+                    : "text-muted-foreground hover:text-foreground"
+                }`}
+              >
+                Next reply test
+              </button>
+              <button
+                onClick={() => setActiveTab("tool-invocation")}
+                className={`flex-1 py-3 md:py-4 text-sm md:text-base font-medium transition-colors cursor-pointer ${
+                  activeTab === "tool-invocation"
+                    ? "text-foreground border-b-2 border-foreground"
+                    : "text-muted-foreground hover:text-foreground"
+                }`}
+              >
+                Tool invocation test
+              </button>
+            </div>
+          )}
 
           {/* Content */}
           <div className="flex-1 overflow-y-auto overflow-x-visible p-4 md:p-6">
@@ -1290,16 +1392,16 @@ export function AddTestDialog({
               </div>
             ) : activeTab === "next-reply" ? (
               <div className="space-y-6">
-                {/* Test Name */}
+                {/* Name */}
                 <div>
                   <label className="block text-base font-medium text-foreground mb-2">
-                    Test name
+                    {ItemNoun} name
                   </label>
                   <input
                     type="text"
                     value={testName}
                     onChange={(e) => setTestName(e.target.value)}
-                    placeholder="Your test name"
+                    placeholder={`Your ${itemNoun} name`}
                     className={`w-full h-11 px-4 rounded-lg text-base bg-background text-foreground placeholder:text-muted-foreground border focus:outline-none focus:ring-2 focus:ring-accent ${
                       localValidationAttempted &&
                       activeTab === "next-reply" &&
@@ -1308,6 +1410,13 @@ export function AddTestDialog({
                         : "border-border"
                     }`}
                   />
+                  {localValidationAttempted &&
+                    activeTab === "next-reply" &&
+                    !testName.trim() && (
+                      <p className="text-xs text-red-500 mt-1">
+                        {ItemNoun} name cannot be empty
+                      </p>
+                    )}
                 </div>
 
                 {/* Evaluators (next-reply tab only) */}
@@ -1316,38 +1425,39 @@ export function AddTestDialog({
                     <label className="text-base font-medium text-foreground">
                       Evaluators
                     </label>
-                    {(() => {
-                      const remainingOptions = availableLLMEvaluators.filter(
-                        (o) =>
-                          !attachedEvaluators.some(
-                            (a) => a.evaluator_uuid === o.uuid
-                          )
-                      );
-                      const noOptionsLeft = remainingOptions.length === 0;
-                      return (
-                        <button
-                          onClick={() => {
-                            if (evaluatorPickerOpen) {
-                              closeEvaluatorPicker();
-                            } else {
-                              setEvaluatorPickerOpen(true);
+                    {!isLabelItem &&
+                      (() => {
+                        const remainingOptions = availableLLMEvaluators.filter(
+                          (o) =>
+                            !attachedEvaluators.some(
+                              (a) => a.evaluator_uuid === o.uuid,
+                            ),
+                        );
+                        const noOptionsLeft = remainingOptions.length === 0;
+                        return (
+                          <button
+                            onClick={() => {
+                              if (evaluatorPickerOpen) {
+                                closeEvaluatorPicker();
+                              } else {
+                                setEvaluatorPickerOpen(true);
+                              }
+                            }}
+                            disabled={
+                              evaluatorsLoading || isLoading || noOptionsLeft
                             }
-                          }}
-                          disabled={
-                            evaluatorsLoading || isLoading || noOptionsLeft
-                          }
-                          className={`px-3 py-1.5 text-sm font-medium bg-background text-foreground rounded-lg hover:bg-muted transition-colors cursor-pointer border border-border disabled:opacity-50 disabled:cursor-not-allowed ${
-                            localValidationAttempted &&
-                            activeTab === "next-reply" &&
-                            attachedEvaluators.length === 0
-                              ? "border-red-500 text-red-400"
-                              : ""
-                          }`}
-                        >
-                          Add evaluator
-                        </button>
-                      );
-                    })()}
+                            className={`px-3 py-1.5 text-sm font-medium bg-background text-foreground rounded-lg hover:bg-muted transition-colors cursor-pointer border border-border disabled:opacity-50 disabled:cursor-not-allowed ${
+                              localValidationAttempted &&
+                              activeTab === "next-reply" &&
+                              attachedEvaluators.length === 0
+                                ? "border-red-500 text-red-400"
+                                : ""
+                            }`}
+                          >
+                            Add evaluator
+                          </button>
+                        );
+                      })()}
                   </div>
 
                   {/* Evaluator picker dropdown */}
@@ -1376,8 +1486,8 @@ export function AddTestDialog({
                             const remaining = availableLLMEvaluators.filter(
                               (o) =>
                                 !attachedEvaluators.some(
-                                  (a) => a.evaluator_uuid === o.uuid
-                                )
+                                  (a) => a.evaluator_uuid === o.uuid,
+                                ),
                             );
                             if (remaining.length === 0) {
                               return (
@@ -1399,8 +1509,7 @@ export function AddTestDialog({
                                     o.description ?? ""
                                   ).toLowerCase();
                                   return (
-                                    name.includes(query) ||
-                                    desc.includes(query)
+                                    name.includes(query) || desc.includes(query)
                                   );
                                 })
                               : remaining;
@@ -1413,10 +1522,10 @@ export function AddTestDialog({
                               );
                             }
                             const defaults = matches.filter(
-                              (o) => o.owner_user_id === null
+                              (o) => o.owner_user_id === null,
                             );
                             const mine = matches.filter(
-                              (o) => o.owner_user_id !== null
+                              (o) => o.owner_user_id !== null,
                             );
                             const renderRow = (o: LLMEvaluatorOption) => (
                               <button
@@ -1462,24 +1571,41 @@ export function AddTestDialog({
 
                   {/* Empty / loading state */}
                   {evaluatorsLoading && attachedEvaluators.length === 0 && (
-                    <div className="text-sm text-muted-foreground py-4">
-                      Loading evaluators...
+                    <div className="flex items-center gap-2 text-sm text-muted-foreground py-4">
+                      <svg
+                        className="w-4 h-4 animate-spin"
+                        fill="none"
+                        viewBox="0 0 24 24"
+                      >
+                        <circle
+                          className="opacity-25"
+                          cx="12"
+                          cy="12"
+                          r="10"
+                          stroke="currentColor"
+                          strokeWidth="4"
+                        />
+                        <path
+                          className="opacity-75"
+                          fill="currentColor"
+                          d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+                        />
+                      </svg>
+                      Loading evaluators
                     </div>
                   )}
-                  {!evaluatorsLoading &&
-                    attachedEvaluators.length === 0 && (
-                      <div
-                        className={`text-sm py-4 ${
-                          localValidationAttempted &&
-                          activeTab === "next-reply"
-                            ? "text-red-500"
-                            : "text-muted-foreground"
-                        }`}
-                      >
-                        Add at least one evaluator to grade the agent&apos;s
-                        next reply.
-                      </div>
-                    )}
+                  {!evaluatorsLoading && attachedEvaluators.length === 0 && (
+                    <div
+                      className={`text-sm py-4 ${
+                        localValidationAttempted && activeTab === "next-reply"
+                          ? "text-red-500"
+                          : "text-muted-foreground"
+                      }`}
+                    >
+                      Add at least one evaluator to grade the agent&apos;s next
+                      reply.
+                    </div>
+                  )}
 
                   {/* Attached evaluator cards */}
                   <div className="space-y-4">
@@ -1499,27 +1625,29 @@ export function AddTestDialog({
                               </div>
                             )}
                           </div>
-                          <button
-                            onClick={() =>
-                              removeAttachedEvaluator(ev.evaluator_uuid)
-                            }
-                            className="text-muted-foreground hover:text-red-500 transition-colors cursor-pointer"
-                            aria-label={`Remove ${ev.name}`}
-                          >
-                            <svg
-                              className="w-4 h-4"
-                              fill="none"
-                              viewBox="0 0 24 24"
-                              stroke="currentColor"
-                              strokeWidth={2}
+                          {!isLabelItem && (
+                            <button
+                              onClick={() =>
+                                removeAttachedEvaluator(ev.evaluator_uuid)
+                              }
+                              className="text-muted-foreground hover:text-red-500 transition-colors cursor-pointer"
+                              aria-label={`Remove ${ev.name}`}
                             >
-                              <path
-                                strokeLinecap="round"
-                                strokeLinejoin="round"
-                                d="M6 18L18 6M6 6l12 12"
-                              />
-                            </svg>
-                          </button>
+                              <svg
+                                className="w-4 h-4"
+                                fill="none"
+                                viewBox="0 0 24 24"
+                                stroke="currentColor"
+                                strokeWidth={2}
+                              >
+                                <path
+                                  strokeLinecap="round"
+                                  strokeLinejoin="round"
+                                  d="M6 18L18 6M6 6l12 12"
+                                />
+                              </svg>
+                            </button>
+                          )}
                         </div>
 
                         {ev.variables.length > 0 && (
@@ -1535,8 +1663,8 @@ export function AddTestDialog({
                                 v.description && v.description.length > 0
                                   ? v.description
                                   : v.default && v.default.length > 0
-                                  ? v.default
-                                  : `Enter value for {{${v.name}}}`;
+                                    ? v.default
+                                    : `Enter value for {{${v.name}}}`;
                               const value = ev.variable_values[v.name] ?? "";
                               const isMissing =
                                 localValidationAttempted &&
@@ -1553,7 +1681,7 @@ export function AddTestDialog({
                                       updateEvaluatorVariableValue(
                                         ev.evaluator_uuid,
                                         v.name,
-                                        e.target.value
+                                        e.target.value,
                                       )
                                     }
                                     placeholder={placeholder}
@@ -1564,6 +1692,11 @@ export function AddTestDialog({
                                         : "border-border"
                                     }`}
                                   />
+                                  {isMissing && (
+                                    <p className="text-xs text-red-500 mt-1">
+                                      Value cannot be empty
+                                    </p>
+                                  )}
                                 </div>
                               );
                             })}
@@ -1762,7 +1895,7 @@ export function AddTestDialog({
                                           updateToolParameterValue(
                                             tool.id,
                                             param.id,
-                                            e.target.value
+                                            e.target.value,
                                           )
                                         }
                                         placeholder="Expected value"
@@ -1803,10 +1936,23 @@ export function AddTestDialog({
               </button>
               {(() => {
                 const lastMessage = chatMessages[chatMessages.length - 1];
-                const isLastMessageAgent =
-                  lastMessage?.role === "agent" || chatMessages.length === 0;
+                const isEmpty = chatMessages.length === 0;
+                let isLastMessageInvalid: boolean;
+                if (requireAssistantLastMessage) {
+                  isLastMessageInvalid =
+                    isEmpty || lastMessage?.role !== "agent";
+                } else if (allowAgentLastMessage) {
+                  isLastMessageInvalid = isEmpty;
+                } else {
+                  isLastMessageInvalid =
+                    isEmpty || lastMessage?.role === "agent";
+                }
+                const isLastMessageAgent = isLastMessageInvalid;
+                const tooltipMessage = requireAssistantLastMessage
+                  ? `The conversation history should end with an agent message, not a user message`
+                  : `The conversation history should end with a user message, not an agent message`;
                 const isButtonDisabled =
-                  isCreating || isLoading || isLastMessageAgent;
+                  isCreating || isLoading || isLastMessageInvalid;
 
                 return (
                   <div className="relative group">
@@ -1848,8 +1994,7 @@ export function AddTestDialog({
                     {isLastMessageAgent && !isCreating && !isLoading && (
                       <div className="absolute bottom-full mb-2 right-0 opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none z-50">
                         <div className="px-3 py-2 text-sm bg-background text-foreground border border-border rounded-lg shadow-lg w-72">
-                          A test should end with a user message, not an agent
-                          message or agent tool call
+                          {tooltipMessage}
                         </div>
                         {/* Arrow */}
                         <div className="absolute top-full right-4 -mt-1 w-0 h-0 border-l-[6px] border-l-transparent border-r-[6px] border-r-transparent border-t-[6px] border-t-border"></div>
@@ -1864,6 +2009,29 @@ export function AddTestDialog({
 
         {/* Right Column - Chat Messages */}
         <div className="w-full md:w-3/5 flex flex-col bg-muted/30 overflow-visible">
+          {/* Info banner */}
+          <div className="px-4 md:px-6 py-3 md:py-4 border-b border-border bg-blue-500/5">
+            <div className="flex items-start gap-3">
+              <svg
+                className="w-5 h-5 text-blue-600 dark:text-blue-400 mt-0.5 flex-shrink-0"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+                strokeWidth={2}
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M11.25 11.25l.041-.02a.75.75 0 011.063.852l-.708 2.836a.75.75 0 001.063.853l.041-.021M21 12a9 9 0 11-18 0 9 9 0 0118 0zm-9-3.75h.008v.008H12V8.25z"
+                />
+              </svg>
+              <p className="text-sm text-foreground leading-relaxed">
+                {requireAssistantLastMessage
+                  ? "Your evaluators read this whole conversation and evaluate the last agent message (the one highlighted) against the evaluators. Only that final reply is scored."
+                  : "The agent's response to the last user message, given the conversation history, will be evaluated against the evaluators added to the test"}
+              </p>
+            </div>
+          </div>
           {/* Chat Messages Area */}
           <div className="flex-1 overflow-y-auto overflow-x-visible p-4 md:p-6">
             {chatMessages.length === 0 ? (
@@ -1987,319 +2155,415 @@ export function AddTestDialog({
               </div>
             ) : (
               <div className="space-y-4">
-                {chatMessages.map((message, index) => (
-                  <div
-                    key={message.id}
-                    className={`space-y-2 ${
-                      message.role === "user" ? "flex flex-col items-end" : ""
-                    }`}
-                  >
-                    {/* Message Header - show for agent messages and tool calls */}
-                    {(message.role === "agent" ||
-                      message.role === "tool_call") && (
-                      <div className="flex items-center gap-2">
-                        <span className="text-sm font-medium text-foreground">
-                          {message.role === "tool_call"
-                            ? "Agent Tool Call"
-                            : "Agent"}
-                        </span>
-                      </div>
-                    )}
-
-                    {/* Message Bubble - for agent and user messages */}
-                    {(message.role === "agent" || message.role === "user") && (
-                      <div className="w-1/2">
-                        <textarea
-                          value={message.content}
-                          onChange={(e) => {
-                            updateChatMessage(message.id, e.target.value);
-                            // Auto-resize textarea
-                            e.target.style.height = "auto";
-                            e.target.style.height = `${e.target.scrollHeight}px`;
-                          }}
-                          onInput={(e) => {
-                            // Auto-resize on initial render and paste
-                            const target = e.target as HTMLTextAreaElement;
-                            target.style.height = "auto";
-                            target.style.height = `${target.scrollHeight}px`;
-                          }}
-                          ref={(el) => {
-                            // Auto-resize on mount
-                            if (el) {
-                              el.style.height = "auto";
-                              el.style.height = `${el.scrollHeight}px`;
-                            }
-                          }}
-                          rows={1}
-                          className={`w-full px-4 py-2 rounded-xl text-sm text-foreground border focus:outline-none focus:ring-1 focus:ring-accent resize-none overflow-hidden ${
-                            message.role === "agent"
-                              ? "bg-background border-border"
-                              : "bg-accent border-border"
-                          }`}
-                        />
-                      </div>
-                    )}
-
-                    {/* Tool Call Display */}
-                    {message.role === "tool_call" && (
-                      <div className="w-1/2">
-                        <div className="bg-muted border border-border rounded-2xl p-4">
-                          <div className="flex items-center gap-2 mb-2">
-                            <svg
-                              className="w-4 h-4 text-muted-foreground"
-                              fill="none"
-                              viewBox="0 0 24 24"
-                              stroke="currentColor"
-                              strokeWidth={1.5}
-                            >
-                              <path
-                                strokeLinecap="round"
-                                strokeLinejoin="round"
-                                d="M11.42 15.17L17.25 21A2.652 2.652 0 0021 17.25l-5.877-5.877M11.42 15.17l2.496-3.03c.317-.384.74-.626 1.208-.766M11.42 15.17l-4.655 5.653a2.548 2.548 0 11-3.586-3.586l6.837-5.63m5.108-.233c.55-.164 1.163-.188 1.743-.14a4.5 4.5 0 004.486-6.336l-3.276 3.277a3.004 3.004 0 01-2.25-2.25l3.276-3.276a4.5 4.5 0 00-6.336 4.486c.091 1.076-.071 2.264-.904 2.95l-.102.085m-1.745 1.437L5.909 7.5H4.5L2.25 3.75l1.5-1.5L7.5 4.5v1.409l4.26 4.26m-1.745 1.437l1.745-1.437m6.615 8.206L15.75 15.75M4.867 19.125h.008v.008h-.008v-.008z"
-                              />
-                            </svg>
-                            <span className="text-sm font-medium text-foreground">
-                              {message.toolName}
+                {chatMessages.map((message, index) => {
+                  const evalTargetIndex =
+                    requireAssistantLastMessage &&
+                    chatMessages.length > 0 &&
+                    chatMessages[chatMessages.length - 1].role === "agent"
+                      ? chatMessages.length - 1
+                      : -1;
+                  const isEvalTarget = index === evalTargetIndex;
+                  const lastNonToolResponseIndex =
+                    chatMessages.length -
+                    1 -
+                    (chatMessages[chatMessages.length - 1]?.role ===
+                    "tool_response"
+                      ? 1
+                      : 0);
+                  const isLastNonToolResponse =
+                    index === lastNonToolResponseIndex;
+                  const showInlineDelete =
+                    message.role !== "tool_response" && !isLastNonToolResponse;
+                  return (
+                    <div
+                      key={message.id}
+                      className={`space-y-2 ${
+                        message.role === "user" ? "flex flex-col items-end" : ""
+                      } ${
+                        isEvalTarget
+                          ? "border-l-2 border-blue-500 pl-4 -ml-4"
+                          : ""
+                      }`}
+                    >
+                      {/* Message Header - show for agent messages and tool calls */}
+                      {(message.role === "agent" ||
+                        message.role === "tool_call") && (
+                        <div className="flex items-center gap-2">
+                          <span className="text-sm font-medium text-foreground">
+                            {message.role === "tool_call"
+                              ? "Agent Tool Call"
+                              : "Agent"}
+                          </span>
+                          {isEvalTarget && (
+                            <span className="inline-flex items-center px-2 py-0.5 rounded-md text-[10px] font-medium uppercase tracking-wide bg-blue-500/10 text-blue-600 dark:text-blue-400">
+                              Evaluation target
                             </span>
-                            {message.isWebhook && (
-                              <span className="text-xs text-muted-foreground bg-background px-2 py-0.5 rounded">
-                                Webhook
-                              </span>
-                            )}
-                          </div>
-                          {message.toolParams &&
-                            message.toolParams.length > 0 && (
-                              <div className="space-y-3 mt-3">
-                                {/* Group parameters by type for webhook tools */}
-                                {message.isWebhook ? (
-                                  <>
-                                    {/* Query Parameters */}
-                                    {message.toolParams.filter(
-                                      (p) => p.group === "query"
-                                    ).length > 0 && (
-                                      <div className="bg-background border border-border rounded-xl p-3">
-                                        <h5 className="text-xs font-medium text-muted-foreground mb-3 uppercase tracking-wide">
-                                          Query
-                                        </h5>
-                                        <div className="space-y-3">
-                                          {message.toolParams
-                                            .filter((p) => p.group === "query")
-                                            .map((param, idx) => {
-                                              const isEmpty =
-                                                !param.value.trim();
-                                              const showError =
-                                                localValidationAttempted &&
-                                                isEmpty;
-                                              return (
-                                                <div key={idx}>
-                                                  <label className="block text-sm font-medium text-foreground mb-1.5">
-                                                    {param.name}
-                                                  </label>
-                                                  <input
-                                                    type="text"
-                                                    value={param.value}
-                                                    onChange={(e) =>
-                                                      updateToolCallParam(
-                                                        message.id,
-                                                        param.name,
-                                                        e.target.value,
-                                                        param.group
-                                                      )
-                                                    }
-                                                    placeholder={`Enter ${param.name}`}
-                                                    className={`w-full h-10 px-3 rounded-lg text-sm bg-muted text-foreground placeholder:text-muted-foreground border focus:outline-none focus:ring-2 focus:ring-accent ${
-                                                      showError
-                                                        ? "border-red-500"
-                                                        : "border-border"
-                                                    }`}
-                                                  />
-                                                  {showError && (
-                                                    <p className="text-xs text-red-500 mt-1">
-                                                      This field cannot be empty
-                                                    </p>
-                                                  )}
-                                                </div>
-                                              );
-                                            })}
-                                        </div>
-                                      </div>
-                                    )}
-                                    {/* Body Parameters */}
-                                    {message.toolParams.filter(
-                                      (p) => p.group === "body"
-                                    ).length > 0 && (
-                                      <div className="bg-background border border-border rounded-xl p-3">
-                                        <h5 className="text-xs font-medium text-muted-foreground mb-3 uppercase tracking-wide">
-                                          Body
-                                        </h5>
-                                        <div className="space-y-3">
-                                          {message.toolParams
-                                            .filter((p) => p.group === "body")
-                                            .map((param, idx) => {
-                                              const isEmpty =
-                                                !param.value.trim();
-                                              const showError =
-                                                localValidationAttempted &&
-                                                isEmpty;
-                                              return (
-                                                <div key={idx}>
-                                                  <label className="block text-sm font-medium text-foreground mb-1.5">
-                                                    {param.name}
-                                                  </label>
-                                                  <input
-                                                    type="text"
-                                                    value={param.value}
-                                                    onChange={(e) =>
-                                                      updateToolCallParam(
-                                                        message.id,
-                                                        param.name,
-                                                        e.target.value,
-                                                        param.group
-                                                      )
-                                                    }
-                                                    placeholder={`Enter ${param.name}`}
-                                                    className={`w-full h-10 px-3 rounded-lg text-sm bg-muted text-foreground placeholder:text-muted-foreground border focus:outline-none focus:ring-2 focus:ring-accent ${
-                                                      showError
-                                                        ? "border-red-500"
-                                                        : "border-border"
-                                                    }`}
-                                                  />
-                                                  {showError && (
-                                                    <p className="text-xs text-red-500 mt-1">
-                                                      This field cannot be empty
-                                                    </p>
-                                                  )}
-                                                </div>
-                                              );
-                                            })}
-                                        </div>
-                                      </div>
-                                    )}
-                                  </>
-                                ) : (
-                                  /* Regular tool parameters */
-                                  <div className="space-y-3">
-                                    {message.toolParams.map((param, idx) => {
-                                      const isEmpty = !param.value.trim();
-                                      const showError =
-                                        localValidationAttempted && isEmpty;
-                                      return (
-                                        <div key={idx}>
-                                          <label className="block text-sm font-medium text-foreground mb-1.5">
-                                            {param.name}
-                                          </label>
-                                          <input
-                                            type="text"
-                                            value={param.value}
-                                            onChange={(e) =>
-                                              updateToolCallParam(
-                                                message.id,
-                                                param.name,
-                                                e.target.value,
-                                                param.group
-                                              )
-                                            }
-                                            placeholder={`Enter ${param.name}`}
-                                            className={`w-full h-10 px-4 rounded-lg text-sm bg-background text-foreground placeholder:text-muted-foreground border focus:outline-none focus:ring-2 focus:ring-accent ${
-                                              showError
-                                                ? "border-red-500"
-                                                : "border-border"
-                                            }`}
-                                          />
-                                          {showError && (
-                                            <p className="text-xs text-red-500 mt-1">
-                                              This field cannot be empty
-                                            </p>
-                                          )}
-                                        </div>
-                                      );
-                                    })}
-                                  </div>
+                          )}
+                        </div>
+                      )}
+
+                      {/* Message Bubble - for agent and user messages */}
+                      {(message.role === "agent" || message.role === "user") &&
+                        (() => {
+                          const isEmpty =
+                            localValidationAttempted && !message.content.trim();
+                          const inlineDeleteBtn = showInlineDelete ? (
+                            <button
+                              onClick={() => removeChatMessage(message.id)}
+                              className="w-8 h-8 flex-shrink-0 rounded-lg border border-border flex items-center justify-center text-muted-foreground hover:text-red-400 hover:border-red-400/50 transition-colors cursor-pointer"
+                              title="Remove message"
+                            >
+                              <svg
+                                className="w-4 h-4"
+                                fill="none"
+                                viewBox="0 0 24 24"
+                                stroke="currentColor"
+                                strokeWidth={2}
+                              >
+                                <path
+                                  strokeLinecap="round"
+                                  strokeLinejoin="round"
+                                  d="M14.74 9l-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 01-2.244 2.077H8.084a2.25 2.25 0 01-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 00-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 013.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 00-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 00-7.5 0"
+                                />
+                              </svg>
+                            </button>
+                          ) : null;
+                          return (
+                            <div
+                              className={`flex w-full items-start gap-2 ${
+                                message.role === "user"
+                                  ? "flex-row-reverse"
+                                  : ""
+                              }`}
+                            >
+                              {inlineDeleteBtn}
+                              <div className="w-1/2">
+                                <textarea
+                                  value={message.content}
+                                  placeholder={
+                                    message.role === "agent"
+                                      ? "Enter agent message"
+                                      : "Enter user message"
+                                  }
+                                  onChange={(e) => {
+                                    updateChatMessage(
+                                      message.id,
+                                      e.target.value,
+                                    );
+                                    // Auto-resize textarea
+                                    e.target.style.height = "auto";
+                                    e.target.style.height = `${e.target.scrollHeight}px`;
+                                  }}
+                                  onInput={(e) => {
+                                    // Auto-resize on initial render and paste
+                                    const target =
+                                      e.target as HTMLTextAreaElement;
+                                    target.style.height = "auto";
+                                    target.style.height = `${target.scrollHeight}px`;
+                                  }}
+                                  ref={autoSizeOnMount}
+                                  data-msg-id={message.id}
+                                  rows={1}
+                                  className={`w-full px-4 py-2 rounded-xl text-sm text-foreground border focus:outline-none focus:ring-1 resize-none overflow-hidden placeholder:text-muted-foreground ${
+                                    isEmpty
+                                      ? "border-red-500 focus:ring-red-500"
+                                      : "focus:ring-accent " +
+                                        (message.role === "agent"
+                                          ? "bg-background border-border"
+                                          : "bg-accent border-border")
+                                  }`}
+                                />
+                                {isEmpty && (
+                                  <p className="text-xs text-red-500 mt-1">
+                                    Message cannot be empty
+                                  </p>
                                 )}
                               </div>
-                            )}
-                        </div>
-                      </div>
-                    )}
+                            </div>
+                          );
+                        })()}
 
-                    {/* Tool Response Display (for webhook tools) */}
-                    {message.role === "tool_response" && (
-                      <div className="w-1/2">
-                        <div className="bg-muted border border-border rounded-2xl p-4">
-                          <div className="flex items-center gap-2 mb-2">
-                            <svg
-                              className="w-4 h-4 text-muted-foreground"
-                              fill="none"
-                              viewBox="0 0 24 24"
-                              stroke="currentColor"
-                              strokeWidth={1.5}
-                            >
-                              <path
-                                strokeLinecap="round"
-                                strokeLinejoin="round"
-                                d="M9 12.75L11.25 15 15 9.75M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
-                              />
-                            </svg>
-                            <span className="text-sm font-medium text-foreground">
-                              Tool Response
-                            </span>
-                            <span className="text-xs text-muted-foreground">
-                              ({message.toolName})
-                            </span>
+                      {/* Tool Call Display */}
+                      {message.role === "tool_call" && (
+                        <div className="flex w-full items-start gap-2">
+                          <div className="w-1/2">
+                          <div className="bg-muted border border-border rounded-2xl p-4">
+                            <div className="flex items-center gap-2 mb-2">
+                              <svg
+                                className="w-4 h-4 text-muted-foreground"
+                                fill="none"
+                                viewBox="0 0 24 24"
+                                stroke="currentColor"
+                                strokeWidth={1.5}
+                              >
+                                <path
+                                  strokeLinecap="round"
+                                  strokeLinejoin="round"
+                                  d="M11.42 15.17L17.25 21A2.652 2.652 0 0021 17.25l-5.877-5.877M11.42 15.17l2.496-3.03c.317-.384.74-.626 1.208-.766M11.42 15.17l-4.655 5.653a2.548 2.548 0 11-3.586-3.586l6.837-5.63m5.108-.233c.55-.164 1.163-.188 1.743-.14a4.5 4.5 0 004.486-6.336l-3.276 3.277a3.004 3.004 0 01-2.25-2.25l3.276-3.276a4.5 4.5 0 00-6.336 4.486c.091 1.076-.071 2.264-.904 2.95l-.102.085m-1.745 1.437L5.909 7.5H4.5L2.25 3.75l1.5-1.5L7.5 4.5v1.409l4.26 4.26m-1.745 1.437l1.745-1.437m6.615 8.206L15.75 15.75M4.867 19.125h.008v.008h-.008v-.008z"
+                                />
+                              </svg>
+                              <span className="text-sm font-medium text-foreground">
+                                {message.toolName}
+                              </span>
+                              {message.isWebhook && (
+                                <span className="text-xs text-muted-foreground bg-background px-2 py-0.5 rounded">
+                                  Webhook
+                                </span>
+                              )}
+                            </div>
+                            {message.toolParams &&
+                              message.toolParams.length > 0 && (
+                                <div className="space-y-3 mt-3">
+                                  {/* Group parameters by type for webhook tools */}
+                                  {message.isWebhook ? (
+                                    <>
+                                      {/* Query Parameters */}
+                                      {message.toolParams.filter(
+                                        (p) => p.group === "query",
+                                      ).length > 0 && (
+                                        <div className="bg-background border border-border rounded-xl p-3">
+                                          <h5 className="text-xs font-medium text-muted-foreground mb-3 uppercase tracking-wide">
+                                            Query
+                                          </h5>
+                                          <div className="space-y-3">
+                                            {message.toolParams
+                                              .filter(
+                                                (p) => p.group === "query",
+                                              )
+                                              .map((param, idx) => {
+                                                const isEmpty =
+                                                  !param.value.trim();
+                                                const showError =
+                                                  localValidationAttempted &&
+                                                  isEmpty;
+                                                return (
+                                                  <div key={idx}>
+                                                    <label className="block text-sm font-medium text-foreground mb-1.5">
+                                                      {param.name}
+                                                    </label>
+                                                    <input
+                                                      type="text"
+                                                      value={param.value}
+                                                      onChange={(e) =>
+                                                        updateToolCallParam(
+                                                          message.id,
+                                                          param.name,
+                                                          e.target.value,
+                                                          param.group,
+                                                        )
+                                                      }
+                                                      placeholder={`Enter ${param.name}`}
+                                                      data-tool-call-id={message.id}
+                                                      className={`w-full h-10 px-3 rounded-lg text-sm bg-muted text-foreground placeholder:text-muted-foreground border focus:outline-none focus:ring-2 focus:ring-accent ${
+                                                        showError
+                                                          ? "border-red-500"
+                                                          : "border-border"
+                                                      }`}
+                                                    />
+                                                    {showError && (
+                                                      <p className="text-xs text-red-500 mt-1">
+                                                        This field cannot be
+                                                        empty
+                                                      </p>
+                                                    )}
+                                                  </div>
+                                                );
+                                              })}
+                                          </div>
+                                        </div>
+                                      )}
+                                      {/* Body Parameters */}
+                                      {message.toolParams.filter(
+                                        (p) => p.group === "body",
+                                      ).length > 0 && (
+                                        <div className="bg-background border border-border rounded-xl p-3">
+                                          <h5 className="text-xs font-medium text-muted-foreground mb-3 uppercase tracking-wide">
+                                            Body
+                                          </h5>
+                                          <div className="space-y-3">
+                                            {message.toolParams
+                                              .filter((p) => p.group === "body")
+                                              .map((param, idx) => {
+                                                const isEmpty =
+                                                  !param.value.trim();
+                                                const showError =
+                                                  localValidationAttempted &&
+                                                  isEmpty;
+                                                return (
+                                                  <div key={idx}>
+                                                    <label className="block text-sm font-medium text-foreground mb-1.5">
+                                                      {param.name}
+                                                    </label>
+                                                    <input
+                                                      type="text"
+                                                      value={param.value}
+                                                      onChange={(e) =>
+                                                        updateToolCallParam(
+                                                          message.id,
+                                                          param.name,
+                                                          e.target.value,
+                                                          param.group,
+                                                        )
+                                                      }
+                                                      placeholder={`Enter ${param.name}`}
+                                                      data-tool-call-id={message.id}
+                                                      className={`w-full h-10 px-3 rounded-lg text-sm bg-muted text-foreground placeholder:text-muted-foreground border focus:outline-none focus:ring-2 focus:ring-accent ${
+                                                        showError
+                                                          ? "border-red-500"
+                                                          : "border-border"
+                                                      }`}
+                                                    />
+                                                    {showError && (
+                                                      <p className="text-xs text-red-500 mt-1">
+                                                        This field cannot be
+                                                        empty
+                                                      </p>
+                                                    )}
+                                                  </div>
+                                                );
+                                              })}
+                                          </div>
+                                        </div>
+                                      )}
+                                    </>
+                                  ) : (
+                                    /* Regular tool parameters */
+                                    <div className="space-y-3">
+                                      {message.toolParams.map((param, idx) => {
+                                        const isEmpty = !param.value.trim();
+                                        const showError =
+                                          localValidationAttempted && isEmpty;
+                                        return (
+                                          <div key={idx}>
+                                            <label className="block text-sm font-medium text-foreground mb-1.5">
+                                              {param.name}
+                                            </label>
+                                            <input
+                                              type="text"
+                                              value={param.value}
+                                              onChange={(e) =>
+                                                updateToolCallParam(
+                                                  message.id,
+                                                  param.name,
+                                                  e.target.value,
+                                                  param.group,
+                                                )
+                                              }
+                                              placeholder={`Enter ${param.name}`}
+                                              className={`w-full h-10 px-4 rounded-lg text-sm bg-background text-foreground placeholder:text-muted-foreground border focus:outline-none focus:ring-2 focus:ring-accent ${
+                                                showError
+                                                  ? "border-red-500"
+                                                  : "border-border"
+                                              }`}
+                                            />
+                                            {showError && (
+                                              <p className="text-xs text-red-500 mt-1">
+                                                This field cannot be empty
+                                              </p>
+                                            )}
+                                          </div>
+                                        );
+                                      })}
+                                    </div>
+                                  )}
+                                </div>
+                              )}
                           </div>
-                          <div className="mt-2">
-                            <label className="block text-xs font-medium text-muted-foreground mb-1.5">
-                              JSON Response{" "}
-                              <span className="text-red-500">*</span>
-                            </label>
-                            <textarea
-                              value={message.content}
-                              onChange={(e) =>
-                                updateChatMessage(message.id, e.target.value)
-                              }
-                              placeholder='{"status": "success", "response": {}}'
-                              rows={5}
-                              className={`w-full px-3 py-2 rounded-lg text-sm font-mono bg-background text-foreground placeholder:text-muted-foreground border focus:outline-none focus:ring-2 focus:ring-accent ${(() => {
+                          </div>
+                          {showInlineDelete && (
+                            <button
+                              onClick={() => removeChatMessage(message.id)}
+                              className="w-8 h-8 flex-shrink-0 rounded-lg border border-border flex items-center justify-center text-muted-foreground hover:text-red-400 hover:border-red-400/50 transition-colors cursor-pointer"
+                              title="Remove message"
+                            >
+                              <svg
+                                className="w-4 h-4"
+                                fill="none"
+                                viewBox="0 0 24 24"
+                                stroke="currentColor"
+                                strokeWidth={2}
+                              >
+                                <path
+                                  strokeLinecap="round"
+                                  strokeLinejoin="round"
+                                  d="M14.74 9l-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 01-2.244 2.077H8.084a2.25 2.25 0 01-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 00-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 013.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 00-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 00-7.5 0"
+                                />
+                              </svg>
+                            </button>
+                          )}
+                        </div>
+                      )}
+
+                      {/* Tool Response Display (for webhook tools) */}
+                      {message.role === "tool_response" && (
+                        <div className="w-1/2">
+                          <div className="bg-muted border border-border rounded-2xl p-4">
+                            <div className="flex items-center gap-2 mb-2">
+                              <svg
+                                className="w-4 h-4 text-muted-foreground"
+                                fill="none"
+                                viewBox="0 0 24 24"
+                                stroke="currentColor"
+                                strokeWidth={1.5}
+                              >
+                                <path
+                                  strokeLinecap="round"
+                                  strokeLinejoin="round"
+                                  d="M9 12.75L11.25 15 15 9.75M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+                                />
+                              </svg>
+                              <span className="text-sm font-medium text-foreground">
+                                Tool Response
+                              </span>
+                              <span className="text-xs text-muted-foreground">
+                                ({message.toolName})
+                              </span>
+                            </div>
+                            <div className="mt-2">
+                              <label className="block text-xs font-medium text-muted-foreground mb-1.5">
+                                JSON Response{" "}
+                                <span className="text-red-500">*</span>
+                              </label>
+                              <textarea
+                                value={message.content}
+                                onChange={(e) =>
+                                  updateChatMessage(message.id, e.target.value)
+                                }
+                                placeholder='{"status": "success", "response": {}}'
+                                rows={5}
+                                className={`w-full px-3 py-2 rounded-lg text-sm font-mono bg-background text-foreground placeholder:text-muted-foreground border focus:outline-none focus:ring-2 focus:ring-accent ${(() => {
+                                  try {
+                                    JSON.parse(message.content);
+                                    return "border-border";
+                                  } catch {
+                                    return message.content.trim()
+                                      ? "border-red-500"
+                                      : "border-border";
+                                  }
+                                })()}`}
+                              />
+                              {(() => {
                                 try {
                                   JSON.parse(message.content);
-                                  return "border-border";
+                                  return null;
                                 } catch {
-                                  return message.content.trim()
-                                    ? "border-red-500"
-                                    : "border-border";
+                                  return message.content.trim() ? (
+                                    <p className="text-xs text-red-500 mt-1">
+                                      Invalid JSON format
+                                    </p>
+                                  ) : null;
                                 }
-                              })()}`}
-                            />
-                            {(() => {
-                              try {
-                                JSON.parse(message.content);
-                                return null;
-                              } catch {
-                                return message.content.trim() ? (
-                                  <p className="text-xs text-red-500 mt-1">
-                                    Invalid JSON format
-                                  </p>
-                                ) : null;
-                              }
-                            })()}
+                              })()}
+                            </div>
                           </div>
                         </div>
-                      </div>
-                    )}
+                      )}
 
-                    {/* Message Actions - Delete button for all messages, Add button only for last */}
-                    <div className="flex items-center gap-2 relative">
-                      {/* Delete and Add Message Buttons - only for last non-tool-response message */}
-                      {/* Tool response messages are linked to their tool call and shouldn't have independent actions */}
-                      {message.role !== "tool_response" &&
-                        index ===
-                          chatMessages.length -
-                            1 -
-                            (chatMessages[chatMessages.length - 1]?.role ===
-                            "tool_response"
-                              ? 1
-                              : 0) && (
-                          <>
+                      {/* Message Actions — Delete + Add on the last non-tool-response message only.
+                           Earlier messages get an inline delete button beside the bubble. */}
+                      <div className="flex items-center gap-2 relative">
+                        {message.role !== "tool_response" &&
+                          isLastNonToolResponse && (
                             <button
                               onClick={() => removeChatMessage(message.id)}
                               className="w-8 h-8 rounded-lg border border-border flex items-center justify-center text-muted-foreground hover:text-red-400 hover:border-red-400/50 transition-colors cursor-pointer"
@@ -2319,360 +2583,351 @@ export function AddTestDialog({
                                 />
                               </svg>
                             </button>
-                            <div className="relative">
-                              <button
-                                onClick={() =>
-                                  setAddMessageDropdownOpen(
-                                    !addMessageDropdownOpen
-                                  )
-                                }
-                                className="w-8 h-8 rounded-lg border border-border flex items-center justify-center text-muted-foreground hover:text-foreground hover:border-muted-foreground transition-colors cursor-pointer"
-                                title="Add message"
-                              >
-                                <svg
-                                  className="w-4 h-4"
-                                  fill="none"
-                                  viewBox="0 0 24 24"
-                                  stroke="currentColor"
-                                  strokeWidth={2}
+                          )}
+                        {message.role !== "tool_response" &&
+                          index ===
+                            chatMessages.length -
+                              1 -
+                              (chatMessages[chatMessages.length - 1]?.role ===
+                              "tool_response"
+                                ? 1
+                                : 0) && (
+                            <>
+                              <div className="relative">
+                                <button
+                                  onClick={() =>
+                                    setAddMessageDropdownOpen(
+                                      !addMessageDropdownOpen,
+                                    )
+                                  }
+                                  className="w-8 h-8 rounded-lg border border-border flex items-center justify-center text-muted-foreground hover:text-foreground hover:border-muted-foreground transition-colors cursor-pointer"
+                                  title="Add message"
                                 >
-                                  <path
-                                    strokeLinecap="round"
-                                    strokeLinejoin="round"
-                                    d="M12 4.5v15m7.5-7.5h-15"
-                                  />
-                                </svg>
-                              </button>
-
-                              {/* Dropdown Menu */}
-                              {addMessageDropdownOpen && (
-                                <>
-                                  <div
-                                    className="fixed inset-0 z-[150]"
-                                    onClick={() =>
-                                      setAddMessageDropdownOpen(false)
-                                    }
-                                  />
-                                  <div
-                                    className={`absolute bg-background border border-border rounded-lg shadow-xl z-[200] overflow-hidden py-1 whitespace-nowrap ${
-                                      message.role === "user"
-                                        ? chatMessages.length <= 2
-                                          ? "right-0 top-10"
-                                          : "right-0 bottom-full mb-2"
-                                        : chatMessages.length <= 2
-                                        ? "left-0 top-10"
-                                        : "left-0 bottom-full mb-2"
-                                    }`}
+                                  <svg
+                                    className="w-4 h-4"
+                                    fill="none"
+                                    viewBox="0 0 24 24"
+                                    stroke="currentColor"
+                                    strokeWidth={2}
                                   >
-                                    <button
-                                      onClick={() => {
-                                        addChatMessage("user");
-                                        setAddMessageDropdownOpen(false);
-                                      }}
-                                      className="w-full px-3 py-1.5 flex items-center gap-2 text-foreground hover:bg-muted transition-colors cursor-pointer"
-                                    >
-                                      <svg
-                                        className="w-4 h-4 text-muted-foreground"
-                                        fill="none"
-                                        viewBox="0 0 24 24"
-                                        stroke="currentColor"
-                                        strokeWidth={1.5}
-                                      >
-                                        <path
-                                          strokeLinecap="round"
-                                          strokeLinejoin="round"
-                                          d="M15.75 6a3.75 3.75 0 11-7.5 0 3.75 3.75 0 017.5 0zM4.501 20.118a7.5 7.5 0 0114.998 0A17.933 17.933 0 0112 21.75c-2.676 0-5.216-.584-7.499-1.632z"
-                                        />
-                                      </svg>
-                                      <span className="text-sm">
-                                        User message
-                                      </span>
-                                    </button>
-                                    <button
-                                      onClick={() => {
-                                        addChatMessage("agent");
-                                        setAddMessageDropdownOpen(false);
-                                      }}
-                                      className="w-full px-3 py-1.5 flex items-center gap-2 text-foreground hover:bg-muted transition-colors cursor-pointer"
-                                    >
-                                      <svg
-                                        className="w-4 h-4 text-muted-foreground"
-                                        fill="none"
-                                        viewBox="0 0 24 24"
-                                        stroke="currentColor"
-                                        strokeWidth={1.5}
-                                      >
-                                        <path
-                                          strokeLinecap="round"
-                                          strokeLinejoin="round"
-                                          d="M8.25 3v1.5M4.5 8.25H3m18 0h-1.5M4.5 12H3m18 0h-1.5m-15 3.75H3m18 0h-1.5M8.25 19.5V21M12 3v1.5m0 15V21m3.75-18v1.5m0 15V21m-9-1.5h10.5a2.25 2.25 0 002.25-2.25V6.75a2.25 2.25 0 00-2.25-2.25H6.75A2.25 2.25 0 004.5 6.75v10.5a2.25 2.25 0 002.25 2.25zm.75-12h9v9h-9v-9z"
-                                        />
-                                      </svg>
-                                      <span className="text-sm">
-                                        Agent message
-                                      </span>
-                                    </button>
-                                    <button
-                                      onClick={() => {
-                                        setAddMessageDropdownOpen(false);
-                                        setToolCallDropdownOpen(true);
-                                      }}
-                                      className="w-full px-3 py-1.5 flex items-center gap-2 text-foreground hover:bg-muted transition-colors cursor-pointer"
-                                    >
-                                      <svg
-                                        className="w-4 h-4 text-muted-foreground"
-                                        fill="none"
-                                        viewBox="0 0 24 24"
-                                        stroke="currentColor"
-                                        strokeWidth={1.5}
-                                      >
-                                        <path
-                                          strokeLinecap="round"
-                                          strokeLinejoin="round"
-                                          d="M11.42 15.17L17.25 21A2.652 2.652 0 0021 17.25l-5.877-5.877M11.42 15.17l2.496-3.03c.317-.384.74-.626 1.208-.766M11.42 15.17l-4.655 5.653a2.548 2.548 0 11-3.586-3.586l6.837-5.63m5.108-.233c.55-.164 1.163-.188 1.743-.14a4.5 4.5 0 004.486-6.336l-3.276 3.277a3.004 3.004 0 01-2.25-2.25l3.276-3.276a4.5 4.5 0 00-6.336 4.486c.091 1.076-.071 2.264-.904 2.95l-.102.085m-1.745 1.437L5.909 7.5H4.5L2.25 3.75l1.5-1.5L7.5 4.5v1.409l4.26 4.26m-1.745 1.437l1.745-1.437m6.615 8.206L15.75 15.75M4.867 19.125h.008v.008h-.008v-.008z"
-                                        />
-                                      </svg>
-                                      <span className="text-sm">
-                                        Agent tool call
-                                      </span>
-                                    </button>
-                                  </div>
-                                </>
-                              )}
+                                    <path
+                                      strokeLinecap="round"
+                                      strokeLinejoin="round"
+                                      d="M12 4.5v15m7.5-7.5h-15"
+                                    />
+                                  </svg>
+                                </button>
 
-                              {/* Tool Call Selection Dropdown */}
-                              {toolCallDropdownOpen && (
-                                <>
-                                  <div
-                                    className="fixed inset-0 z-[150]"
-                                    onClick={() => {
-                                      setToolCallDropdownOpen(false);
-                                      setPendingToolCall(null);
-                                    }}
-                                  />
-                                  <div
-                                    className={`absolute bg-background border border-border rounded-xl shadow-xl z-[200] overflow-hidden min-w-[320px] ${
-                                      message.role === "user"
-                                        ? chatMessages.length <= 2
-                                          ? "right-0 top-10"
-                                          : "right-0 bottom-full mb-2"
-                                        : chatMessages.length <= 2
-                                        ? "left-0 top-10"
-                                        : "left-0 bottom-full mb-2"
-                                    }`}
-                                  >
-                                    {!pendingToolCall ? (
-                                      <ToolPicker
-                                        availableTools={availableTools}
-                                        isLoading={availableToolsLoading}
-                                        onSelectInbuiltTool={(
-                                          toolId,
-                                          toolName
-                                        ) => {
-                                          addToolCallMessage(
+                                {/* Dropdown Menu */}
+                                {addMessageDropdownOpen && (
+                                  <>
+                                    <div
+                                      className="fixed inset-0 z-[150]"
+                                      onClick={() =>
+                                        setAddMessageDropdownOpen(false)
+                                      }
+                                    />
+                                    <div
+                                      className={`absolute bg-background border border-border rounded-lg shadow-xl z-[200] overflow-hidden py-1 whitespace-nowrap ${
+                                        message.role === "user"
+                                          ? chatMessages.length <= 2
+                                            ? "right-0 top-10"
+                                            : "right-0 bottom-full mb-2"
+                                          : chatMessages.length <= 2
+                                            ? "left-0 top-10"
+                                            : "left-0 bottom-full mb-2"
+                                      }`}
+                                    >
+                                      <button
+                                        onClick={() => {
+                                          addChatMessage("user");
+                                          setAddMessageDropdownOpen(false);
+                                        }}
+                                        className="w-full px-3 py-1.5 flex items-center gap-2 text-foreground hover:bg-muted transition-colors cursor-pointer"
+                                      >
+                                        <svg
+                                          className="w-4 h-4 text-muted-foreground"
+                                          fill="none"
+                                          viewBox="0 0 24 24"
+                                          stroke="currentColor"
+                                          strokeWidth={1.5}
+                                        >
+                                          <path
+                                            strokeLinecap="round"
+                                            strokeLinejoin="round"
+                                            d="M15.75 6a3.75 3.75 0 11-7.5 0 3.75 3.75 0 017.5 0zM4.501 20.118a7.5 7.5 0 0114.998 0A17.933 17.933 0 0112 21.75c-2.676 0-5.216-.584-7.499-1.632z"
+                                          />
+                                        </svg>
+                                        <span className="text-sm">
+                                          User message
+                                        </span>
+                                      </button>
+                                      <button
+                                        onClick={() => {
+                                          addChatMessage("agent");
+                                          setAddMessageDropdownOpen(false);
+                                        }}
+                                        className="w-full px-3 py-1.5 flex items-center gap-2 text-foreground hover:bg-muted transition-colors cursor-pointer"
+                                      >
+                                        <svg
+                                          className="w-4 h-4 text-muted-foreground"
+                                          fill="none"
+                                          viewBox="0 0 24 24"
+                                          stroke="currentColor"
+                                          strokeWidth={1.5}
+                                        >
+                                          <path
+                                            strokeLinecap="round"
+                                            strokeLinejoin="round"
+                                            d="M8.25 3v1.5M4.5 8.25H3m18 0h-1.5M4.5 12H3m18 0h-1.5m-15 3.75H3m18 0h-1.5M8.25 19.5V21M12 3v1.5m0 15V21m3.75-18v1.5m0 15V21m-9-1.5h10.5a2.25 2.25 0 002.25-2.25V6.75a2.25 2.25 0 00-2.25-2.25H6.75A2.25 2.25 0 004.5 6.75v10.5a2.25 2.25 0 002.25 2.25zm.75-12h9v9h-9v-9z"
+                                          />
+                                        </svg>
+                                        <span className="text-sm">
+                                          Agent message
+                                        </span>
+                                      </button>
+                                      <button
+                                        onClick={() => {
+                                          setAddMessageDropdownOpen(false);
+                                          setToolCallDropdownOpen(true);
+                                        }}
+                                        className="w-full px-3 py-1.5 flex items-center gap-2 text-foreground hover:bg-muted transition-colors cursor-pointer"
+                                      >
+                                        <svg
+                                          className="w-4 h-4 text-muted-foreground"
+                                          fill="none"
+                                          viewBox="0 0 24 24"
+                                          stroke="currentColor"
+                                          strokeWidth={1.5}
+                                        >
+                                          <path
+                                            strokeLinecap="round"
+                                            strokeLinejoin="round"
+                                            d="M11.42 15.17L17.25 21A2.652 2.652 0 0021 17.25l-5.877-5.877M11.42 15.17l2.496-3.03c.317-.384.74-.626 1.208-.766M11.42 15.17l-4.655 5.653a2.548 2.548 0 11-3.586-3.586l6.837-5.63m5.108-.233c.55-.164 1.163-.188 1.743-.14a4.5 4.5 0 004.486-6.336l-3.276 3.277a3.004 3.004 0 01-2.25-2.25l3.276-3.276a4.5 4.5 0 00-6.336 4.486c.091 1.076-.071 2.264-.904 2.95l-.102.085m-1.745 1.437L5.909 7.5H4.5L2.25 3.75l1.5-1.5L7.5 4.5v1.409l4.26 4.26m-1.745 1.437l1.745-1.437m6.615 8.206L15.75 15.75M4.867 19.125h.008v.008h-.008v-.008z"
+                                          />
+                                        </svg>
+                                        <span className="text-sm">
+                                          Agent tool call
+                                        </span>
+                                      </button>
+                                    </div>
+                                  </>
+                                )}
+
+                                {/* Tool Call Selection Dropdown */}
+                                {toolCallDropdownOpen && (
+                                  <>
+                                    <div
+                                      className="fixed inset-0 z-[150]"
+                                      onClick={() => {
+                                        setToolCallDropdownOpen(false);
+                                        setPendingToolCall(null);
+                                      }}
+                                    />
+                                    <div
+                                      className={`absolute bg-background border border-border rounded-xl shadow-xl z-[200] overflow-hidden min-w-[320px] ${
+                                        message.role === "user"
+                                          ? chatMessages.length <= 2
+                                            ? "right-0 top-10"
+                                            : "right-0 bottom-full mb-2"
+                                          : chatMessages.length <= 2
+                                            ? "left-0 top-10"
+                                            : "left-0 bottom-full mb-2"
+                                      }`}
+                                    >
+                                      {!pendingToolCall ? (
+                                        <ToolPicker
+                                          availableTools={availableTools}
+                                          isLoading={availableToolsLoading}
+                                          onSelectInbuiltTool={(
                                             toolId,
                                             toolName,
-                                            []
-                                          );
-                                        }}
-                                        onSelectCustomTool={(tool) => {
-                                          const isWebhook =
-                                            tool.config?.type === "webhook";
-                                          let allParams: Array<{
-                                            name: string;
-                                            value: string;
-                                            group?: string;
-                                          }> = [];
+                                          ) => {
+                                            addToolCallMessage(
+                                              toolId,
+                                              toolName,
+                                              [],
+                                            );
+                                          }}
+                                          onSelectCustomTool={(tool) => {
+                                            const isWebhook =
+                                              tool.config?.type === "webhook";
+                                            let allParams: Array<{
+                                              name: string;
+                                              value: string;
+                                              group?: string;
+                                            }> = [];
 
-                                          if (
-                                            isWebhook &&
-                                            tool.config?.webhook
-                                          ) {
-                                            // Extract webhook-specific parameters
-                                            const webhook = tool.config.webhook;
-
-                                            // Query parameters (for GET requests)
                                             if (
-                                              webhook.queryParameters &&
-                                              Array.isArray(
-                                                webhook.queryParameters
-                                              )
+                                              isWebhook &&
+                                              tool.config?.webhook
                                             ) {
-                                              webhook.queryParameters.forEach(
-                                                (p: any) => {
-                                                  allParams.push({
-                                                    name: p.id || p.name || "",
-                                                    value: "",
-                                                    group: "query",
-                                                  });
-                                                }
-                                              );
-                                            }
+                                              // Extract webhook-specific parameters
+                                              const webhook =
+                                                tool.config.webhook;
 
-                                            // Body parameters (for POST requests)
-                                            if (
-                                              webhook.body?.parameters &&
-                                              Array.isArray(
-                                                webhook.body.parameters
-                                              )
-                                            ) {
-                                              webhook.body.parameters.forEach(
-                                                (p: any) => {
-                                                  allParams.push({
-                                                    name: p.id || p.name || "",
-                                                    value: "",
-                                                    group: "body",
-                                                  });
-                                                }
-                                              );
-                                            }
-                                            // Note: Headers are not shown in conversation history UI
-                                          } else {
-                                            // Structured output tool - use regular parameters
-                                            const params =
-                                              tool.config?.parameters;
-                                            if (Array.isArray(params)) {
-                                              allParams = params.map(
-                                                (p: any) => ({
-                                                  name: p.id || p.name || "",
-                                                  value: "",
-                                                })
-                                              );
+                                              // Query parameters (for GET requests)
+                                              if (
+                                                webhook.queryParameters &&
+                                                Array.isArray(
+                                                  webhook.queryParameters,
+                                                )
+                                              ) {
+                                                webhook.queryParameters.forEach(
+                                                  (p: any) => {
+                                                    allParams.push({
+                                                      name:
+                                                        p.id || p.name || "",
+                                                      value: "",
+                                                      group: "query",
+                                                    });
+                                                  },
+                                                );
+                                              }
+
+                                              // Body parameters (for POST requests)
+                                              if (
+                                                webhook.body?.parameters &&
+                                                Array.isArray(
+                                                  webhook.body.parameters,
+                                                )
+                                              ) {
+                                                webhook.body.parameters.forEach(
+                                                  (p: any) => {
+                                                    allParams.push({
+                                                      name:
+                                                        p.id || p.name || "",
+                                                      value: "",
+                                                      group: "body",
+                                                    });
+                                                  },
+                                                );
+                                              }
+                                              // Note: Headers are not shown in conversation history UI
                                             } else {
-                                              const propsObj =
-                                                tool.config?.parameters
-                                                  ?.properties ||
-                                                tool.config?.function
-                                                  ?.parameters?.properties ||
-                                                tool.config?.properties ||
-                                                tool.config?.parameters ||
-                                                {};
-                                              allParams = Object.keys(
-                                                propsObj
-                                              ).map((name) => ({
-                                                name,
-                                                value: "",
-                                              }));
+                                              // Structured output tool - use regular parameters
+                                              const params =
+                                                tool.config?.parameters;
+                                              if (Array.isArray(params)) {
+                                                allParams = params.map(
+                                                  (p: any) => ({
+                                                    name: p.id || p.name || "",
+                                                    value: "",
+                                                  }),
+                                                );
+                                              } else {
+                                                const propsObj =
+                                                  tool.config?.parameters
+                                                    ?.properties ||
+                                                  tool.config?.function
+                                                    ?.parameters?.properties ||
+                                                  tool.config?.properties ||
+                                                  tool.config?.parameters ||
+                                                  {};
+                                                allParams = Object.keys(
+                                                  propsObj,
+                                                ).map((name) => ({
+                                                  name,
+                                                  value: "",
+                                                }));
+                                              }
                                             }
-                                          }
 
-                                          addToolCallMessage(
-                                            tool.uuid,
-                                            tool.name,
-                                            allParams,
-                                            isWebhook
-                                          );
-                                        }}
-                                      />
-                                    ) : (
-                                      <div className="p-4">
-                                        <div className="flex items-center gap-2 mb-4">
+                                            addToolCallMessage(
+                                              tool.uuid,
+                                              tool.name,
+                                              allParams,
+                                              isWebhook,
+                                            );
+                                          }}
+                                        />
+                                      ) : (
+                                        <div className="p-4">
+                                          <div className="flex items-center gap-2 mb-4">
+                                            <button
+                                              onClick={() =>
+                                                setPendingToolCall(null)
+                                              }
+                                              className="text-muted-foreground hover:text-foreground transition-colors"
+                                            >
+                                              <svg
+                                                className="w-4 h-4"
+                                                fill="none"
+                                                viewBox="0 0 24 24"
+                                                stroke="currentColor"
+                                                strokeWidth={2}
+                                              >
+                                                <path
+                                                  strokeLinecap="round"
+                                                  strokeLinejoin="round"
+                                                  d="M15.75 19.5L8.25 12l7.5-7.5"
+                                                />
+                                              </svg>
+                                            </button>
+                                            <h4 className="text-sm font-medium text-foreground">
+                                              {pendingToolCall.toolName}
+                                            </h4>
+                                          </div>
+                                          <p className="text-xs text-muted-foreground mb-3">
+                                            Enter values for parameters:
+                                          </p>
+                                          <div className="space-y-2 max-h-[200px] overflow-y-auto">
+                                            {pendingToolCall.params.map(
+                                              (param, idx) => (
+                                                <div key={idx}>
+                                                  <label className="block text-xs text-muted-foreground mb-1">
+                                                    {param.name}
+                                                  </label>
+                                                  <input
+                                                    type="text"
+                                                    value={param.value}
+                                                    onChange={(e) => {
+                                                      const newParams = [
+                                                        ...pendingToolCall.params,
+                                                      ];
+                                                      newParams[idx].value =
+                                                        e.target.value;
+                                                      setPendingToolCall({
+                                                        ...pendingToolCall,
+                                                        params: newParams,
+                                                      });
+                                                    }}
+                                                    placeholder={`Enter ${param.name}`}
+                                                    className="w-full h-9 px-3 rounded-lg text-sm bg-background text-foreground placeholder:text-muted-foreground border border-border focus:outline-none focus:ring-1 focus:ring-accent"
+                                                  />
+                                                </div>
+                                              ),
+                                            )}
+                                          </div>
                                           <button
                                             onClick={() =>
-                                              setPendingToolCall(null)
+                                              addToolCallMessage(
+                                                pendingToolCall.toolId,
+                                                pendingToolCall.toolName,
+                                                pendingToolCall.params,
+                                              )
                                             }
-                                            className="text-muted-foreground hover:text-foreground transition-colors"
+                                            className="w-full mt-4 h-9 px-4 rounded-lg text-sm font-medium bg-foreground text-background hover:opacity-90 transition-opacity cursor-pointer"
                                           >
-                                            <svg
-                                              className="w-4 h-4"
-                                              fill="none"
-                                              viewBox="0 0 24 24"
-                                              stroke="currentColor"
-                                              strokeWidth={2}
-                                            >
-                                              <path
-                                                strokeLinecap="round"
-                                                strokeLinejoin="round"
-                                                d="M15.75 19.5L8.25 12l7.5-7.5"
-                                              />
-                                            </svg>
+                                            Add tool call
                                           </button>
-                                          <h4 className="text-sm font-medium text-foreground">
-                                            {pendingToolCall.toolName}
-                                          </h4>
                                         </div>
-                                        <p className="text-xs text-muted-foreground mb-3">
-                                          Enter values for parameters:
-                                        </p>
-                                        <div className="space-y-2 max-h-[200px] overflow-y-auto">
-                                          {pendingToolCall.params.map(
-                                            (param, idx) => (
-                                              <div key={idx}>
-                                                <label className="block text-xs text-muted-foreground mb-1">
-                                                  {param.name}
-                                                </label>
-                                                <input
-                                                  type="text"
-                                                  value={param.value}
-                                                  onChange={(e) => {
-                                                    const newParams = [
-                                                      ...pendingToolCall.params,
-                                                    ];
-                                                    newParams[idx].value =
-                                                      e.target.value;
-                                                    setPendingToolCall({
-                                                      ...pendingToolCall,
-                                                      params: newParams,
-                                                    });
-                                                  }}
-                                                  placeholder={`Enter ${param.name}`}
-                                                  className="w-full h-9 px-3 rounded-lg text-sm bg-background text-foreground placeholder:text-muted-foreground border border-border focus:outline-none focus:ring-1 focus:ring-accent"
-                                                />
-                                              </div>
-                                            )
-                                          )}
-                                        </div>
-                                        <button
-                                          onClick={() =>
-                                            addToolCallMessage(
-                                              pendingToolCall.toolId,
-                                              pendingToolCall.toolName,
-                                              pendingToolCall.params
-                                            )
-                                          }
-                                          className="w-full mt-4 h-9 px-4 rounded-lg text-sm font-medium bg-foreground text-background hover:opacity-90 transition-opacity cursor-pointer"
-                                        >
-                                          Add tool call
-                                        </button>
-                                      </div>
-                                    )}
-                                  </div>
-                                </>
-                              )}
-                            </div>
-                          </>
-                        )}
+                                      )}
+                                    </div>
+                                  </>
+                                )}
+                              </div>
+                            </>
+                          )}
+                      </div>
                     </div>
-                  </div>
-                ))}
+                  );
+                })}
                 <div ref={chatEndRef} />
               </div>
             )}
           </div>
 
-          {/* Info Footer */}
-          <div className="px-4 md:px-6 py-3 md:py-4 border-t border-border">
-            <div className="flex items-start gap-2">
-              <svg
-                className="w-4 h-4 text-muted-foreground mt-0.5 flex-shrink-0"
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke="currentColor"
-                strokeWidth={2}
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  d="M11.25 11.25l.041-.02a.75.75 0 011.063.852l-.708 2.836a.75.75 0 001.063.853l.041-.021M21 12a9 9 0 11-18 0 9 9 0 0118 0zm-9-3.75h.008v.008H12V8.25z"
-                />
-              </svg>
-              <p className="text-xs text-muted-foreground leading-relaxed">
-                The agent&apos;s response to the last user message will be
-                evaluated against the success criteria using examples provided.
-                Previous messages will be passed as context.
-              </p>
-            </div>
-          </div>
         </div>
       </div>
     </div>

--- a/src/components/AgentPicker.tsx
+++ b/src/components/AgentPicker.tsx
@@ -3,6 +3,7 @@
 import React, { useState, useEffect, useRef } from "react";
 import { signOut } from "next-auth/react";
 import { useAccessToken } from "@/hooks";
+import { SingleSelectPicker } from "@/components/SingleSelectPicker";
 
 export type Agent = {
   uuid: string;
@@ -20,6 +21,59 @@ type AgentPickerProps = {
   disabled?: boolean;
 };
 
+function UnverifiedPill() {
+  return (
+    <span className="inline-flex items-center gap-1 text-xs px-1.5 py-0.5 rounded font-medium bg-yellow-500/10 text-yellow-500 flex-shrink-0">
+      <svg
+        className="w-3 h-3"
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke="currentColor"
+        strokeWidth={2.5}
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126zM12 15.75h.007v.008H12v-.008z"
+        />
+      </svg>
+      Unverified
+    </span>
+  );
+}
+
+function AgentTypePill({ type }: { type?: "agent" | "connection" }) {
+  return (
+    <span
+      className={`text-xs px-1.5 py-0.5 rounded font-medium ${
+        type === "connection"
+          ? "bg-blue-500/10 text-blue-500"
+          : "bg-muted text-muted-foreground"
+      }`}
+    >
+      {type === "connection" ? "Connection" : "Agent"}
+    </span>
+  );
+}
+
+function CheckIcon() {
+  return (
+    <svg
+      className="w-4 h-4 text-foreground flex-shrink-0"
+      fill="none"
+      viewBox="0 0 24 24"
+      stroke="currentColor"
+      strokeWidth={2}
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M4.5 12.75l6 6 9-13.5"
+      />
+    </svg>
+  );
+}
+
 export function AgentPicker({
   selectedAgentUuid,
   onSelectAgent,
@@ -31,10 +85,7 @@ export function AgentPicker({
   const backendAccessToken = useAccessToken();
   const [agents, setAgents] = useState<Agent[]>([]);
   const [agentsLoading, setAgentsLoading] = useState(false);
-  const [dropdownOpen, setDropdownOpen] = useState(false);
-  const [searchQuery, setSearchQuery] = useState("");
 
-  // Fetch agents on mount
   useEffect(() => {
     const fetchAgents = async () => {
       if (!backendAccessToken) return;
@@ -87,163 +138,35 @@ export function AgentPicker({
     fetchAgents();
   }, [backendAccessToken]);
 
-  const filteredAgents = agents.filter((agent) =>
-    agent.name.toLowerCase().includes(searchQuery.toLowerCase())
-  );
-
-  const selectedAgent = agents.find((a) => a.uuid === selectedAgentUuid);
-
   return (
-    <div className={`space-y-1.5 ${className}`}>
-      {label && (
-        <label className="block text-sm font-medium text-foreground">
-          {label}
-        </label>
-      )}
-      <div className="relative">
-        <div
-          onClick={() => !disabled && setDropdownOpen(!dropdownOpen)}
-          className={`w-full h-11 px-4 rounded-xl text-sm bg-transparent text-foreground border border-border transition-colors flex items-center justify-between ${
-            disabled
-              ? "cursor-default"
-              : "hover:border-muted-foreground cursor-pointer"
-          }`}
-        >
-          <span
-            className={
-              selectedAgent ? "text-foreground" : "text-muted-foreground"
-            }
-          >
-            {selectedAgent ? selectedAgent.name : placeholder}
+    <SingleSelectPicker<Agent>
+      items={agents}
+      selectedId={selectedAgentUuid}
+      onSelect={(agent) => onSelectAgent(agent)}
+      getId={(a) => a.uuid}
+      label={label}
+      placeholder={placeholder}
+      className={className}
+      disabled={disabled}
+      loading={agentsLoading}
+      loadingLabel="Loading agents"
+      emptyLabel="No agents found"
+      searchPlaceholder="Search agents"
+      matchesSearch={(a, q) => a.name.toLowerCase().includes(q.toLowerCase())}
+      renderTrigger={(agent) => agent?.name ?? ""}
+      renderOption={(agent, isSelected) => (
+        <>
+          <span className="truncate flex items-center gap-1.5">
+            {agent.name}
+            {agent.verified === false && <UnverifiedPill />}
           </span>
-          {!disabled && (
-            <svg
-              className={`w-5 h-5 text-muted-foreground transition-transform ${
-                dropdownOpen ? "rotate-180" : ""
-              }`}
-              fill="none"
-              viewBox="0 0 24 24"
-              stroke="currentColor"
-              strokeWidth={2}
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                d="M19.5 8.25l-7.5 7.5-7.5-7.5"
-              />
-            </svg>
-          )}
-        </div>
-
-        {/* Dropdown */}
-        {dropdownOpen && !disabled && (
-          <>
-            <div
-              className="fixed inset-0 z-[99]"
-              onClick={() => setDropdownOpen(false)}
-            />
-            <div className="absolute left-0 right-0 top-full mt-2 bg-background border border-border rounded-xl shadow-xl z-[100] overflow-hidden">
-              {/* Search */}
-              <div className="p-3 border-b border-border">
-                <input
-                  type="text"
-                  value={searchQuery}
-                  onChange={(e) => setSearchQuery(e.target.value)}
-                  placeholder="Search agents"
-                  className="w-full h-10 px-4 rounded-lg text-sm bg-background text-foreground placeholder:text-muted-foreground border border-border focus:outline-none focus:ring-1 focus:ring-accent"
-                  onClick={(e) => e.stopPropagation()}
-                />
-              </div>
-
-              {/* Options */}
-              <div className="max-h-60 overflow-y-auto">
-                {agentsLoading ? (
-                  <div className="px-4 py-3 flex items-center gap-2 text-sm text-muted-foreground">
-                    <svg
-                      className="w-4 h-4 animate-spin"
-                      fill="none"
-                      viewBox="0 0 24 24"
-                    >
-                      <circle
-                        className="opacity-25"
-                        cx="12"
-                        cy="12"
-                        r="10"
-                        stroke="currentColor"
-                        strokeWidth="4"
-                      />
-                      <path
-                        className="opacity-75"
-                        fill="currentColor"
-                        d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
-                      />
-                    </svg>
-                    Loading agents
-                  </div>
-                ) : filteredAgents.length === 0 ? (
-                  <div className="px-4 py-3 text-sm text-muted-foreground">
-                    No agents found
-                  </div>
-                ) : (
-                  filteredAgents.map((agent) => (
-                    <button
-                      key={agent.uuid}
-                      onClick={() => {
-                        onSelectAgent(agent);
-                        setDropdownOpen(false);
-                      }}
-                      className={`w-full px-4 py-3 text-left text-sm transition-colors cursor-pointer flex items-center justify-between gap-2 ${
-                        selectedAgentUuid === agent.uuid
-                          ? "bg-accent text-foreground"
-                          : "text-foreground hover:bg-muted"
-                      }`}
-                    >
-                      <span className="truncate flex items-center gap-1.5">
-                        {agent.name}
-                        {agent.verified === false && (
-                          <span className="inline-flex items-center gap-1 text-xs px-1.5 py-0.5 rounded font-medium bg-yellow-500/10 text-yellow-500 flex-shrink-0">
-                            <svg className="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5}>
-                              <path strokeLinecap="round" strokeLinejoin="round" d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126zM12 15.75h.007v.008H12v-.008z" />
-                            </svg>
-                            Unverified
-                          </span>
-                        )}
-                      </span>
-                      <div className="flex items-center gap-2 flex-shrink-0">
-                        <span
-                          className={`text-xs px-1.5 py-0.5 rounded font-medium ${
-                            agent.type === "connection"
-                              ? "bg-blue-500/10 text-blue-500"
-                              : "bg-muted text-muted-foreground"
-                          }`}
-                        >
-                          {agent.type === "connection" ? "Connection" : "Agent"}
-                        </span>
-                        {selectedAgentUuid === agent.uuid && (
-                          <svg
-                            className="w-4 h-4 text-foreground"
-                            fill="none"
-                            viewBox="0 0 24 24"
-                            stroke="currentColor"
-                            strokeWidth={2}
-                          >
-                            <path
-                              strokeLinecap="round"
-                              strokeLinejoin="round"
-                              d="M4.5 12.75l6 6 9-13.5"
-                            />
-                          </svg>
-                        )}
-                      </div>
-                    </button>
-                  ))
-                )}
-              </div>
-            </div>
-          </>
-        )}
-      </div>
-    </div>
+          <div className="flex items-center gap-2 flex-shrink-0">
+            <AgentTypePill type={agent.type} />
+            {isSelected && <CheckIcon />}
+          </div>
+        </>
+      )}
+    />
   );
 }
 

--- a/src/components/AgentPicker.tsx
+++ b/src/components/AgentPicker.tsx
@@ -158,7 +158,26 @@ export function AgentPicker({
               {/* Options */}
               <div className="max-h-60 overflow-y-auto">
                 {agentsLoading ? (
-                  <div className="px-4 py-3 text-sm text-muted-foreground">
+                  <div className="px-4 py-3 flex items-center gap-2 text-sm text-muted-foreground">
+                    <svg
+                      className="w-4 h-4 animate-spin"
+                      fill="none"
+                      viewBox="0 0 24 24"
+                    >
+                      <circle
+                        className="opacity-25"
+                        cx="12"
+                        cy="12"
+                        r="10"
+                        stroke="currentColor"
+                        strokeWidth="4"
+                      />
+                      <path
+                        className="opacity-75"
+                        fill="currentColor"
+                        d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+                      />
+                    </svg>
                     Loading agents
                   </div>
                 ) : filteredAgents.length === 0 ? (
@@ -407,8 +426,27 @@ export function MultiAgentPicker({
             </div>
             <div className="max-h-48 overflow-y-auto">
               {agentsLoading ? (
-                <div className="px-4 py-3 text-sm text-muted-foreground">
-                  Loading agents...
+                <div className="px-4 py-3 flex items-center gap-2 text-sm text-muted-foreground">
+                  <svg
+                    className="w-4 h-4 animate-spin"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                  >
+                    <circle
+                      className="opacity-25"
+                      cx="12"
+                      cy="12"
+                      r="10"
+                      stroke="currentColor"
+                      strokeWidth="4"
+                    />
+                    <path
+                      className="opacity-75"
+                      fill="currentColor"
+                      d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+                    />
+                  </svg>
+                  Loading agents
                 </div>
               ) : filteredAgents.length === 0 ? (
                 <div className="px-4 py-3 text-sm text-muted-foreground">

--- a/src/components/AppLayout.tsx
+++ b/src/components/AppLayout.tsx
@@ -85,6 +85,30 @@ const navSections: NavSection[] = [
           </svg>
         ),
       },
+      {
+        id: "human-labelling",
+        label: "Human Labelling",
+        icon: (
+          <svg
+            className="w-4 h-4"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            strokeWidth={1.5}
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              d="M9.568 3H5.25A2.25 2.25 0 003 5.25v4.318c0 .597.237 1.17.659 1.591l9.581 9.581c.699.699 1.78.872 2.607.33a18.095 18.095 0 005.223-5.223c.542-.827.369-1.908-.33-2.607L11.16 3.66A2.25 2.25 0 009.568 3z"
+            />
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              d="M6 6h.008v.008H6V6z"
+            />
+          </svg>
+        ),
+      },
     ],
   },
   {

--- a/src/components/BenchmarkResultsDialog.tsx
+++ b/src/components/BenchmarkResultsDialog.tsx
@@ -521,7 +521,7 @@ export function BenchmarkResultsDialog({
           <div className="flex-1 flex items-center justify-center">
             <div className="flex flex-col items-center gap-4">
               <SpinnerIcon className="w-8 h-8 animate-spin text-muted-foreground" />
-              <p className="text-sm text-muted-foreground">Loading...</p>
+              <p className="text-sm text-muted-foreground">Loading</p>
             </div>
           </div>
         )}

--- a/src/components/BulkUploadTestsModal.tsx
+++ b/src/components/BulkUploadTestsModal.tsx
@@ -1370,7 +1370,7 @@ export function BulkUploadTestsModal({
                 </label>
                 <button
                   onClick={downloadSampleCsv}
-                  className="h-9 px-3 rounded-md text-xs font-medium border border-border bg-background text-foreground hover:bg-muted hover:border-foreground/30 transition-colors cursor-pointer flex items-center gap-1.5 shadow-sm"
+                  className="h-9 px-3 rounded-md text-xs font-medium border border-border bg-muted/40 text-foreground hover:bg-muted hover:border-foreground/30 transition-colors cursor-pointer flex items-center gap-1.5 shadow-sm"
                 >
                   <svg
                     className="w-4 h-4"

--- a/src/components/EvaluatorPills.tsx
+++ b/src/components/EvaluatorPills.tsx
@@ -35,7 +35,7 @@ export const EVALUATOR_TYPE_TOOLTIPS: Record<EvaluatorType, string> = {
 const EVALUATOR_TYPE_COLORS: Record<EvaluatorType, string> = {
   tts: "bg-purple-500/10 text-purple-600 dark:text-purple-400",
   stt: "bg-blue-500/10 text-blue-600 dark:text-blue-400",
-  llm: "bg-cyan-500/10 text-cyan-600 dark:text-cyan-400",
+  llm: "bg-orange-500/10 text-orange-600 dark:text-orange-400",
   simulation: "bg-pink-500/10 text-pink-600 dark:text-pink-400",
 };
 

--- a/src/components/EvaluatorVerdictCard.tsx
+++ b/src/components/EvaluatorVerdictCard.tsx
@@ -1,0 +1,536 @@
+"use client";
+
+// Single source of truth for the per-evaluator card surface used in:
+//
+//   - LLM / benchmark test results        (read mode)
+//   - Public labelling annotation UI      (write mode for binary / rating)
+//   - Admin "view submitted" labelling    (read mode)
+//
+// Two modes:
+//
+//   "read"  — the verdict is final. Show coloured surface, verdict pill
+//             (Pass/Fail or score / max), optional variables block, and
+//             reasoning behind a "See reasoning" toggle.
+//
+//   "write" — annotator picks a verdict and may add reasoning. Surface
+//             stays neutral until they pick. Reasoning sits behind an
+//             "Add reasoning" toggle to match the read-mode card visually.
+//
+// `ReasoningToggleButton` and `ReasoningExpandedContent` are exported so
+// other callers (tool-call verdicts in test-results/shared.tsx) reuse the
+// exact same toggle visual without duplicating it.
+
+import Link from "next/link";
+import { useState } from "react";
+
+export type EvaluatorOutputType = "binary" | "rating";
+
+type CommonProps = {
+  /** Evaluator's display name. */
+  name: string;
+  /** Short evaluator description, shown under the name. */
+  description?: string | null;
+  /** "binary" → Correct/Wrong, "rating" → 1..scaleMax buttons. */
+  outputType: EvaluatorOutputType;
+  /** Evaluator uuid — used for linking the name to its detail page. */
+  evaluatorUuid?: string;
+  /** When true, the name links to /evaluators/<uuid>. Default false. */
+  enableLink?: boolean;
+  /** Variable substitutions used by the evaluator for this item. */
+  variableValues?: Record<string, string> | null;
+  /** Lower bound of a rating scale; only meaningful for rating evaluators. */
+  scaleMin?: number;
+  /** Upper bound of a rating scale; rating buttons render 1..scaleMax. */
+  scaleMax?: number;
+};
+
+type ReadProps = CommonProps & {
+  mode: "read";
+  /** Binary verdict — true=pass, false=fail, null/undefined=no verdict. */
+  match?: boolean | null;
+  /** Rating verdict — number when scored, null/undefined for no verdict. */
+  score?: number | null;
+  /** Reasoning attached to the verdict, if any. */
+  reasoning?: string | null;
+};
+
+type WriteProps = CommonProps & {
+  mode: "write";
+  /** Current value the annotator picked. Boolean for binary, number for rating. */
+  value?: boolean | number;
+  /** Current free-text reasoning the annotator entered. */
+  comment?: string;
+  /** Called when the annotator picks a new verdict. */
+  onValueChange?: (v: boolean | number) => void;
+  /** Called when the reasoning textarea changes. */
+  onCommentChange?: (s: string) => void;
+  /** Renders the controls but disables interaction (e.g. saving in flight). */
+  disabled?: boolean;
+};
+
+export type EvaluatorVerdictCardProps = ReadProps | WriteProps;
+
+export type Tone = "green" | "red" | "amber" | "neutral";
+
+export function readVerdictTone(p: {
+  match?: boolean | null;
+  score?: number | null;
+  scaleMin?: number;
+  scaleMax?: number;
+}): Tone {
+  const isBinary = p.match !== null && p.match !== undefined;
+  const isRating = p.score !== null && p.score !== undefined;
+  if (isBinary) return p.match ? "green" : "red";
+  if (isRating) {
+    if (p.scaleMax !== undefined && p.score === p.scaleMax) return "green";
+    if (p.scaleMin !== undefined && p.score === p.scaleMin) return "red";
+    return "amber";
+  }
+  return "neutral";
+}
+
+export function evaluatorCardSurfaceClass(tone: Tone): string {
+  const base = "rounded-lg border shadow-md dark:shadow-lg transition-colors";
+  switch (tone) {
+    case "green":
+      return `${base} border-green-500/40 bg-green-500/[0.14] dark:border-green-500/45 dark:bg-green-500/[0.16] dark:shadow-green-950/35`;
+    case "red":
+      return `${base} border-red-500/40 bg-red-500/[0.12] dark:border-red-500/45 dark:bg-red-500/[0.14] dark:shadow-red-950/30`;
+    case "amber":
+      return `${base} border-amber-500/40 bg-amber-500/[0.12] dark:border-amber-500/45 dark:bg-amber-500/[0.13] dark:shadow-amber-950/30`;
+    default:
+      return `${base} border-border bg-muted/30 dark:bg-muted/40 dark:border-border dark:shadow-black/25`;
+  }
+}
+
+export function EvaluatorVerdictCard(props: EvaluatorVerdictCardProps) {
+  const tone: Tone = props.mode === "read" ? readVerdictTone(props) : "neutral";
+
+  const hasVariables =
+    !!props.variableValues &&
+    typeof props.variableValues === "object" &&
+    Object.keys(props.variableValues).length > 0;
+
+  // Read mode collapses both variables and reasoning behind one toggle
+  // (matches the LLM test output cards). Write mode shows everything
+  // inline so annotators can see variables and write reasoning in one
+  // pass — no toggle.
+  const hasReasoning =
+    props.mode === "read" && !!props.reasoning?.trim();
+  const hasCollapsibleBody =
+    props.mode === "read" && (hasVariables || hasReasoning);
+
+  const [open, setOpen] = useState(false);
+
+  const onSurfaceClick = (e: React.MouseEvent) => {
+    if (props.mode !== "read" || !hasCollapsibleBody) return;
+    const el = e.target as HTMLElement;
+    if (el.closest("button") || el.closest("a[href]")) return;
+    if (el.closest("[data-reasoning-body]")) return;
+    if (el.closest("[data-evaluator-verdict-chips]")) return;
+    setOpen((o) => !o);
+  };
+
+  const surface = evaluatorCardSurfaceClass(tone);
+  const isReadCollapsibleClickable =
+    props.mode === "read" && hasCollapsibleBody;
+
+  return (
+    <div
+      onClick={isReadCollapsibleClickable ? onSurfaceClick : undefined}
+      className={`${surface} p-3 space-y-3${
+        isReadCollapsibleClickable ? " cursor-pointer" : ""
+      }`}
+    >
+      {/* Header: name + description + verdict pill (read) + toggle (read) */}
+      <div className="flex items-start justify-between gap-2">
+        <div className="min-w-0">
+          <NameLabel
+            name={props.name}
+            uuid={props.evaluatorUuid}
+            enableLink={props.enableLink}
+          />
+          {props.description && (
+            <p className="text-xs text-muted-foreground whitespace-normal break-words mt-0.5">
+              {props.description}
+            </p>
+          )}
+        </div>
+        <div
+          className="flex-shrink-0 flex items-center gap-1.5"
+          data-evaluator-verdict-chips
+        >
+          {props.mode === "read" && (
+            <ReadVerdictPill
+              outputType={props.outputType}
+              match={props.match}
+              score={props.score}
+              scaleMin={props.scaleMin}
+              scaleMax={props.scaleMax}
+            />
+          )}
+          {hasCollapsibleBody && (
+            <ReasoningToggleButton
+              open={open}
+              onToggle={() => setOpen((o) => !o)}
+            />
+          )}
+        </div>
+      </div>
+
+      {props.mode === "write" && (
+        <>
+          <WriteControls
+            outputType={props.outputType}
+            scaleMax={props.scaleMax}
+            value={props.value}
+            onChange={(v) => props.onValueChange?.(v)}
+            disabled={props.disabled}
+          />
+          {hasVariables && (
+            <VariableValuesBlock values={props.variableValues!} />
+          )}
+          <WriteReasoning
+            value={props.comment ?? ""}
+            onChange={(s) => props.onCommentChange?.(s)}
+            disabled={props.disabled}
+          />
+        </>
+      )}
+
+      {props.mode === "read" && open && hasCollapsibleBody && (
+        <div
+          data-reasoning-body
+          className="pt-2 border-t border-border/60 space-y-3"
+        >
+          {hasVariables && (
+            <VariableValuesBlock values={props.variableValues!} />
+          )}
+          {props.reasoning?.trim() && (
+            <ReasoningExpandedContent
+              text={props.reasoning}
+              showReasoningLabel
+              mutedBody={false}
+            />
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function NameLabel({
+  name,
+  uuid,
+  enableLink,
+}: {
+  name: string;
+  uuid?: string;
+  enableLink?: boolean;
+}) {
+  const cls =
+    "text-sm font-medium text-foreground break-words inline-block max-w-full align-top";
+  if (enableLink && uuid) {
+    return (
+      <Link
+        href={`/evaluators/${uuid}`}
+        className={`${cls} hover:underline underline-offset-2 cursor-pointer`}
+      >
+        {name}
+      </Link>
+    );
+  }
+  return <span className={cls}>{name}</span>;
+}
+
+function ReadVerdictPill({
+  outputType,
+  match,
+  score,
+  scaleMin,
+  scaleMax,
+}: {
+  outputType: EvaluatorOutputType;
+  match?: boolean | null;
+  score?: number | null;
+  scaleMin?: number;
+  scaleMax?: number;
+}) {
+  if (outputType === "binary") {
+    if (match === null || match === undefined) return null;
+    return (
+      <span
+        className={`flex-shrink-0 inline-flex items-center gap-1 px-2 py-0.5 rounded-md text-[11px] font-medium ${
+          match
+            ? "bg-green-500/15 text-green-600 dark:text-green-400"
+            : "bg-red-500/15 text-red-600 dark:text-red-400"
+        }`}
+      >
+        {match ? (
+          <CheckIcon className="w-3 h-3" />
+        ) : (
+          <XIcon className="w-3 h-3" />
+        )}
+        {match ? "Correct" : "Wrong"}
+      </span>
+    );
+  }
+  if (score === null || score === undefined) return null;
+  const tone: Tone =
+    scaleMax !== undefined && score === scaleMax
+      ? "green"
+      : scaleMin !== undefined && score === scaleMin
+        ? "red"
+        : "amber";
+  const toneClass =
+    tone === "green"
+      ? "bg-green-500/15 text-green-600 dark:text-green-400"
+      : tone === "red"
+        ? "bg-red-500/15 text-red-600 dark:text-red-400"
+        : "bg-amber-500/15 text-amber-600 dark:text-amber-400";
+  return (
+    <span
+      className={`flex-shrink-0 inline-flex items-center px-2 py-0.5 rounded-md text-[11px] font-medium ${toneClass}`}
+    >
+      {scaleMax !== undefined ? `${score} / ${scaleMax}` : `Score: ${score}`}
+    </span>
+  );
+}
+
+function WriteControls({
+  outputType,
+  scaleMax,
+  value,
+  onChange,
+  disabled,
+}: {
+  outputType: EvaluatorOutputType;
+  scaleMax?: number;
+  value?: boolean | number;
+  onChange: (v: boolean | number) => void;
+  disabled?: boolean;
+}) {
+  if (outputType === "binary") {
+    const baseBtn =
+      "h-9 px-4 rounded-md text-sm font-medium border transition-colors cursor-pointer disabled:opacity-60 disabled:cursor-not-allowed";
+    return (
+      <div className="flex items-center gap-2">
+        <button
+          type="button"
+          disabled={disabled}
+          onClick={() => onChange(true)}
+          className={`${baseBtn} ${
+            value === true
+              ? "border-green-200 bg-green-100 text-green-700 dark:border-green-500/30 dark:bg-green-500/20 dark:text-green-400"
+              : "border-border bg-background hover:bg-muted/50"
+          }`}
+        >
+          Correct
+        </button>
+        <button
+          type="button"
+          disabled={disabled}
+          onClick={() => onChange(false)}
+          className={`${baseBtn} ${
+            value === false
+              ? "border-red-200 bg-red-100 text-red-700 dark:border-red-500/30 dark:bg-red-500/20 dark:text-red-400"
+              : "border-border bg-background hover:bg-muted/50"
+          }`}
+        >
+          Wrong
+        </button>
+      </div>
+    );
+  }
+  const max = typeof scaleMax === "number" && scaleMax > 0 ? scaleMax : 5;
+  const options = Array.from({ length: max }, (_, i) => i + 1);
+  return (
+    <div className="flex items-center gap-1.5 flex-wrap">
+      {options.map((n) => {
+        const active = value === n;
+        return (
+          <button
+            key={n}
+            type="button"
+            disabled={disabled}
+            onClick={() => onChange(n)}
+            className={`w-9 h-9 rounded-md border text-sm font-medium transition-colors cursor-pointer disabled:opacity-60 disabled:cursor-not-allowed ${
+              active
+                ? "border-foreground bg-foreground text-background"
+                : "border-border bg-background hover:bg-muted/50"
+            }`}
+          >
+            {n}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+function VariableValuesBlock({ values }: { values: Record<string, string> }) {
+  const names = Object.keys(values);
+  return (
+    <div className="space-y-2">
+      {names.map((name) => (
+        <div key={name}>
+          <span className="font-mono text-[10px] text-muted-foreground">
+            {`{{${name}}}`}
+          </span>
+          <p className="text-xs text-foreground whitespace-pre-wrap break-words mt-0.5">
+            {String(values[name])}
+          </p>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function WriteReasoning({
+  value,
+  onChange,
+  disabled,
+}: {
+  value: string;
+  onChange: (s: string) => void;
+  disabled?: boolean;
+}) {
+  return (
+    <div className="space-y-1.5">
+      <div className="text-xs font-medium text-muted-foreground">
+        Reasoning {disabled ? "" : "(optional)"}
+      </div>
+      <textarea
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        disabled={disabled}
+        placeholder={disabled ? "" : "Add your reasoning"}
+        rows={2}
+        className="w-full text-sm rounded-md border border-border bg-background px-3 py-2 resize-y focus:outline-none focus:ring-2 focus:ring-foreground/20 disabled:opacity-60"
+      />
+    </div>
+  );
+}
+
+/** Toggle button used to expand/collapse the variables + reasoning body
+ * on every evaluator verdict surface. Same visual everywhere — read
+ * mode test cards, write mode labelling cards, and the standalone
+ * tool-call reasoning strip in test-results/shared.tsx. */
+export function ReasoningToggleButton({
+  open,
+  onToggle,
+}: {
+  open: boolean;
+  onToggle: () => void;
+}) {
+  const label = open ? "Hide reasoning" : "See reasoning";
+  return (
+    <button
+      type="button"
+      onClick={(e) => {
+        e.stopPropagation();
+        onToggle();
+      }}
+      aria-expanded={open}
+      className={`inline-flex items-center gap-1.5 max-w-[min(100%,14rem)] rounded-md border px-2 py-1 text-[11px] font-medium transition-colors cursor-pointer shrink-0 ${
+        open
+          ? "border-fuchsia-500/50 bg-fuchsia-500/16 text-fuchsia-950 dark:border-fuchsia-500/45 dark:bg-fuchsia-500/18 dark:text-fuchsia-100 hover:bg-fuchsia-500/26 dark:hover:bg-fuchsia-500/28"
+          : "border-cyan-500/50 bg-cyan-500/14 text-cyan-950 dark:border-cyan-500/45 dark:bg-cyan-500/16 dark:text-cyan-100 hover:bg-cyan-500/24 dark:hover:bg-cyan-500/22"
+      }`}
+    >
+      <span className="truncate">{label}</span>
+      <ChevronDownIcon
+        className={`w-3.5 h-3.5 shrink-0 transition-transform duration-200 ${
+          open ? "rotate-180" : ""
+        }`}
+      />
+    </button>
+  );
+}
+
+/** Read-only reasoning body — shared with the tool-call collapsible
+ * strip in shared.tsx so all reasoning content uses the same typography. */
+export function ReasoningExpandedContent({
+  text,
+  showReasoningLabel = false,
+  mutedBody = true,
+  italic = false,
+}: {
+  text: string;
+  showReasoningLabel?: boolean;
+  mutedBody?: boolean;
+  italic?: boolean;
+}) {
+  return (
+    <div className="space-y-1">
+      {showReasoningLabel && (
+        <span className="text-[10px] font-medium text-muted-foreground uppercase tracking-wide block">
+          Reasoning
+        </span>
+      )}
+      <p
+        className={`${
+          mutedBody
+            ? "text-xs text-muted-foreground whitespace-pre-wrap break-words"
+            : "text-xs text-foreground whitespace-pre-wrap break-words"
+        }${italic ? " italic" : ""}`}
+      >
+        {text}
+      </p>
+    </div>
+  );
+}
+
+function CheckIcon({ className = "" }: { className?: string }) {
+  return (
+    <svg
+      className={className}
+      fill="none"
+      viewBox="0 0 24 24"
+      stroke="currentColor"
+      strokeWidth={3}
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M5 13l4 4L19 7"
+      />
+    </svg>
+  );
+}
+
+function XIcon({ className = "" }: { className?: string }) {
+  return (
+    <svg
+      className={className}
+      fill="none"
+      viewBox="0 0 24 24"
+      stroke="currentColor"
+      strokeWidth={3}
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M6 18L18 6M6 6l12 12"
+      />
+    </svg>
+  );
+}
+
+function ChevronDownIcon({ className = "" }: { className?: string }) {
+  return (
+    <svg
+      className={className}
+      fill="none"
+      viewBox="0 0 24 24"
+      stroke="currentColor"
+      strokeWidth={2}
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M19.5 8.25l-7.5 7.5-7.5-7.5"
+      />
+    </svg>
+  );
+}

--- a/src/components/EvaluatorVerdictCard.tsx
+++ b/src/components/EvaluatorVerdictCard.tsx
@@ -195,6 +195,7 @@ export function EvaluatorVerdictCard(props: EvaluatorVerdictCardProps) {
         <>
           <WriteControls
             outputType={props.outputType}
+            scaleMin={props.scaleMin}
             scaleMax={props.scaleMax}
             value={props.value}
             onChange={(v) => props.onValueChange?.(v)}
@@ -312,12 +313,14 @@ function ReadVerdictPill({
 
 function WriteControls({
   outputType,
+  scaleMin,
   scaleMax,
   value,
   onChange,
   disabled,
 }: {
   outputType: EvaluatorOutputType;
+  scaleMin?: number;
   scaleMax?: number;
   value?: boolean | number;
   onChange: (v: boolean | number) => void;
@@ -355,8 +358,14 @@ function WriteControls({
       </div>
     );
   }
-  const max = typeof scaleMax === "number" && scaleMax > 0 ? scaleMax : 5;
-  const options = Array.from({ length: max }, (_, i) => i + 1);
+  // Build the rating options as `scaleMin..scaleMax` so evaluators with a
+  // non-1 minimum (e.g. 0..5) work correctly. Default to 1..5 when no
+  // bounds are provided. Guard against an inverted range as a sanity
+  // fallback.
+  const min = typeof scaleMin === "number" ? scaleMin : 1;
+  const rawMax = typeof scaleMax === "number" && scaleMax > 0 ? scaleMax : 5;
+  const max = rawMax >= min ? rawMax : min;
+  const options = Array.from({ length: max - min + 1 }, (_, i) => min + i);
   return (
     <div className="flex items-center gap-1.5 flex-wrap">
       {options.map((n) => {

--- a/src/components/EvaluatorVerdictCard.tsx
+++ b/src/components/EvaluatorVerdictCard.tsx
@@ -30,6 +30,11 @@ type CommonProps = {
   name: string;
   /** Short evaluator description, shown under the name. */
   description?: string | null;
+  /** Optional version label (e.g. "v3") shown as a small monospace pill
+   * next to the name. Use this when annotators are evaluating against a
+   * specific evaluator version so it stays visually distinct from the
+   * evaluator's display name. */
+  versionLabel?: string | null;
   /** "binary" → Correct/Wrong, "rating" → 1..scaleMax buttons. */
   outputType: EvaluatorOutputType;
   /** Evaluator uuid — used for linking the name to its detail page. */
@@ -142,40 +147,48 @@ export function EvaluatorVerdictCard(props: EvaluatorVerdictCardProps) {
         isReadCollapsibleClickable ? " cursor-pointer" : ""
       }`}
     >
-      {/* Header: name + description + verdict pill (read) + toggle (read) */}
-      <div className="flex items-start justify-between gap-2">
-        <div className="min-w-0">
-          <NameLabel
-            name={props.name}
-            uuid={props.evaluatorUuid}
-            enableLink={props.enableLink}
-          />
-          {props.description && (
-            <p className="text-xs text-muted-foreground whitespace-normal break-words mt-0.5">
-              {props.description}
-            </p>
-          )}
-        </div>
-        <div
-          className="flex-shrink-0 flex items-center gap-1.5"
-          data-evaluator-verdict-chips
-        >
-          {props.mode === "read" && (
-            <ReadVerdictPill
-              outputType={props.outputType}
-              match={props.match}
-              score={props.score}
-              scaleMin={props.scaleMin}
-              scaleMax={props.scaleMax}
+      {/* Header: name + verdict pill + toggle on one row; description
+          on its own row below so it can use the full card width. */}
+      <div className="space-y-1">
+        <div className="flex items-center justify-between gap-2">
+          <div className="flex-1 min-w-0 flex items-center gap-2 flex-wrap">
+            <NameLabel
+              name={props.name}
+              uuid={props.evaluatorUuid}
+              enableLink={props.enableLink}
             />
-          )}
-          {hasCollapsibleBody && (
-            <ReasoningToggleButton
-              open={open}
-              onToggle={() => setOpen((o) => !o)}
-            />
-          )}
+            {props.versionLabel && (
+              <span className="font-mono text-[10px] px-1.5 py-0.5 rounded-md border border-foreground/20 bg-background text-foreground">
+                {props.versionLabel}
+              </span>
+            )}
+          </div>
+          <div
+            className="flex-shrink-0 flex items-center gap-1.5"
+            data-evaluator-verdict-chips
+          >
+            {props.mode === "read" && (
+              <ReadVerdictPill
+                outputType={props.outputType}
+                match={props.match}
+                score={props.score}
+                scaleMin={props.scaleMin}
+                scaleMax={props.scaleMax}
+              />
+            )}
+            {hasCollapsibleBody && (
+              <ReasoningToggleButton
+                open={open}
+                onToggle={() => setOpen((o) => !o)}
+              />
+            )}
+          </div>
         </div>
+        {props.description && (
+          <p className="text-xs text-muted-foreground whitespace-normal break-words">
+            {props.description}
+          </p>
+        )}
       </div>
 
       {props.mode === "write" && (

--- a/src/components/MultiSelectPicker.tsx
+++ b/src/components/MultiSelectPicker.tsx
@@ -88,7 +88,9 @@ export function MultiSelectPicker({
         >
           <div className="flex-1 flex flex-wrap gap-2 items-center">
             {selectedItems.length === 0 ? (
-              <span className="text-muted-foreground">{placeholder}</span>
+              <span className="text-muted-foreground">
+                {placeholder}
+              </span>
             ) : (
               selectedItems.map((item) => (
                 <span

--- a/src/components/MultiSelectPicker.tsx
+++ b/src/components/MultiSelectPicker.tsx
@@ -177,7 +177,7 @@ export function MultiSelectPicker({
                       d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
                     ></path>
                   </svg>
-                  Loading...
+                  Loading
                 </div>
               ) : filteredItems.length === 0 ? (
                 <div className="px-4 py-3 text-sm text-muted-foreground">

--- a/src/components/SingleSelectPicker.tsx
+++ b/src/components/SingleSelectPicker.tsx
@@ -1,0 +1,260 @@
+"use client";
+
+import React, { useEffect, useLayoutEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+
+// Generic single-select dropdown. Owns the open/closed UI: rounded-xl
+// trigger with chevron, an outside-click overlay, and a panel that's
+// rendered in a portal with fixed positioning so it escapes any parent
+// `overflow:hidden`/`overflow-auto` clipping (e.g. inside a modal body).
+type SingleSelectPickerProps<T> = {
+  items: T[];
+  selectedId: string | null | undefined;
+  onSelect: (item: T) => void;
+  getId: (item: T) => string;
+  renderTrigger: (item: T | null) => React.ReactNode;
+  renderOption: (item: T, isSelected: boolean) => React.ReactNode;
+  matchesSearch?: (item: T, query: string) => boolean;
+  searchPlaceholder?: string;
+  loading?: boolean;
+  loadingLabel?: string;
+  emptyLabel?: string;
+  placeholder?: string;
+  disabled?: boolean;
+  label?: string;
+  className?: string;
+  ariaLabel?: string;
+  // Tighter rows + smaller trigger; useful when the picker sits inside
+  // dense layouts (e.g. a row of evaluator versions inside a dialog).
+  compact?: boolean;
+};
+
+type Rect = { left: number; top: number; width: number; bottom: number };
+
+export function SingleSelectPicker<T>({
+  items,
+  selectedId,
+  onSelect,
+  getId,
+  renderTrigger,
+  renderOption,
+  matchesSearch,
+  searchPlaceholder = "Search...",
+  loading = false,
+  loadingLabel = "Loading",
+  emptyLabel = "No items found",
+  placeholder = "Select",
+  disabled = false,
+  label,
+  className = "",
+  ariaLabel,
+  compact = false,
+}: SingleSelectPickerProps<T>) {
+  const [open, setOpen] = useState(false);
+  const [search, setSearch] = useState("");
+  const [rect, setRect] = useState<Rect | null>(null);
+  const triggerRef = useRef<HTMLDivElement>(null);
+
+  const selected = items.find((it) => getId(it) === selectedId) ?? null;
+  const filtered =
+    matchesSearch && search.length > 0
+      ? items.filter((it) => matchesSearch(it, search))
+      : items;
+
+  const updateRect = () => {
+    if (!triggerRef.current) return;
+    const r = triggerRef.current.getBoundingClientRect();
+    setRect({ left: r.left, top: r.top, width: r.width, bottom: r.bottom });
+  };
+
+  useLayoutEffect(() => {
+    if (!open) return;
+    updateRect();
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+    const onScroll = () => updateRect();
+    const onResize = () => updateRect();
+    window.addEventListener("scroll", onScroll, true);
+    window.addEventListener("resize", onResize);
+    return () => {
+      window.removeEventListener("scroll", onScroll, true);
+      window.removeEventListener("resize", onResize);
+    };
+  }, [open]);
+
+  const triggerSizeClass = compact
+    ? "h-9 px-3 rounded-lg"
+    : "h-11 px-4 rounded-xl";
+  const optionPaddingClass = compact ? "px-3 py-1.5" : "px-4 py-3";
+  const statusPaddingClass = compact ? "px-3 py-2" : "px-4 py-3";
+
+  const dropdownStyle: React.CSSProperties | undefined = rect
+    ? (() => {
+        const dropdownEstHeight = 240;
+        const margin = 8;
+        const spaceBelow = window.innerHeight - rect.bottom - margin;
+        const openAbove =
+          spaceBelow < dropdownEstHeight && rect.top > dropdownEstHeight;
+        return {
+          left: rect.left,
+          width: rect.width,
+          ...(openAbove
+            ? { bottom: window.innerHeight - rect.top + margin }
+            : { top: rect.bottom + margin }),
+        };
+      })()
+    : undefined;
+
+  return (
+    <div className={`space-y-1.5 ${className}`}>
+      {label && (
+        <label className="block text-sm font-medium text-foreground">
+          {label}
+        </label>
+      )}
+      <div className="relative">
+        <div
+          ref={triggerRef}
+          role="button"
+          tabIndex={disabled ? -1 : 0}
+          aria-label={ariaLabel}
+          aria-haspopup="listbox"
+          aria-expanded={open}
+          onClick={() => !disabled && setOpen((o) => !o)}
+          onKeyDown={(e) => {
+            if (disabled) return;
+            if (e.key === "Enter" || e.key === " ") {
+              e.preventDefault();
+              setOpen((o) => !o);
+            } else if (e.key === "Escape") {
+              setOpen(false);
+            }
+          }}
+          className={`w-full ${triggerSizeClass} text-sm bg-transparent text-foreground border border-border transition-colors flex items-center justify-between gap-2 ${
+            disabled
+              ? "cursor-not-allowed opacity-50"
+              : "hover:border-muted-foreground cursor-pointer"
+          }`}
+        >
+          <span
+            className={`truncate ${
+              selected ? "text-foreground" : "text-muted-foreground"
+            }`}
+          >
+            {selected ? renderTrigger(selected) : placeholder}
+          </span>
+          {!disabled && (
+            <svg
+              className={`${
+                compact ? "w-4 h-4" : "w-5 h-5"
+              } text-muted-foreground transition-transform flex-shrink-0 ${
+                open ? "rotate-180" : ""
+              }`}
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              strokeWidth={2}
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M19.5 8.25l-7.5 7.5-7.5-7.5"
+              />
+            </svg>
+          )}
+        </div>
+      </div>
+
+      {open &&
+        !disabled &&
+        typeof window !== "undefined" &&
+        createPortal(
+          <>
+            <div
+              className="fixed inset-0 z-[99]"
+              onClick={() => setOpen(false)}
+            />
+            <div
+              role="listbox"
+              style={dropdownStyle}
+              className="fixed bg-background border border-border rounded-xl shadow-xl z-[100] overflow-hidden"
+            >
+              {matchesSearch && (
+                <div className="p-3 border-b border-border">
+                  <input
+                    type="text"
+                    value={search}
+                    onChange={(e) => setSearch(e.target.value)}
+                    placeholder={searchPlaceholder}
+                    className="w-full h-10 px-4 rounded-lg text-sm bg-background text-foreground placeholder:text-muted-foreground border border-border focus:outline-none focus:ring-1 focus:ring-accent"
+                    onClick={(e) => e.stopPropagation()}
+                  />
+                </div>
+              )}
+              <div className="max-h-60 overflow-y-auto">
+                {loading ? (
+                  <div
+                    className={`${statusPaddingClass} flex items-center gap-2 text-sm text-muted-foreground`}
+                  >
+                    <svg
+                      className="w-4 h-4 animate-spin"
+                      fill="none"
+                      viewBox="0 0 24 24"
+                    >
+                      <circle
+                        className="opacity-25"
+                        cx="12"
+                        cy="12"
+                        r="10"
+                        stroke="currentColor"
+                        strokeWidth="4"
+                      />
+                      <path
+                        className="opacity-75"
+                        fill="currentColor"
+                        d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+                      />
+                    </svg>
+                    {loadingLabel}
+                  </div>
+                ) : filtered.length === 0 ? (
+                  <div
+                    className={`${statusPaddingClass} text-sm text-muted-foreground`}
+                  >
+                    {emptyLabel}
+                  </div>
+                ) : (
+                  filtered.map((item) => {
+                    const id = getId(item);
+                    const isSelected = id === selectedId;
+                    return (
+                      <button
+                        key={id}
+                        type="button"
+                        role="option"
+                        aria-selected={isSelected}
+                        onClick={() => {
+                          onSelect(item);
+                          setOpen(false);
+                        }}
+                        className={`w-full ${optionPaddingClass} text-left text-sm transition-colors cursor-pointer flex items-center justify-between gap-2 ${
+                          isSelected
+                            ? "bg-accent text-foreground"
+                            : "text-foreground hover:bg-muted"
+                        }`}
+                      >
+                        {renderOption(item, isSelected)}
+                      </button>
+                    );
+                  })
+                )}
+              </div>
+            </div>
+          </>,
+          document.body,
+        )}
+    </div>
+  );
+}

--- a/src/components/SingleSelectPicker.tsx
+++ b/src/components/SingleSelectPicker.tsx
@@ -53,7 +53,7 @@ export function SingleSelectPicker<T>({
   const [open, setOpen] = useState(false);
   const [search, setSearch] = useState("");
   const [rect, setRect] = useState<Rect | null>(null);
-  const triggerRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
 
   const selected = items.find((it) => getId(it) === selectedId) ?? null;
   const filtered =
@@ -115,24 +115,18 @@ export function SingleSelectPicker<T>({
         </label>
       )}
       <div className="relative">
-        <div
+        <button
           ref={triggerRef}
-          role="button"
-          tabIndex={disabled ? -1 : 0}
+          type="button"
+          disabled={disabled}
           aria-label={ariaLabel}
           aria-haspopup="listbox"
           aria-expanded={open}
-          onClick={() => !disabled && setOpen((o) => !o)}
+          onClick={() => setOpen((o) => !o)}
           onKeyDown={(e) => {
-            if (disabled) return;
-            if (e.key === "Enter" || e.key === " ") {
-              e.preventDefault();
-              setOpen((o) => !o);
-            } else if (e.key === "Escape") {
-              setOpen(false);
-            }
+            if (e.key === "Escape") setOpen(false);
           }}
-          className={`w-full ${triggerSizeClass} text-sm bg-transparent text-foreground border border-border transition-colors flex items-center justify-between gap-2 ${
+          className={`w-full ${triggerSizeClass} text-sm bg-transparent text-foreground border border-border transition-colors flex items-center justify-between gap-2 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent ${
             disabled
               ? "cursor-not-allowed opacity-50"
               : "hover:border-muted-foreground cursor-pointer"
@@ -164,7 +158,7 @@ export function SingleSelectPicker<T>({
               />
             </svg>
           )}
-        </div>
+        </button>
       </div>
 
       {open &&
@@ -186,7 +180,14 @@ export function SingleSelectPicker<T>({
                   <input
                     type="text"
                     value={search}
+                    autoFocus
                     onChange={(e) => setSearch(e.target.value)}
+                    onKeyDown={(e) => {
+                      if (e.key === "Escape") {
+                        e.stopPropagation();
+                        setOpen(false);
+                      }
+                    }}
                     placeholder={searchPlaceholder}
                     className="w-full h-10 px-4 rounded-lg text-sm bg-background text-foreground placeholder:text-muted-foreground border border-border focus:outline-none focus:ring-1 focus:ring-accent"
                     onClick={(e) => e.stopPropagation()}

--- a/src/components/Tooltip.tsx
+++ b/src/components/Tooltip.tsx
@@ -115,7 +115,7 @@ export function Tooltip({
         transform: position === "top" || position === "bottom" ? "translateX(-50%)" : "translateY(-50%)",
       }}
     >
-      <div className="px-3 py-2 text-xs text-gray-900 bg-white rounded-lg shadow-lg whitespace-normal break-words w-64">
+      <div className="px-3 py-2 text-xs text-gray-900 bg-white rounded-lg shadow-lg whitespace-normal break-words max-w-64 w-max">
         {content}
         {/* Arrow */}
         <div className={`absolute ${arrowClasses[position]}`}></div>

--- a/src/components/agent-tabs/LLMSelectorModal.tsx
+++ b/src/components/agent-tabs/LLMSelectorModal.tsx
@@ -121,8 +121,27 @@ export function LLMSelectorModal({
               </button>
             </div>
           ) : isLoading && providers.length === 0 ? (
-            <div className="p-8 text-center text-sm text-muted-foreground">
-              Loading models...
+            <div className="p-8 flex items-center justify-center gap-2 text-sm text-muted-foreground">
+              <svg
+                className="w-4 h-4 animate-spin"
+                fill="none"
+                viewBox="0 0 24 24"
+              >
+                <circle
+                  className="opacity-25"
+                  cx="12"
+                  cy="12"
+                  r="10"
+                  stroke="currentColor"
+                  strokeWidth="4"
+                />
+                <path
+                  className="opacity-75"
+                  fill="currentColor"
+                  d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+                />
+              </svg>
+              Loading models
             </div>
           ) : filteredProviders.length === 0 ? (
             <div className="p-8 text-center text-sm text-muted-foreground">

--- a/src/components/agent-tabs/TestsTabContent.tsx
+++ b/src/components/agent-tabs/TestsTabContent.tsx
@@ -839,7 +839,7 @@ export function TestsTabContent({
   );
 
   const pastRunsPanel = (
-    <div className="w-full lg:w-[400px] xl:w-[560px] flex-shrink-0 border border-border rounded-xl overflow-hidden bg-muted/30">
+    <div className="w-full lg:w-[400px] xl:w-[560px] flex-shrink-0 border border-border rounded-xl overflow-hidden">
       <div className="px-3 md:px-4 py-2 md:py-3">
         <h3 className="text-sm md:text-base font-semibold text-foreground">
           Past runs
@@ -1377,21 +1377,8 @@ export function TestsTabContent({
                           )}
                         </button>
                       </div>
-                      {/* Name Column with Edit Icon */}
-                      <div className="flex items-center gap-2 min-w-0">
-                        <svg
-                          className="w-4 h-4 text-muted-foreground flex-shrink-0"
-                          fill="none"
-                          viewBox="0 0 24 24"
-                          stroke="currentColor"
-                          strokeWidth={1.5}
-                        >
-                          <path
-                            strokeLinecap="round"
-                            strokeLinejoin="round"
-                            d="M16.862 4.487l1.687-1.688a1.875 1.875 0 112.652 2.652L10.582 16.07a4.5 4.5 0 01-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 011.13-1.897l8.932-8.931zm0 0L19.5 7.125M18 14v4.75A2.25 2.25 0 0115.75 21H5.25A2.25 2.25 0 013 18.75V8.25A2.25 2.25 0 015.25 6H10"
-                          />
-                        </svg>
+                      {/* Name Column */}
+                      <div className="flex items-center min-w-0">
                         <span className="text-sm font-medium text-foreground overflow-x-auto whitespace-nowrap">
                           {test.name}
                         </span>

--- a/src/components/human-labelling/AddSttItemsDialog.tsx
+++ b/src/components/human-labelling/AddSttItemsDialog.tsx
@@ -1,0 +1,293 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useHideFloatingButton } from "@/components/AppLayout";
+
+type SttRowDraft = {
+  id: string;
+  uuid?: string; // present in edit mode; undefined for new rows
+  actual: string;
+  predicted: string;
+};
+
+export type SttItemRowSubmission = {
+  uuid?: string;
+  actual_transcript: string;
+  predicted_transcript: string;
+};
+
+type AddSttItemsDialogProps = {
+  isOpen: boolean;
+  mode?: "add" | "edit";
+  initialRows?: { uuid: string; actual: string; predicted: string }[];
+  onClose: () => void;
+  onSubmit: (rows: SttItemRowSubmission[]) => Promise<void> | void;
+};
+
+const newRow = (): SttRowDraft => ({
+  id:
+    typeof crypto !== "undefined" && "randomUUID" in crypto
+      ? crypto.randomUUID()
+      : `${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  actual: "",
+  predicted: "",
+});
+
+export function AddSttItemsDialog({
+  isOpen,
+  mode = "add",
+  initialRows,
+  onClose,
+  onSubmit,
+}: AddSttItemsDialogProps) {
+  useHideFloatingButton(isOpen);
+
+  const isEdit = mode === "edit";
+
+  const [rows, setRows] = useState<SttRowDraft[]>(() =>
+    initialRows && initialRows.length > 0
+      ? initialRows.map((r) => ({
+          id: r.uuid,
+          uuid: r.uuid,
+          actual: r.actual,
+          predicted: r.predicted,
+        }))
+      : [newRow()],
+  );
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Reset rows whenever the dialog opens (so a fresh edit starts from the
+  // latest selected items, and a reopened add starts blank).
+  useEffect(() => {
+    if (isOpen) {
+      setRows(
+        initialRows && initialRows.length > 0
+          ? initialRows.map((r) => ({
+              id: r.uuid,
+              uuid: r.uuid,
+              actual: r.actual,
+              predicted: r.predicted,
+            }))
+          : [newRow()],
+      );
+      setError(null);
+    }
+  }, [isOpen, initialRows]);
+
+  if (!isOpen) return null;
+
+  const updateRow = (id: string, patch: Partial<SttRowDraft>) => {
+    setRows((prev) => prev.map((r) => (r.id === id ? { ...r, ...patch } : r)));
+  };
+
+  const removeRow = (id: string) => {
+    setRows((prev) =>
+      prev.length === 1 ? prev : prev.filter((r) => r.id !== id),
+    );
+  };
+
+  const addRow = () => {
+    setRows((prev) => [...prev, newRow()]);
+  };
+
+  const validRows: SttItemRowSubmission[] = rows
+    .map((r) => ({
+      uuid: r.uuid,
+      actual_transcript: r.actual.trim(),
+      predicted_transcript: r.predicted.trim(),
+    }))
+    .filter((r) => r.actual_transcript && r.predicted_transcript);
+
+  const handleClose = () => {
+    if (!submitting) {
+      setError(null);
+      onClose();
+    }
+  };
+
+  const handleSubmit = async () => {
+    if (validRows.length === 0 || submitting) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      await onSubmit(validRows);
+    } catch (err) {
+      setError(
+        err instanceof Error
+          ? err.message
+          : isEdit
+            ? "Failed to save items"
+            : "Failed to add items",
+      );
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm p-4"
+      onClick={handleClose}
+    >
+      <div
+        className="bg-background border border-border rounded-xl w-full max-w-3xl shadow-2xl flex flex-col max-h-[90vh]"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-start justify-between gap-3 px-5 md:px-6 py-4 border-b border-border">
+          <div>
+            <h2 className="text-base md:text-lg font-semibold text-foreground">
+              {isEdit ? "Edit items" : "Add items"}
+            </h2>
+            <p className="text-xs md:text-sm text-muted-foreground mt-1">
+              {isEdit
+                ? "Update the reference and predicted transcripts for each row"
+                : "Annotators will compare the predicted transcript against the reference"}
+            </p>
+          </div>
+          <button
+            onClick={handleClose}
+            disabled={submitting}
+            className="flex items-center justify-center w-8 h-8 rounded-md hover:bg-muted transition-colors cursor-pointer flex-shrink-0 disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            <svg
+              className="w-5 h-5"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              strokeWidth={2}
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M6 18L18 6M6 6l12 12"
+              />
+            </svg>
+          </button>
+        </div>
+
+        <div className="flex-1 overflow-y-auto p-4 md:p-6 space-y-2">
+          {/* Column headers (shown once) */}
+          <div className="grid grid-cols-[1fr_1fr_28px] gap-2 px-1 pb-1">
+            <div className="text-xs font-medium text-muted-foreground">
+              Reference transcript
+            </div>
+            <div className="text-xs font-medium text-muted-foreground">
+              Predicted transcript
+            </div>
+            <div />
+          </div>
+
+          {rows.map((row, idx) => (
+            <div
+              key={row.id}
+              className="grid grid-cols-[1fr_1fr_28px] gap-2 items-center"
+            >
+              <input
+                type="text"
+                value={row.actual}
+                onChange={(e) => updateRow(row.id, { actual: e.target.value })}
+                placeholder="What was actually said"
+                disabled={submitting}
+                className="w-full h-9 px-3 rounded-md text-sm border border-border bg-background text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-accent disabled:opacity-50"
+              />
+              <input
+                type="text"
+                value={row.predicted}
+                onChange={(e) =>
+                  updateRow(row.id, { predicted: e.target.value })
+                }
+                placeholder="What the system transcribed"
+                disabled={submitting}
+                className="w-full h-9 px-3 rounded-md text-sm border border-border bg-background text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-accent disabled:opacity-50"
+              />
+              {isEdit ? (
+                <div />
+              ) : (
+                <button
+                  onClick={() => removeRow(row.id)}
+                  disabled={rows.length === 1 || submitting}
+                  className="w-7 h-7 flex items-center justify-center rounded-md text-muted-foreground hover:text-red-500 hover:bg-red-500/10 transition-colors cursor-pointer disabled:opacity-30 disabled:cursor-not-allowed"
+                  aria-label={`Remove item ${idx + 1}`}
+                  title="Remove this item"
+                >
+                  <svg
+                    className="w-4 h-4"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                    strokeWidth={2}
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      d="M6 18L18 6M6 6l12 12"
+                    />
+                  </svg>
+                </button>
+              )}
+            </div>
+          ))}
+
+          {!isEdit && (
+            <button
+              onClick={addRow}
+              disabled={submitting}
+              className="w-full h-10 rounded-md text-sm font-medium border border-dashed border-border bg-background hover:bg-muted/50 text-muted-foreground hover:text-foreground transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-1.5"
+            >
+              <svg
+                className="w-4 h-4"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+                strokeWidth={2}
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M12 4.5v15m7.5-7.5h-15"
+                />
+              </svg>
+              Add another item
+            </button>
+          )}
+
+          {error && (
+            <div className="rounded-md border border-red-500/30 bg-red-500/10 p-3 text-sm text-red-500">
+              {error}
+            </div>
+          )}
+        </div>
+
+        <div className="flex items-center justify-end gap-2 md:gap-3 px-5 md:px-6 py-4 border-t border-border">
+          <div className="flex items-center gap-2 md:gap-3">
+            <button
+              onClick={handleClose}
+              disabled={submitting}
+              className="h-9 md:h-10 px-4 rounded-md text-sm md:text-base font-medium border border-border bg-background dark:bg-muted hover:bg-muted/50 dark:hover:bg-accent transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              Cancel
+            </button>
+            <button
+              onClick={handleSubmit}
+              disabled={validRows.length === 0 || submitting}
+              className="h-9 md:h-10 px-4 rounded-md text-sm md:text-base font-medium bg-foreground text-background hover:opacity-90 transition-opacity cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {submitting
+                ? isEdit
+                  ? "Saving..."
+                  : "Adding..."
+                : isEdit
+                  ? validRows.length > 1
+                    ? `Save ${validRows.length} items`
+                    : "Save item"
+                  : validRows.length > 1
+                    ? `Add ${validRows.length} items`
+                    : "Add item"}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/human-labelling/AnnotationJobView.tsx
+++ b/src/components/human-labelling/AnnotationJobView.tsx
@@ -165,26 +165,37 @@ export function AnnotationJobView({
   const [submitting, setSubmitting] = useState(false);
   const [topError, setTopError] = useState<string | null>(null);
 
-  const initialise = useCallback((data: JobResponse) => {
-    const next: Record<FieldKey, FieldValue> = {};
-    const saved = new Set<FieldKey>();
-    for (const a of data.annotations) {
-      if (!a.evaluator_id) continue;
-      const k = fieldKey(a.item_id, a.evaluator_id);
-      next[k] = {
-        value: readSavedValue(a.value),
-        comment: readSavedComment(a.value),
-      };
-      saved.add(k);
-    }
-    setFields(next);
-    setSavedKeys(saved);
+  const initialise = useCallback(
+    (data: JobResponse) => {
+      const next: Record<FieldKey, FieldValue> = {};
+      const saved = new Set<FieldKey>();
+      for (const a of data.annotations) {
+        if (!a.evaluator_id) continue;
+        const k = fieldKey(a.item_id, a.evaluator_id);
+        next[k] = {
+          value: readSavedValue(a.value),
+          comment: readSavedComment(a.value),
+        };
+        saved.add(k);
+      }
+      setFields(next);
+      setSavedKeys(saved);
 
-    const firstIncomplete = data.items.findIndex((it) =>
-      data.evaluators.some((ev) => !saved.has(fieldKey(it.uuid, ev.uuid))),
-    );
-    setCurrentIndex(firstIncomplete >= 0 ? firstIncomplete : 0);
-  }, []);
+      // Admin (read-only) view always starts on the first item — admins
+      // are reviewing what's been labelled, not picking up where the
+      // annotator left off. Write mode jumps to the first item that
+      // still has at least one unlabelled evaluator.
+      if (mode === "admin") {
+        setCurrentIndex(0);
+        return;
+      }
+      const firstIncomplete = data.items.findIndex((it) =>
+        data.evaluators.some((ev) => !saved.has(fieldKey(it.uuid, ev.uuid))),
+      );
+      setCurrentIndex(firstIncomplete >= 0 ? firstIncomplete : 0);
+    },
+    [mode],
+  );
 
   useEffect(() => {
     if (!token) return;

--- a/src/components/human-labelling/AnnotationJobView.tsx
+++ b/src/components/human-labelling/AnnotationJobView.tsx
@@ -1,0 +1,781 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import confetti from "canvas-confetti";
+import { getBackendUrl } from "@/lib/api";
+import { EvaluatorVerdictCard } from "@/components/EvaluatorVerdictCard";
+import { LlmItemPane } from "./item-panes/LlmItemPane";
+import { Section } from "./item-panes/shared";
+import { SimulationItemPane } from "./item-panes/SimulationItemPane";
+import { SttItemPane } from "./item-panes/SttItemPane";
+
+function fireConfetti() {
+  if (typeof window === "undefined") return;
+  const burst = (originX: number) => {
+    confetti({
+      particleCount: 80,
+      spread: 70,
+      startVelocity: 45,
+      origin: { x: originX, y: 0.7 },
+      colors: ["#22c55e", "#3b82f6", "#a855f7", "#f59e0b", "#ef4444"],
+    });
+  };
+  burst(0.2);
+  burst(0.5);
+  burst(0.8);
+  setTimeout(() => burst(0.5), 250);
+}
+
+type Job = {
+  uuid: string;
+  status: "pending" | "in_progress" | "completed";
+  created_at: string;
+  completed_at: string | null;
+};
+
+type Annotator = { uuid: string; name: string };
+
+export type Task = {
+  uuid: string;
+  name: string;
+  type: "llm" | "stt" | "tts" | "simulation";
+  description: string | null;
+};
+
+type Evaluator = {
+  uuid: string;
+  name: string;
+  description: string | null;
+  evaluator_type: string;
+  output_type: "binary" | "rating" | string;
+};
+
+export type Item = {
+  id: number;
+  uuid: string;
+  task_id: string;
+  payload: Record<string, unknown> | unknown;
+  created_at: string;
+  deleted_at: string | null;
+};
+
+type Annotation = {
+  uuid: string;
+  job_id: string;
+  item_id: string;
+  evaluator_id: string | null;
+  value: { value?: unknown; comment?: unknown } | unknown;
+  created_at: string;
+  updated_at: string;
+};
+
+type JobResponse = {
+  job: Job;
+  annotator: Annotator;
+  task: Task;
+  evaluators: Evaluator[];
+  items: Item[];
+  annotations: Annotation[];
+};
+
+type LoadState =
+  | { status: "loading" }
+  | { status: "ok"; data: JobResponse }
+  | { status: "not_found" }
+  | { status: "error"; message: string };
+
+type FieldKey = string;
+type FieldValue = { value: unknown; comment: string };
+
+function fieldKey(itemId: string, evaluatorId: string): FieldKey {
+  return `${itemId}:${evaluatorId}`;
+}
+
+function readSavedValue(v: unknown): unknown {
+  if (v && typeof v === "object" && "value" in (v as Record<string, unknown>)) {
+    return (v as Record<string, unknown>).value;
+  }
+  return v;
+}
+
+function readSavedComment(v: unknown): string {
+  if (
+    v &&
+    typeof v === "object" &&
+    "comment" in (v as Record<string, unknown>) &&
+    typeof (v as Record<string, unknown>).comment === "string"
+  ) {
+    return (v as Record<string, unknown>).comment as string;
+  }
+  return "";
+}
+
+async function publicFetch<T>(
+  path: string,
+  init?: { method?: string; body?: unknown },
+): Promise<{ ok: true; data: T } | { ok: false; status: number; text: string }> {
+  const res = await fetch(`${getBackendUrl()}${path}`, {
+    method: init?.method ?? "GET",
+    headers: {
+      accept: "application/json",
+      "ngrok-skip-browser-warning": "true",
+      ...(init?.body ? { "Content-Type": "application/json" } : {}),
+    },
+    body: init?.body ? JSON.stringify(init.body) : undefined,
+  });
+  if (!res.ok) {
+    let text = "";
+    try {
+      text = await res.text();
+    } catch {
+      // ignore
+    }
+    return { ok: false, status: res.status, text };
+  }
+  const data = (await res.json()) as T;
+  return { ok: true, data };
+}
+
+export type AnnotationJobMode = "public" | "admin";
+
+export type AnnotationJobMeta = {
+  task: { uuid: string; name: string; type: string };
+  annotator: { uuid: string; name: string };
+  jobStatus: "pending" | "in_progress" | "completed";
+  evaluators: { uuid: string; name: string }[];
+};
+
+export function AnnotationJobView({
+  token,
+  mode,
+  fillViewport = true,
+  onLoaded,
+}: {
+  token: string;
+  mode: AnnotationJobMode;
+  /** Use min-h-screen on the outer wrapper. Set false when embedded in AppLayout. */
+  fillViewport?: boolean;
+  /** Called once the job data is fetched. Useful for the admin wrapper to render task/annotator info above the card. */
+  onLoaded?: (meta: AnnotationJobMeta) => void;
+}) {
+  const [state, setState] = useState<LoadState>({ status: "loading" });
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const [fields, setFields] = useState<Record<FieldKey, FieldValue>>({});
+  const [savedKeys, setSavedKeys] = useState<Set<FieldKey>>(new Set());
+  const [submitting, setSubmitting] = useState(false);
+  const [topError, setTopError] = useState<string | null>(null);
+
+  const initialise = useCallback((data: JobResponse) => {
+    const next: Record<FieldKey, FieldValue> = {};
+    const saved = new Set<FieldKey>();
+    for (const a of data.annotations) {
+      if (!a.evaluator_id) continue;
+      const k = fieldKey(a.item_id, a.evaluator_id);
+      next[k] = {
+        value: readSavedValue(a.value),
+        comment: readSavedComment(a.value),
+      };
+      saved.add(k);
+    }
+    setFields(next);
+    setSavedKeys(saved);
+
+    const firstIncomplete = data.items.findIndex((it) =>
+      data.evaluators.some((ev) => !saved.has(fieldKey(it.uuid, ev.uuid))),
+    );
+    setCurrentIndex(firstIncomplete >= 0 ? firstIncomplete : 0);
+  }, []);
+
+  useEffect(() => {
+    if (!token) return;
+    let cancelled = false;
+    const run = async () => {
+      const result = await publicFetch<JobResponse>(
+        `/public/annotation-jobs/${encodeURIComponent(token)}`,
+      );
+      if (cancelled) return;
+      if (!result.ok) {
+        if (result.status === 404) setState({ status: "not_found" });
+        else
+          setState({
+            status: "error",
+            message: `Request failed (${result.status})`,
+          });
+        return;
+      }
+      initialise(result.data);
+      setState({ status: "ok", data: result.data });
+      onLoaded?.({
+        task: {
+          uuid: result.data.task.uuid,
+          name: result.data.task.name,
+          type: result.data.task.type,
+        },
+        annotator: {
+          uuid: result.data.annotator.uuid,
+          name: result.data.annotator.name,
+        },
+        jobStatus: result.data.job.status,
+        evaluators: result.data.evaluators.map((e) => ({
+          uuid: e.uuid,
+          name: e.name,
+        })),
+      });
+    };
+    run().catch((err) => {
+      if (!cancelled)
+        setState({
+          status: "error",
+          message: err instanceof Error ? err.message : "Network error",
+        });
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [token, initialise, onLoaded]);
+
+  const wrapperClass = fillViewport
+    ? "h-screen bg-background text-foreground flex flex-col overflow-hidden"
+    : "flex flex-col flex-1 min-h-0";
+
+  if (state.status === "loading") {
+    return (
+      <div
+        className={`${wrapperClass} items-center justify-center p-6`}
+      >
+        <div className="flex items-center gap-2 text-sm text-muted-foreground">
+          <svg
+            className="w-4 h-4 animate-spin"
+            fill="none"
+            viewBox="0 0 24 24"
+          >
+            <circle
+              className="opacity-25"
+              cx="12"
+              cy="12"
+              r="10"
+              stroke="currentColor"
+              strokeWidth="4"
+            />
+            <path
+              className="opacity-75"
+              fill="currentColor"
+              d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+            />
+          </svg>
+          Loading
+        </div>
+      </div>
+    );
+  }
+
+  if (state.status === "not_found") {
+    return (
+      <div className={`${wrapperClass} items-center justify-center p-6`}>
+        <div className="max-w-md w-full text-center space-y-3">
+          <div className="text-5xl font-bold">404</div>
+          <h1 className="text-lg font-semibold">Link not found</h1>
+          <p className="text-sm text-muted-foreground">
+            This annotation link is invalid or has been removed
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  if (state.status === "error") {
+    return (
+      <div className={`${wrapperClass} items-center justify-center p-6`}>
+        <div className="max-w-md w-full text-center space-y-2">
+          <h1 className="text-lg font-semibold">Something went wrong</h1>
+          <p className="text-sm text-muted-foreground">{state.message}</p>
+        </div>
+      </div>
+    );
+  }
+
+  const { data } = state;
+  const isAdmin = mode === "admin";
+  const items = data.items;
+  const evaluators = data.evaluators;
+  const total = items.length;
+  const safeIndex = Math.min(Math.max(currentIndex, 0), Math.max(total - 1, 0));
+  const currentItem = items[safeIndex];
+
+  return (
+    <AnnotateView
+      data={data}
+      isAdmin={isAdmin}
+      currentIndex={safeIndex}
+      onJumpTo={setCurrentIndex}
+      currentItem={currentItem}
+      evaluators={evaluators}
+      fields={fields}
+      setFields={setFields}
+      savedKeys={savedKeys}
+      setSavedKeys={setSavedKeys}
+      submitting={submitting}
+      setSubmitting={setSubmitting}
+      topError={topError}
+      setTopError={setTopError}
+      token={token}
+      fillViewport={fillViewport}
+      onJobUpdate={(job) => setState({ status: "ok", data: { ...data, job } })}
+    />
+  );
+}
+
+type ViewProps = {
+  data: JobResponse;
+  isAdmin: boolean;
+  fillViewport: boolean;
+  currentIndex: number;
+  onJumpTo: (i: number) => void;
+  currentItem: Item;
+  evaluators: Evaluator[];
+  fields: Record<FieldKey, FieldValue>;
+  setFields: React.Dispatch<React.SetStateAction<Record<FieldKey, FieldValue>>>;
+  savedKeys: Set<FieldKey>;
+  setSavedKeys: React.Dispatch<React.SetStateAction<Set<FieldKey>>>;
+  submitting: boolean;
+  setSubmitting: (b: boolean) => void;
+  topError: string | null;
+  setTopError: (s: string | null) => void;
+  token: string;
+  onJobUpdate: (job: Job) => void;
+};
+
+function AnnotateView({
+  data,
+  isAdmin,
+  fillViewport,
+  currentIndex,
+  onJumpTo,
+  currentItem,
+  evaluators,
+  fields,
+  setFields,
+  savedKeys,
+  setSavedKeys,
+  submitting,
+  setSubmitting,
+  topError,
+  setTopError,
+  token,
+  onJobUpdate,
+}: ViewProps) {
+  const items = data.items;
+  const total = items.length;
+  const isCompleted = data.job.status === "completed";
+
+  const prevStatus = useRef(data.job.status);
+  useEffect(() => {
+    if (
+      !isAdmin &&
+      prevStatus.current !== "completed" &&
+      data.job.status === "completed"
+    ) {
+      fireConfetti();
+    }
+    prevStatus.current = data.job.status;
+  }, [data.job.status, isAdmin]);
+
+  const itemCompleted = useCallback(
+    (itemId: string) =>
+      evaluators.every((ev) => savedKeys.has(fieldKey(itemId, ev.uuid))),
+    [evaluators, savedKeys],
+  );
+
+  const setField = (key: FieldKey, partial: Partial<FieldValue>) => {
+    setFields((prev) => ({
+      ...prev,
+      [key]: {
+        value: prev[key]?.value,
+        comment: prev[key]?.comment ?? "",
+        ...partial,
+      },
+    }));
+  };
+
+  const handleSubmitItem = async () => {
+    if (isAdmin) return;
+    if (!currentItem || submitting) return;
+    setTopError(null);
+
+    const annotationsBody: {
+      evaluator_id: string;
+      value: Record<string, unknown>;
+    }[] = [];
+    for (const ev of evaluators) {
+      const k = fieldKey(currentItem.uuid, ev.uuid);
+      const f = fields[k];
+      if (!f || f.value === undefined || f.value === null || f.value === "") {
+        return;
+      }
+      annotationsBody.push({
+        evaluator_id: ev.uuid,
+        value: {
+          value: f.value,
+          ...(f.comment ? { comment: f.comment } : {}),
+        },
+      });
+    }
+
+    setSubmitting(true);
+    try {
+      const result = await publicFetch<{
+        saved: string[];
+        count: number;
+        status: Job["status"];
+      }>(`/public/annotation-jobs/${encodeURIComponent(token)}/annotations`, {
+        method: "POST",
+        body: {
+          item_id: currentItem.uuid,
+          annotations: annotationsBody,
+        },
+      });
+      if (!result.ok) {
+        if (result.status === 400) {
+          setTopError("This job has already been marked complete.");
+        } else {
+          setTopError(`Save failed (${result.status})`);
+        }
+        return;
+      }
+
+      const justSaved = new Set<FieldKey>();
+      for (const ev of evaluators) {
+        justSaved.add(fieldKey(currentItem.uuid, ev.uuid));
+      }
+      setSavedKeys((prev) => {
+        const next = new Set(prev);
+        justSaved.forEach((k) => next.add(k));
+        return next;
+      });
+
+      if (result.data.status === "completed") {
+        onJobUpdate({
+          ...data.job,
+          status: "completed",
+          completed_at: data.job.completed_at ?? new Date().toISOString(),
+        });
+        return;
+      }
+
+      const isItemDone = (itemId: string) =>
+        evaluators.every((ev) => {
+          const k = fieldKey(itemId, ev.uuid);
+          return justSaved.has(k) || savedKeys.has(k);
+        });
+      const nextIncomplete = items.findIndex(
+        (it, i) => i !== currentIndex && !isItemDone(it.uuid),
+      );
+      if (nextIncomplete >= 0) onJumpTo(nextIncomplete);
+      else if (currentIndex < total - 1) onJumpTo(currentIndex + 1);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const wrapperClass = fillViewport
+    ? "h-screen bg-background text-foreground flex flex-col overflow-hidden"
+    : "flex flex-col flex-1 min-h-0";
+
+  return (
+    <div className={wrapperClass}>
+      <header className="border-b border-border px-4 md:px-6 py-3 flex flex-col gap-3 md:grid md:grid-cols-3 md:items-center md:gap-4">
+        <div className="min-w-0">
+          {!isAdmin && (
+            <>
+              <div className="flex items-center gap-2 min-w-0">
+                <h1 className="text-base md:text-lg font-semibold truncate">
+                  {data.task.name}
+                </h1>
+                {isCompleted && (
+                  <span className="shrink-0 inline-flex items-center gap-1.5 px-2 py-0.5 rounded-full text-xs font-medium border border-green-200 bg-green-100 text-green-700 dark:border-green-500/30 dark:bg-green-500/20 dark:text-green-400">
+                    <svg
+                      className="w-3 h-3"
+                      fill="none"
+                      viewBox="0 0 24 24"
+                      stroke="currentColor"
+                      strokeWidth={3}
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        d="M5 13l4 4L19 7"
+                      />
+                    </svg>
+                    Completed
+                  </span>
+                )}
+              </div>
+              <p className="text-xs text-muted-foreground">
+                {data.annotator.name}
+              </p>
+            </>
+          )}
+        </div>
+        <div className="flex items-center justify-center gap-2 flex-wrap">
+          <button
+            onClick={() => onJumpTo(Math.max(0, currentIndex - 1))}
+            disabled={currentIndex === 0}
+            className="h-9 px-3 rounded-md text-sm font-medium border border-border bg-background hover:bg-muted/50 transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            Previous
+          </button>
+          <span className="text-sm text-muted-foreground tabular-nums px-2">
+            Item {Math.min(currentIndex + 1, Math.max(total, 1))} of {total}
+          </span>
+          <button
+            onClick={() => onJumpTo(Math.min(total - 1, currentIndex + 1))}
+            disabled={currentIndex >= total - 1}
+            className="h-9 px-3 rounded-md text-sm font-medium border border-border bg-background hover:bg-muted/50 transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            Next
+          </button>
+        </div>
+        <div className="flex justify-stretch md:justify-end [&>button]:w-full md:[&>button]:w-auto">
+          {!isAdmin &&
+            (() => {
+              const currentItemSaved = currentItem
+                ? evaluators.every((ev) =>
+                    savedKeys.has(fieldKey(currentItem.uuid, ev.uuid)),
+                  )
+                : false;
+              const unsavedCount = items.reduce(
+                (n, it) =>
+                  evaluators.every((ev) =>
+                    savedKeys.has(fieldKey(it.uuid, ev.uuid)),
+                  )
+                    ? n
+                    : n + 1,
+                0,
+              );
+              const isLastUnsaved =
+                !!currentItem && !currentItemSaved && unsavedCount === 1;
+              const allEvaluatorsAnswered =
+                !!currentItem &&
+                evaluators.length > 0 &&
+                evaluators.every((ev) => {
+                  const f = fields[fieldKey(currentItem.uuid, ev.uuid)];
+                  return (
+                    f &&
+                    f.value !== undefined &&
+                    f.value !== null &&
+                    f.value !== ""
+                  );
+                });
+              const disabled =
+                submitting || total === 0 || !allEvaluatorsAnswered;
+              const label = submitting
+                ? "Saving..."
+                : currentItemSaved
+                  ? "Update"
+                  : isLastUnsaved
+                    ? "Mark as complete"
+                    : "Submit & Next";
+              const tooltip = !allEvaluatorsAnswered
+                ? "Judgements should be given for all evaluators before submitting"
+                : undefined;
+              return (
+                <button
+                  onClick={handleSubmitItem}
+                  disabled={disabled}
+                  title={tooltip}
+                  className="h-9 px-4 rounded-md text-sm font-medium bg-foreground text-background hover:opacity-90 transition-opacity cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+                >
+                  {label}
+                </button>
+              );
+            })()}
+        </div>
+      </header>
+
+      {topError && (
+        <div className="mx-4 md:mx-6 mt-3 rounded-md border border-red-500/30 bg-red-500/10 px-3 py-2 text-sm text-red-500">
+          {topError}
+        </div>
+      )}
+
+      <div className="flex-1 flex flex-col md:flex-row min-h-0">
+        <aside className="w-full md:w-20 max-h-32 md:max-h-none border-b md:border-b-0 md:border-r border-border bg-muted/20 overflow-y-auto">
+          <div className="p-2 md:p-3 grid grid-cols-8 md:grid-cols-1 gap-2">
+            {items.map((it, i) => {
+              const done = itemCompleted(it.uuid);
+              const isCurrent = i === currentIndex;
+              return (
+                <button
+                  key={it.uuid}
+                  onClick={() => onJumpTo(i)}
+                  title={`Item ${i + 1}${done ? " (completed)" : ""}`}
+                  className={`h-10 w-full rounded-md border text-sm font-medium transition-colors cursor-pointer flex items-center justify-center ${
+                    isCurrent
+                      ? "border-foreground bg-foreground text-background"
+                      : done
+                        ? "border-blue-200 bg-blue-100 text-blue-700 dark:border-blue-500/30 dark:bg-blue-500/20 dark:text-blue-400"
+                        : "border-border bg-background text-foreground hover:bg-muted/50"
+                  }`}
+                >
+                  {i + 1}
+                </button>
+              );
+            })}
+          </div>
+        </aside>
+
+        <main className="flex-1 min-h-0 flex flex-col md:flex-row overflow-y-auto md:overflow-hidden">
+          {!currentItem ? (
+            <div className="flex items-center justify-center h-full p-8 text-sm text-muted-foreground w-full">
+              No items in this job.
+            </div>
+          ) : data.task.type === "stt" ? (
+            // STT shows two short transcripts side-by-side; keep a single
+            // outer scroll container so they stay vertically aligned.
+            <div className="p-4 md:p-6 grid grid-cols-1 md:grid-cols-2 gap-4 md:gap-6 w-full md:overflow-y-auto">
+              <ItemPane item={currentItem} taskType={data.task.type} />
+              <EvaluatorsPane
+                evaluators={evaluators}
+                itemId={currentItem.uuid}
+                fields={fields}
+                setField={setField}
+                readOnly={isAdmin}
+              />
+            </div>
+          ) : (
+            // LLM / simulation: long conversation on the left, evaluators
+            // on the right. Each panel scrolls independently so the
+            // evaluator controls stay visible while the annotator scrolls
+            // through history.
+            <>
+              <div className="md:flex-[7] md:min-h-0 md:overflow-y-auto md:border-r border-border p-4 md:p-6">
+                <ItemPane item={currentItem} taskType={data.task.type} />
+              </div>
+              <div className="md:flex-[3] md:min-h-0 md:overflow-y-auto p-4 md:p-6">
+                <EvaluatorsPane
+                  evaluators={evaluators}
+                  itemId={currentItem.uuid}
+                  fields={fields}
+                  setField={setField}
+                  readOnly={isAdmin}
+                />
+              </div>
+            </>
+          )}
+        </main>
+      </div>
+    </div>
+  );
+}
+
+export function ItemPane({
+  item,
+  taskType,
+}: {
+  item: Item;
+  taskType: Task["type"];
+}) {
+  const payload = (item.payload ?? {}) as Record<string, unknown>;
+  if (taskType === "stt") return <SttItemPane payload={payload} />;
+  if (taskType === "llm") return <LlmItemPane payload={payload} />;
+  if (taskType === "simulation")
+    return <SimulationItemPane payload={payload} />;
+  return (
+    <div className="space-y-2">
+      <Section title="Item payload">
+        <pre className="text-xs font-mono whitespace-pre-wrap break-words text-muted-foreground">
+          {JSON.stringify(payload, null, 2)}
+        </pre>
+      </Section>
+    </div>
+  );
+}
+
+function EvaluatorsPane({
+  evaluators,
+  itemId,
+  fields,
+  setField,
+  readOnly,
+}: {
+  evaluators: Evaluator[];
+  itemId: string;
+  fields: Record<FieldKey, FieldValue>;
+  setField: (key: FieldKey, partial: Partial<FieldValue>) => void;
+  readOnly: boolean;
+}) {
+  if (evaluators.length === 0) {
+    return (
+      <div className="border border-border rounded-xl p-4 text-sm text-muted-foreground">
+        No evaluators are attached to this task.
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      {evaluators.map((ev) => {
+        const k = fieldKey(itemId, ev.uuid);
+        const f = fields[k];
+        const outputType =
+          ev.output_type === "binary" || ev.output_type === "rating"
+            ? ev.output_type
+            : null;
+        if (!outputType) {
+          return (
+            <div
+              key={ev.uuid}
+              className="border border-border rounded-xl p-4 space-y-2"
+            >
+              <h3 className="text-sm font-semibold">{ev.name}</h3>
+              <p className="text-xs text-muted-foreground">
+                Unsupported evaluator type ({ev.output_type})
+              </p>
+            </div>
+          );
+        }
+        if (readOnly) {
+          // Admin / "view submitted" surface — show the verdict the
+          // annotator picked (and any reasoning) using the read view.
+          return (
+            <EvaluatorVerdictCard
+              key={ev.uuid}
+              mode="read"
+              name={ev.name}
+              description={ev.description}
+              outputType={outputType}
+              evaluatorUuid={ev.uuid}
+              match={
+                outputType === "binary" && typeof f?.value === "boolean"
+                  ? f.value
+                  : null
+              }
+              score={
+                outputType === "rating" && typeof f?.value === "number"
+                  ? f.value
+                  : null
+              }
+              reasoning={
+                typeof f?.comment === "string" ? f.comment : null
+              }
+            />
+          );
+        }
+        return (
+          <EvaluatorVerdictCard
+            key={ev.uuid}
+            mode="write"
+            name={ev.name}
+            description={ev.description}
+            outputType={outputType}
+            evaluatorUuid={ev.uuid}
+            value={f?.value as boolean | number | undefined}
+            comment={typeof f?.comment === "string" ? f.comment : ""}
+            onValueChange={(v) => setField(k, { value: v })}
+            onCommentChange={(s) => setField(k, { comment: s })}
+          />
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/human-labelling/AnnotationJobView.tsx
+++ b/src/components/human-labelling/AnnotationJobView.tsx
@@ -648,10 +648,18 @@ function AnnotateView({
             // evaluator controls stay visible while the annotator scrolls
             // through history.
             <>
-              <div className="md:flex-[7] md:min-h-0 md:overflow-y-auto md:border-r border-border p-4 md:p-6">
+              <div
+                className={`${
+                  isAdmin ? "md:flex-[6]" : "md:flex-[7]"
+                } md:min-h-0 md:overflow-y-auto md:border-r border-border p-4 md:p-6`}
+              >
                 <ItemPane item={currentItem} taskType={data.task.type} />
               </div>
-              <div className="md:flex-[3] md:min-h-0 md:overflow-y-auto p-4 md:p-6">
+              <div
+                className={`${
+                  isAdmin ? "md:flex-[4]" : "md:flex-[3]"
+                } md:min-h-0 md:overflow-y-auto p-4 md:p-6`}
+              >
                 <EvaluatorsPane
                   evaluators={evaluators}
                   itemId={currentItem.uuid}

--- a/src/components/human-labelling/AssignAnnotatorsDialog.tsx
+++ b/src/components/human-labelling/AssignAnnotatorsDialog.tsx
@@ -1,0 +1,235 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { useHideFloatingButton } from "@/components/AppLayout";
+import { EmptyState } from "@/components/ui/LoadingState";
+import { apiClient } from "@/lib/api";
+
+type Annotator = {
+  uuid: string;
+  name: string;
+};
+
+function parseApiError(err: unknown, fallback: string): string {
+  if (!(err instanceof Error)) return fallback;
+  const match = err.message.match(/Request failed: \d+ - (.+)$/);
+  if (match) {
+    try {
+      const parsed = JSON.parse(match[1]);
+      if (parsed && typeof parsed.detail === "string") return parsed.detail;
+    } catch {
+      // not JSON
+    }
+    return match[1];
+  }
+  return err.message || fallback;
+}
+
+type AssignAnnotatorsDialogProps = {
+  isOpen: boolean;
+  accessToken: string;
+  selectedItemCount: number;
+  onClose: () => void;
+  onConfirm: (annotatorIds: string[]) => Promise<void> | void;
+};
+
+export function AssignAnnotatorsDialog({
+  isOpen,
+  accessToken,
+  selectedItemCount,
+  onClose,
+  onConfirm,
+}: AssignAnnotatorsDialogProps) {
+  useHideFloatingButton(isOpen);
+
+  const [annotators, setAnnotators] = useState<Annotator[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [loadError, setLoadError] = useState<string | null>(null);
+
+  const [picked, setPicked] = useState<Set<string>>(new Set());
+  const [submitting, setSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    setPicked(new Set());
+    setSubmitError(null);
+    let cancelled = false;
+    const run = async () => {
+      setLoading(true);
+      setLoadError(null);
+      try {
+        const data = await apiClient<Annotator[]>("/annotators", accessToken);
+        if (!cancelled) setAnnotators(Array.isArray(data) ? data : []);
+      } catch (err) {
+        if (!cancelled)
+          setLoadError(parseApiError(err, "Failed to load annotators"));
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    };
+    run();
+    return () => {
+      cancelled = true;
+    };
+  }, [isOpen, accessToken]);
+
+  if (!isOpen) return null;
+
+  const toggle = (id: string) => {
+    setPicked((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
+
+  const handleConfirm = async () => {
+    if (picked.size === 0 || submitting) return;
+    setSubmitting(true);
+    setSubmitError(null);
+    try {
+      await onConfirm(Array.from(picked));
+    } catch (err) {
+      setSubmitError(parseApiError(err, "Failed to create jobs"));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm p-4"
+      onClick={() => {
+        if (!submitting) onClose();
+      }}
+    >
+      <div
+        className="bg-background border border-border rounded-xl shadow-2xl w-full max-w-md flex flex-col max-h-[90vh]"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="px-6 py-4 border-b border-border flex items-center justify-between">
+          <div>
+            <h2 className="text-lg font-semibold">Assign annotators</h2>
+            <p className="text-xs text-muted-foreground mt-1">
+              One labelling job will be created for each selected annotator
+            </p>
+          </div>
+          <button
+            onClick={onClose}
+            disabled={submitting}
+            className="w-8 h-8 flex items-center justify-center rounded-md hover:bg-muted transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            <svg
+              className="w-5 h-5"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              strokeWidth={2}
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M6 18L18 6M6 6l12 12"
+              />
+            </svg>
+          </button>
+        </div>
+        <div className="p-4 md:p-6 space-y-2 max-h-80 overflow-y-auto">
+          {loading ? (
+            <div className="flex items-center gap-2 text-sm text-muted-foreground">
+              <svg
+                className="w-4 h-4 animate-spin"
+                fill="none"
+                viewBox="0 0 24 24"
+              >
+                <circle
+                  className="opacity-25"
+                  cx="12"
+                  cy="12"
+                  r="10"
+                  stroke="currentColor"
+                  strokeWidth="4"
+                />
+                <path
+                  className="opacity-75"
+                  fill="currentColor"
+                  d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+                />
+              </svg>
+              Loading annotators
+            </div>
+          ) : loadError ? (
+            <p className="text-sm text-red-500">{loadError}</p>
+          ) : annotators.length === 0 ? (
+            <EmptyState
+              icon={
+                <svg
+                  className="w-7 h-7 text-muted-foreground"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                  strokeWidth={1.5}
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    d="M15 19.128a9.38 9.38 0 002.625.372 9.337 9.337 0 004.121-.952 4.125 4.125 0 00-7.533-2.493M15 19.128v-.003c0-1.113-.285-2.16-.786-3.07M15 19.128v.106A12.318 12.318 0 018.624 21c-2.331 0-4.512-.645-6.374-1.766l-.001-.109a6.375 6.375 0 0111.964-3.07M12 6.375a3.375 3.375 0 11-6.75 0 3.375 3.375 0 016.75 0zm8.25 2.25a2.625 2.625 0 11-5.25 0 2.625 2.625 0 015.25 0z"
+                  />
+                </svg>
+              }
+              title="No annotators yet"
+              description={
+                <>
+                  <Link
+                    href="/human-labelling?tab=annotators"
+                    className="underline underline-offset-2 hover:text-foreground transition-colors"
+                  >
+                    Add annotators
+                  </Link>{" "}
+                  to your account first
+                </>
+              }
+            />
+          ) : (
+            annotators.map((a) => (
+              <label
+                key={a.uuid}
+                className="flex items-center gap-3 px-3 py-2 rounded-md border border-border hover:bg-muted/30 transition-colors cursor-pointer"
+              >
+                <input
+                  type="checkbox"
+                  checked={picked.has(a.uuid)}
+                  onChange={() => toggle(a.uuid)}
+                  className="w-4 h-4 cursor-pointer accent-foreground"
+                />
+                <div className="flex-1 min-w-0">
+                  <div className="text-sm font-medium truncate">{a.name}</div>
+                </div>
+              </label>
+            ))
+          )}
+          {submitError && <p className="text-sm text-red-500">{submitError}</p>}
+        </div>
+        <div className="px-6 py-4 border-t border-border flex items-center justify-end gap-3">
+          <button
+            onClick={onClose}
+            disabled={submitting}
+            className="h-10 px-4 rounded-md text-sm font-medium border border-border bg-background hover:bg-muted/50 transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={handleConfirm}
+            disabled={picked.size === 0 || submitting}
+            className="h-10 px-4 rounded-md text-sm font-medium bg-foreground text-background hover:opacity-90 transition-opacity cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {submitting ? "Assigning..." : "Assign"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/human-labelling/BulkUploadLlmItemsDialog.tsx
+++ b/src/components/human-labelling/BulkUploadLlmItemsDialog.tsx
@@ -148,6 +148,19 @@ function resolveEvaluatorsCell(
   const trimmed = cell.trim();
   const errors: string[] = [];
 
+  // A single-object spec (`{"name":"…","variables":{…}}`) is a common
+  // mistake — without the outer `[...]` it would otherwise silently
+  // fall through to the plain-string path below and be treated as a
+  // criteria string for the default evaluator. Reject explicitly.
+  if (trimmed.startsWith("{")) {
+    return {
+      refs: [],
+      errors: [
+        'evaluators must be a JSON array — wrap a single evaluator object in [...] (e.g. [{"name":"…","variables":{…}}])',
+      ],
+    };
+  }
+
   if (trimmed.startsWith("[")) {
     let parsed: unknown;
     try {

--- a/src/components/human-labelling/BulkUploadLlmItemsDialog.tsx
+++ b/src/components/human-labelling/BulkUploadLlmItemsDialog.tsx
@@ -1,18 +1,24 @@
 "use client";
 
-import React, { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 import Papa from "papaparse";
 import { useHideFloatingButton } from "@/components/AppLayout";
 import { apiClient } from "@/lib/api";
+import {
+  CsvDropzone,
+  FormatHelpToggle,
+  type TurnObject,
+  findHeaderKey,
+  parseApiError,
+  roleLabel,
+  rolePillClass,
+  turnContentString,
+} from "./bulk-upload-shared";
 
 // Slug used by BulkUploadTestsModal for the plain-string evaluators
 // shortcut. We follow the same convention here so the CSV format the
 // user already knows from the Tests page works in this dialog too.
 const DEFAULT_NEXT_REPLY_EVALUATOR_SLUG = "default-llm-next-reply";
-
-// One CSV may mix next-reply rows (with `evaluators`) and tool-call rows
-// (with `tool_calls`) freely; either column is optional, but every row
-// must populate at least one of them.
 
 type EvaluatorVariableDef = {
   name: string;
@@ -25,13 +31,6 @@ export type LinkedEvaluator = {
   name: string;
   slug: string | null;
   variables: EvaluatorVariableDef[];
-};
-
-type TurnObject = {
-  role: string;
-  content?: unknown;
-  tool_calls?: unknown;
-  [key: string]: unknown;
 };
 
 type EvaluatorRef = {
@@ -69,7 +68,10 @@ function csvEscape(s: string): string {
 // Build a sample CSV that uses the *actual* evaluators linked to the
 // current task in JSON-array form, so users can edit one of the rows
 // instead of figuring the format out from scratch. Both rows share the
-// same evaluator set; only the variable values differ.
+// same evaluator set; only the variable values differ. Caller is
+// expected to guarantee `linked.length > 0` (the page disables the
+// "Bulk upload" button otherwise) — but we keep a defensive fallback so
+// this can't crash if it's invoked in an unexpected state.
 function buildSampleCsv(linked: LinkedEvaluator[]): string {
   const fallback: LinkedEvaluator[] = [
     {
@@ -135,65 +137,6 @@ type BulkUploadLlmItemsDialogProps = {
   onClose: () => void;
   onSuccess: (count: number) => void;
 };
-
-function parseApiError(err: unknown, fallback: string): string {
-  if (!(err instanceof Error)) return fallback;
-  const m = err.message.match(/Request failed: \d+ - (.+)$/);
-  if (m) {
-    try {
-      const parsed = JSON.parse(m[1]);
-      if (parsed && typeof parsed.detail === "string") return parsed.detail;
-    } catch {
-      // ignore
-    }
-    return m[1];
-  }
-  return err.message || fallback;
-}
-
-function findHeaderKey(headers: string[], candidates: string[]): string | null {
-  const norm = (s: string) => s.trim().toLowerCase().replace(/\s+/g, "_");
-  const normalized = headers.map(norm);
-  for (const cand of candidates) {
-    const idx = normalized.indexOf(cand);
-    if (idx >= 0) return headers[idx];
-  }
-  return null;
-}
-
-function turnContentString(t: TurnObject): string {
-  if (typeof t.content === "string") return t.content;
-  if (t.content === undefined || t.content === null) return "";
-  try {
-    return JSON.stringify(t.content);
-  } catch {
-    return String(t.content);
-  }
-}
-
-function roleLabel(role: string): string {
-  if (role === "user") return "User";
-  if (role === "assistant") return "AI";
-  if (role === "system") return "System";
-  if (role === "tool") return "Tool";
-  return role;
-}
-
-function rolePillClass(role: string): string {
-  if (role === "user") {
-    return "bg-blue-500/10 text-blue-600 dark:text-blue-400 border border-blue-500/20";
-  }
-  if (role === "assistant") {
-    return "bg-purple-500/10 text-purple-600 dark:text-purple-400 border border-purple-500/20";
-  }
-  if (role === "system") {
-    return "bg-amber-500/10 text-amber-600 dark:text-amber-400 border border-amber-500/20";
-  }
-  if (role === "tool") {
-    return "bg-emerald-500/10 text-emerald-600 dark:text-emerald-400 border border-emerald-500/20";
-  }
-  return "bg-muted text-muted-foreground border border-border";
-}
 
 // Resolve a row's `evaluators` cell to UUID-keyed refs, mirroring the
 // semantics of BulkUploadTestsModal but validating against the
@@ -366,7 +309,6 @@ export function BulkUploadLlmItemsDialog({
 }: BulkUploadLlmItemsDialogProps) {
   useHideFloatingButton(isOpen);
 
-  const fileInputRef = useRef<HTMLInputElement>(null);
   const [csvFile, setCsvFile] = useState<File | null>(null);
   const [parsedItems, setParsedItems] = useState<ParsedItem[]>([]);
   const [parseError, setParseError] = useState<string | null>(null);
@@ -380,7 +322,6 @@ export function BulkUploadLlmItemsDialog({
     setParseError(null);
     setUploadError(null);
     setFormatHelpOpen(true);
-    if (fileInputRef.current) fileInputRef.current.value = "";
   };
 
   useEffect(() => {
@@ -437,7 +378,7 @@ export function BulkUploadLlmItemsDialog({
           const row = results.data[i];
           const name = (row[nameKey] ?? "").trim();
           const conversationRaw = (row[conversationKey] ?? "").trim();
-          const responseRaw = row[responseKey] ?? "";
+          const responseRaw = (row[responseKey] ?? "").trim();
           const evaluatorsRaw = (row[evaluatorsKey] ?? "").trim();
 
           if (!name && !conversationRaw && !responseRaw && !evaluatorsRaw)
@@ -448,6 +389,10 @@ export function BulkUploadLlmItemsDialog({
           }
           if (!conversationRaw) {
             setParseError(`Row ${i + 1}: "conversation_history" is required.`);
+            return;
+          }
+          if (!responseRaw) {
+            setParseError(`Row ${i + 1}: "agent_response" is required.`);
             return;
           }
           if (!evaluatorsRaw) {
@@ -497,10 +442,7 @@ export function BulkUploadLlmItemsDialog({
           items.push({
             name,
             chat_history: turns,
-            agent_response:
-              typeof responseRaw === "string"
-                ? responseRaw
-                : String(responseRaw),
+            agent_response: responseRaw,
             evaluators: resolved.refs,
           });
         }
@@ -513,12 +455,6 @@ export function BulkUploadLlmItemsDialog({
       },
       error: (err) => setParseError(err.message || "Failed to parse CSV"),
     });
-  };
-
-  const handleDrop = (e: React.DragEvent) => {
-    e.preventDefault();
-    const f = e.dataTransfer.files?.[0];
-    if (f) handleFile(f);
   };
 
   const handleUpload = async () => {
@@ -627,31 +563,10 @@ export function BulkUploadLlmItemsDialog({
             </div>
 
             {parsedItems.length > 0 && (
-              <button
-                type="button"
-                onClick={() => setFormatHelpOpen((o) => !o)}
-                className="mb-3 inline-flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors cursor-pointer"
-                aria-expanded={formatHelpOpen}
-              >
-                <svg
-                  className={`w-3.5 h-3.5 transition-transform ${
-                    formatHelpOpen ? "rotate-90" : ""
-                  }`}
-                  fill="none"
-                  viewBox="0 0 24 24"
-                  stroke="currentColor"
-                  strokeWidth={2.5}
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    d="M8.25 4.5l7.5 7.5-7.5 7.5"
-                  />
-                </svg>
-                {formatHelpOpen
-                  ? "Hide CSV format details"
-                  : "Show CSV format details"}
-              </button>
+              <FormatHelpToggle
+                open={formatHelpOpen}
+                onToggle={() => setFormatHelpOpen((o) => !o)}
+              />
             )}
 
             {formatHelpOpen && (
@@ -697,93 +612,11 @@ export function BulkUploadLlmItemsDialog({
               </div>
             )}
 
-            {/* Drop zone */}
-            <div
-              onDragOver={(e) => e.preventDefault()}
-              onDrop={handleDrop}
-              onClick={() => fileInputRef.current?.click()}
-              className={`border-2 border-dashed rounded-xl p-8 text-center transition-colors cursor-pointer ${
-                csvFile
-                  ? "border-foreground/30 bg-muted/30"
-                  : "border-border hover:border-muted-foreground"
-              }`}
-            >
-              <input
-                ref={fileInputRef}
-                type="file"
-                accept=".csv,text/csv"
-                onChange={(e) => handleFile(e.target.files?.[0] || null)}
-                className="hidden"
-              />
-              {csvFile ? (
-                <div className="flex items-center justify-center gap-2">
-                  <svg
-                    className="w-5 h-5 text-foreground"
-                    fill="none"
-                    viewBox="0 0 24 24"
-                    stroke="currentColor"
-                    strokeWidth={2}
-                  >
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      d="M19.5 14.25v-2.625a3.375 3.375 0 00-3.375-3.375h-1.5A1.125 1.125 0 0113.5 7.125v-1.5a3.375 3.375 0 00-3.375-3.375H8.25m0 12.75h7.5m-7.5 3H12M10.5 2.25H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 00-9-9z"
-                    />
-                  </svg>
-                  <span className="text-sm font-medium text-foreground">
-                    {csvFile.name}
-                  </span>
-                  <button
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      setCsvFile(null);
-                      setParsedItems([]);
-                      setParseError(null);
-                      setUploadError(null);
-                      if (fileInputRef.current) fileInputRef.current.value = "";
-                    }}
-                    aria-label="Remove file"
-                    className="ml-1 text-muted-foreground hover:text-foreground"
-                  >
-                    <svg
-                      className="w-4 h-4"
-                      fill="none"
-                      viewBox="0 0 24 24"
-                      stroke="currentColor"
-                      strokeWidth={2}
-                    >
-                      <path
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        d="M6 18L18 6M6 6l12 12"
-                      />
-                    </svg>
-                  </button>
-                </div>
-              ) : (
-                <>
-                  <svg
-                    className="w-8 h-8 text-muted-foreground mx-auto mb-2"
-                    fill="none"
-                    viewBox="0 0 24 24"
-                    stroke="currentColor"
-                    strokeWidth={1.5}
-                  >
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5m-13.5-9L12 3m0 0l4.5 4.5M12 3v13.5"
-                    />
-                  </svg>
-                  <p className="text-sm text-foreground font-medium">
-                    Drop a CSV here or click to browse
-                  </p>
-                  <p className="text-xs text-muted-foreground mt-1">
-                    Up to a few thousand rows is fine
-                  </p>
-                </>
-              )}
-            </div>
+            <CsvDropzone
+              csvFile={csvFile}
+              onFile={handleFile}
+              onClear={reset}
+            />
 
             {parseError && (
               <p className="text-xs text-red-500 mt-3">{parseError}</p>

--- a/src/components/human-labelling/BulkUploadLlmItemsDialog.tsx
+++ b/src/components/human-labelling/BulkUploadLlmItemsDialog.tsx
@@ -1,0 +1,868 @@
+"use client";
+
+import React, { useEffect, useRef, useState } from "react";
+import Papa from "papaparse";
+import { useHideFloatingButton } from "@/components/AppLayout";
+import { apiClient } from "@/lib/api";
+
+// Slug used by BulkUploadTestsModal for the plain-string evaluators
+// shortcut. We follow the same convention here so the CSV format the
+// user already knows from the Tests page works in this dialog too.
+const DEFAULT_NEXT_REPLY_EVALUATOR_SLUG = "default-llm-next-reply";
+
+// One CSV may mix next-reply rows (with `evaluators`) and tool-call rows
+// (with `tool_calls`) freely; either column is optional, but every row
+// must populate at least one of them.
+
+type EvaluatorVariableDef = {
+  name: string;
+  description?: string;
+  default?: string;
+};
+
+export type LinkedEvaluator = {
+  uuid: string;
+  name: string;
+  slug: string | null;
+  variables: EvaluatorVariableDef[];
+};
+
+type TurnObject = {
+  role: string;
+  content?: unknown;
+  tool_calls?: unknown;
+  [key: string]: unknown;
+};
+
+type EvaluatorRef = {
+  evaluator_uuid: string;
+  variable_values?: Record<string, string>;
+};
+
+type ParsedItem = {
+  name: string;
+  chat_history: TurnObject[];
+  agent_response: string;
+  evaluators: EvaluatorRef[];
+};
+
+const NAME_HEADERS = ["name", "title"];
+const CONVERSATION_HEADERS = [
+  "conversation_history",
+  "conversation",
+  "chat_history",
+  "chat_history_json",
+];
+const RESPONSE_HEADERS = [
+  "agent_response",
+  "response",
+  "assistant_response",
+  "ai_response",
+];
+const EVALUATORS_HEADERS = ["evaluators"];
+
+// CSV-escape: wrap in double quotes and double any inner double quotes.
+function csvEscape(s: string): string {
+  return `"${s.replace(/"/g, '""')}"`;
+}
+
+// Build a sample CSV that uses the *actual* evaluators linked to the
+// current task in JSON-array form, so users can edit one of the rows
+// instead of figuring the format out from scratch. Both rows share the
+// same evaluator set; only the variable values differ.
+function buildSampleCsv(linked: LinkedEvaluator[]): string {
+  const fallback: LinkedEvaluator[] = [
+    {
+      uuid: "",
+      name: "Correctness",
+      slug: DEFAULT_NEXT_REPLY_EVALUATOR_SLUG,
+      variables: [{ name: "criteria" }],
+    },
+  ];
+  const evaluators = linked.length > 0 ? linked : fallback;
+
+  const rows = [
+    {
+      name: "Greeting reply",
+      conversation: [
+        { role: "user", content: "What is your return policy?" },
+      ],
+      response: "You can return any item within 30 days for a full refund.",
+      sampleVariableValue:
+        "The agent should clearly explain the return policy in a helpful and friendly tone.",
+    },
+    {
+      name: "Refund flow",
+      conversation: [{ role: "user", content: "I was charged twice" }],
+      response:
+        "I'm sorry to hear that. Can you confirm the order ID so I can investigate?",
+      sampleVariableValue:
+        "The agent should apologize for the duplicate charge and offer to investigate the order.",
+    },
+  ];
+
+  const rowEvaluatorsCell = (rowIdx: number): string => {
+    const sampleValue = rows[rowIdx].sampleVariableValue;
+    const arr = evaluators.map((e) => {
+      if (e.variables.length === 0) return { name: e.name };
+      const variables: Record<string, string> = {};
+      for (const v of e.variables) {
+        variables[v.name] = sampleValue;
+      }
+      return { name: e.name, variables };
+    });
+    return JSON.stringify(arr);
+  };
+
+  const header = "name,conversation_history,agent_response,evaluators";
+  const lines = rows.map((r, i) =>
+    [
+      csvEscape(r.name),
+      csvEscape(JSON.stringify(r.conversation)),
+      csvEscape(r.response),
+      csvEscape(rowEvaluatorsCell(i)),
+    ].join(","),
+  );
+  return `${header}\n${lines.join("\n")}\n`;
+}
+
+
+type BulkUploadLlmItemsDialogProps = {
+  isOpen: boolean;
+  accessToken: string;
+  taskUuid: string;
+  linkedEvaluators: LinkedEvaluator[];
+  onClose: () => void;
+  onSuccess: (count: number) => void;
+};
+
+function parseApiError(err: unknown, fallback: string): string {
+  if (!(err instanceof Error)) return fallback;
+  const m = err.message.match(/Request failed: \d+ - (.+)$/);
+  if (m) {
+    try {
+      const parsed = JSON.parse(m[1]);
+      if (parsed && typeof parsed.detail === "string") return parsed.detail;
+    } catch {
+      // ignore
+    }
+    return m[1];
+  }
+  return err.message || fallback;
+}
+
+function findHeaderKey(headers: string[], candidates: string[]): string | null {
+  const norm = (s: string) => s.trim().toLowerCase().replace(/\s+/g, "_");
+  const normalized = headers.map(norm);
+  for (const cand of candidates) {
+    const idx = normalized.indexOf(cand);
+    if (idx >= 0) return headers[idx];
+  }
+  return null;
+}
+
+function turnContentString(t: TurnObject): string {
+  if (typeof t.content === "string") return t.content;
+  if (t.content === undefined || t.content === null) return "";
+  try {
+    return JSON.stringify(t.content);
+  } catch {
+    return String(t.content);
+  }
+}
+
+function roleLabel(role: string): string {
+  if (role === "user") return "User";
+  if (role === "assistant") return "AI";
+  if (role === "system") return "System";
+  if (role === "tool") return "Tool";
+  return role;
+}
+
+function rolePillClass(role: string): string {
+  if (role === "user") {
+    return "bg-blue-500/10 text-blue-600 dark:text-blue-400 border border-blue-500/20";
+  }
+  if (role === "assistant") {
+    return "bg-purple-500/10 text-purple-600 dark:text-purple-400 border border-purple-500/20";
+  }
+  if (role === "system") {
+    return "bg-amber-500/10 text-amber-600 dark:text-amber-400 border border-amber-500/20";
+  }
+  if (role === "tool") {
+    return "bg-emerald-500/10 text-emerald-600 dark:text-emerald-400 border border-emerald-500/20";
+  }
+  return "bg-muted text-muted-foreground border border-border";
+}
+
+// Resolve a row's `evaluators` cell to UUID-keyed refs, mirroring the
+// semantics of BulkUploadTestsModal but validating against the
+// evaluators linked to *this* annotation task (not the tenant-wide list).
+function resolveEvaluatorsCell(
+  cell: string,
+  linked: LinkedEvaluator[],
+): { refs: EvaluatorRef[]; errors: string[] } {
+  const trimmed = cell.trim();
+  const errors: string[] = [];
+
+  if (trimmed.startsWith("[")) {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(trimmed);
+    } catch {
+      return { refs: [], errors: ["evaluators is not valid JSON"] };
+    }
+    if (!Array.isArray(parsed)) {
+      return { refs: [], errors: ["evaluators must be a JSON array"] };
+    }
+    if (parsed.length === 0) {
+      return {
+        refs: [],
+        errors: ["evaluators array must contain at least one evaluator"],
+      };
+    }
+
+    const refs: EvaluatorRef[] = [];
+    const seenUuids = new Set<string>();
+    parsed.forEach((entry, i) => {
+      const label = `evaluator #${i + 1}`;
+      if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+        errors.push(`${label}: must be a JSON object`);
+        return;
+      }
+      const obj = entry as Record<string, unknown>;
+      const name = typeof obj.name === "string" ? obj.name.trim() : "";
+      if (!name) {
+        errors.push(`${label}: missing "name"`);
+        return;
+      }
+      const evaluator = linked.find((e) => e.name === name);
+      if (!evaluator) {
+        errors.push(
+          `evaluator "${name}" is not linked to this task — link it first or remove it from the CSV`,
+        );
+        return;
+      }
+      if (seenUuids.has(evaluator.uuid)) {
+        errors.push(`evaluator "${name}" listed more than once`);
+        return;
+      }
+      seenUuids.add(evaluator.uuid);
+
+      let providedVars: Record<string, unknown> = {};
+      if (obj.variables !== undefined && obj.variables !== null) {
+        if (typeof obj.variables !== "object" || Array.isArray(obj.variables)) {
+          errors.push(`evaluator "${name}": "variables" must be an object`);
+          return;
+        }
+        providedVars = obj.variables as Record<string, unknown>;
+      }
+      const expectedNames = evaluator.variables.map((v) => v.name);
+      const variableValues: Record<string, string> = {};
+      const missing: string[] = [];
+      for (const v of evaluator.variables) {
+        const raw = providedVars[v.name];
+        if (typeof raw !== "string" || !raw.trim()) {
+          missing.push(v.name);
+          continue;
+        }
+        variableValues[v.name] = raw;
+      }
+      if (missing.length > 0) {
+        errors.push(
+          `evaluator "${name}": missing variable value(s) for ${missing
+            .map((n) => `"${n}"`)
+            .join(", ")}`,
+        );
+      }
+      const extras = Object.keys(providedVars).filter(
+        (k) => !expectedNames.includes(k),
+      );
+      if (extras.length > 0) {
+        errors.push(
+          `evaluator "${name}": unknown variable(s) ${extras
+            .map((n) => `"${n}"`)
+            .join(", ")}`,
+        );
+      }
+
+      const ref: EvaluatorRef = { evaluator_uuid: evaluator.uuid };
+      if (evaluator.variables.length > 0) {
+        ref.variable_values = variableValues;
+      }
+      refs.push(ref);
+    });
+    return { refs, errors };
+  }
+
+  // Plain-string form → default LLM next-reply evaluator (resolved by
+  // slug). Must be linked to this task.
+  const correctness = linked.find(
+    (e) => e.slug === DEFAULT_NEXT_REPLY_EVALUATOR_SLUG,
+  );
+  if (!correctness) {
+    return {
+      refs: [],
+      errors: [
+        `default LLM next-reply evaluator (slug "${DEFAULT_NEXT_REPLY_EVALUATOR_SLUG}") is not linked to this task — link it or use the JSON-array form`,
+      ],
+    };
+  }
+  return {
+    refs: [
+      {
+        evaluator_uuid: correctness.uuid,
+        variable_values: { criteria: trimmed },
+      },
+    ],
+    errors: [],
+  };
+}
+
+function ChatHistoryPreview({ turns }: { turns: TurnObject[] }) {
+  return (
+    <div className="max-h-24 overflow-y-auto pr-1 space-y-2">
+      {turns.map((t, i) => {
+        const role = typeof t.role === "string" ? t.role : "?";
+        const content = turnContentString(t);
+        return (
+          <div key={`h-${i}`} className="space-y-1 leading-snug">
+            <span
+              className={`inline-flex items-center text-[10px] font-semibold uppercase tracking-wide px-1.5 py-0.5 rounded ${rolePillClass(role)}`}
+            >
+              {roleLabel(role)}
+            </span>
+            <div className="text-foreground break-words whitespace-pre-wrap">
+              {content || (
+                <span className="text-muted-foreground italic">
+                  (no content)
+                </span>
+              )}
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+function AgentReplyPreview({ agentResponse }: { agentResponse: string }) {
+  return (
+    <div className="max-h-24 overflow-y-auto pr-1 leading-snug text-foreground break-words whitespace-pre-wrap">
+      {agentResponse || (
+        <span className="text-muted-foreground italic">(empty)</span>
+      )}
+    </div>
+  );
+}
+
+export function BulkUploadLlmItemsDialog({
+  isOpen,
+  accessToken,
+  taskUuid,
+  linkedEvaluators,
+  onClose,
+  onSuccess,
+}: BulkUploadLlmItemsDialogProps) {
+  useHideFloatingButton(isOpen);
+
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [csvFile, setCsvFile] = useState<File | null>(null);
+  const [parsedItems, setParsedItems] = useState<ParsedItem[]>([]);
+  const [parseError, setParseError] = useState<string | null>(null);
+  const [isUploading, setIsUploading] = useState(false);
+  const [uploadError, setUploadError] = useState<string | null>(null);
+  const [formatHelpOpen, setFormatHelpOpen] = useState(true);
+
+  const reset = () => {
+    setCsvFile(null);
+    setParsedItems([]);
+    setParseError(null);
+    setUploadError(null);
+    setFormatHelpOpen(true);
+    if (fileInputRef.current) fileInputRef.current.value = "";
+  };
+
+  useEffect(() => {
+    if (isOpen) reset();
+  }, [isOpen]);
+
+  useEffect(() => {
+    setFormatHelpOpen(parsedItems.length === 0);
+  }, [parsedItems.length]);
+
+  if (!isOpen) return null;
+
+  const downloadSampleCsv = () => {
+    const blob = new Blob([buildSampleCsv(linkedEvaluators)], {
+      type: "text/csv",
+    });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement("a");
+    link.href = url;
+    link.download = "sample_llm_items.csv";
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
+  };
+
+  const handleFile = (file: File | null) => {
+    setUploadError(null);
+    setParseError(null);
+    setParsedItems([]);
+    setCsvFile(file);
+    if (!file) return;
+    Papa.parse<Record<string, string>>(file, {
+      header: true,
+      skipEmptyLines: true,
+      transformHeader: (h) => h.trim(),
+      complete: (results) => {
+        const headers = results.meta.fields ?? [];
+        const nameKey = findHeaderKey(headers, NAME_HEADERS);
+        const conversationKey = findHeaderKey(headers, CONVERSATION_HEADERS);
+        const responseKey = findHeaderKey(headers, RESPONSE_HEADERS);
+        const evaluatorsKey = findHeaderKey(headers, EVALUATORS_HEADERS);
+
+        if (!nameKey || !conversationKey || !responseKey || !evaluatorsKey) {
+          setParseError(
+            `CSV must include "name", "conversation_history", "agent_response" and "evaluators" columns. Found: ${headers.join(", ") || "(none)"}`,
+          );
+          return;
+        }
+
+        const items: ParsedItem[] = [];
+
+        for (let i = 0; i < results.data.length; i++) {
+          const row = results.data[i];
+          const name = (row[nameKey] ?? "").trim();
+          const conversationRaw = (row[conversationKey] ?? "").trim();
+          const responseRaw = row[responseKey] ?? "";
+          const evaluatorsRaw = (row[evaluatorsKey] ?? "").trim();
+
+          if (!name && !conversationRaw && !responseRaw && !evaluatorsRaw)
+            continue;
+          if (!name) {
+            setParseError(`Row ${i + 1}: "name" is required.`);
+            return;
+          }
+          if (!conversationRaw) {
+            setParseError(`Row ${i + 1}: "conversation_history" is required.`);
+            return;
+          }
+          if (!evaluatorsRaw) {
+            setParseError(`Row ${i + 1}: "evaluators" is required.`);
+            return;
+          }
+
+          let conversation: unknown;
+          try {
+            conversation = JSON.parse(conversationRaw);
+          } catch {
+            setParseError(
+              `Row ${i + 1}: "conversation_history" must be valid JSON. Wrap the JSON in double quotes and escape inner double quotes by doubling them.`,
+            );
+            return;
+          }
+          if (!Array.isArray(conversation) || conversation.length === 0) {
+            setParseError(
+              `Row ${i + 1}: "conversation_history" must be a non-empty array of turn objects.`,
+            );
+            return;
+          }
+          for (let j = 0; j < conversation.length; j++) {
+            const t = conversation[j];
+            if (
+              !t ||
+              typeof t !== "object" ||
+              typeof (t as TurnObject).role !== "string"
+            ) {
+              setParseError(
+                `Row ${i + 1}, turn ${j + 1}: each turn must be an object with a string "role".`,
+              );
+              return;
+            }
+          }
+          const turns = conversation as TurnObject[];
+
+          const resolved = resolveEvaluatorsCell(
+            evaluatorsRaw,
+            linkedEvaluators,
+          );
+          if (resolved.errors.length > 0) {
+            setParseError(`Row ${i + 1}: ${resolved.errors[0]}`);
+            return;
+          }
+
+          items.push({
+            name,
+            chat_history: turns,
+            agent_response:
+              typeof responseRaw === "string"
+                ? responseRaw
+                : String(responseRaw),
+            evaluators: resolved.refs,
+          });
+        }
+
+        if (items.length === 0) {
+          setParseError("No rows with content were found in the CSV.");
+          return;
+        }
+        setParsedItems(items);
+      },
+      error: (err) => setParseError(err.message || "Failed to parse CSV"),
+    });
+  };
+
+  const handleDrop = (e: React.DragEvent) => {
+    e.preventDefault();
+    const f = e.dataTransfer.files?.[0];
+    if (f) handleFile(f);
+  };
+
+  const handleUpload = async () => {
+    if (parsedItems.length === 0 || isUploading) return;
+    setIsUploading(true);
+    setUploadError(null);
+    try {
+      await apiClient(`/annotation-tasks/${taskUuid}/items`, accessToken, {
+        method: "POST",
+        body: {
+          items: parsedItems.map((p) => {
+            const evaluator_variables: Record<
+              string,
+              Record<string, string>
+            > = {};
+            for (const ref of p.evaluators) {
+              if (ref.variable_values) {
+                evaluator_variables[ref.evaluator_uuid] = {
+                  ...ref.variable_values,
+                };
+              }
+            }
+            return {
+              payload: {
+                name: p.name,
+                chat_history: p.chat_history,
+                agent_response: p.agent_response,
+                evaluator_variables,
+              },
+            };
+          }),
+        },
+      });
+      onSuccess(parsedItems.length);
+    } catch (err) {
+      setUploadError(parseApiError(err, "Failed to upload items"));
+    } finally {
+      setIsUploading(false);
+    }
+  };
+
+  const handleClose = () => {
+    if (!isUploading) onClose();
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm p-4"
+      onClick={handleClose}
+    >
+      <div
+        className="bg-background border border-border rounded-xl shadow-2xl w-full max-w-2xl flex flex-col max-h-[90vh]"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-center justify-between px-6 py-4 border-b border-border">
+          <h2 className="text-lg font-semibold text-foreground">
+            Bulk upload items
+          </h2>
+          <button
+            onClick={handleClose}
+            disabled={isUploading}
+            aria-label="Close"
+            className="w-8 h-8 flex items-center justify-center rounded-lg text-muted-foreground hover:text-foreground hover:bg-muted transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            <svg
+              className="w-5 h-5"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              strokeWidth={2}
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M6 18L18 6M6 6l12 12"
+              />
+            </svg>
+          </button>
+        </div>
+
+        <div className="flex-1 overflow-y-auto px-6 py-5 space-y-5">
+          <div>
+            <div className="flex items-center justify-between mb-3">
+              <label className="block text-sm font-medium text-foreground">
+                Upload CSV
+              </label>
+              <button
+                onClick={downloadSampleCsv}
+                className="h-9 px-3 rounded-md text-xs font-medium border border-border bg-muted/40 text-foreground hover:bg-muted hover:border-foreground/30 transition-colors cursor-pointer flex items-center gap-1.5 shadow-sm"
+              >
+                <svg
+                  className="w-4 h-4"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                  strokeWidth={2}
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5M16.5 12L12 16.5m0 0L7.5 12m4.5 4.5V3"
+                  />
+                </svg>
+                Download sample CSV
+              </button>
+            </div>
+
+            {parsedItems.length > 0 && (
+              <button
+                type="button"
+                onClick={() => setFormatHelpOpen((o) => !o)}
+                className="mb-3 inline-flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors cursor-pointer"
+                aria-expanded={formatHelpOpen}
+              >
+                <svg
+                  className={`w-3.5 h-3.5 transition-transform ${
+                    formatHelpOpen ? "rotate-90" : ""
+                  }`}
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                  strokeWidth={2.5}
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    d="M8.25 4.5l7.5 7.5-7.5 7.5"
+                  />
+                </svg>
+                {formatHelpOpen
+                  ? "Hide CSV format details"
+                  : "Show CSV format details"}
+              </button>
+            )}
+
+            {formatHelpOpen && (
+              <div className="text-xs text-muted-foreground mb-3 leading-relaxed space-y-2">
+                <p>Each row creates one LLM annotation item:</p>
+                <ul className="list-disc pl-5 space-y-1.5">
+                  <li>
+                    <code className="font-mono text-foreground">name</code> — a
+                    unique item name
+                  </li>
+                  <li>
+                    <code className="font-mono text-foreground">
+                      conversation_history
+                    </code>{" "}
+                    — JSON array representing a conversation up to (but not
+                    including) the agent response being judged. Each turn should
+                    have <code className="font-mono text-foreground">role</code>{" "}
+                    and{" "}
+                    <code className="font-mono text-foreground">content</code>{" "}
+                    fields.
+                  </li>
+                  <li>
+                    <code className="font-mono text-foreground">
+                      agent_response
+                    </code>{" "}
+                    — the agent response being judged
+                  </li>
+                  <li>
+                    <code className="font-mono text-foreground">
+                      evaluators
+                    </code>{" "}
+                    — a JSON array{" "}
+                    <code className="font-mono text-foreground">
+                      {`[{"name":"...","variables":{...}}]`}
+                    </code>{" "}
+                    attaching evaluators by name. Evaluator names must match
+                    evaluators linked to this task and if any evaluator requires
+                    variables, the{" "}
+                    <code className="font-mono text-foreground">variables</code>{" "}
+                    must be filled for each such evaluator for each row.
+                  </li>
+                </ul>
+              </div>
+            )}
+
+            {/* Drop zone */}
+            <div
+              onDragOver={(e) => e.preventDefault()}
+              onDrop={handleDrop}
+              onClick={() => fileInputRef.current?.click()}
+              className={`border-2 border-dashed rounded-xl p-8 text-center transition-colors cursor-pointer ${
+                csvFile
+                  ? "border-foreground/30 bg-muted/30"
+                  : "border-border hover:border-muted-foreground"
+              }`}
+            >
+              <input
+                ref={fileInputRef}
+                type="file"
+                accept=".csv,text/csv"
+                onChange={(e) => handleFile(e.target.files?.[0] || null)}
+                className="hidden"
+              />
+              {csvFile ? (
+                <div className="flex items-center justify-center gap-2">
+                  <svg
+                    className="w-5 h-5 text-foreground"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                    strokeWidth={2}
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      d="M19.5 14.25v-2.625a3.375 3.375 0 00-3.375-3.375h-1.5A1.125 1.125 0 0113.5 7.125v-1.5a3.375 3.375 0 00-3.375-3.375H8.25m0 12.75h7.5m-7.5 3H12M10.5 2.25H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 00-9-9z"
+                    />
+                  </svg>
+                  <span className="text-sm font-medium text-foreground">
+                    {csvFile.name}
+                  </span>
+                  <button
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      setCsvFile(null);
+                      setParsedItems([]);
+                      setParseError(null);
+                      setUploadError(null);
+                      if (fileInputRef.current) fileInputRef.current.value = "";
+                    }}
+                    aria-label="Remove file"
+                    className="ml-1 text-muted-foreground hover:text-foreground"
+                  >
+                    <svg
+                      className="w-4 h-4"
+                      fill="none"
+                      viewBox="0 0 24 24"
+                      stroke="currentColor"
+                      strokeWidth={2}
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        d="M6 18L18 6M6 6l12 12"
+                      />
+                    </svg>
+                  </button>
+                </div>
+              ) : (
+                <>
+                  <svg
+                    className="w-8 h-8 text-muted-foreground mx-auto mb-2"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                    strokeWidth={1.5}
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5m-13.5-9L12 3m0 0l4.5 4.5M12 3v13.5"
+                    />
+                  </svg>
+                  <p className="text-sm text-foreground font-medium">
+                    Drop a CSV here or click to browse
+                  </p>
+                  <p className="text-xs text-muted-foreground mt-1">
+                    Up to a few thousand rows is fine
+                  </p>
+                </>
+              )}
+            </div>
+
+            {parseError && (
+              <p className="text-xs text-red-500 mt-3">{parseError}</p>
+            )}
+          </div>
+
+          {parsedItems.length > 0 && (
+            <div className="space-y-2">
+              <p className="text-sm font-medium text-foreground">
+                {parsedItems.length}{" "}
+                {parsedItems.length === 1 ? "item" : "items"} ready to upload
+              </p>
+              <div className="border border-border rounded-xl overflow-hidden">
+                <div className="grid grid-cols-[160px_minmax(0,1fr)_minmax(0,1fr)] gap-3 px-4 py-2 border-b border-border bg-muted/30">
+                  <div className="text-xs font-medium text-muted-foreground">
+                    Name
+                  </div>
+                  <div className="text-xs font-medium text-muted-foreground">
+                    Chat history
+                  </div>
+                  <div className="text-xs font-medium text-muted-foreground">
+                    AI reply
+                  </div>
+                </div>
+                <div className="max-h-[15rem] overflow-y-auto divide-y divide-border">
+                  {parsedItems.slice(0, 50).map((p, idx) => (
+                    <div
+                      key={idx}
+                      className="grid grid-cols-[160px_minmax(0,1fr)_minmax(0,1fr)] gap-3 px-4 py-2 text-xs items-start"
+                    >
+                      <div className="truncate text-foreground" title={p.name}>
+                        {p.name}
+                      </div>
+                      <div className="min-w-0">
+                        <ChatHistoryPreview turns={p.chat_history} />
+                      </div>
+                      <div className="min-w-0">
+                        <AgentReplyPreview agentResponse={p.agent_response} />
+                      </div>
+                    </div>
+                  ))}
+                  {parsedItems.length > 50 && (
+                    <div className="px-4 py-2 text-xs text-muted-foreground">
+                      + {parsedItems.length - 50} more rows
+                    </div>
+                  )}
+                </div>
+              </div>
+            </div>
+          )}
+
+          {uploadError && (
+            <div className="rounded-md border border-red-500/30 bg-red-500/10 p-3 text-sm text-red-500">
+              {uploadError}
+            </div>
+          )}
+        </div>
+
+        <div className="flex items-center justify-end gap-3 px-6 py-4 border-t border-border">
+          <button
+            onClick={handleClose}
+            disabled={isUploading}
+            className="h-10 px-4 rounded-md text-sm font-medium border border-border bg-background hover:bg-muted/50 transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={handleUpload}
+            disabled={parsedItems.length === 0 || isUploading || !!parseError}
+            className="h-10 px-4 rounded-md text-sm font-medium bg-foreground text-background hover:opacity-90 transition-opacity cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {isUploading
+              ? "Uploading…"
+              : parsedItems.length > 1
+                ? `Upload ${parsedItems.length} items`
+                : "Upload item"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/human-labelling/BulkUploadSimulationItemsDialog.tsx
+++ b/src/components/human-labelling/BulkUploadSimulationItemsDialog.tsx
@@ -1,9 +1,19 @@
 "use client";
 
-import React, { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 import Papa from "papaparse";
 import { useHideFloatingButton } from "@/components/AppLayout";
 import { apiClient } from "@/lib/api";
+import {
+  CsvDropzone,
+  FormatHelpToggle,
+  type TurnObject,
+  findHeaderKey,
+  parseApiError,
+  roleLabel,
+  rolePillClass,
+  turnContentString,
+} from "./bulk-upload-shared";
 
 const TRANSCRIPT_HEADERS = [
   "transcript",
@@ -18,13 +28,6 @@ const SAMPLE_SIMULATION_CSV = `name,transcript
 "Refund flow","[{""role"":""user"",""content"":""I was charged twice""},{""role"":""assistant"",""content"":""I'm sorry to hear that. Let me investigate the duplicate charge for you.""}]"
 `;
 
-type TurnObject = {
-  role: string;
-  content?: unknown;
-  tool_calls?: unknown;
-  [key: string]: unknown;
-};
-
 type ParsedItem = {
   name: string;
   transcript: TurnObject[];
@@ -37,68 +40,6 @@ type BulkUploadSimulationItemsDialogProps = {
   onClose: () => void;
   onSuccess: (count: number) => void;
 };
-
-function parseApiError(err: unknown, fallback: string): string {
-  if (!(err instanceof Error)) return fallback;
-  const m = err.message.match(/Request failed: \d+ - (.+)$/);
-  if (m) {
-    try {
-      const parsed = JSON.parse(m[1]);
-      if (parsed && typeof parsed.detail === "string") return parsed.detail;
-    } catch {
-      // ignore
-    }
-    return m[1];
-  }
-  return err.message || fallback;
-}
-
-function findHeaderKey(headers: string[], candidates: string[]): string | null {
-  const norm = (s: string) => s.trim().toLowerCase().replace(/\s+/g, "_");
-  const normalized = headers.map(norm);
-  for (const cand of candidates) {
-    const idx = normalized.indexOf(cand);
-    if (idx >= 0) return headers[idx];
-  }
-  return null;
-}
-
-function turnContentString(t: TurnObject): string {
-  if (typeof t.content === "string") return t.content;
-  if (t.content === undefined || t.content === null) return "";
-  try {
-    return JSON.stringify(t.content);
-  } catch {
-    return String(t.content);
-  }
-}
-
-function roleLabel(role: string): string {
-  // Friendly labels for the common simulation roles, falling back to the
-  // raw role for anything custom (tool, function, etc).
-  if (role === "user") return "User";
-  if (role === "assistant") return "AI";
-  if (role === "system") return "System";
-  if (role === "tool") return "Tool";
-  return role;
-}
-
-// Distinct colour per role so users can scan the transcript at a glance.
-function rolePillClass(role: string): string {
-  if (role === "user") {
-    return "bg-blue-500/10 text-blue-600 dark:text-blue-400 border border-blue-500/20";
-  }
-  if (role === "assistant") {
-    return "bg-purple-500/10 text-purple-600 dark:text-purple-400 border border-purple-500/20";
-  }
-  if (role === "system") {
-    return "bg-amber-500/10 text-amber-600 dark:text-amber-400 border border-amber-500/20";
-  }
-  if (role === "tool") {
-    return "bg-emerald-500/10 text-emerald-600 dark:text-emerald-400 border border-emerald-500/20";
-  }
-  return "bg-muted text-muted-foreground border border-border";
-}
 
 // Vertical preview of a transcript: each turn rendered as a "Role" label
 // above its content. The container is sized so that ~2 turns are visible
@@ -139,7 +80,6 @@ export function BulkUploadSimulationItemsDialog({
 }: BulkUploadSimulationItemsDialogProps) {
   useHideFloatingButton(isOpen);
 
-  const fileInputRef = useRef<HTMLInputElement>(null);
   const [csvFile, setCsvFile] = useState<File | null>(null);
   const [parsedItems, setParsedItems] = useState<ParsedItem[]>([]);
   const [parseError, setParseError] = useState<string | null>(null);
@@ -153,7 +93,6 @@ export function BulkUploadSimulationItemsDialog({
     setParseError(null);
     setUploadError(null);
     setFormatHelpOpen(true);
-    if (fileInputRef.current) fileInputRef.current.value = "";
   };
 
   useEffect(() => {
@@ -254,12 +193,6 @@ export function BulkUploadSimulationItemsDialog({
     });
   };
 
-  const handleDrop = (e: React.DragEvent) => {
-    e.preventDefault();
-    const f = e.dataTransfer.files?.[0];
-    if (f) handleFile(f);
-  };
-
   const handleUpload = async () => {
     if (parsedItems.length === 0 || isUploading) return;
     setIsUploading(true);
@@ -349,31 +282,10 @@ export function BulkUploadSimulationItemsDialog({
             </div>
 
             {parsedItems.length > 0 && (
-              <button
-                type="button"
-                onClick={() => setFormatHelpOpen((o) => !o)}
-                className="mb-3 inline-flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors cursor-pointer"
-                aria-expanded={formatHelpOpen}
-              >
-                <svg
-                  className={`w-3.5 h-3.5 transition-transform ${
-                    formatHelpOpen ? "rotate-90" : ""
-                  }`}
-                  fill="none"
-                  viewBox="0 0 24 24"
-                  stroke="currentColor"
-                  strokeWidth={2.5}
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    d="M8.25 4.5l7.5 7.5-7.5 7.5"
-                  />
-                </svg>
-                {formatHelpOpen
-                  ? "Hide CSV format details"
-                  : "Show CSV format details"}
-              </button>
+              <FormatHelpToggle
+                open={formatHelpOpen}
+                onToggle={() => setFormatHelpOpen((o) => !o)}
+              />
             )}
 
             {formatHelpOpen && (
@@ -398,89 +310,11 @@ export function BulkUploadSimulationItemsDialog({
               </div>
             )}
 
-            {/* Drop zone */}
-            <div
-              onDragOver={(e) => e.preventDefault()}
-              onDrop={handleDrop}
-              onClick={() => fileInputRef.current?.click()}
-              className={`border-2 border-dashed rounded-xl p-8 text-center transition-colors cursor-pointer ${
-                csvFile
-                  ? "border-foreground/30 bg-muted/30"
-                  : "border-border hover:border-muted-foreground"
-              }`}
-            >
-              <input
-                ref={fileInputRef}
-                type="file"
-                accept=".csv,text/csv"
-                onChange={(e) => handleFile(e.target.files?.[0] || null)}
-                className="hidden"
-              />
-              {csvFile ? (
-                <div className="flex items-center justify-center gap-2">
-                  <svg
-                    className="w-5 h-5 text-foreground"
-                    fill="none"
-                    viewBox="0 0 24 24"
-                    stroke="currentColor"
-                    strokeWidth={2}
-                  >
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      d="M19.5 14.25v-2.625a3.375 3.375 0 00-3.375-3.375h-1.5A1.125 1.125 0 0113.5 7.125v-1.5a3.375 3.375 0 00-3.375-3.375H8.25m0 12.75h7.5m-7.5 3H12M10.5 2.25H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 00-9-9z"
-                    />
-                  </svg>
-                  <span className="text-sm font-medium text-foreground">
-                    {csvFile.name}
-                  </span>
-                  <button
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      reset();
-                    }}
-                    aria-label="Remove file"
-                    className="ml-1 text-muted-foreground hover:text-foreground"
-                  >
-                    <svg
-                      className="w-4 h-4"
-                      fill="none"
-                      viewBox="0 0 24 24"
-                      stroke="currentColor"
-                      strokeWidth={2}
-                    >
-                      <path
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        d="M6 18L18 6M6 6l12 12"
-                      />
-                    </svg>
-                  </button>
-                </div>
-              ) : (
-                <>
-                  <svg
-                    className="w-8 h-8 text-muted-foreground mx-auto mb-2"
-                    fill="none"
-                    viewBox="0 0 24 24"
-                    stroke="currentColor"
-                    strokeWidth={1.5}
-                  >
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5m-13.5-9L12 3m0 0l4.5 4.5M12 3v13.5"
-                    />
-                  </svg>
-                  <p className="text-sm text-foreground font-medium">
-                    Drop a CSV here or click to browse
-                  </p>
-                  <p className="text-xs text-muted-foreground mt-1">
-                    Up to a few thousand rows is fine
-                  </p>
-                </>
-              )}
-            </div>
+            <CsvDropzone
+              csvFile={csvFile}
+              onFile={handleFile}
+              onClear={reset}
+            />
 
             {parseError && (
               <p className="text-xs text-red-500 mt-3">{parseError}</p>

--- a/src/components/human-labelling/BulkUploadSimulationItemsDialog.tsx
+++ b/src/components/human-labelling/BulkUploadSimulationItemsDialog.tsx
@@ -1,0 +1,565 @@
+"use client";
+
+import React, { useEffect, useRef, useState } from "react";
+import Papa from "papaparse";
+import { useHideFloatingButton } from "@/components/AppLayout";
+import { apiClient } from "@/lib/api";
+
+const TRANSCRIPT_HEADERS = [
+  "transcript",
+  "transcript_json",
+  "conversation",
+  "conversation_history",
+];
+const NAME_HEADERS = ["name", "title", "simulation_name"];
+
+const SAMPLE_SIMULATION_CSV = `name,transcript
+"Card lost - happy path","[{""role"":""assistant"",""content"":""Hi, how can I help?""},{""role"":""user"",""content"":""I lost my card""},{""role"":""assistant"",""content"":""I can help block it. Can you confirm the last 4 digits?""}]"
+"Refund flow","[{""role"":""user"",""content"":""I was charged twice""},{""role"":""assistant"",""content"":""I'm sorry to hear that. Let me investigate the duplicate charge for you.""}]"
+`;
+
+type TurnObject = {
+  role: string;
+  content?: unknown;
+  tool_calls?: unknown;
+  [key: string]: unknown;
+};
+
+type ParsedItem = {
+  name: string;
+  transcript: TurnObject[];
+};
+
+type BulkUploadSimulationItemsDialogProps = {
+  isOpen: boolean;
+  accessToken: string;
+  taskUuid: string;
+  onClose: () => void;
+  onSuccess: (count: number) => void;
+};
+
+function parseApiError(err: unknown, fallback: string): string {
+  if (!(err instanceof Error)) return fallback;
+  const m = err.message.match(/Request failed: \d+ - (.+)$/);
+  if (m) {
+    try {
+      const parsed = JSON.parse(m[1]);
+      if (parsed && typeof parsed.detail === "string") return parsed.detail;
+    } catch {
+      // ignore
+    }
+    return m[1];
+  }
+  return err.message || fallback;
+}
+
+function findHeaderKey(headers: string[], candidates: string[]): string | null {
+  const norm = (s: string) => s.trim().toLowerCase().replace(/\s+/g, "_");
+  const normalized = headers.map(norm);
+  for (const cand of candidates) {
+    const idx = normalized.indexOf(cand);
+    if (idx >= 0) return headers[idx];
+  }
+  return null;
+}
+
+function turnContentString(t: TurnObject): string {
+  if (typeof t.content === "string") return t.content;
+  if (t.content === undefined || t.content === null) return "";
+  try {
+    return JSON.stringify(t.content);
+  } catch {
+    return String(t.content);
+  }
+}
+
+function roleLabel(role: string): string {
+  // Friendly labels for the common simulation roles, falling back to the
+  // raw role for anything custom (tool, function, etc).
+  if (role === "user") return "User";
+  if (role === "assistant") return "AI";
+  if (role === "system") return "System";
+  if (role === "tool") return "Tool";
+  return role;
+}
+
+// Distinct colour per role so users can scan the transcript at a glance.
+function rolePillClass(role: string): string {
+  if (role === "user") {
+    return "bg-blue-500/10 text-blue-600 dark:text-blue-400 border border-blue-500/20";
+  }
+  if (role === "assistant") {
+    return "bg-purple-500/10 text-purple-600 dark:text-purple-400 border border-purple-500/20";
+  }
+  if (role === "system") {
+    return "bg-amber-500/10 text-amber-600 dark:text-amber-400 border border-amber-500/20";
+  }
+  if (role === "tool") {
+    return "bg-emerald-500/10 text-emerald-600 dark:text-emerald-400 border border-emerald-500/20";
+  }
+  return "bg-muted text-muted-foreground border border-border";
+}
+
+// Vertical preview of a transcript: each turn rendered as a "Role" label
+// above its content. The container is sized so that ~2 turns are visible
+// at once; anything beyond that scrolls inside the cell.
+function TranscriptPreview({ turns }: { turns: TurnObject[] }) {
+  return (
+    <div className="max-h-24 overflow-y-auto pr-1 space-y-2">
+      {turns.map((t, i) => {
+        const role = typeof t.role === "string" ? t.role : "?";
+        const content = turnContentString(t);
+        return (
+          <div key={i} className="space-y-1 leading-snug">
+            <span
+              className={`inline-flex items-center text-[10px] font-semibold uppercase tracking-wide px-1.5 py-0.5 rounded ${rolePillClass(role)}`}
+            >
+              {roleLabel(role)}
+            </span>
+            <div className="text-foreground break-words whitespace-pre-wrap">
+              {content || (
+                <span className="text-muted-foreground italic">
+                  (no content)
+                </span>
+              )}
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+export function BulkUploadSimulationItemsDialog({
+  isOpen,
+  accessToken,
+  taskUuid,
+  onClose,
+  onSuccess,
+}: BulkUploadSimulationItemsDialogProps) {
+  useHideFloatingButton(isOpen);
+
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [csvFile, setCsvFile] = useState<File | null>(null);
+  const [parsedItems, setParsedItems] = useState<ParsedItem[]>([]);
+  const [parseError, setParseError] = useState<string | null>(null);
+  const [isUploading, setIsUploading] = useState(false);
+  const [uploadError, setUploadError] = useState<string | null>(null);
+  const [formatHelpOpen, setFormatHelpOpen] = useState(true);
+
+  const reset = () => {
+    setCsvFile(null);
+    setParsedItems([]);
+    setParseError(null);
+    setUploadError(null);
+    setFormatHelpOpen(true);
+    if (fileInputRef.current) fileInputRef.current.value = "";
+  };
+
+  useEffect(() => {
+    if (isOpen) reset();
+  }, [isOpen]);
+
+  useEffect(() => {
+    setFormatHelpOpen(parsedItems.length === 0);
+  }, [parsedItems.length]);
+
+  if (!isOpen) return null;
+
+  const downloadSampleCsv = () => {
+    const blob = new Blob([SAMPLE_SIMULATION_CSV], { type: "text/csv" });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement("a");
+    link.href = url;
+    link.download = "sample_simulation_items.csv";
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
+  };
+
+  const handleFile = (file: File | null) => {
+    setUploadError(null);
+    setParseError(null);
+    setParsedItems([]);
+    setCsvFile(file);
+    if (!file) return;
+    Papa.parse<Record<string, string>>(file, {
+      header: true,
+      skipEmptyLines: true,
+      transformHeader: (h) => h.trim(),
+      complete: (results) => {
+        const headers = results.meta.fields ?? [];
+        const transcriptKey = findHeaderKey(headers, TRANSCRIPT_HEADERS);
+        const nameKey = findHeaderKey(headers, NAME_HEADERS);
+        if (!nameKey || !transcriptKey) {
+          setParseError(
+            `CSV must include "name" and "transcript" columns. Found: ${headers.join(", ") || "(none)"}`,
+          );
+          return;
+        }
+        const items: ParsedItem[] = [];
+        for (let i = 0; i < results.data.length; i++) {
+          const row = results.data[i];
+          const raw = (row[transcriptKey] ?? "").trim();
+          const name = (row[nameKey] ?? "").trim();
+          if (!raw && !name) continue;
+          if (!name) {
+            setParseError(`Row ${i + 1}: "name" is required.`);
+            return;
+          }
+          if (!raw) {
+            setParseError(`Row ${i + 1}: "transcript" is required.`);
+            return;
+          }
+          let parsed: unknown;
+          try {
+            parsed = JSON.parse(raw);
+          } catch {
+            setParseError(
+              `Row ${i + 1}: "transcript" must be valid JSON. Wrap the JSON in double quotes and escape inner double quotes by doubling them.`,
+            );
+            return;
+          }
+          if (!Array.isArray(parsed) || parsed.length === 0) {
+            setParseError(
+              `Row ${i + 1}: "transcript" must be a non-empty array of turn objects.`,
+            );
+            return;
+          }
+          for (let j = 0; j < parsed.length; j++) {
+            const t = parsed[j];
+            if (!t || typeof t !== "object") {
+              setParseError(
+                `Row ${i + 1}, turn ${j + 1}: each turn must be an object with a "role".`,
+              );
+              return;
+            }
+            if (typeof (t as TurnObject).role !== "string") {
+              setParseError(
+                `Row ${i + 1}, turn ${j + 1}: each turn must have a string "role".`,
+              );
+              return;
+            }
+          }
+          items.push({ name, transcript: parsed as TurnObject[] });
+        }
+        if (items.length === 0) {
+          setParseError("No rows with a transcript were found in the CSV.");
+          return;
+        }
+        setParsedItems(items);
+      },
+      error: (err) => setParseError(err.message || "Failed to parse CSV"),
+    });
+  };
+
+  const handleDrop = (e: React.DragEvent) => {
+    e.preventDefault();
+    const f = e.dataTransfer.files?.[0];
+    if (f) handleFile(f);
+  };
+
+  const handleUpload = async () => {
+    if (parsedItems.length === 0 || isUploading) return;
+    setIsUploading(true);
+    setUploadError(null);
+    try {
+      await apiClient(`/annotation-tasks/${taskUuid}/items`, accessToken, {
+        method: "POST",
+        body: {
+          items: parsedItems.map((p) => ({
+            payload: { name: p.name, transcript: p.transcript },
+          })),
+        },
+      });
+      onSuccess(parsedItems.length);
+    } catch (err) {
+      setUploadError(parseApiError(err, "Failed to upload items"));
+    } finally {
+      setIsUploading(false);
+    }
+  };
+
+  const handleClose = () => {
+    if (!isUploading) onClose();
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm p-4"
+      onClick={handleClose}
+    >
+      <div
+        className="bg-background border border-border rounded-xl shadow-2xl w-full max-w-2xl flex flex-col max-h-[90vh]"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-center justify-between px-6 py-4 border-b border-border">
+          <h2 className="text-lg font-semibold text-foreground">
+            Bulk upload items
+          </h2>
+          <button
+            onClick={handleClose}
+            disabled={isUploading}
+            aria-label="Close"
+            className="w-8 h-8 flex items-center justify-center rounded-lg text-muted-foreground hover:text-foreground hover:bg-muted transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            <svg
+              className="w-5 h-5"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              strokeWidth={2}
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M6 18L18 6M6 6l12 12"
+              />
+            </svg>
+          </button>
+        </div>
+
+        <div className="flex-1 overflow-y-auto px-6 py-5 space-y-5">
+          <div>
+            <div className="flex items-center justify-between mb-3">
+              <label className="block text-sm font-medium text-foreground">
+                Upload CSV
+              </label>
+              <button
+                type="button"
+                onClick={downloadSampleCsv}
+                className="h-9 px-3 rounded-md text-xs font-medium border border-border bg-muted/40 text-foreground hover:bg-muted hover:border-foreground/30 transition-colors cursor-pointer flex items-center gap-1.5 shadow-sm"
+              >
+                <svg
+                  className="w-4 h-4"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                  strokeWidth={2}
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5M16.5 12L12 16.5m0 0L7.5 12m4.5 4.5V3"
+                  />
+                </svg>
+                Download sample CSV
+              </button>
+            </div>
+
+            {parsedItems.length > 0 && (
+              <button
+                type="button"
+                onClick={() => setFormatHelpOpen((o) => !o)}
+                className="mb-3 inline-flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors cursor-pointer"
+                aria-expanded={formatHelpOpen}
+              >
+                <svg
+                  className={`w-3.5 h-3.5 transition-transform ${
+                    formatHelpOpen ? "rotate-90" : ""
+                  }`}
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                  strokeWidth={2.5}
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    d="M8.25 4.5l7.5 7.5-7.5 7.5"
+                  />
+                </svg>
+                {formatHelpOpen
+                  ? "Hide CSV format details"
+                  : "Show CSV format details"}
+              </button>
+            )}
+
+            {formatHelpOpen && (
+              <div className="text-xs text-muted-foreground mb-3 leading-relaxed space-y-2">
+                <p>Each row creates one simulation item:</p>
+                <ul className="list-disc pl-5 space-y-1.5">
+                  <li>
+                    <code className="font-mono text-foreground">name</code> — a
+                    name for the item
+                  </li>
+                  <li>
+                    <code className="font-mono text-foreground">
+                      transcript
+                    </code>{" "}
+                    — JSON array representing a conversation with each turn
+                    having a{" "}
+                    <code className="font-mono text-foreground">role</code> and{" "}
+                    <code className="font-mono text-foreground">content</code>{" "}
+                    fields
+                  </li>
+                </ul>
+              </div>
+            )}
+
+            {/* Drop zone */}
+            <div
+              onDragOver={(e) => e.preventDefault()}
+              onDrop={handleDrop}
+              onClick={() => fileInputRef.current?.click()}
+              className={`border-2 border-dashed rounded-xl p-8 text-center transition-colors cursor-pointer ${
+                csvFile
+                  ? "border-foreground/30 bg-muted/30"
+                  : "border-border hover:border-muted-foreground"
+              }`}
+            >
+              <input
+                ref={fileInputRef}
+                type="file"
+                accept=".csv,text/csv"
+                onChange={(e) => handleFile(e.target.files?.[0] || null)}
+                className="hidden"
+              />
+              {csvFile ? (
+                <div className="flex items-center justify-center gap-2">
+                  <svg
+                    className="w-5 h-5 text-foreground"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                    strokeWidth={2}
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      d="M19.5 14.25v-2.625a3.375 3.375 0 00-3.375-3.375h-1.5A1.125 1.125 0 0113.5 7.125v-1.5a3.375 3.375 0 00-3.375-3.375H8.25m0 12.75h7.5m-7.5 3H12M10.5 2.25H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 00-9-9z"
+                    />
+                  </svg>
+                  <span className="text-sm font-medium text-foreground">
+                    {csvFile.name}
+                  </span>
+                  <button
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      reset();
+                    }}
+                    aria-label="Remove file"
+                    className="ml-1 text-muted-foreground hover:text-foreground"
+                  >
+                    <svg
+                      className="w-4 h-4"
+                      fill="none"
+                      viewBox="0 0 24 24"
+                      stroke="currentColor"
+                      strokeWidth={2}
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        d="M6 18L18 6M6 6l12 12"
+                      />
+                    </svg>
+                  </button>
+                </div>
+              ) : (
+                <>
+                  <svg
+                    className="w-8 h-8 text-muted-foreground mx-auto mb-2"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                    strokeWidth={1.5}
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5m-13.5-9L12 3m0 0l4.5 4.5M12 3v13.5"
+                    />
+                  </svg>
+                  <p className="text-sm text-foreground font-medium">
+                    Drop a CSV here or click to browse
+                  </p>
+                  <p className="text-xs text-muted-foreground mt-1">
+                    Up to a few thousand rows is fine
+                  </p>
+                </>
+              )}
+            </div>
+
+            {parseError && (
+              <p className="text-xs text-red-500 mt-3">{parseError}</p>
+            )}
+          </div>
+
+          {parsedItems.length > 0 && (
+            <div className="space-y-2">
+              <p className="text-sm font-medium text-foreground">
+                {parsedItems.length}{" "}
+                {parsedItems.length === 1 ? "item" : "items"} ready to upload
+              </p>
+              <div className="border border-border rounded-xl overflow-hidden">
+                <div className="grid grid-cols-[180px_1fr_60px] gap-3 px-4 py-2 border-b border-border bg-muted/30">
+                  <div className="text-xs font-medium text-muted-foreground">
+                    Name
+                  </div>
+                  <div className="text-xs font-medium text-muted-foreground">
+                    Transcript
+                  </div>
+                  <div className="text-xs font-medium text-muted-foreground text-right">
+                    Turns
+                  </div>
+                </div>
+                <div className="max-h-[15rem] overflow-y-auto divide-y divide-border">
+                  {parsedItems.slice(0, 50).map((p, idx) => (
+                    <div
+                      key={idx}
+                      className="grid grid-cols-[180px_1fr_60px] gap-3 px-4 py-2 text-xs items-start"
+                    >
+                      <div className="truncate text-foreground" title={p.name}>
+                        {p.name}
+                      </div>
+                      <div className="min-w-0">
+                        <TranscriptPreview turns={p.transcript} />
+                      </div>
+                      <div className="text-right tabular-nums text-muted-foreground">
+                        {p.transcript.length}
+                      </div>
+                    </div>
+                  ))}
+                  {parsedItems.length > 50 && (
+                    <div className="px-4 py-2 text-xs text-muted-foreground">
+                      + {parsedItems.length - 50} more rows
+                    </div>
+                  )}
+                </div>
+              </div>
+            </div>
+          )}
+
+          {uploadError && (
+            <div className="rounded-md border border-red-500/30 bg-red-500/10 p-3 text-sm text-red-500">
+              {uploadError}
+            </div>
+          )}
+        </div>
+
+        <div className="flex items-center justify-end gap-3 px-6 py-4 border-t border-border">
+          <button
+            onClick={handleClose}
+            disabled={isUploading}
+            className="h-10 px-4 rounded-md text-sm font-medium border border-border bg-background hover:bg-muted/50 transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={handleUpload}
+            disabled={parsedItems.length === 0 || isUploading || !!parseError}
+            className="h-10 px-4 rounded-md text-sm font-medium bg-foreground text-background hover:opacity-90 transition-opacity cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {isUploading
+              ? "Uploading…"
+              : parsedItems.length > 1
+                ? `Upload ${parsedItems.length} items`
+                : "Upload item"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/human-labelling/BulkUploadSttItemsDialog.tsx
+++ b/src/components/human-labelling/BulkUploadSttItemsDialog.tsx
@@ -1,0 +1,463 @@
+"use client";
+
+import React, { useEffect, useRef, useState } from "react";
+import Papa from "papaparse";
+import { useHideFloatingButton } from "@/components/AppLayout";
+import { apiClient } from "@/lib/api";
+
+const REFERENCE_HEADERS = [
+  "reference_transcript",
+  "reference",
+  "actual_transcript",
+  "actual",
+  "ground_truth",
+  "text",
+];
+const PREDICTED_HEADERS = [
+  "predicted_transcript",
+  "predicted",
+  "prediction",
+  "hypothesis",
+];
+
+const SAMPLE_STT_CSV = `reference_transcript,predicted_transcript
+"Hello, how are you today?","hello how are you today"
+"I would like to book a flight.","I'd like to book a flight"
+"Can you repeat that, please?","can you repeat that please"
+`;
+
+type ParsedItem = {
+  reference_transcript: string;
+  predicted_transcript: string;
+};
+
+type BulkUploadSttItemsDialogProps = {
+  isOpen: boolean;
+  accessToken: string;
+  taskUuid: string;
+  onClose: () => void;
+  onSuccess: (count: number) => void;
+};
+
+function parseApiError(err: unknown, fallback: string): string {
+  if (!(err instanceof Error)) return fallback;
+  const m = err.message.match(/Request failed: \d+ - (.+)$/);
+  if (m) {
+    try {
+      const parsed = JSON.parse(m[1]);
+      if (parsed && typeof parsed.detail === "string") return parsed.detail;
+    } catch {
+      // ignore
+    }
+    return m[1];
+  }
+  return err.message || fallback;
+}
+
+function findHeaderKey(headers: string[], candidates: string[]): string | null {
+  const norm = (s: string) => s.trim().toLowerCase().replace(/\s+/g, "_");
+  const normalized = headers.map(norm);
+  for (const cand of candidates) {
+    const idx = normalized.indexOf(cand);
+    if (idx >= 0) return headers[idx];
+  }
+  return null;
+}
+
+export function BulkUploadSttItemsDialog({
+  isOpen,
+  accessToken,
+  taskUuid,
+  onClose,
+  onSuccess,
+}: BulkUploadSttItemsDialogProps) {
+  useHideFloatingButton(isOpen);
+
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [csvFile, setCsvFile] = useState<File | null>(null);
+  const [parsedItems, setParsedItems] = useState<ParsedItem[]>([]);
+  const [parseError, setParseError] = useState<string | null>(null);
+  const [isUploading, setIsUploading] = useState(false);
+  const [uploadError, setUploadError] = useState<string | null>(null);
+  // Format help: open by default; auto-collapses once a CSV parses.
+  const [formatHelpOpen, setFormatHelpOpen] = useState(true);
+
+  const reset = () => {
+    setCsvFile(null);
+    setParsedItems([]);
+    setParseError(null);
+    setUploadError(null);
+    setFormatHelpOpen(true);
+    if (fileInputRef.current) fileInputRef.current.value = "";
+  };
+
+  useEffect(() => {
+    if (isOpen) reset();
+  }, [isOpen]);
+
+  useEffect(() => {
+    setFormatHelpOpen(parsedItems.length === 0);
+  }, [parsedItems.length]);
+
+  if (!isOpen) return null;
+
+  const downloadSampleCsv = () => {
+    const blob = new Blob([SAMPLE_STT_CSV], { type: "text/csv" });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement("a");
+    link.href = url;
+    link.download = "sample_stt_items.csv";
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
+  };
+
+  const handleFile = (file: File | null) => {
+    setUploadError(null);
+    setParseError(null);
+    setParsedItems([]);
+    setCsvFile(file);
+    if (!file) return;
+    Papa.parse<Record<string, string>>(file, {
+      header: true,
+      skipEmptyLines: true,
+      transformHeader: (h) => h.trim(),
+      complete: (results) => {
+        const headers = results.meta.fields ?? [];
+        const refKey = findHeaderKey(headers, REFERENCE_HEADERS);
+        const predKey = findHeaderKey(headers, PREDICTED_HEADERS);
+        if (!refKey || !predKey) {
+          setParseError(
+            `CSV must include "reference_transcript" and "predicted_transcript" columns. Found: ${headers.join(", ") || "(none)"}`,
+          );
+          return;
+        }
+        const items: ParsedItem[] = [];
+        for (const r of results.data) {
+          const reference_transcript = (r[refKey] ?? "").trim();
+          const predicted_transcript = (r[predKey] ?? "").trim();
+          if (!reference_transcript && !predicted_transcript) continue;
+          if (!reference_transcript || !predicted_transcript) {
+            setParseError(
+              "Every row must have both a reference and a predicted transcript.",
+            );
+            return;
+          }
+          items.push({ reference_transcript, predicted_transcript });
+        }
+        if (items.length === 0) {
+          setParseError("No rows with content were found in the CSV.");
+          return;
+        }
+        setParsedItems(items);
+      },
+      error: (err) => setParseError(err.message || "Failed to parse CSV"),
+    });
+  };
+
+  const handleDrop = (e: React.DragEvent) => {
+    e.preventDefault();
+    const f = e.dataTransfer.files?.[0];
+    if (f) handleFile(f);
+  };
+
+  const handleUpload = async () => {
+    if (parsedItems.length === 0 || isUploading) return;
+    setIsUploading(true);
+    setUploadError(null);
+    try {
+      await apiClient(`/annotation-tasks/${taskUuid}/items`, accessToken, {
+        method: "POST",
+        body: {
+          items: parsedItems.map((p) => ({ payload: p })),
+        },
+      });
+      onSuccess(parsedItems.length);
+    } catch (err) {
+      setUploadError(parseApiError(err, "Failed to upload items"));
+    } finally {
+      setIsUploading(false);
+    }
+  };
+
+  const handleClose = () => {
+    if (!isUploading) onClose();
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm p-4"
+      onClick={handleClose}
+    >
+      <div
+        className="bg-background border border-border rounded-xl shadow-2xl w-full max-w-2xl flex flex-col max-h-[90vh]"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-center justify-between px-6 py-4 border-b border-border">
+          <h2 className="text-lg font-semibold text-foreground">
+            Bulk upload items
+          </h2>
+          <button
+            onClick={handleClose}
+            disabled={isUploading}
+            aria-label="Close"
+            className="w-8 h-8 flex items-center justify-center rounded-lg text-muted-foreground hover:text-foreground hover:bg-muted transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            <svg
+              className="w-5 h-5"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              strokeWidth={2}
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M6 18L18 6M6 6l12 12"
+              />
+            </svg>
+          </button>
+        </div>
+
+        <div className="flex-1 overflow-y-auto px-6 py-5 space-y-5">
+          <div>
+            <div className="flex items-center justify-between mb-3">
+              <label className="block text-sm font-medium text-foreground">
+                Upload CSV
+              </label>
+              <button
+                type="button"
+                onClick={downloadSampleCsv}
+                className="h-9 px-3 rounded-md text-xs font-medium border border-border bg-muted/40 text-foreground hover:bg-muted hover:border-foreground/30 transition-colors cursor-pointer flex items-center gap-1.5 shadow-sm"
+              >
+                <svg
+                  className="w-4 h-4"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                  strokeWidth={2}
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5M16.5 12L12 16.5m0 0L7.5 12m4.5 4.5V3"
+                  />
+                </svg>
+                Download sample CSV
+              </button>
+            </div>
+
+            {parsedItems.length > 0 && (
+              <button
+                type="button"
+                onClick={() => setFormatHelpOpen((o) => !o)}
+                className="mb-3 inline-flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors cursor-pointer"
+                aria-expanded={formatHelpOpen}
+              >
+                <svg
+                  className={`w-3.5 h-3.5 transition-transform ${
+                    formatHelpOpen ? "rotate-90" : ""
+                  }`}
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                  strokeWidth={2.5}
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    d="M8.25 4.5l7.5 7.5-7.5 7.5"
+                  />
+                </svg>
+                {formatHelpOpen
+                  ? "Hide CSV format details"
+                  : "Show CSV format details"}
+              </button>
+            )}
+
+            {formatHelpOpen && (
+              <div className="text-xs text-muted-foreground mb-3 leading-relaxed space-y-2">
+                <p>Your CSV needs two columns per row:</p>
+                <ul className="list-disc pl-5 space-y-1.5">
+                  <li>
+                    <code className="font-mono text-foreground">
+                      reference_transcript
+                    </code>{" "}
+                    — what was actually said
+                  </li>
+                  <li>
+                    <code className="font-mono text-foreground">
+                      predicted_transcript
+                    </code>{" "}
+                    — what the system transcribed
+                  </li>
+                </ul>
+              </div>
+            )}
+
+            {/* Drop zone */}
+            <div
+              onDragOver={(e) => e.preventDefault()}
+              onDrop={handleDrop}
+              onClick={() => fileInputRef.current?.click()}
+              className={`border-2 border-dashed rounded-xl p-8 text-center transition-colors cursor-pointer ${
+                csvFile
+                  ? "border-foreground/30 bg-muted/30"
+                  : "border-border hover:border-muted-foreground"
+              }`}
+            >
+              <input
+                ref={fileInputRef}
+                type="file"
+                accept=".csv,text/csv"
+                onChange={(e) => handleFile(e.target.files?.[0] || null)}
+                className="hidden"
+              />
+              {csvFile ? (
+                <div className="flex items-center justify-center gap-2">
+                  <svg
+                    className="w-5 h-5 text-foreground"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                    strokeWidth={2}
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      d="M19.5 14.25v-2.625a3.375 3.375 0 00-3.375-3.375h-1.5A1.125 1.125 0 0113.5 7.125v-1.5a3.375 3.375 0 00-3.375-3.375H8.25m0 12.75h7.5m-7.5 3H12M10.5 2.25H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 00-9-9z"
+                    />
+                  </svg>
+                  <span className="text-sm font-medium text-foreground">
+                    {csvFile.name}
+                  </span>
+                  <button
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      reset();
+                    }}
+                    aria-label="Remove file"
+                    className="ml-1 text-muted-foreground hover:text-foreground"
+                  >
+                    <svg
+                      className="w-4 h-4"
+                      fill="none"
+                      viewBox="0 0 24 24"
+                      stroke="currentColor"
+                      strokeWidth={2}
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        d="M6 18L18 6M6 6l12 12"
+                      />
+                    </svg>
+                  </button>
+                </div>
+              ) : (
+                <>
+                  <svg
+                    className="w-8 h-8 text-muted-foreground mx-auto mb-2"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                    strokeWidth={1.5}
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5m-13.5-9L12 3m0 0l4.5 4.5M12 3v13.5"
+                    />
+                  </svg>
+                  <p className="text-sm text-foreground font-medium">
+                    Drop a CSV here or click to browse
+                  </p>
+                  <p className="text-xs text-muted-foreground mt-1">
+                    Up to a few thousand rows is fine
+                  </p>
+                </>
+              )}
+            </div>
+
+            {parseError && (
+              <p className="text-xs text-red-500 mt-3">{parseError}</p>
+            )}
+          </div>
+
+          {parsedItems.length > 0 && (
+            <div className="space-y-2">
+              <p className="text-sm font-medium text-foreground">
+                {parsedItems.length}{" "}
+                {parsedItems.length === 1 ? "item" : "items"} ready to upload
+              </p>
+              <div className="border border-border rounded-xl overflow-hidden">
+                <div className="grid grid-cols-2 gap-3 px-4 py-2 border-b border-border bg-muted/30">
+                  <div className="text-xs font-medium text-muted-foreground">
+                    Reference transcript
+                  </div>
+                  <div className="text-xs font-medium text-muted-foreground">
+                    Predicted transcript
+                  </div>
+                </div>
+                <div className="max-h-64 overflow-y-auto divide-y divide-border">
+                  {parsedItems.slice(0, 50).map((p, idx) => (
+                    <div
+                      key={idx}
+                      className="grid grid-cols-2 gap-3 px-4 py-2 text-xs"
+                    >
+                      <div
+                        className="truncate text-foreground"
+                        title={p.reference_transcript}
+                      >
+                        {p.reference_transcript}
+                      </div>
+                      <div
+                        className="truncate text-foreground"
+                        title={p.predicted_transcript}
+                      >
+                        {p.predicted_transcript}
+                      </div>
+                    </div>
+                  ))}
+                  {parsedItems.length > 50 && (
+                    <div className="px-4 py-2 text-xs text-muted-foreground">
+                      + {parsedItems.length - 50} more rows
+                    </div>
+                  )}
+                </div>
+              </div>
+            </div>
+          )}
+
+          {uploadError && (
+            <div className="rounded-md border border-red-500/30 bg-red-500/10 p-3 text-sm text-red-500">
+              {uploadError}
+            </div>
+          )}
+        </div>
+
+        <div className="flex items-center justify-end gap-3 px-6 py-4 border-t border-border">
+          <button
+            onClick={handleClose}
+            disabled={isUploading}
+            className="h-10 px-4 rounded-md text-sm font-medium border border-border bg-background hover:bg-muted/50 transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={handleUpload}
+            disabled={parsedItems.length === 0 || isUploading || !!parseError}
+            className="h-10 px-4 rounded-md text-sm font-medium bg-foreground text-background hover:opacity-90 transition-opacity cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {isUploading
+              ? "Uploading…"
+              : parsedItems.length > 1
+                ? `Upload ${parsedItems.length} items`
+                : "Upload item"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/human-labelling/BulkUploadSttItemsDialog.tsx
+++ b/src/components/human-labelling/BulkUploadSttItemsDialog.tsx
@@ -1,9 +1,15 @@
 "use client";
 
-import React, { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 import Papa from "papaparse";
 import { useHideFloatingButton } from "@/components/AppLayout";
 import { apiClient } from "@/lib/api";
+import {
+  CsvDropzone,
+  FormatHelpToggle,
+  findHeaderKey,
+  parseApiError,
+} from "./bulk-upload-shared";
 
 const REFERENCE_HEADERS = [
   "reference_transcript",
@@ -39,31 +45,6 @@ type BulkUploadSttItemsDialogProps = {
   onSuccess: (count: number) => void;
 };
 
-function parseApiError(err: unknown, fallback: string): string {
-  if (!(err instanceof Error)) return fallback;
-  const m = err.message.match(/Request failed: \d+ - (.+)$/);
-  if (m) {
-    try {
-      const parsed = JSON.parse(m[1]);
-      if (parsed && typeof parsed.detail === "string") return parsed.detail;
-    } catch {
-      // ignore
-    }
-    return m[1];
-  }
-  return err.message || fallback;
-}
-
-function findHeaderKey(headers: string[], candidates: string[]): string | null {
-  const norm = (s: string) => s.trim().toLowerCase().replace(/\s+/g, "_");
-  const normalized = headers.map(norm);
-  for (const cand of candidates) {
-    const idx = normalized.indexOf(cand);
-    if (idx >= 0) return headers[idx];
-  }
-  return null;
-}
-
 export function BulkUploadSttItemsDialog({
   isOpen,
   accessToken,
@@ -73,7 +54,6 @@ export function BulkUploadSttItemsDialog({
 }: BulkUploadSttItemsDialogProps) {
   useHideFloatingButton(isOpen);
 
-  const fileInputRef = useRef<HTMLInputElement>(null);
   const [csvFile, setCsvFile] = useState<File | null>(null);
   const [parsedItems, setParsedItems] = useState<ParsedItem[]>([]);
   const [parseError, setParseError] = useState<string | null>(null);
@@ -88,7 +68,6 @@ export function BulkUploadSttItemsDialog({
     setParseError(null);
     setUploadError(null);
     setFormatHelpOpen(true);
-    if (fileInputRef.current) fileInputRef.current.value = "";
   };
 
   useEffect(() => {
@@ -154,12 +133,6 @@ export function BulkUploadSttItemsDialog({
       },
       error: (err) => setParseError(err.message || "Failed to parse CSV"),
     });
-  };
-
-  const handleDrop = (e: React.DragEvent) => {
-    e.preventDefault();
-    const f = e.dataTransfer.files?.[0];
-    if (f) handleFile(f);
   };
 
   const handleUpload = async () => {
@@ -249,31 +222,10 @@ export function BulkUploadSttItemsDialog({
             </div>
 
             {parsedItems.length > 0 && (
-              <button
-                type="button"
-                onClick={() => setFormatHelpOpen((o) => !o)}
-                className="mb-3 inline-flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors cursor-pointer"
-                aria-expanded={formatHelpOpen}
-              >
-                <svg
-                  className={`w-3.5 h-3.5 transition-transform ${
-                    formatHelpOpen ? "rotate-90" : ""
-                  }`}
-                  fill="none"
-                  viewBox="0 0 24 24"
-                  stroke="currentColor"
-                  strokeWidth={2.5}
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    d="M8.25 4.5l7.5 7.5-7.5 7.5"
-                  />
-                </svg>
-                {formatHelpOpen
-                  ? "Hide CSV format details"
-                  : "Show CSV format details"}
-              </button>
+              <FormatHelpToggle
+                open={formatHelpOpen}
+                onToggle={() => setFormatHelpOpen((o) => !o)}
+              />
             )}
 
             {formatHelpOpen && (
@@ -296,89 +248,11 @@ export function BulkUploadSttItemsDialog({
               </div>
             )}
 
-            {/* Drop zone */}
-            <div
-              onDragOver={(e) => e.preventDefault()}
-              onDrop={handleDrop}
-              onClick={() => fileInputRef.current?.click()}
-              className={`border-2 border-dashed rounded-xl p-8 text-center transition-colors cursor-pointer ${
-                csvFile
-                  ? "border-foreground/30 bg-muted/30"
-                  : "border-border hover:border-muted-foreground"
-              }`}
-            >
-              <input
-                ref={fileInputRef}
-                type="file"
-                accept=".csv,text/csv"
-                onChange={(e) => handleFile(e.target.files?.[0] || null)}
-                className="hidden"
-              />
-              {csvFile ? (
-                <div className="flex items-center justify-center gap-2">
-                  <svg
-                    className="w-5 h-5 text-foreground"
-                    fill="none"
-                    viewBox="0 0 24 24"
-                    stroke="currentColor"
-                    strokeWidth={2}
-                  >
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      d="M19.5 14.25v-2.625a3.375 3.375 0 00-3.375-3.375h-1.5A1.125 1.125 0 0113.5 7.125v-1.5a3.375 3.375 0 00-3.375-3.375H8.25m0 12.75h7.5m-7.5 3H12M10.5 2.25H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 00-9-9z"
-                    />
-                  </svg>
-                  <span className="text-sm font-medium text-foreground">
-                    {csvFile.name}
-                  </span>
-                  <button
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      reset();
-                    }}
-                    aria-label="Remove file"
-                    className="ml-1 text-muted-foreground hover:text-foreground"
-                  >
-                    <svg
-                      className="w-4 h-4"
-                      fill="none"
-                      viewBox="0 0 24 24"
-                      stroke="currentColor"
-                      strokeWidth={2}
-                    >
-                      <path
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        d="M6 18L18 6M6 6l12 12"
-                      />
-                    </svg>
-                  </button>
-                </div>
-              ) : (
-                <>
-                  <svg
-                    className="w-8 h-8 text-muted-foreground mx-auto mb-2"
-                    fill="none"
-                    viewBox="0 0 24 24"
-                    stroke="currentColor"
-                    strokeWidth={1.5}
-                  >
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5m-13.5-9L12 3m0 0l4.5 4.5M12 3v13.5"
-                    />
-                  </svg>
-                  <p className="text-sm text-foreground font-medium">
-                    Drop a CSV here or click to browse
-                  </p>
-                  <p className="text-xs text-muted-foreground mt-1">
-                    Up to a few thousand rows is fine
-                  </p>
-                </>
-              )}
-            </div>
+            <CsvDropzone
+              csvFile={csvFile}
+              onFile={handleFile}
+              onClear={reset}
+            />
 
             {parseError && (
               <p className="text-xs text-red-500 mt-3">{parseError}</p>

--- a/src/components/human-labelling/CreateLabellingTaskDialog.tsx
+++ b/src/components/human-labelling/CreateLabellingTaskDialog.tsx
@@ -1,0 +1,429 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { useHideFloatingButton } from "@/components/AppLayout";
+import {
+  EVALUATOR_TYPE_LABELS,
+  type EvaluatorType,
+} from "@/components/EvaluatorPills";
+import { apiClient } from "@/lib/api";
+
+// Only these three task types are allowed for labelling tasks
+type TaskType = Extract<EvaluatorType, "llm" | "stt" | "simulation">;
+
+const TASK_TYPE_OPTIONS: {
+  value: TaskType;
+  title: string;
+  description: string;
+}[] = [
+  {
+    value: "llm",
+    title: "LLM response",
+    description:
+      "Given a conversation history, evaluate the agent's next response.",
+  },
+  {
+    value: "stt",
+    title: "Speech to Text",
+    description: "Evaluate the transcription quality against a reference text.",
+  },
+  {
+    value: "simulation",
+    title: "Simulation",
+    description:
+      "Evaluate the agent's performance in an entire conversation history.",
+  },
+];
+
+type EvaluatorListItem = {
+  uuid: string;
+  name: string;
+  description?: string;
+  evaluator_type?: EvaluatorType;
+  owner_user_id?: string | null;
+};
+
+function parseApiError(err: unknown, fallback: string): string {
+  if (!(err instanceof Error)) return fallback;
+  const match = err.message.match(/Request failed: \d+ - (.+)$/);
+  if (match) {
+    try {
+      const parsed = JSON.parse(match[1]);
+      if (parsed && typeof parsed.detail === "string") return parsed.detail;
+    } catch {
+      // not JSON
+    }
+    return match[1];
+  }
+  return err.message || fallback;
+}
+
+type CreateLabellingTaskDialogProps = {
+  accessToken: string;
+  onClose: () => void;
+  onCreated: (taskUuid: string) => void;
+};
+
+export function CreateLabellingTaskDialog({
+  accessToken,
+  onClose,
+  onCreated,
+}: CreateLabellingTaskDialogProps) {
+  useHideFloatingButton(true);
+
+  const [name, setName] = useState("");
+  const [description, setDescription] = useState("");
+  const [taskType, setTaskType] = useState<TaskType | null>(null);
+  const [selectedEvaluatorIds, setSelectedEvaluatorIds] = useState<Set<string>>(
+    new Set(),
+  );
+  const [evaluatorSearch, setEvaluatorSearch] = useState("");
+
+  const [evaluators, setEvaluators] = useState<EvaluatorListItem[]>([]);
+  const [evaluatorsLoading, setEvaluatorsLoading] = useState(false);
+  const [evaluatorsError, setEvaluatorsError] = useState<string | null>(null);
+
+  const [submitting, setSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+
+  // Fetch evaluator list once on mount; filter client-side by selected type.
+  useEffect(() => {
+    let cancelled = false;
+    const run = async () => {
+      setEvaluatorsLoading(true);
+      setEvaluatorsError(null);
+      try {
+        const data = await apiClient<EvaluatorListItem[]>(
+          "/evaluators?include_defaults=true",
+          accessToken,
+        );
+        if (!cancelled) setEvaluators(Array.isArray(data) ? data : []);
+      } catch (err) {
+        if (!cancelled)
+          setEvaluatorsError(parseApiError(err, "Failed to load evaluators"));
+      } finally {
+        if (!cancelled) setEvaluatorsLoading(false);
+      }
+    };
+    run();
+    return () => {
+      cancelled = true;
+    };
+  }, [accessToken]);
+
+  // When the type changes, drop selections that don't belong to the new type.
+  useEffect(() => {
+    if (!taskType) return;
+    setSelectedEvaluatorIds((prev) => {
+      const next = new Set<string>();
+      for (const ev of evaluators) {
+        if (ev.evaluator_type === taskType && prev.has(ev.uuid)) {
+          next.add(ev.uuid);
+        }
+      }
+      return next;
+    });
+  }, [taskType, evaluators]);
+
+  const filteredEvaluators = useMemo(() => {
+    if (!taskType) return [];
+    const q = evaluatorSearch.trim().toLowerCase();
+    return evaluators
+      .filter((ev) => ev.evaluator_type === taskType)
+      .filter((ev) => (q ? ev.name.toLowerCase().includes(q) : true));
+  }, [evaluators, taskType, evaluatorSearch]);
+
+  const toggleEvaluator = (uuid: string) => {
+    setSelectedEvaluatorIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(uuid)) next.delete(uuid);
+      else next.add(uuid);
+      return next;
+    });
+  };
+
+  const canSubmit =
+    !!name.trim() &&
+    !!taskType &&
+    !submitting &&
+    selectedEvaluatorIds.size >= 1;
+
+  const handleSubmit = async () => {
+    if (!canSubmit || !taskType) return;
+    setSubmitting(true);
+    setSubmitError(null);
+    try {
+      const body: {
+        name: string;
+        type: TaskType;
+        description?: string;
+        evaluator_ids?: string[];
+      } = { name: name.trim(), type: taskType };
+      if (description.trim()) body.description = description.trim();
+      if (selectedEvaluatorIds.size > 0)
+        body.evaluator_ids = Array.from(selectedEvaluatorIds);
+      const res = await apiClient<{ uuid: string; message: string }>(
+        "/annotation-tasks",
+        accessToken,
+        { method: "POST", body },
+      );
+      onCreated(res.uuid);
+    } catch (err) {
+      setSubmitError(parseApiError(err, "Failed to create task"));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm p-4"
+      onClick={() => {
+        if (!submitting) onClose();
+      }}
+    >
+      <div
+        className="bg-background border border-border rounded-xl w-full max-w-2xl shadow-2xl flex flex-col max-h-[90vh]"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-start justify-between gap-3 px-5 md:px-6 py-4 border-b border-border">
+          <div>
+            <h2 className="text-base md:text-lg font-semibold text-foreground">
+              Create labelling task
+            </h2>
+          </div>
+          <button
+            onClick={onClose}
+            disabled={submitting}
+            className="flex items-center justify-center w-8 h-8 rounded-md hover:bg-muted transition-colors cursor-pointer flex-shrink-0 disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            <svg
+              className="w-5 h-5"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              strokeWidth={2}
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M6 18L18 6M6 6l12 12"
+              />
+            </svg>
+          </button>
+        </div>
+
+        <div className="flex-1 overflow-y-auto p-4 md:p-6 space-y-5">
+          {/* Name */}
+          <div>
+            <label className="block text-sm font-medium mb-2">
+              Name <span className="text-red-500">*</span>
+            </label>
+            <input
+              autoFocus
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="e.g., Helpfulness review — Q2 batch"
+              className="w-full h-10 px-3 rounded-md text-sm border border-border bg-background text-foreground focus:outline-none focus:ring-2 focus:ring-accent"
+            />
+          </div>
+
+          {/* Description */}
+          <div>
+            <label className="block text-sm font-medium mb-2">
+              Description
+            </label>
+            <textarea
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              placeholder="Short description of the labelling task"
+              rows={3}
+              className="w-full px-3 py-2 rounded-md text-sm border border-border bg-background text-foreground focus:outline-none focus:ring-2 focus:ring-accent resize-y"
+            />
+          </div>
+
+          {/* Type picker */}
+          <div>
+            <label className="block text-sm font-medium mb-1">
+              Type <span className="text-red-500">*</span>
+            </label>
+            <p className="text-xs text-muted-foreground mb-2">
+              Type can&apos;t be changed after the task is created.
+            </p>
+            <div className="mb-2 flex items-start gap-2.5 p-3 rounded-lg bg-yellow-500/10 border border-yellow-500/20">
+              <svg
+                className="w-4 h-4 flex-shrink-0 mt-0.5 text-yellow-500"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+                strokeWidth={2}
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126zM12 15.75h.007v.008H12v-.008z"
+                />
+              </svg>
+              <span className="text-xs md:text-sm text-foreground">
+                Human labelling for{" "}
+                <span className="font-semibold">Text-to-Speech (TTS)</span>{" "}
+                evaluators is not supported yet
+              </span>
+            </div>
+            <div className="grid grid-cols-1 sm:grid-cols-3 gap-2">
+              {TASK_TYPE_OPTIONS.map((opt) => {
+                const active = taskType === opt.value;
+                return (
+                  <button
+                    key={opt.value}
+                    type="button"
+                    onClick={() => setTaskType(opt.value)}
+                    className={`flex flex-col items-start text-left p-3 rounded-md border transition-colors cursor-pointer ${
+                      active
+                        ? "border-foreground bg-muted/40 dark:bg-accent"
+                        : "border-border bg-background dark:bg-muted hover:bg-muted/40 dark:hover:bg-accent"
+                    }`}
+                  >
+                    <div className="text-sm font-medium text-foreground">
+                      {opt.title}
+                    </div>
+                    <div className="text-xs text-muted-foreground mt-1 leading-relaxed">
+                      {opt.description}
+                    </div>
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+
+          {/* Evaluator picker — only shown once a type is chosen */}
+          {taskType && (
+            <div>
+              <label className="block text-sm font-medium mb-2">
+                Evaluators <span className="text-red-500">*</span>
+                <span className="ml-2 text-xs font-normal text-muted-foreground">
+                  ({selectedEvaluatorIds.size} selected)
+                </span>
+              </label>
+              <p className="text-xs text-muted-foreground mb-2">
+                Pick at least one evaluator that annotators will grade against.
+              </p>
+
+              <div className="relative mb-2">
+                <div className="absolute inset-y-0 left-0 flex items-center pl-3 pointer-events-none">
+                  <svg
+                    className="w-4 h-4 text-muted-foreground"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                    strokeWidth={2}
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      d="M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 5.196a7.5 7.5 0 0010.607 10.607z"
+                    />
+                  </svg>
+                </div>
+                <input
+                  type="text"
+                  value={evaluatorSearch}
+                  onChange={(e) => setEvaluatorSearch(e.target.value)}
+                  placeholder={`Search evaluators`}
+                  className="w-full h-9 pl-9 pr-3 rounded-md text-sm border border-border bg-background text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-accent"
+                />
+              </div>
+
+              <div className="border border-border rounded-md max-h-60 overflow-y-auto divide-y divide-border">
+                {evaluatorsLoading ? (
+                  <div className="p-4 flex items-center gap-2 text-sm text-muted-foreground">
+                    <svg
+                      className="w-4 h-4 animate-spin"
+                      fill="none"
+                      viewBox="0 0 24 24"
+                    >
+                      <circle
+                        className="opacity-25"
+                        cx="12"
+                        cy="12"
+                        r="10"
+                        stroke="currentColor"
+                        strokeWidth="4"
+                      />
+                      <path
+                        className="opacity-75"
+                        fill="currentColor"
+                        d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+                      />
+                    </svg>
+                    Loading evaluators
+                  </div>
+                ) : evaluatorsError ? (
+                  <div className="p-4 text-sm text-red-500">
+                    {evaluatorsError}
+                  </div>
+                ) : filteredEvaluators.length === 0 ? (
+                  <div className="p-4 text-sm text-muted-foreground">
+                    {evaluatorSearch.trim()
+                      ? "No matching evaluators."
+                      : `No ${EVALUATOR_TYPE_LABELS[taskType]} evaluators yet.`}
+                  </div>
+                ) : (
+                  filteredEvaluators.map((ev) => {
+                    const checked = selectedEvaluatorIds.has(ev.uuid);
+                    return (
+                      <label
+                        key={ev.uuid}
+                        className="flex items-start gap-3 px-3 py-2.5 hover:bg-muted/30 transition-colors cursor-pointer"
+                      >
+                        <input
+                          type="checkbox"
+                          checked={checked}
+                          onChange={() => toggleEvaluator(ev.uuid)}
+                          className="mt-0.5 w-4 h-4 cursor-pointer accent-foreground"
+                        />
+                        <div className="min-w-0 flex-1">
+                          <div className="text-sm font-medium truncate">
+                            {ev.name}
+                          </div>
+                          {ev.description && (
+                            <div className="text-xs text-muted-foreground line-clamp-2 mt-0.5">
+                              {ev.description}
+                            </div>
+                          )}
+                        </div>
+                      </label>
+                    );
+                  })
+                )}
+              </div>
+            </div>
+          )}
+
+          {submitError && (
+            <div className="rounded-md border border-red-500/30 bg-red-500/10 p-3 text-sm text-red-500">
+              {submitError}
+            </div>
+          )}
+        </div>
+
+        <div className="flex items-center justify-end gap-2 md:gap-3 px-5 md:px-6 py-4 border-t border-border">
+          <button
+            onClick={onClose}
+            disabled={submitting}
+            className="h-9 md:h-10 px-4 rounded-md text-sm md:text-base font-medium border border-border bg-background dark:bg-muted hover:bg-muted/50 dark:hover:bg-accent transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={handleSubmit}
+            disabled={!canSubmit}
+            className="h-9 md:h-10 px-4 rounded-md text-sm md:text-base font-medium bg-foreground text-background hover:opacity-90 transition-opacity cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {submitting ? "Creating..." : "Create task"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/human-labelling/CreateLabellingTaskDialog.tsx
+++ b/src/components/human-labelling/CreateLabellingTaskDialog.tsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo, useState } from "react";
 import { useHideFloatingButton } from "@/components/AppLayout";
 import {
   EVALUATOR_TYPE_LABELS,
+  EvaluatorTypePill,
   type EvaluatorType,
 } from "@/components/EvaluatorPills";
 import { apiClient } from "@/lib/api";
@@ -34,6 +35,30 @@ const TASK_TYPE_OPTIONS: {
       "Evaluate the agent's performance in an entire conversation history.",
   },
 ];
+
+// Per-type tints, mirroring EvaluatorTypePill's palette
+// (llm=orange, stt=blue, simulation=pink) so the picker reads as the
+// same "type" affordance the user sees on evaluator cards. We use a
+// subtle tint by default (so the cards announce their type at rest)
+// and a stronger tint + bordered ring when active.
+const TASK_TYPE_INACTIVE_CLASSES: Record<TaskType, string> = {
+  llm: "border-orange-500/20 bg-orange-500/[0.04] hover:bg-orange-500/10 hover:border-orange-500/40",
+  stt: "border-blue-500/20 bg-blue-500/[0.04] hover:bg-blue-500/10 hover:border-blue-500/40",
+  simulation:
+    "border-pink-500/20 bg-pink-500/[0.04] hover:bg-pink-500/10 hover:border-pink-500/40",
+};
+
+const TASK_TYPE_ACTIVE_CLASSES: Record<TaskType, string> = {
+  llm: "border-orange-500/60 bg-orange-500/15 ring-1 ring-orange-500/40",
+  stt: "border-blue-500/60 bg-blue-500/15 ring-1 ring-blue-500/40",
+  simulation: "border-pink-500/60 bg-pink-500/15 ring-1 ring-pink-500/40",
+};
+
+const TASK_TYPE_TITLE_CLASSES: Record<TaskType, string> = {
+  llm: "text-orange-700 dark:text-orange-300",
+  stt: "text-blue-700 dark:text-blue-300",
+  simulation: "text-pink-700 dark:text-pink-300",
+};
 
 type EvaluatorListItem = {
   uuid: string;
@@ -183,7 +208,9 @@ export function CreateLabellingTaskDialog({
       }}
     >
       <div
-        className="bg-background border border-border rounded-xl w-full max-w-2xl shadow-2xl flex flex-col max-h-[90vh]"
+        className={`bg-background border border-border rounded-xl w-full ${
+          taskType ? "max-w-6xl" : "max-w-2xl"
+        } shadow-2xl flex flex-col max-h-[90vh] transition-all`}
         onClick={(e) => e.stopPropagation()}
       >
         <div className="flex items-start justify-between gap-3 px-5 md:px-6 py-4 border-b border-border">
@@ -213,7 +240,18 @@ export function CreateLabellingTaskDialog({
           </button>
         </div>
 
-        <div className="flex-1 overflow-y-auto p-4 md:p-6 space-y-5">
+        <div className="flex-1 overflow-y-auto p-4 md:p-6">
+          {/* When a type is selected we make the left column the
+              flow-sized parent and float the right column absolutely
+              over its remainder. That way the right column's bottom
+              aligns with the bottom of the type-picker cards (left
+              column's last child) — never extending past it. */}
+          <div className={taskType ? "md:relative" : ""}>
+          <div
+            className={`min-w-0 space-y-5 ${
+              taskType ? "md:max-w-[42rem]" : ""
+            }`}
+          >
           {/* Name */}
           <div>
             <label className="block text-sm font-medium mb-2">
@@ -264,9 +302,9 @@ export function CreateLabellingTaskDialog({
                   d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126zM12 15.75h.007v.008H12v-.008z"
                 />
               </svg>
-              <span className="text-xs md:text-sm text-foreground">
-                Human labelling for{" "}
-                <span className="font-semibold">Text-to-Speech (TTS)</span>{" "}
+              <span className="text-xs md:text-sm text-foreground inline-flex items-center gap-1.5 flex-wrap">
+                Human labelling for
+                <EvaluatorTypePill evaluatorType="tts" />
                 evaluators is not supported yet
               </span>
             </div>
@@ -280,11 +318,13 @@ export function CreateLabellingTaskDialog({
                     onClick={() => setTaskType(opt.value)}
                     className={`flex flex-col items-start text-left p-3 rounded-md border transition-colors cursor-pointer ${
                       active
-                        ? "border-foreground bg-muted/40 dark:bg-accent"
-                        : "border-border bg-background dark:bg-muted hover:bg-muted/40 dark:hover:bg-accent"
+                        ? TASK_TYPE_ACTIVE_CLASSES[opt.value]
+                        : TASK_TYPE_INACTIVE_CLASSES[opt.value]
                     }`}
                   >
-                    <div className="text-sm font-medium text-foreground">
+                    <div
+                      className={`text-sm font-medium ${TASK_TYPE_TITLE_CLASSES[opt.value]}`}
+                    >
                       {opt.title}
                     </div>
                     <div className="text-xs text-muted-foreground mt-1 leading-relaxed">
@@ -295,10 +335,18 @@ export function CreateLabellingTaskDialog({
               })}
             </div>
           </div>
+          </div>
 
-          {/* Evaluator picker — only shown once a type is chosen */}
+          {/* Evaluator picker — only shown once a type is chosen.
+              On md+ this is positioned absolutely so its top/bottom
+              align with the left column's content (bottom = bottom of
+              the type-picker cards). On mobile it falls back to the
+              normal flow underneath. The list inside flexes to fill
+              the remaining vertical space. */}
           {taskType && (
-            <div>
+            <div
+              className="mt-5 md:mt-0 md:absolute md:top-0 md:bottom-0 md:left-[calc(42rem+1.5rem)] md:right-0 flex flex-col md:overflow-hidden"
+            >
               <label className="block text-sm font-medium mb-2">
                 Evaluators <span className="text-red-500">*</span>
                 <span className="ml-2 text-xs font-normal text-muted-foreground">
@@ -334,7 +382,7 @@ export function CreateLabellingTaskDialog({
                 />
               </div>
 
-              <div className="border border-border rounded-md max-h-60 overflow-y-auto divide-y divide-border">
+              <div className="border border-border rounded-md min-h-0 overflow-y-auto divide-y divide-border">
                 {evaluatorsLoading ? (
                   <div className="p-4 flex items-center gap-2 text-sm text-muted-foreground">
                     <svg
@@ -399,9 +447,12 @@ export function CreateLabellingTaskDialog({
               </div>
             </div>
           )}
+          </div>
 
           {submitError && (
-            <div className="rounded-md border border-red-500/30 bg-red-500/10 p-3 text-sm text-red-500">
+            <div
+              className={`mt-5 rounded-md border border-red-500/30 bg-red-500/10 p-3 text-sm text-red-500`}
+            >
               {submitError}
             </div>
           )}

--- a/src/components/human-labelling/EditTaskDialog.tsx
+++ b/src/components/human-labelling/EditTaskDialog.tsx
@@ -1,0 +1,212 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useHideFloatingButton } from "@/components/AppLayout";
+import { apiClient } from "@/lib/api";
+
+function parseApiError(err: unknown, fallback: string): string {
+  if (!(err instanceof Error)) return fallback;
+  const match = err.message.match(/Request failed: \d+ - (.+)$/);
+  if (match) {
+    try {
+      const parsed = JSON.parse(match[1]);
+      if (parsed && typeof parsed.detail === "string") return parsed.detail;
+    } catch {
+      // not JSON
+    }
+    return match[1];
+  }
+  return err.message || fallback;
+}
+
+type EditTaskDialogProps = {
+  isOpen: boolean;
+  accessToken: string;
+  taskUuid: string;
+  initialName: string;
+  initialDescription: string;
+  onClose: () => void;
+  onSaved: () => void;
+};
+
+export function EditTaskDialog({
+  isOpen,
+  accessToken,
+  taskUuid,
+  initialName,
+  initialDescription,
+  onClose,
+  onSaved,
+}: EditTaskDialogProps) {
+  useHideFloatingButton(isOpen);
+
+  const [name, setName] = useState(initialName);
+  const [description, setDescription] = useState(initialDescription);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [nameError, setNameError] = useState<string | null>(null);
+
+  // Reset fields whenever the dialog opens for a (potentially) different task.
+  useEffect(() => {
+    if (isOpen) {
+      setName(initialName);
+      setDescription(initialDescription);
+      setError(null);
+      setNameError(null);
+    }
+  }, [isOpen, initialName, initialDescription]);
+
+  if (!isOpen) return null;
+
+  const handleSave = async () => {
+    if (!name.trim()) {
+      setError("Name is required");
+      return;
+    }
+    setSaving(true);
+    setError(null);
+    setNameError(null);
+    try {
+      await apiClient(`/annotation-tasks/${taskUuid}`, accessToken, {
+        method: "PUT",
+        body: {
+          name: name.trim(),
+          description: description.trim(),
+        },
+      });
+      onSaved();
+    } catch (err) {
+      const msg = parseApiError(err, "Failed to save task");
+      // Mirror the evaluator-edit pattern: show name conflicts inline.
+      if (msg.toLowerCase().includes("already exists")) {
+        setNameError(msg);
+      } else {
+        setError(msg);
+      }
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm p-4"
+      onClick={() => {
+        if (!saving) onClose();
+      }}
+    >
+      <div
+        className="bg-background border border-border rounded-xl w-full max-w-md shadow-2xl flex flex-col max-h-[90vh]"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-center justify-between px-5 md:px-6 py-4 border-b border-border">
+          <h2 className="text-base md:text-lg font-semibold text-foreground">
+            Edit task
+          </h2>
+          <button
+            onClick={() => {
+              if (!saving) onClose();
+            }}
+            disabled={saving}
+            className="flex items-center justify-center w-8 h-8 rounded-md hover:bg-muted transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            <svg
+              className="w-5 h-5"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              strokeWidth={2}
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M6 18L18 6M6 6l12 12"
+              />
+            </svg>
+          </button>
+        </div>
+
+        <div className="flex-1 overflow-y-auto px-5 md:px-6 py-4 md:py-5 space-y-4">
+          <div>
+            <label className="block text-xs md:text-sm font-medium mb-2">
+              Name <span className="text-red-500">*</span>
+            </label>
+            <input
+              type="text"
+              value={name}
+              onChange={(e) => {
+                setName(e.target.value);
+                setNameError(null);
+                if (error) setError(null);
+              }}
+              placeholder="Task name"
+              className={`w-full h-9 md:h-10 px-3 md:px-4 rounded-md text-sm md:text-base border bg-background text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-accent focus:border-transparent ${
+                (!name.trim() && error) || nameError
+                  ? "border-red-500"
+                  : "border-border"
+              }`}
+            />
+            {nameError && (
+              <p className="text-xs md:text-sm text-red-500 mt-1">
+                {nameError}
+              </p>
+            )}
+          </div>
+          <div>
+            <label className="block text-xs md:text-sm font-medium mb-2">
+              Description
+            </label>
+            <textarea
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              placeholder="Short description of the labelling task"
+              rows={3}
+              className="w-full px-3 md:px-4 py-2 rounded-md text-sm md:text-base border border-border bg-background text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-accent focus:border-transparent resize-none"
+            />
+          </div>
+          {error && <p className="text-sm text-red-500">{error}</p>}
+        </div>
+
+        <div className="flex items-center justify-end gap-2 md:gap-3 px-5 md:px-6 py-4 border-t border-border">
+          <button
+            onClick={() => {
+              if (!saving) onClose();
+            }}
+            disabled={saving}
+            className="h-9 md:h-10 px-4 rounded-md text-sm md:text-base font-medium border border-border bg-background hover:bg-muted/50 transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={handleSave}
+            disabled={saving}
+            className="h-9 md:h-10 px-4 rounded-md text-sm md:text-base font-medium bg-foreground text-background hover:opacity-90 transition-opacity cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2"
+          >
+            {saving && (
+              <svg
+                className="w-4 h-4 animate-spin"
+                fill="none"
+                viewBox="0 0 24 24"
+              >
+                <circle
+                  className="opacity-25"
+                  cx="12"
+                  cy="12"
+                  r="10"
+                  stroke="currentColor"
+                  strokeWidth="4"
+                ></circle>
+                <path
+                  className="opacity-75"
+                  fill="currentColor"
+                  d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+                ></path>
+              </svg>
+            )}
+            Save
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/human-labelling/ItemResultsDialog.tsx
+++ b/src/components/human-labelling/ItemResultsDialog.tsx
@@ -1,0 +1,127 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useHideFloatingButton } from "@/components/AppLayout";
+
+export type ItemResultsEvaluator = {
+  uuid: string;
+  name: string;
+};
+
+type ItemResultsDialogProps = {
+  isOpen: boolean;
+  onClose: () => void;
+  itemName: string;
+  evaluators: ItemResultsEvaluator[];
+};
+
+export function ItemResultsDialog({
+  isOpen,
+  onClose,
+  itemName,
+  evaluators,
+}: ItemResultsDialogProps) {
+  useHideFloatingButton(isOpen);
+
+  const [activeUuid, setActiveUuid] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    setActiveUuid(evaluators[0]?.uuid ?? null);
+  }, [isOpen, evaluators]);
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm p-0 md:p-4">
+      <div className="bg-background rounded-none md:rounded-xl w-full max-w-[92rem] h-full md:h-[92vh] flex flex-col shadow-2xl border border-border">
+        {/* Header */}
+        <div className="flex items-center justify-between px-4 md:px-6 py-3 md:py-4 border-b border-border">
+          <div className="min-w-0">
+            <h2 className="text-base md:text-lg font-semibold truncate">
+              Results
+            </h2>
+            <p className="text-xs text-muted-foreground truncate">{itemName}</p>
+          </div>
+          <button
+            onClick={onClose}
+            aria-label="Close"
+            className="w-8 h-8 flex items-center justify-center rounded-md hover:bg-muted transition-colors cursor-pointer"
+          >
+            <svg
+              className="w-5 h-5"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              strokeWidth={2}
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M6 18L18 6M6 6l12 12"
+              />
+            </svg>
+          </button>
+        </div>
+
+        {/* Tabs */}
+        {evaluators.length > 0 ? (
+          <>
+            <div className="px-4 md:px-6 border-b border-border overflow-x-auto">
+              <div className="flex items-center gap-1 min-w-max">
+                {evaluators.map((ev) => (
+                  <button
+                    key={ev.uuid}
+                    onClick={() => setActiveUuid(ev.uuid)}
+                    className={`px-3 py-2 text-sm font-medium -mb-px border-b-2 transition-colors cursor-pointer whitespace-nowrap ${
+                      activeUuid === ev.uuid
+                        ? "border-foreground text-foreground"
+                        : "border-transparent text-muted-foreground hover:text-foreground"
+                    }`}
+                  >
+                    {ev.name}
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            {/* Active tab body — placeholder for now */}
+            <div className="flex-1 overflow-y-auto p-6 md:p-8">
+              <div className="max-w-2xl mx-auto text-center space-y-3 py-12">
+                <div className="inline-flex items-center justify-center w-12 h-12 rounded-full bg-muted/50">
+                  <svg
+                    className="w-6 h-6 text-muted-foreground"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                    strokeWidth={1.5}
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      d="M3 13.125C3 12.504 3.504 12 4.125 12h2.25c.621 0 1.125.504 1.125 1.125v6.75C7.5 20.496 6.996 21 6.375 21h-2.25A1.125 1.125 0 013 19.875v-6.75zM9.75 8.625c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125v11.25c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 01-1.125-1.125V8.625zM16.5 4.125c0-.621.504-1.125 1.125-1.125h2.25C20.496 3 21 3.504 21 4.125v15.75c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 01-1.125-1.125V4.125z"
+                    />
+                  </svg>
+                </div>
+                <h3 className="text-base font-semibold">
+                  Results for{" "}
+                  {evaluators.find((e) => e.uuid === activeUuid)?.name ??
+                    "this evaluator"}
+                </h3>
+                <p className="text-sm text-muted-foreground">
+                  Per-evaluator analytics for this item will appear here —
+                  agreement with annotators, evaluator runs over time, and
+                  pass/fail breakdowns.
+                </p>
+              </div>
+            </div>
+          </>
+        ) : (
+          <div className="flex-1 flex items-center justify-center text-sm text-muted-foreground">
+            No evaluators are linked to this task.
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/human-labelling/JobsCreatedDialog.tsx
+++ b/src/components/human-labelling/JobsCreatedDialog.tsx
@@ -1,0 +1,138 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useHideFloatingButton } from "@/components/AppLayout";
+
+export type CreatedJob = {
+  uuid: string;
+  public_token: string;
+  annotator_id: string;
+  annotator_name: string;
+  item_count: number;
+  status: string;
+};
+
+type JobsCreatedDialogProps = {
+  isOpen: boolean;
+  jobs: CreatedJob[];
+  onClose: () => void;
+};
+
+function buildJobUrl(token: string): string {
+  if (typeof window === "undefined") return `/annotate-job/${token}`;
+  return `${window.location.origin}/annotate-job/${token}`;
+}
+
+export function JobsCreatedDialog({
+  isOpen,
+  jobs,
+  onClose,
+}: JobsCreatedDialogProps) {
+  useHideFloatingButton(isOpen);
+  const [copiedToken, setCopiedToken] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!copiedToken) return;
+    const t = setTimeout(() => setCopiedToken(null), 1500);
+    return () => clearTimeout(t);
+  }, [copiedToken]);
+
+  if (!isOpen) return null;
+
+  const handleCopy = async (token: string) => {
+    try {
+      await navigator.clipboard.writeText(buildJobUrl(token));
+      setCopiedToken(token);
+    } catch {
+      // ignore clipboard failures
+    }
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm p-4"
+      onClick={onClose}
+    >
+      <div
+        className="bg-background border border-border rounded-xl shadow-2xl w-full max-w-4xl flex flex-col max-h-[90vh]"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="px-6 py-4 border-b border-border flex items-center justify-between">
+          <h2 className="text-lg font-semibold">
+            {jobs.length} new job{jobs.length === 1 ? "" : "s"} created
+          </h2>
+          <button
+            onClick={onClose}
+            className="w-8 h-8 flex items-center justify-center rounded-md hover:bg-muted transition-colors cursor-pointer"
+          >
+            <svg
+              className="w-5 h-5"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              strokeWidth={2}
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M6 18L18 6M6 6l12 12"
+              />
+            </svg>
+          </button>
+        </div>
+
+        <div className="p-4 md:p-6 space-y-4 overflow-y-auto">
+          <p className="text-sm text-muted-foreground">
+            Copy each link and send it to the corresponding annotator
+          </p>
+
+          <div className="border border-border rounded-lg overflow-hidden">
+            <div className="grid grid-cols-[minmax(0,1fr)_minmax(0,3fr)_auto] gap-4 px-4 py-2.5 bg-muted/30 text-xs font-medium text-muted-foreground uppercase tracking-wide">
+              <div>Annotator</div>
+              <div>Link</div>
+              <div className="w-16" />
+            </div>
+            {jobs.map((job, idx) => {
+              const url = buildJobUrl(job.public_token);
+              const copied = copiedToken === job.public_token;
+              return (
+                <div
+                  key={job.uuid}
+                  className={`grid grid-cols-[minmax(0,1fr)_minmax(0,3fr)_auto] gap-4 items-center px-4 py-3 ${
+                    idx > 0 ? "border-t border-border" : ""
+                  }`}
+                >
+                  <div className="text-sm font-medium truncate">
+                    {job.annotator_name}
+                  </div>
+                  <div className="text-xs font-mono text-muted-foreground break-all">
+                    {url}
+                  </div>
+                  <button
+                    onClick={() => handleCopy(job.public_token)}
+                    className={`h-8 px-3 rounded-md text-xs font-medium border transition-colors cursor-pointer w-16 ${
+                      copied
+                        ? "border-emerald-500/40 bg-emerald-500/10 text-emerald-500"
+                        : "border-border bg-background hover:bg-muted/50"
+                    }`}
+                  >
+                    {copied ? "Copied" : "Copy"}
+                  </button>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+
+        <div className="px-6 py-4 border-t border-border flex items-center justify-end">
+          <button
+            onClick={onClose}
+            className="h-10 px-4 rounded-md text-sm font-medium bg-foreground text-background hover:opacity-90 transition-opacity cursor-pointer"
+          >
+            Done
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/human-labelling/ManageEvaluatorsDialog.tsx
+++ b/src/components/human-labelling/ManageEvaluatorsDialog.tsx
@@ -1,0 +1,347 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { useHideFloatingButton } from "@/components/AppLayout";
+import {
+  EVALUATOR_TYPE_LABELS,
+  EvaluatorTypePill,
+  type EvaluatorType,
+} from "@/components/EvaluatorPills";
+import { apiClient } from "@/lib/api";
+
+type EvaluatorListItem = {
+  uuid: string;
+  name: string;
+  description?: string;
+  evaluator_type?: EvaluatorType;
+};
+
+function parseApiError(err: unknown, fallback: string): string {
+  if (!(err instanceof Error)) return fallback;
+  const match = err.message.match(/Request failed: \d+ - (.+)$/);
+  if (match) {
+    try {
+      const parsed = JSON.parse(match[1]);
+      if (parsed && typeof parsed.detail === "string") return parsed.detail;
+    } catch {
+      // not JSON
+    }
+    return match[1];
+  }
+  return err.message || fallback;
+}
+
+type ManageEvaluatorsDialogProps = {
+  accessToken: string;
+  taskUuid: string;
+  taskType?: EvaluatorType;
+  currentEvaluatorIds: string[];
+  onClose: () => void;
+  onSaved: () => void;
+};
+
+export function ManageEvaluatorsDialog({
+  accessToken,
+  taskUuid,
+  taskType,
+  currentEvaluatorIds,
+  onClose,
+  onSaved,
+}: ManageEvaluatorsDialogProps) {
+  useHideFloatingButton(true);
+
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(
+    new Set(currentEvaluatorIds),
+  );
+  const [search, setSearch] = useState("");
+
+  const [evaluators, setEvaluators] = useState<EvaluatorListItem[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [loadError, setLoadError] = useState<string | null>(null);
+
+  const [saving, setSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    const run = async () => {
+      setLoading(true);
+      setLoadError(null);
+      try {
+        const data = await apiClient<EvaluatorListItem[]>(
+          "/evaluators?include_defaults=true",
+          accessToken,
+        );
+        if (!cancelled) setEvaluators(Array.isArray(data) ? data : []);
+      } catch (err) {
+        if (!cancelled)
+          setLoadError(parseApiError(err, "Failed to load evaluators"));
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    };
+    run();
+    return () => {
+      cancelled = true;
+    };
+  }, [accessToken]);
+
+  const filteredEvaluators = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    return evaluators
+      .filter((ev) => (taskType ? ev.evaluator_type === taskType : true))
+      .filter((ev) => (q ? ev.name.toLowerCase().includes(q) : true));
+  }, [evaluators, taskType, search]);
+
+  const toggle = (uuid: string) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(uuid)) next.delete(uuid);
+      else next.add(uuid);
+      return next;
+    });
+  };
+
+  const currentSet = useMemo(
+    () => new Set(currentEvaluatorIds),
+    [currentEvaluatorIds],
+  );
+
+  const toAdd = useMemo(
+    () => Array.from(selectedIds).filter((id) => !currentSet.has(id)),
+    [selectedIds, currentSet],
+  );
+  const toRemove = useMemo(
+    () => currentEvaluatorIds.filter((id) => !selectedIds.has(id)),
+    [currentEvaluatorIds, selectedIds],
+  );
+
+  const hasChanges = toAdd.length > 0 || toRemove.length > 0;
+  const wouldRemoveAll = selectedIds.size === 0;
+  const canSave = hasChanges && !wouldRemoveAll;
+
+  const handleSave = async () => {
+    if (!canSave || saving) return;
+    setSaving(true);
+    setSaveError(null);
+    try {
+      const adds = toAdd.map((evaluator_id) =>
+        apiClient<{ message: string }>(
+          `/annotation-tasks/${taskUuid}/evaluators`,
+          accessToken,
+          { method: "POST", body: { evaluator_id } },
+        ),
+      );
+      const removes = toRemove.map((evaluatorUuid) =>
+        apiClient<{ message: string }>(
+          `/annotation-tasks/${taskUuid}/evaluators/${evaluatorUuid}`,
+          accessToken,
+          { method: "DELETE" },
+        ),
+      );
+      await Promise.all([...adds, ...removes]);
+      onSaved();
+    } catch (err) {
+      setSaveError(parseApiError(err, "Failed to update evaluators"));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm p-4"
+      onClick={() => {
+        if (!saving) onClose();
+      }}
+    >
+      <div
+        className="bg-background border border-border rounded-xl w-full max-w-2xl shadow-2xl flex flex-col max-h-[90vh]"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-start justify-between gap-3 px-5 md:px-6 py-4 border-b border-border">
+          <div>
+            <h2 className="text-base md:text-lg font-semibold text-foreground">
+              Manage evaluators
+            </h2>
+            <p className="text-xs md:text-sm text-muted-foreground mt-1">
+              {taskType ? (
+                <span className="inline-flex flex-wrap items-center gap-1.5">
+                  Choose which
+                  <EvaluatorTypePill evaluatorType={taskType} />
+                  evaluators need to be aligned with humans
+                </span>
+              ) : (
+                "Choose which evaluators need to be aligned with humans"
+              )}
+            </p>
+          </div>
+          <button
+            onClick={onClose}
+            disabled={saving}
+            className="flex items-center justify-center w-8 h-8 rounded-md hover:bg-muted transition-colors cursor-pointer flex-shrink-0 disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            <svg
+              className="w-5 h-5"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              strokeWidth={2}
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M6 18L18 6M6 6l12 12"
+              />
+            </svg>
+          </button>
+        </div>
+
+        <div className="flex-1 overflow-y-auto p-4 md:p-6 space-y-3">
+          <div className="flex items-center justify-between gap-3">
+            <div className="flex items-center gap-2 text-xs text-muted-foreground">
+              <span>{selectedIds.size} selected</span>
+            </div>
+            {hasChanges && (
+              <span className="text-xs flex items-center gap-2">
+                {toAdd.length > 0 && (
+                  <span className="text-emerald-600">
+                    +{toAdd.length} to add
+                  </span>
+                )}
+                {toRemove.length > 0 && (
+                  <span className="text-red-500">
+                    −{toRemove.length} to remove
+                  </span>
+                )}
+              </span>
+            )}
+          </div>
+
+          <div className="relative">
+            <div className="absolute inset-y-0 left-0 flex items-center pl-3 pointer-events-none">
+              <svg
+                className="w-4 h-4 text-muted-foreground"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+                strokeWidth={2}
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 5.196a7.5 7.5 0 0010.607 10.607z"
+                />
+              </svg>
+            </div>
+            <input
+              type="text"
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              placeholder="Search evaluators"
+              className="w-full h-9 pl-9 pr-3 rounded-md text-sm border border-border bg-background text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-accent"
+            />
+          </div>
+
+          <div className="border border-border rounded-md max-h-80 overflow-y-auto divide-y divide-border">
+            {loading ? (
+              <div className="p-4 flex items-center gap-2 text-sm text-muted-foreground">
+                <svg
+                  className="w-4 h-4 animate-spin"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                >
+                  <circle
+                    className="opacity-25"
+                    cx="12"
+                    cy="12"
+                    r="10"
+                    stroke="currentColor"
+                    strokeWidth="4"
+                  />
+                  <path
+                    className="opacity-75"
+                    fill="currentColor"
+                    d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+                  />
+                </svg>
+                Loading evaluators
+              </div>
+            ) : loadError ? (
+              <div className="p-4 text-sm text-red-500">{loadError}</div>
+            ) : filteredEvaluators.length === 0 ? (
+              <div className="p-4 text-sm text-muted-foreground">
+                {search.trim()
+                  ? "No matching evaluators."
+                  : taskType
+                    ? `No ${EVALUATOR_TYPE_LABELS[taskType]} evaluators yet.`
+                    : "No evaluators yet."}
+              </div>
+            ) : (
+              filteredEvaluators.map((ev) => {
+                const checked = selectedIds.has(ev.uuid);
+                return (
+                  <label
+                    key={ev.uuid}
+                    className="flex items-start gap-3 px-3 py-2.5 hover:bg-muted/30 transition-colors cursor-pointer"
+                  >
+                    <input
+                      type="checkbox"
+                      checked={checked}
+                      onChange={() => toggle(ev.uuid)}
+                      className="mt-0.5 w-4 h-4 cursor-pointer accent-foreground"
+                    />
+                    <div className="min-w-0 flex-1">
+                      <div className="text-sm font-medium truncate">
+                        {ev.name}
+                      </div>
+                      {ev.description && (
+                        <div className="text-xs text-muted-foreground line-clamp-2 mt-0.5">
+                          {ev.description}
+                        </div>
+                      )}
+                    </div>
+                  </label>
+                );
+              })
+            )}
+          </div>
+
+          {wouldRemoveAll && (
+            <p className="text-xs text-red-500">
+              A task must have at least one evaluator.
+            </p>
+          )}
+
+          {saveError && (
+            <div className="rounded-md border border-red-500/30 bg-red-500/10 p-3 text-sm text-red-500">
+              {saveError}
+            </div>
+          )}
+        </div>
+
+        <div className="flex items-center justify-end gap-2 md:gap-3 px-5 md:px-6 py-4 border-t border-border">
+          <button
+            onClick={onClose}
+            disabled={saving}
+            className="h-9 md:h-10 px-4 rounded-md text-sm md:text-base font-medium border border-border bg-background dark:bg-muted hover:bg-muted/50 dark:hover:bg-accent transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={handleSave}
+            disabled={!canSave || saving}
+            title={
+              wouldRemoveAll
+                ? "A task must have at least one evaluator"
+                : undefined
+            }
+            className="h-9 md:h-10 px-4 rounded-md text-sm md:text-base font-medium bg-foreground text-background hover:opacity-90 transition-opacity cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {saving ? "Saving..." : "Save changes"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/human-labelling/ManageEvaluatorsDialog.tsx
+++ b/src/components/human-labelling/ManageEvaluatorsDialog.tsx
@@ -164,17 +164,17 @@ export function ManageEvaluatorsDialog({
             <h2 className="text-base md:text-lg font-semibold text-foreground">
               Manage evaluators
             </h2>
-            <p className="text-xs md:text-sm text-muted-foreground mt-1">
+            <div className="text-xs md:text-sm text-muted-foreground mt-1">
               {taskType ? (
-                <span className="inline-flex flex-wrap items-center gap-1.5">
+                <div className="inline-flex flex-wrap items-center gap-1.5">
                   Choose which
                   <EvaluatorTypePill evaluatorType={taskType} />
                   evaluators need to be aligned with humans
-                </span>
+                </div>
               ) : (
                 "Choose which evaluators need to be aligned with humans"
               )}
-            </p>
+            </div>
           </div>
           <button
             onClick={onClose}

--- a/src/components/human-labelling/RunEvaluatorsDialog.tsx
+++ b/src/components/human-labelling/RunEvaluatorsDialog.tsx
@@ -1,0 +1,375 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { useHideFloatingButton } from "@/components/AppLayout";
+import { SingleSelectPicker } from "@/components/SingleSelectPicker";
+import { apiClient } from "@/lib/api";
+
+type LinkedEvaluator = { uuid: string; name: string };
+
+type EvaluatorVersion = {
+  uuid: string;
+  version_number: number;
+};
+
+type EvaluatorDetail = {
+  uuid: string;
+  live_version_id: string | null;
+  live_version: EvaluatorVersion | null;
+  versions?: EvaluatorVersion[];
+};
+
+export type RunEvaluatorsSelection = {
+  evaluator_id: string;
+  evaluator_version_id: string;
+};
+
+function parseApiError(err: unknown, fallback: string): string {
+  if (!(err instanceof Error)) return fallback;
+  const match = err.message.match(/Request failed: \d+ - (.+)$/);
+  if (match) {
+    try {
+      const parsed = JSON.parse(match[1]);
+      if (parsed && typeof parsed.detail === "string") return parsed.detail;
+    } catch {
+      // not JSON
+    }
+    return match[1];
+  }
+  return err.message || fallback;
+}
+
+type EvaluatorVersionInfo = {
+  versions: EvaluatorVersion[];
+  liveVersionId: string | null;
+};
+
+type RunEvaluatorsDialogProps = {
+  isOpen: boolean;
+  accessToken: string;
+  evaluators: LinkedEvaluator[];
+  submitting: boolean;
+  submitError: string | null;
+  onClose: () => void;
+  onConfirm: (selections: RunEvaluatorsSelection[]) => void | Promise<void>;
+};
+
+function VersionLabel({
+  version,
+  liveVersionId,
+}: {
+  version: EvaluatorVersion;
+  liveVersionId: string | null;
+}) {
+  const isLive = version.uuid === liveVersionId;
+  return (
+    <span className="inline-flex items-center gap-1.5 min-w-0">
+      <span className="truncate">v{version.version_number}</span>
+      {isLive && (
+        <span className="inline-flex items-center text-[10px] font-semibold px-1.5 py-0.5 rounded bg-green-500/10 text-green-600 dark:text-green-400 leading-none flex-shrink-0">
+          Live
+        </span>
+      )}
+    </span>
+  );
+}
+
+export function RunEvaluatorsDialog({
+  isOpen,
+  accessToken,
+  evaluators,
+  submitting,
+  submitError,
+  onClose,
+  onConfirm,
+}: RunEvaluatorsDialogProps) {
+  useHideFloatingButton(isOpen);
+
+  // evaluator_uuid -> versions + live id
+  const [info, setInfo] = useState<Record<string, EvaluatorVersionInfo>>({});
+  const [loading, setLoading] = useState(false);
+  const [loadError, setLoadError] = useState<string | null>(null);
+
+  // evaluator_uuid -> picked (default true)
+  const [picked, setPicked] = useState<Record<string, boolean>>({});
+  // evaluator_uuid -> chosen version uuid (defaults to live)
+  const [chosenVersion, setChosenVersion] = useState<Record<string, string>>(
+    {},
+  );
+
+  useEffect(() => {
+    if (!isOpen) return;
+    setLoadError(null);
+    setPicked(Object.fromEntries(evaluators.map((e) => [e.uuid, true])));
+    setChosenVersion({});
+    let cancelled = false;
+    const run = async () => {
+      if (evaluators.length === 0) return;
+      setLoading(true);
+      try {
+        const results = await Promise.all(
+          evaluators.map(async (e) => {
+            const data = await apiClient<EvaluatorDetail>(
+              `/evaluators/${e.uuid}`,
+              accessToken,
+            );
+            const all =
+              data.versions && data.versions.length > 0
+                ? [...data.versions]
+                : data.live_version
+                  ? [data.live_version]
+                  : [];
+            all.sort((a, b) => b.version_number - a.version_number);
+            const liveVersionId =
+              data.live_version_id ?? data.live_version?.uuid ?? null;
+            return [e.uuid, { versions: all, liveVersionId }] as const;
+          }),
+        );
+        if (cancelled) return;
+        const next: Record<string, EvaluatorVersionInfo> = {};
+        const initialChosen: Record<string, string> = {};
+        for (const [evUuid, val] of results) {
+          next[evUuid] = val;
+          const fallback = val.liveVersionId ?? val.versions[0]?.uuid ?? null;
+          if (fallback) initialChosen[evUuid] = fallback;
+        }
+        setInfo(next);
+        setChosenVersion(initialChosen);
+      } catch (err) {
+        if (!cancelled)
+          setLoadError(parseApiError(err, "Failed to load evaluator versions"));
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    };
+    run();
+    return () => {
+      cancelled = true;
+    };
+  }, [isOpen, accessToken, evaluators]);
+
+  const pickedCount = useMemo(
+    () => Object.values(picked).filter(Boolean).length,
+    [picked],
+  );
+
+  if (!isOpen) return null;
+
+  const togglePicked = (id: string) => {
+    setPicked((prev) => ({ ...prev, [id]: !prev[id] }));
+  };
+
+  const handleConfirm = async () => {
+    if (pickedCount === 0 || submitting) return;
+    const selections: RunEvaluatorsSelection[] = [];
+    for (const e of evaluators) {
+      if (!picked[e.uuid]) continue;
+      const versionId = chosenVersion[e.uuid];
+      if (!versionId) continue;
+      selections.push({
+        evaluator_id: e.uuid,
+        evaluator_version_id: versionId,
+      });
+    }
+    if (selections.length === 0) return;
+    await onConfirm(selections);
+  };
+
+  const subtitle =
+    "Decide which evaluators to run and which versions to use for each";
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm p-4"
+      onClick={() => {
+        if (!submitting) onClose();
+      }}
+    >
+      <div
+        className="bg-background border border-border rounded-xl shadow-2xl w-full max-w-lg flex flex-col max-h-[90vh]"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="px-6 py-4 border-b border-border flex items-center justify-between">
+          <div>
+            <h2 className="text-lg font-semibold">Run evaluators</h2>
+            <p className="text-xs text-muted-foreground mt-1">{subtitle}</p>
+          </div>
+          <button
+            onClick={onClose}
+            disabled={submitting}
+            aria-label="Close"
+            className="w-8 h-8 flex items-center justify-center rounded-md hover:bg-muted transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            <svg
+              className="w-5 h-5"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              strokeWidth={2}
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M6 18L18 6M6 6l12 12"
+              />
+            </svg>
+          </button>
+        </div>
+        <div className="p-4 md:p-6 space-y-2 overflow-y-auto">
+          {loading ? (
+            <div className="flex items-center gap-2 text-sm text-muted-foreground">
+              <svg
+                className="w-4 h-4 animate-spin"
+                fill="none"
+                viewBox="0 0 24 24"
+              >
+                <circle
+                  className="opacity-25"
+                  cx="12"
+                  cy="12"
+                  r="10"
+                  stroke="currentColor"
+                  strokeWidth="4"
+                />
+                <path
+                  className="opacity-75"
+                  fill="currentColor"
+                  d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+                />
+              </svg>
+              Loading evaluator versions
+            </div>
+          ) : loadError ? (
+            <p className="text-sm text-red-500">{loadError}</p>
+          ) : evaluators.length === 0 ? (
+            <p className="text-sm text-muted-foreground">
+              No evaluators are linked to this task.
+            </p>
+          ) : (
+            evaluators.map((ev) => {
+              const evInfo = info[ev.uuid];
+              const versions = evInfo?.versions ?? [];
+              const liveVersionId = evInfo?.liveVersionId ?? null;
+              const isPicked = !!picked[ev.uuid];
+              const value =
+                chosenVersion[ev.uuid] ??
+                liveVersionId ??
+                versions[0]?.uuid ??
+                "";
+              return (
+                <div
+                  key={ev.uuid}
+                  role="button"
+                  tabIndex={0}
+                  onClick={() => togglePicked(ev.uuid)}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter" || e.key === " ") {
+                      e.preventDefault();
+                      togglePicked(ev.uuid);
+                    }
+                  }}
+                  className={`flex items-center gap-3 px-3 py-2 rounded-md border transition-colors cursor-pointer hover:bg-muted/30 ${
+                    isPicked
+                      ? "border-border bg-background"
+                      : "border-border bg-muted/20 opacity-60"
+                  }`}
+                >
+                  <input
+                    type="checkbox"
+                    checked={isPicked}
+                    onChange={() => togglePicked(ev.uuid)}
+                    onClick={(e) => e.stopPropagation()}
+                    aria-label={`Pick ${ev.name}`}
+                    className="w-4 h-4 cursor-pointer accent-foreground"
+                  />
+                  <div className="flex-1 min-w-0">
+                    <div
+                      className="text-sm font-medium truncate"
+                      title={ev.name}
+                    >
+                      {ev.name}
+                    </div>
+                  </div>
+                  {versions.length === 0 ? (
+                    <span className="text-xs text-muted-foreground">
+                      No versions
+                    </span>
+                  ) : (
+                    <div onClick={(e) => e.stopPropagation()}>
+                    <SingleSelectPicker<EvaluatorVersion>
+                      items={versions}
+                      selectedId={value}
+                      onSelect={(v) =>
+                        setChosenVersion((prev) => ({
+                          ...prev,
+                          [ev.uuid]: v.uuid,
+                        }))
+                      }
+                      getId={(v) => v.uuid}
+                      disabled={!isPicked}
+                      ariaLabel={`Version for ${ev.name}`}
+                      placeholder="Select version"
+                      className="w-36 shrink-0"
+                      compact
+                      renderTrigger={(v) =>
+                        v ? (
+                          <VersionLabel
+                            version={v}
+                            liveVersionId={liveVersionId}
+                          />
+                        ) : (
+                          ""
+                        )
+                      }
+                      renderOption={(v, isSel) => (
+                        <>
+                          <VersionLabel
+                            version={v}
+                            liveVersionId={liveVersionId}
+                          />
+                          {isSel && (
+                            <svg
+                              className="w-4 h-4 text-foreground flex-shrink-0"
+                              fill="none"
+                              viewBox="0 0 24 24"
+                              stroke="currentColor"
+                              strokeWidth={2}
+                            >
+                              <path
+                                strokeLinecap="round"
+                                strokeLinejoin="round"
+                                d="M4.5 12.75l6 6 9-13.5"
+                              />
+                            </svg>
+                          )}
+                        </>
+                      )}
+                    />
+                    </div>
+                  )}
+                </div>
+              );
+            })
+          )}
+          {submitError && <p className="text-sm text-red-500">{submitError}</p>}
+        </div>
+        <div className="px-6 py-4 border-t border-border flex items-center justify-end gap-3">
+          <button
+            onClick={onClose}
+            disabled={submitting}
+            className="h-10 px-4 rounded-md text-sm font-medium border border-border bg-background hover:bg-muted/50 transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={handleConfirm}
+            disabled={pickedCount === 0 || submitting || loading}
+            className="h-10 px-4 rounded-md text-sm font-medium bg-foreground text-background hover:opacity-90 transition-opacity cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {submitting ? "Starting..." : "Run"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/human-labelling/RunEvaluatorsDialog.tsx
+++ b/src/components/human-labelling/RunEvaluatorsDialog.tsx
@@ -97,6 +97,17 @@ export function RunEvaluatorsDialog({
     {},
   );
 
+  // The parent rebuilds the `evaluators` array on every render, so we
+  // depend on a stable string key derived from the actual UUIDs. Without
+  // this, parent re-renders during the dialog's lifetime (e.g. submit
+  // sets `submitting=true`) would re-fire the effect and wipe the user's
+  // picks/version selections back to defaults.
+  const evaluatorIdsKey = evaluators
+    .map((e) => e.uuid)
+    .slice()
+    .sort()
+    .join(",");
+
   useEffect(() => {
     if (!isOpen) return;
     setLoadError(null);
@@ -146,7 +157,11 @@ export function RunEvaluatorsDialog({
     return () => {
       cancelled = true;
     };
-  }, [isOpen, accessToken, evaluators]);
+    // `evaluators` is intentionally excluded — we re-key on the stable
+    // `evaluatorIdsKey` instead. Including the array reference would
+    // re-fire the effect on every parent render and wipe state.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isOpen, accessToken, evaluatorIdsKey]);
 
   const pickedCount = useMemo(
     () => Object.values(picked).filter(Boolean).length,
@@ -257,17 +272,15 @@ export function RunEvaluatorsDialog({
                 versions[0]?.uuid ??
                 "";
               return (
+                // Plain clickable surface — the real interactive
+                // controls (checkbox + version picker) are inside, so
+                // this wrapper isn't an ARIA "button". Clicking it
+                // toggles the checkbox via its native label-like
+                // behaviour; keyboard users use the inner controls
+                // directly.
                 <div
                   key={ev.uuid}
-                  role="button"
-                  tabIndex={0}
                   onClick={() => togglePicked(ev.uuid)}
-                  onKeyDown={(e) => {
-                    if (e.key === "Enter" || e.key === " ") {
-                      e.preventDefault();
-                      togglePicked(ev.uuid);
-                    }
-                  }}
                   className={`flex items-center gap-3 px-3 py-2 rounded-md border transition-colors cursor-pointer hover:bg-muted/30 ${
                     isPicked
                       ? "border-border bg-background"

--- a/src/components/human-labelling/bulk-upload-shared.tsx
+++ b/src/components/human-labelling/bulk-upload-shared.tsx
@@ -1,0 +1,227 @@
+"use client";
+
+import React from "react";
+
+// ─── Shared types ─────────────────────────────────────────────────────────
+
+export type TurnObject = {
+  role: string;
+  content?: unknown;
+  tool_calls?: unknown;
+  [key: string]: unknown;
+};
+
+// ─── Shared helpers ───────────────────────────────────────────────────────
+
+export function parseApiError(err: unknown, fallback: string): string {
+  if (!(err instanceof Error)) return fallback;
+  const m = err.message.match(/Request failed: \d+ - (.+)$/);
+  if (m) {
+    try {
+      const parsed = JSON.parse(m[1]);
+      if (parsed && typeof parsed.detail === "string") return parsed.detail;
+    } catch {
+      // not JSON — fall through to the captured message
+    }
+    return m[1];
+  }
+  return err.message || fallback;
+}
+
+// Match `headers` against a list of canonical/alias names case-insensitively
+// and ignoring whitespace differences. Returns the original header string
+// (so the caller can index into Papa's parsed row dict) or null.
+export function findHeaderKey(
+  headers: string[],
+  candidates: string[],
+): string | null {
+  const norm = (s: string) => s.trim().toLowerCase().replace(/\s+/g, "_");
+  const normalized = headers.map(norm);
+  for (const cand of candidates) {
+    const idx = normalized.indexOf(cand);
+    if (idx >= 0) return headers[idx];
+  }
+  return null;
+}
+
+// Coerce a turn's `content` to a string for preview purposes.
+export function turnContentString(t: TurnObject): string {
+  if (typeof t.content === "string") return t.content;
+  if (t.content === undefined || t.content === null) return "";
+  try {
+    return JSON.stringify(t.content);
+  } catch {
+    return String(t.content);
+  }
+}
+
+export function roleLabel(role: string): string {
+  if (role === "user") return "User";
+  if (role === "assistant") return "AI";
+  if (role === "system") return "System";
+  if (role === "tool") return "Tool";
+  return role;
+}
+
+// Tailwind classes for the colored role pill rendered next to each turn.
+export function rolePillClass(role: string): string {
+  if (role === "user") {
+    return "bg-blue-500/10 text-blue-600 dark:text-blue-400 border border-blue-500/20";
+  }
+  if (role === "assistant") {
+    return "bg-purple-500/10 text-purple-600 dark:text-purple-400 border border-purple-500/20";
+  }
+  if (role === "system") {
+    return "bg-amber-500/10 text-amber-600 dark:text-amber-400 border border-amber-500/20";
+  }
+  if (role === "tool") {
+    return "bg-emerald-500/10 text-emerald-600 dark:text-emerald-400 border border-emerald-500/20";
+  }
+  return "bg-muted text-muted-foreground border border-border";
+}
+
+// ─── Shared sub-components ────────────────────────────────────────────────
+
+type CsvDropzoneProps = {
+  csvFile: File | null;
+  onFile: (file: File | null) => void;
+  onClear: () => void;
+  // Optional helper text shown below the prompt when no file is selected.
+  helperText?: string;
+};
+
+// Drop-or-click zone for picking a single CSV. Renders the chosen file
+// with a clear button when one is selected; emits null/`File` through
+// `onFile`.
+export function CsvDropzone({
+  csvFile,
+  onFile,
+  onClear,
+  helperText = "Up to a few thousand rows is fine",
+}: CsvDropzoneProps) {
+  const inputRef = React.useRef<HTMLInputElement>(null);
+  const handleDrop = (e: React.DragEvent) => {
+    e.preventDefault();
+    const f = e.dataTransfer.files?.[0];
+    if (f) onFile(f);
+  };
+  return (
+    <div
+      onDragOver={(e) => e.preventDefault()}
+      onDrop={handleDrop}
+      onClick={() => inputRef.current?.click()}
+      className={`border-2 border-dashed rounded-xl p-8 text-center transition-colors cursor-pointer ${
+        csvFile
+          ? "border-foreground/30 bg-muted/30"
+          : "border-border hover:border-muted-foreground"
+      }`}
+    >
+      <input
+        ref={inputRef}
+        type="file"
+        accept=".csv,text/csv"
+        onChange={(e) => onFile(e.target.files?.[0] || null)}
+        className="hidden"
+      />
+      {csvFile ? (
+        <div className="flex items-center justify-center gap-2">
+          <svg
+            className="w-5 h-5 text-foreground"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            strokeWidth={2}
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              d="M19.5 14.25v-2.625a3.375 3.375 0 00-3.375-3.375h-1.5A1.125 1.125 0 0113.5 7.125v-1.5a3.375 3.375 0 00-3.375-3.375H8.25m0 12.75h7.5m-7.5 3H12M10.5 2.25H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 00-9-9z"
+            />
+          </svg>
+          <span className="text-sm font-medium text-foreground">
+            {csvFile.name}
+          </span>
+          <button
+            onClick={(e) => {
+              e.stopPropagation();
+              if (inputRef.current) inputRef.current.value = "";
+              onClear();
+            }}
+            aria-label="Remove file"
+            className="ml-1 text-muted-foreground hover:text-foreground"
+          >
+            <svg
+              className="w-4 h-4"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              strokeWidth={2}
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M6 18L18 6M6 6l12 12"
+              />
+            </svg>
+          </button>
+        </div>
+      ) : (
+        <>
+          <svg
+            className="w-8 h-8 text-muted-foreground mx-auto mb-2"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            strokeWidth={1.5}
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5m-13.5-9L12 3m0 0l4.5 4.5M12 3v13.5"
+            />
+          </svg>
+          <p className="text-sm text-foreground font-medium">
+            Drop a CSV here or click to browse
+          </p>
+          <p className="text-xs text-muted-foreground mt-1">{helperText}</p>
+        </>
+      )}
+    </div>
+  );
+}
+
+// Small "Show / Hide CSV format details" disclosure used after a CSV has
+// parsed to get the help block out of the way.
+export function FormatHelpToggle({
+  open,
+  onToggle,
+}: {
+  open: boolean;
+  onToggle: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onToggle}
+      className="mb-3 inline-flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors cursor-pointer"
+      aria-expanded={open}
+    >
+      <svg
+        className={`w-3.5 h-3.5 transition-transform ${
+          open ? "rotate-90" : ""
+        }`}
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke="currentColor"
+        strokeWidth={2.5}
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          d="M8.25 4.5l7.5 7.5-7.5 7.5"
+        />
+      </svg>
+      {open ? "Hide CSV format details" : "Show CSV format details"}
+    </button>
+  );
+}

--- a/src/components/human-labelling/item-panes/LlmItemPane.tsx
+++ b/src/components/human-labelling/item-panes/LlmItemPane.tsx
@@ -1,0 +1,73 @@
+import {
+  TestDetailView,
+  type TestCaseHistory,
+} from "@/components/test-results/shared";
+
+export function LlmItemPane({
+  payload,
+}: {
+  payload: Record<string, unknown>;
+}) {
+  // Reuse the read-only conversation renderer from the test runner /
+  // benchmark dialogs so labelling stays visually in sync with how the
+  // same conversation is displayed elsewhere in the product.
+  const history: TestCaseHistory[] = [];
+  if (Array.isArray(payload.chat_history)) {
+    for (const m of payload.chat_history) {
+      const norm = normaliseHistoryItem(m);
+      if (norm) history.push(norm);
+    }
+  }
+
+  const agentResponse =
+    typeof payload.agent_response === "string"
+      ? (payload.agent_response as string)
+      : "";
+  if (agentResponse.length > 0) {
+    history.push({ role: "assistant", content: agentResponse });
+  }
+
+  if (history.length === 0) {
+    return (
+      <div className="border border-border rounded-xl p-4">
+        <p className="text-sm text-muted-foreground">—</p>
+      </div>
+    );
+  }
+
+  return (
+    <TestDetailView history={history} passed={true} highlightEvalTarget />
+  );
+}
+
+function normaliseHistoryItem(raw: unknown): TestCaseHistory | null {
+  if (!raw || typeof raw !== "object") return null;
+  const obj = raw as Record<string, unknown>;
+  const role = obj.role;
+  const content = typeof obj.content === "string" ? obj.content : undefined;
+  const toolCalls = obj.tool_calls;
+  const toolCallId =
+    typeof obj.tool_call_id === "string" ? obj.tool_call_id : undefined;
+  if (role === "assistant") {
+    if (Array.isArray(toolCalls) && toolCalls.length > 0) {
+      return {
+        role: "assistant",
+        ...(content != null ? { content } : {}),
+        tool_calls: toolCalls as TestCaseHistory["tool_calls"],
+      };
+    }
+    if (content != null) return { role: "assistant", content };
+    return null;
+  }
+  if (role === "user" && content != null) {
+    return { role: "user", content };
+  }
+  if (role === "tool" && content != null) {
+    return {
+      role: "tool",
+      content,
+      ...(toolCallId ? { tool_call_id: toolCallId } : {}),
+    };
+  }
+  return null;
+}

--- a/src/components/human-labelling/item-panes/SimulationItemPane.tsx
+++ b/src/components/human-labelling/item-panes/SimulationItemPane.tsx
@@ -1,0 +1,63 @@
+import {
+  TestDetailView,
+  type TestCaseHistory,
+} from "@/components/test-results/shared";
+
+export function SimulationItemPane({
+  payload,
+}: {
+  payload: Record<string, unknown>;
+}) {
+  // Reuse the same read-only conversation renderer used by the test
+  // runner / benchmark dialogs (and the LLM labelling pane), so all
+  // surfaces displaying a conversation look the same.
+  const history: TestCaseHistory[] = [];
+  if (Array.isArray(payload.transcript)) {
+    for (const m of payload.transcript) {
+      const norm = normaliseHistoryItem(m);
+      if (norm) history.push(norm);
+    }
+  }
+
+  if (history.length === 0) {
+    return (
+      <div className="border border-border rounded-xl p-4">
+        <p className="text-sm text-muted-foreground">—</p>
+      </div>
+    );
+  }
+
+  return <TestDetailView history={history} passed={true} />;
+}
+
+function normaliseHistoryItem(raw: unknown): TestCaseHistory | null {
+  if (!raw || typeof raw !== "object") return null;
+  const obj = raw as Record<string, unknown>;
+  const role = obj.role;
+  const content = typeof obj.content === "string" ? obj.content : undefined;
+  const toolCalls = obj.tool_calls;
+  const toolCallId =
+    typeof obj.tool_call_id === "string" ? obj.tool_call_id : undefined;
+  if (role === "assistant") {
+    if (Array.isArray(toolCalls) && toolCalls.length > 0) {
+      return {
+        role: "assistant",
+        ...(content != null ? { content } : {}),
+        tool_calls: toolCalls as TestCaseHistory["tool_calls"],
+      };
+    }
+    if (content != null) return { role: "assistant", content };
+    return null;
+  }
+  if (role === "user" && content != null) {
+    return { role: "user", content };
+  }
+  if (role === "tool" && content != null) {
+    return {
+      role: "tool",
+      content,
+      ...(toolCallId ? { tool_call_id: toolCallId } : {}),
+    };
+  }
+  return null;
+}

--- a/src/components/human-labelling/item-panes/SttItemPane.tsx
+++ b/src/components/human-labelling/item-panes/SttItemPane.tsx
@@ -1,0 +1,36 @@
+import { Section } from "./shared";
+
+export function SttItemPane({
+  payload,
+}: {
+  payload: Record<string, unknown>;
+}) {
+  const reference =
+    typeof payload.reference_transcript === "string"
+      ? (payload.reference_transcript as string)
+      : "";
+  const predicted =
+    typeof payload.predicted_transcript === "string"
+      ? (payload.predicted_transcript as string)
+      : "";
+  return (
+    <div className="space-y-4">
+      <Section
+        title="Reference transcript"
+        subtitle="What the speaker actually said"
+      >
+        <p className="text-sm whitespace-pre-wrap break-words">
+          {reference || "—"}
+        </p>
+      </Section>
+      <Section
+        title="Predicted transcript"
+        subtitle="What the STT model produced"
+      >
+        <p className="text-sm whitespace-pre-wrap break-words">
+          {predicted || "—"}
+        </p>
+      </Section>
+    </div>
+  );
+}

--- a/src/components/human-labelling/item-panes/shared.tsx
+++ b/src/components/human-labelling/item-panes/shared.tsx
@@ -1,0 +1,49 @@
+import React from "react";
+
+export function Section({
+  title,
+  subtitle,
+  children,
+}: {
+  title: string;
+  subtitle?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="border border-border rounded-xl p-4 space-y-2">
+      <div>
+        <h3 className="text-sm font-semibold">{title}</h3>
+        {subtitle && (
+          <p className="text-xs text-muted-foreground">{subtitle}</p>
+        )}
+      </div>
+      <div>{children}</div>
+    </div>
+  );
+}
+
+export function ChatMessage({
+  role,
+  content,
+}: {
+  role: string;
+  content: string;
+}) {
+  const isAssistant = role === "assistant" || role === "agent";
+  return (
+    <div className="space-y-1">
+      <div
+        className={`text-[10px] uppercase tracking-wide ${
+          isAssistant
+            ? "text-blue-600 dark:text-blue-400"
+            : "text-muted-foreground"
+        }`}
+      >
+        {isAssistant ? "Agent" : role === "tool" ? "Tool" : "User"}
+      </div>
+      <p className="text-sm whitespace-pre-wrap break-words">
+        {content || "—"}
+      </p>
+    </div>
+  );
+}

--- a/src/components/test-results/shared.tsx
+++ b/src/components/test-results/shared.tsx
@@ -1,6 +1,11 @@
 "use client";
 
-import React, { useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
+import {
+  EvaluatorVerdictCard,
+  ReasoningExpandedContent,
+  ReasoningToggleButton,
+} from "@/components/EvaluatorVerdictCard";
 import Link from "next/link";
 import {
   CheckIcon,
@@ -322,68 +327,6 @@ export function ToolCallCard({
 }
 
 /** Text + chevron toggle for evaluator / tool-call reasoning (compact header control). */
-function ReasoningToggleIconButton({
-  open,
-  onToggle,
-}: {
-  open: boolean;
-  onToggle: () => void;
-}) {
-  return (
-    <button
-      type="button"
-      onClick={(e) => {
-        e.stopPropagation();
-        onToggle();
-      }}
-      aria-expanded={open}
-      className={`inline-flex items-center gap-1.5 max-w-[min(100%,14rem)] rounded-md border px-2 py-1 text-[11px] font-medium transition-colors cursor-pointer shrink-0 ${
-        open
-          ? "border-fuchsia-500/50 bg-fuchsia-500/16 text-fuchsia-950 dark:border-fuchsia-500/45 dark:bg-fuchsia-500/18 dark:text-fuchsia-100 hover:bg-fuchsia-500/26 dark:hover:bg-fuchsia-500/28"
-          : "border-cyan-500/50 bg-cyan-500/14 text-cyan-950 dark:border-cyan-500/45 dark:bg-cyan-500/16 dark:text-cyan-100 hover:bg-cyan-500/24 dark:hover:bg-cyan-500/22"
-      }`}
-    >
-      <span className="truncate">
-        {open ? "Hide reasoning" : "See reasoning"}
-      </span>
-      <ChevronDownIcon
-        className={`w-3.5 h-3.5 shrink-0 transition-transform duration-200 ${open ? "rotate-180" : ""}`}
-      />
-    </button>
-  );
-}
-
-function ReasoningExpandedContent({
-  text,
-  showReasoningLabel = false,
-  mutedBody = true,
-  italic = false,
-}: {
-  text: string;
-  showReasoningLabel?: boolean;
-  mutedBody?: boolean;
-  italic?: boolean;
-}) {
-  return (
-    <div className="space-y-1">
-      {showReasoningLabel && (
-        <span className="text-[10px] font-medium text-muted-foreground uppercase tracking-wide block">
-          Reasoning
-        </span>
-      )}
-      <p
-        className={`${
-          mutedBody
-            ? "text-xs text-muted-foreground whitespace-pre-wrap break-words"
-            : "text-xs text-foreground whitespace-pre-wrap break-words"
-        }${italic ? " italic" : ""}`}
-      >
-        {text}
-      </p>
-    </div>
-  );
-}
-
 /** Tool-call verdict: one header row (label + chevron), body when expanded. */
 function CollapsibleReasoningStrip({
   text,
@@ -404,7 +347,7 @@ function CollapsibleReasoningStrip({
         <span className="text-[10px] font-medium text-muted-foreground uppercase tracking-wide">
           {leadingLabel}
         </span>
-        <ReasoningToggleIconButton
+        <ReasoningToggleButton
           open={open}
           onToggle={() => setOpen((o) => !o)}
         />
@@ -424,55 +367,6 @@ function CollapsibleReasoningStrip({
 }
 
 /** Surface styles for per-evaluator cards: tinted fill + border + left stripe by outcome. */
-type EvaluatorVerdictTone = "green" | "red" | "amber" | "neutral";
-
-function getEvaluatorVerdictTone(
-  result: JudgeResult,
-  scaleMax?: number
-): EvaluatorVerdictTone {
-  const isRating = result.score !== null && result.score !== undefined;
-  const isBinary = result.match !== null && result.match !== undefined;
-  const effectiveScaleMax =
-    typeof result.scale_max === "number" ? result.scale_max : scaleMax;
-  const effectiveScaleMin =
-    typeof result.scale_min === "number" ? result.scale_min : undefined;
-
-  if (isBinary) {
-    return result.match ? "green" : "red";
-  }
-  if (isRating) {
-    if (
-      effectiveScaleMax !== undefined &&
-      result.score === effectiveScaleMax
-    ) {
-      return "green";
-    }
-    if (
-      effectiveScaleMin !== undefined &&
-      result.score === effectiveScaleMin
-    ) {
-      return "red";
-    }
-    return "amber";
-  }
-  return "neutral";
-}
-
-function evaluatorVerdictCardSurfaceClass(tone: EvaluatorVerdictTone): string {
-  const base =
-    "rounded-lg border shadow-md dark:shadow-lg transition-colors";
-  switch (tone) {
-    case "green":
-      return `${base} border-green-500/40 bg-green-500/[0.14] border-l-4 border-l-green-600 dark:border-green-500/45 dark:bg-green-500/[0.16] dark:shadow-green-950/35`;
-    case "red":
-      return `${base} border-red-500/40 bg-red-500/[0.12] border-l-4 border-l-red-600 dark:border-red-500/45 dark:bg-red-500/[0.14] dark:shadow-red-950/30`;
-    case "amber":
-      return `${base} border-amber-500/40 bg-amber-500/[0.12] border-l-4 border-l-amber-600 dark:border-amber-500/45 dark:bg-amber-500/[0.13] dark:shadow-amber-950/30`;
-    default:
-      return `${base} border-border bg-muted/30 border-l-4 border-l-muted-foreground/40 dark:bg-muted/40 dark:border-border dark:shadow-black/25`;
-  }
-}
-
 // Per-evaluator verdict card. Binary evaluators render a ✓/✗ badge; rating
 // evaluators render `score / scale_max` when the scale is known.
 //
@@ -492,107 +386,25 @@ function JudgeResultCard({
   scaleMax?: number;
   enableEvaluatorLinks: boolean;
 }) {
-  const [reasoningOpen, setReasoningOpen] = useState(false);
-  const hasReasoning = !!result.reasoning?.trim();
   const isRating = result.score !== null && result.score !== undefined;
-  const isBinary = result.match !== null && result.match !== undefined;
   const effectiveScaleMax =
     typeof result.scale_max === "number" ? result.scale_max : scaleMax;
   const effectiveScaleMin =
     typeof result.scale_min === "number" ? result.scale_min : undefined;
-  const ratingTone: "green" | "red" | "amber" = !isRating
-    ? "amber"
-    : effectiveScaleMax !== undefined && result.score === effectiveScaleMax
-      ? "green"
-      : effectiveScaleMin !== undefined && result.score === effectiveScaleMin
-        ? "red"
-        : "amber";
-  const verdictTone = getEvaluatorVerdictTone(result, scaleMax);
-
-  const onCardClick = (e: React.MouseEvent) => {
-    if (!hasReasoning) return;
-    const el = e.target as HTMLElement;
-    if (el.closest("button") || el.closest("a[href]")) return;
-    if (el.closest("[data-reasoning-body]")) return;
-    if (el.closest("[data-evaluator-verdict-chips]")) return;
-    setReasoningOpen((o) => !o);
-  };
-
   return (
-    <div
-      onClick={hasReasoning ? onCardClick : undefined}
-      className={`${evaluatorVerdictCardSurfaceClass(verdictTone)} px-3 py-2.5 space-y-1.5${hasReasoning ? " cursor-pointer" : ""}`}
-    >
-      <div className="flex items-center justify-between gap-2">
-        <div className="flex items-center gap-2 min-w-0">
-          <div className="min-w-0">
-            <EvaluatorNameLink
-              uuid={result.evaluator_uuid}
-              name={result.name}
-              className="text-sm font-medium text-foreground truncate inline-block max-w-full align-top"
-              enableLink={enableEvaluatorLinks}
-            />
-            {result.description && (
-              <p className="text-xs text-muted-foreground whitespace-normal break-words">
-                {result.description}
-              </p>
-            )}
-          </div>
-        </div>
-        <div className="flex-shrink-0 flex items-center gap-1.5">
-          <div
-            className="flex items-center gap-1.5"
-            data-evaluator-verdict-chips
-          >
-            {isBinary && (
-              <span
-                className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-md text-[11px] font-medium ${
-                  result.match
-                    ? "bg-green-500/15 text-green-600 dark:text-green-400"
-                    : "bg-red-500/15 text-red-600 dark:text-red-400"
-                }`}
-              >
-                {result.match ? (
-                  <CheckIcon className="w-3 h-3" />
-                ) : (
-                  <XIcon className="w-3 h-3" />
-                )}
-                {result.match ? "Pass" : "Fail"}
-              </span>
-            )}
-            {isRating && (
-              <span
-                className={`inline-flex items-center px-2 py-0.5 rounded-md text-[11px] font-medium ${
-                  ratingTone === "green"
-                    ? "bg-green-500/15 text-green-600 dark:text-green-400"
-                    : ratingTone === "red"
-                      ? "bg-red-500/15 text-red-600 dark:text-red-400"
-                      : "bg-amber-500/15 text-amber-600 dark:text-amber-400"
-                }`}
-              >
-                {effectiveScaleMax !== undefined
-                  ? `${result.score} / ${effectiveScaleMax}`
-                  : `Score: ${result.score}`}
-              </span>
-            )}
-          </div>
-          {hasReasoning && (
-            <ReasoningToggleIconButton
-              open={reasoningOpen}
-              onToggle={() => setReasoningOpen((o) => !o)}
-            />
-          )}
-        </div>
-      </div>
-      {hasReasoning && reasoningOpen && (
-        <div
-          data-reasoning-body
-          className="mt-1.5 pt-1.5 border-t border-border/60"
-        >
-          <ReasoningExpandedContent text={result.reasoning!} mutedBody />
-        </div>
-      )}
-    </div>
+    <EvaluatorVerdictCard
+      mode="read"
+      name={result.name}
+      description={result.description ?? null}
+      outputType={isRating ? "rating" : "binary"}
+      evaluatorUuid={result.evaluator_uuid ?? undefined}
+      enableLink={enableEvaluatorLinks}
+      scaleMin={effectiveScaleMin}
+      scaleMax={effectiveScaleMax}
+      match={result.match}
+      score={result.score}
+      reasoning={result.reasoning}
+    />
   );
 }
 
@@ -643,6 +455,7 @@ export function TestDetailView({
   scaleByEvaluatorUuid,
   legacyDefaultEvaluator,
   enableEvaluatorLinks = true,
+  highlightEvalTarget = false,
 }: {
   history: TestCaseHistory[];
   output?: TestCaseOutput;
@@ -661,7 +474,28 @@ export function TestDetailView({
   legacyDefaultEvaluator?: DefaultEvaluatorSummary | null;
   /** Disable on public share pages because evaluator detail routes require auth. */
   enableEvaluatorLinks?: boolean;
+  /** When true, the trailing assistant message (text reply or tool call)
+   * in `history` is rendered with a blue left border + "Evaluation
+   * target" pill. Used by the LLM labelling pane to indicate which
+   * message annotators are scoring. */
+  highlightEvalTarget?: boolean;
 }) {
+  const evalTargetIndex = highlightEvalTarget
+    ? (() => {
+        for (let i = history.length - 1; i >= 0; i--) {
+          if (history[i].role === "assistant") return i;
+        }
+        return -1;
+      })()
+    : -1;
+
+  // Auto-scroll to the most recent message whenever the list grows or
+  // changes. The sentinel sits after the output section so the last
+  // visible chunk is whatever the agent's final reply is.
+  const bottomRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ block: "end" });
+  }, [history.length, output?.response]);
   const effectiveJudgeResults =
     Array.isArray(judgeResults) && judgeResults.length > 0
       ? judgeResults
@@ -681,11 +515,17 @@ export function TestDetailView({
       {history.length > 0 && (
         <div className="space-y-4">
           <div className="space-y-4">
-            {history.map((message, index) => (
+            {history.map((message, index) => {
+              const isEvalTarget = index === evalTargetIndex;
+              return (
               <div
                 key={index}
                 className={`space-y-1 ${
                   message.role === "user" ? "flex flex-col items-end" : ""
+                } ${
+                  isEvalTarget
+                    ? "border-l-2 border-blue-500 pl-4 -ml-4"
+                    : ""
                 }`}
               >
                 {/* User Message */}
@@ -706,6 +546,11 @@ export function TestDetailView({
                       <span className="text-sm font-medium text-foreground">
                         Agent
                       </span>
+                      {isEvalTarget && (
+                        <span className="inline-flex items-center px-2 py-0.5 rounded-md text-[10px] font-medium uppercase tracking-wide bg-blue-500/10 text-blue-600 dark:text-blue-400">
+                          Evaluation target
+                        </span>
+                      )}
                     </div>
                     <div className="w-[88%] md:w-3/4">
                       <div className="px-3 md:px-4 py-2.5 md:py-3 rounded-xl bg-background border border-border">
@@ -726,6 +571,11 @@ export function TestDetailView({
                         <span className="text-sm font-medium text-foreground">
                           Agent Tool Call
                         </span>
+                        {isEvalTarget && (
+                          <span className="inline-flex items-center px-2 py-0.5 rounded-md text-[10px] font-medium uppercase tracking-wide bg-blue-500/10 text-blue-600 dark:text-blue-400">
+                            Evaluation target
+                          </span>
+                        )}
                       </div>
                       <div className="w-[88%] md:w-3/4">
                         {message.tool_calls.map((toolCall, tcIndex) => {
@@ -743,7 +593,8 @@ export function TestDetailView({
                     </>
                   )}
               </div>
-            ))}
+              );
+            })}
           </div>
         </div>
       )}
@@ -768,7 +619,7 @@ export function TestDetailView({
                   <SmallStatusBadge passed={passed} />
                 </div>
                 {showLegacyReasoningToggle && (
-                  <ReasoningToggleIconButton
+                  <ReasoningToggleButton
                     open={legacyReasoningOpen}
                     onToggle={() => setLegacyReasoningOpen((o) => !o)}
                   />
@@ -848,6 +699,7 @@ export function TestDetailView({
           </p>
         </div>
       )}
+      <div ref={bottomRef} />
     </div>
   );
 }
@@ -890,10 +742,7 @@ function EvaluatorPanelCard({
   scaleMax?: number;
   enableEvaluatorLinks: boolean;
 }) {
-  const [reasoningOpen, setReasoningOpen] = useState(false);
-  const hasReasoning = !!result.reasoning?.trim();
   const isRating = result.score !== null && result.score !== undefined;
-  const isBinary = result.match !== null && result.match !== undefined;
   const effectiveScaleMax =
     typeof result.scale_max === "number" ? result.scale_max : scaleMax;
   const effectiveScaleMin =
@@ -901,138 +750,22 @@ function EvaluatorPanelCard({
   const effectiveVariables =
     result.variable_values && typeof result.variable_values === "object"
       ? result.variable_values
-      : variableValues;
-  // Rating chip color: green only when the score equals scale_max, red
-  // only when it equals scale_min, amber for everything in between or
-  // when either bound is unknown. See `JudgeResultCard` for the same
-  // logic on mobile.
-  const ratingTone: "green" | "red" | "amber" = !isRating
-    ? "amber"
-    : effectiveScaleMax !== undefined && result.score === effectiveScaleMax
-      ? "green"
-      : effectiveScaleMin !== undefined && result.score === effectiveScaleMin
-        ? "red"
-        : "amber";
-
-  const hasVariables =
-    effectiveVariables &&
-    typeof effectiveVariables === "object" &&
-    Object.keys(effectiveVariables).length > 0;
-  const hasCollapsibleBody = hasReasoning || !!hasVariables;
-  const verdictTone = getEvaluatorVerdictTone(result, scaleMax);
-
-  const onCardClick = (e: React.MouseEvent) => {
-    if (!hasCollapsibleBody) return;
-    const el = e.target as HTMLElement;
-    if (el.closest("button") || el.closest("a[href]")) return;
-    if (el.closest("[data-reasoning-body]")) return;
-    if (el.closest("[data-evaluator-verdict-chips]")) return;
-    setReasoningOpen((o) => !o);
-  };
-
+      : variableValues ?? null;
   return (
-    <div
-      onClick={hasCollapsibleBody ? onCardClick : undefined}
-      className={`${evaluatorVerdictCardSurfaceClass(verdictTone)} p-3 space-y-2.5${hasCollapsibleBody ? " cursor-pointer" : ""}`}
-    >
-      {/* Name + verdict header */}
-      <div className="flex items-start justify-between gap-2">
-        <div className="min-w-0">
-          <EvaluatorNameLink
-            uuid={result.evaluator_uuid}
-            name={result.name}
-            className="text-sm font-medium text-foreground break-words inline-block max-w-full align-top"
-            enableLink={enableEvaluatorLinks}
-          />
-          {result.description && (
-            <p className="text-xs text-muted-foreground whitespace-normal break-words mt-0.5">
-              {result.description}
-            </p>
-          )}
-        </div>
-        <div className="flex-shrink-0 flex items-center gap-1.5">
-          <div
-            className="flex items-center gap-1.5"
-            data-evaluator-verdict-chips
-          >
-            {isBinary && (
-              <span
-                className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-md text-[11px] font-medium ${
-                  result.match
-                    ? "bg-green-500/15 text-green-600 dark:text-green-400"
-                    : "bg-red-500/15 text-red-600 dark:text-red-400"
-                }`}
-              >
-                {result.match ? (
-                  <CheckIcon className="w-3 h-3" />
-                ) : (
-                  <XIcon className="w-3 h-3" />
-                )}
-                {result.match ? "Pass" : "Fail"}
-              </span>
-            )}
-            {isRating && (
-              <span
-                className={`inline-flex items-center px-2 py-0.5 rounded-md text-[11px] font-medium ${
-                  ratingTone === "green"
-                    ? "bg-green-500/15 text-green-600 dark:text-green-400"
-                    : ratingTone === "red"
-                      ? "bg-red-500/15 text-red-600 dark:text-red-400"
-                      : "bg-amber-500/15 text-amber-600 dark:text-amber-400"
-                }`}
-              >
-                {effectiveScaleMax !== undefined
-                  ? `${result.score} / ${effectiveScaleMax}`
-                  : `Score: ${result.score}`}
-              </span>
-            )}
-          </div>
-          {hasCollapsibleBody && (
-            <ReasoningToggleIconButton
-              open={reasoningOpen}
-              onToggle={() => setReasoningOpen((o) => !o)}
-            />
-          )}
-        </div>
-      </div>
-
-      {reasoningOpen && hasCollapsibleBody && (
-        <div
-          data-reasoning-body
-          className="mt-1.5 pt-1.5 border-t border-border/60 space-y-3"
-        >
-          {hasVariables && (
-            <div className="space-y-2">
-              {Object.entries(effectiveVariables!).map(([name, value]) => (
-                <div key={name}>
-                  <span className="font-mono text-[10px] text-muted-foreground">
-                    {`{{${name}}}`}
-                  </span>
-                  <p className="text-xs text-foreground whitespace-pre-wrap break-words mt-0.5">
-                    {String(value)}
-                  </p>
-                </div>
-              ))}
-            </div>
-          )}
-          {hasReasoning && (
-            <div
-              className={
-                hasVariables
-                  ? "pt-3 border-t border-border/60"
-                  : undefined
-              }
-            >
-              <ReasoningExpandedContent
-                text={result.reasoning!}
-                showReasoningLabel
-                mutedBody={false}
-              />
-            </div>
-          )}
-        </div>
-      )}
-    </div>
+    <EvaluatorVerdictCard
+      mode="read"
+      name={result.name}
+      description={result.description ?? null}
+      outputType={isRating ? "rating" : "binary"}
+      evaluatorUuid={result.evaluator_uuid ?? undefined}
+      enableLink={enableEvaluatorLinks}
+      variableValues={effectiveVariables}
+      scaleMin={effectiveScaleMin}
+      scaleMax={effectiveScaleMax}
+      match={result.match}
+      score={result.score}
+      reasoning={result.reasoning}
+    />
   );
 }
 

--- a/src/components/ui/LoadingState.tsx
+++ b/src/components/ui/LoadingState.tsx
@@ -73,7 +73,7 @@ export function NotFoundState({
 type EmptyStateProps = {
   icon: React.ReactNode;
   title: string;
-  description: string;
+  description: React.ReactNode;
   action?: {
     label: string;
     onClick: () => void;
@@ -95,8 +95,12 @@ export function EmptyState({
       <div className="w-14 h-14 rounded-xl bg-muted flex items-center justify-center mb-4">
         {icon}
       </div>
-      <h3 className="text-lg font-semibold text-foreground mb-1">{title}</h3>
-      <p className="text-base text-muted-foreground mb-4">{description}</p>
+      <h3 className="text-lg font-semibold text-foreground mb-1 text-center">
+        {title}
+      </h3>
+      <p className="text-base text-muted-foreground mb-4 text-center">
+        {description}
+      </p>
       {action && (
         <button
           onClick={action.onClick}
@@ -118,7 +122,7 @@ type ResourceStateProps = {
   emptyState: {
     icon: React.ReactNode;
     title: string;
-    description: string;
+    description: React.ReactNode;
     action?: {
       label: string;
       onClick: () => void;

--- a/src/components/ui/Select.tsx
+++ b/src/components/ui/Select.tsx
@@ -1,0 +1,40 @@
+import React from "react";
+
+type Props = React.SelectHTMLAttributes<HTMLSelectElement> & {
+  wrapperClassName?: string;
+};
+
+// A styled wrapper around the native <select> that gives the chevron proper
+// breathing room from the right edge. Native selects render their own chevron
+// touching the border, which looks cramped — we hide it with appearance-none
+// and draw our own with adequate padding.
+export function Select({
+  className = "",
+  wrapperClassName = "",
+  children,
+  ...rest
+}: Props) {
+  return (
+    <div className={`relative ${wrapperClassName}`}>
+      <select
+        {...rest}
+        className={`appearance-none w-full h-10 pl-3 pr-9 rounded-md text-sm border border-border bg-background text-foreground focus:outline-none focus:ring-2 focus:ring-accent disabled:cursor-not-allowed disabled:bg-muted/30 disabled:text-muted-foreground ${className}`}
+      >
+        {children}
+      </select>
+      <svg
+        className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground"
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke="currentColor"
+        strokeWidth={2}
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          d="M19.5 8.25l-7.5 7.5-7.5-7.5"
+        />
+      </svg>
+    </div>
+  );
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -25,9 +25,10 @@ export default auth((req) => {
   const isTermsPage = req.nextUrl.pathname === "/terms";
   const isPrivacyPage = req.nextUrl.pathname === "/privacy";
   const isPublicShareRoute = req.nextUrl.pathname.startsWith("/public/");
+  const isAnnotateJobRoute = req.nextUrl.pathname.startsWith("/annotate-job/");
 
-  // Allow public pages: landing page, auth API, debug, docs, about, terms, privacy, public share links
-  if (isHomePage || isAuthRoute || isDebugRoute || isDocsRoute || isAboutPage || isTermsPage || isPrivacyPage || isPublicShareRoute) {
+  // Allow public pages: landing page, auth API, debug, docs, about, terms, privacy, public share links, annotate-job links
+  if (isHomePage || isAuthRoute || isDebugRoute || isDocsRoute || isAboutPage || isTermsPage || isPrivacyPage || isPublicShareRoute || isAnnotateJobRoute) {
     return NextResponse.next();
   }
 


### PR DESCRIPTION
## Summary

Builds out the human-labelling task page with bulk-upload flows, an evaluator-runs dialog with version pickers, an overview "Live versions only" filter, and color/coloring fixes for evaluator results.

## What changed

### Bulk upload of items
New dialogs (one per task type) opened from the **Bulk upload** button on the human-labelling task page. Each accepts a CSV, parses + validates client-side, previews the parsed rows, and posts to `POST /annotation-tasks/{uuid}/items`.

- **STT** ([BulkUploadSttItemsDialog.tsx](src/components/human-labelling/BulkUploadSttItemsDialog.tsx)) — columns: `reference_transcript`, `predicted_transcript`. Lenient on header aliases (`reference`, `actual_transcript`, `predicted`, `hypothesis`, …).
- **Simulation** ([BulkUploadSimulationItemsDialog.tsx](src/components/human-labelling/BulkUploadSimulationItemsDialog.tsx)) — required `name` + `transcript` (JSON array of turn objects). Per-row JSON / role validation, errors annotated by row + turn number. Preview shows colored role pills (User / AI / System / Tool).
- **LLM** ([BulkUploadLlmItemsDialog.tsx](src/components/human-labelling/BulkUploadLlmItemsDialog.tsx)) — required `name`, `conversation_history`, `agent_response`, `evaluators`. The `evaluators` cell mirrors the Tests-page bulk upload semantics (plain criteria string OR JSON array `[{name, variables}]`) but resolves names against evaluators **linked to the task**, then maps them to UUID-keyed `evaluator_variables`. Sample CSV is generated dynamically from the task's linked evaluators with realistic variable values.

### Run evaluators dialog
- New [RunEvaluatorsDialog.tsx](src/components/human-labelling/RunEvaluatorsDialog.tsx) opens from any "Run evaluators" trigger (top button, selected items, per-item). Lists the linked evaluators with checkboxes; each row has a custom version dropdown defaulting to the live version with a green "Live" pill annotation. Submitting posts the picked `[{evaluator_id, evaluator_version_id}]` to `/annotation-tasks/{uuid}/evaluator-runs`, then navigates to the run page.
- Whole evaluator card is clickable to toggle its checkbox (with stop-propagation on the dropdown).

### SingleSelectPicker (new shared component)
Extracted [SingleSelectPicker.tsx](src/components/SingleSelectPicker.tsx) — a generic single-select picker with a portal-rendered fixed-position panel that escapes parent overflow. Caller supplies items, `getId`, `renderTrigger`, `renderOption`, optional `matchesSearch` and a `compact` variant. [AgentPicker](src/components/AgentPicker.tsx) was refactored to use it, dropping ~100 lines of duplicated dropdown machinery.

### "Live versions only" filter
- Toggle pill next to the evaluator filter on the overview tab. Default ON. When checked, sends `?live_only=true` to `/annotation-tasks/{uuid}/summary`. Hover-tooltip explains what it does.
- The same `summary` endpoint is now also fetched on the **Items** tab, so the per-item **View results** button can be disabled (with tooltip) when the item has no rows worth showing.

### Items tab refinements
- Per-item results expansion hides empty rows (no evaluator value, no agreement, no annotator label).
- View results button is disabled with a tooltip when no displayable rows exist for the item.
- Overview table + evaluator filter hide entirely when the task summary has no displayable rows.
- After creating a new item (any type), the items tab is opened automatically.

### Evaluator results coloring
- Run-detail page ([evaluator-runs/[runUuid]/page.tsx](src/app/human-labelling/tasks/%5Buuid%5D/evaluator-runs/%5BrunUuid%5D/page.tsx)) now reads `scale_min` / `scale_max` directly from each run's `evaluator_version` block (newly returned by the backend) and threads them into `EvaluatorVerdictCard`. Rating cards now color correctly: top-of-scale → green, bottom → red, in-between → amber, instead of always rendering amber.

## Test plan
- [ ] STT task → Bulk upload → CSV with `reference_transcript,predicted_transcript` parses, previews, uploads.
- [ ] Simulation task → Bulk upload → CSV with `name,transcript` (JSON arrays) parses, error messages name the offending row/turn.
- [ ] LLM task → Bulk upload → sample CSV download contains the task's actually-linked evaluators in JSON-array form; uploaded items show up in the items tab with the right `evaluator_variables`.
- [ ] Run evaluators dialog: default version is marked "Live"; switching versions and unchecking evaluators both work; submission navigates to the run page.
- [ ] Overview tab "Live versions only" toggle: re-fetches summary; tooltip appears on hover.
- [ ] Run-detail page: rating evaluator cards render green at scale_max and red at scale_min.

🤖 Generated with [Claude Code](https://claude.com/claude-code)