### PR TITLE
Polish bulk-upload CSV guidelines, preview, and annotator flow

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@types/jszip": "^3.4.0",
         "@vercel/analytics": "^1.6.1",
         "canvas-confetti": "^1.9.4",
+        "jspdf": "^4.2.1",
         "jszip": "^3.10.1",
         "next": "16.1.1",
         "next-auth": "^5.0.0-beta.30",
@@ -540,7 +541,6 @@
       "version": "7.29.2",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
       "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -4428,6 +4428,12 @@
         "undici-types": "~6.21.0"
       }
     },
+    "node_modules/@types/pako": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@types/pako/-/pako-2.0.4.tgz",
+      "integrity": "sha512-VWDCbrLeVXJM9fihYodcLiIv0ku+AlOa/TQ1SvYOaBuyrSKgEcro95LJyIsJ4vSo6BXIxOKxiJAat04CmST9Fw==",
+      "license": "MIT"
+    },
     "node_modules/@types/papaparse": {
       "version": "5.5.2",
       "resolved": "https://registry.npmjs.org/@types/papaparse/-/papaparse-5.5.2.tgz",
@@ -4457,6 +4463,13 @@
       "dependencies": {
         "@types/pg": "*"
       }
+    },
+    "node_modules/@types/raf": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/@types/raf/-/raf-3.4.3.tgz",
+      "integrity": "sha512-c4YAvMedbPZ5tEyxzQdMoOhhJ4RD3rngZIdwC2/qDN3d7JpEhB6fiBRKVY1lg5B7Wk+uPBjn5f39j1/2MY1oOw==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@types/react": {
       "version": "19.2.7",
@@ -4500,6 +4513,13 @@
       "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@types/use-sync-external-store": {
       "version": "0.0.6",
@@ -5850,6 +5870,16 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "license": "MIT"
     },
+    "node_modules/base64-arraybuffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
+      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.9.11",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.11.tgz",
@@ -6041,6 +6071,26 @@
       "funding": {
         "type": "donate",
         "url": "https://www.paypal.me/kirilvatev"
+      }
+    },
+    "node_modules/canvg": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/canvg/-/canvg-3.0.11.tgz",
+      "integrity": "sha512-5ON+q7jCTgMp9cjpu4Jo6XbvfYwSB2Ow3kzHKfIyJfaCAOHLbdKPQqGKgfED/R5B+3TFFfe8pegYA+b423SRyA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "@types/raf": "^3.4.0",
+        "core-js": "^3.8.3",
+        "raf": "^3.4.1",
+        "regenerator-runtime": "^0.13.7",
+        "rgbcolor": "^1.0.1",
+        "stackblur-canvas": "^2.0.0",
+        "svg-pathdata": "^6.0.3"
+      },
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/chalk": {
@@ -6306,6 +6356,18 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "license": "MIT"
     },
+    "node_modules/core-js": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.49.0.tgz",
+      "integrity": "sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
     "node_modules/core-util-is": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
@@ -6449,6 +6511,16 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/css-line-break": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz",
+      "integrity": "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "utrie": "^1.0.2"
       }
     },
     "node_modules/css.escape": {
@@ -6918,6 +6990,16 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/dompurify": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.2.tgz",
+      "integrity": "sha512-lHeS9SA/IKeIFFyYciHBr2n0v1VMPlSj843HdLOwjb2OxNwdq9Xykxqhk+FE42MzAdHvInbAolSE4mhahPpjXA==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optional": true,
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/dotenv": {
@@ -7817,6 +7899,23 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-png": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/fast-png/-/fast-png-6.4.0.tgz",
+      "integrity": "sha512-kAqZq1TlgBjZcLr5mcN6NP5Rv4V2f22z00c3g8vRrwkcqjerx7BEhPbOnWCPqaHUl2XWQBJQvOT/FQhdMT7X/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/pako": "^2.0.3",
+        "iobuffer": "^5.3.2",
+        "pako": "^2.1.0"
+      }
+    },
+    "node_modules/fast-png/node_modules/pako": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
+      "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==",
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/fast-uri": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
@@ -7853,6 +7952,12 @@
       "dependencies": {
         "bser": "2.1.1"
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+      "license": "MIT"
     },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
@@ -8398,6 +8503,20 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/html2canvas": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
+      "integrity": "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "css-line-break": "^2.1.0",
+        "text-segmentation": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/http-proxy-agent": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
@@ -8601,6 +8720,12 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/iobuffer": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/iobuffer/-/iobuffer-5.4.0.tgz",
+      "integrity": "sha512-DRebOWuqDvxunfkNJAlc3IzWIPD5xVxwUNbHr7xKB8E6aLJxIPfNX3CoMJghcFjpv6RWQsrcJbghtEwSPoJqMA==",
+      "license": "MIT"
     },
     "node_modules/is-array-buffer": {
       "version": "3.0.5",
@@ -10457,6 +10582,23 @@
         "node": ">=6"
       }
     },
+    "node_modules/jspdf": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-4.2.1.tgz",
+      "integrity": "sha512-YyAXyvnmjTbR4bHQRLzex3CuINCDlQnBqoSYyjJwTP2x9jDLuKDzy7aKUl0hgx3uhcl7xzg32agn5vlie6HIlQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.28.6",
+        "fast-png": "^6.2.0",
+        "fflate": "^0.8.1"
+      },
+      "optionalDependencies": {
+        "canvg": "^3.0.11",
+        "core-js": "^3.6.0",
+        "dompurify": "^3.3.1",
+        "html2canvas": "^1.0.0-rc.5"
+      }
+    },
     "node_modules/jsx-ast-utils": {
       "version": "3.3.5",
       "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.5.tgz",
@@ -11640,6 +11782,13 @@
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "license": "ISC"
     },
+    "node_modules/performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/pg-int8": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
@@ -12039,6 +12188,16 @@
       ],
       "license": "MIT"
     },
+    "node_modules/raf": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
+      "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "performance-now": "^2.1.0"
+      }
+    },
     "node_modules/randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -12214,6 +12373,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/regenerator-runtime": {
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.4",
       "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
@@ -12364,6 +12530,16 @@
       "engines": {
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rgbcolor": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/rgbcolor/-/rgbcolor-1.0.1.tgz",
+      "integrity": "sha512-9aZLIrhRaD97sgVhtJOW6ckOEh6/GnvQtdVNfdZ6s67+3/XwLS9lBcQYzEEhYVeUowN7pRzMLsyGhK2i/xvWbw==",
+      "license": "MIT OR SEE LICENSE IN FEEL-FREE.md",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.8.15"
       }
     },
     "node_modules/rollup": {
@@ -12912,6 +13088,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/stackblur-canvas": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/stackblur-canvas/-/stackblur-canvas-2.7.0.tgz",
+      "integrity": "sha512-yf7OENo23AGJhBriGx0QivY5JP6Y1HbrrDI6WLt6C5auYZXlQrheoY8hD4ibekFKz1HOfE48Ww8kMWMnJD/zcQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.1.14"
+      }
+    },
     "node_modules/stacktrace-parser": {
       "version": "0.1.11",
       "resolved": "https://registry.npmjs.org/stacktrace-parser/-/stacktrace-parser-0.1.11.tgz",
@@ -13288,6 +13474,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/svg-pathdata": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/svg-pathdata/-/svg-pathdata-6.0.3.tgz",
+      "integrity": "sha512-qsjeeq5YjBZ5eMdFuUa4ZosMLxgr5RZ+F+Y1OrDhuOCEInRMA3x74XdBtggJcj9kOeInz0WE+LgCPDkZFlBYJw==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/symbol-tree": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
@@ -13404,6 +13600,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/text-segmentation": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
+      "integrity": "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "utrie": "^1.0.2"
       }
     },
     "node_modules/third-party-capital": {
@@ -13847,6 +14053,16 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
+    },
+    "node_modules/utrie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/utrie/-/utrie-1.0.2.tgz",
+      "integrity": "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "base64-arraybuffer": "^1.0.2"
+      }
     },
     "node_modules/uuid": {
       "version": "9.0.1",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@types/jszip": "^3.4.0",
     "@vercel/analytics": "^1.6.1",
     "canvas-confetti": "^1.9.4",
+    "jspdf": "^4.2.1",
     "jszip": "^3.10.1",
     "next": "16.1.1",
     "next-auth": "^5.0.0-beta.30",

--- a/src/app/human-labelling/tasks/[uuid]/page.tsx
+++ b/src/app/human-labelling/tasks/[uuid]/page.tsx
@@ -249,7 +249,13 @@ type LabellingTask = {
   evaluators?: {
     uuid: string;
     name: string;
+    description?: string | null;
+    slug?: string | null;
     evaluator_type?: "llm" | "stt" | "tts" | "simulation";
+    output_type?: "binary" | "rating" | null;
+    scale_min?: number | boolean | null;
+    scale_max?: number | boolean | null;
+    variables?: EvaluatorVariableDef[] | null;
   }[];
   items?: LabellingItem[];
   jobs?: LabellingJob[];
@@ -1241,86 +1247,10 @@ function LabellingTaskPageInner() {
     }
   };
 
-  // Hydrated evaluator catalogue (with live_version.variables) used to
-  // pre-fill the AddTestDialog's evaluators section for label items.
-  type HydratedEvaluator = {
-    uuid: string;
-    name: string;
-    description?: string | null;
-    slug: string | null;
-    variables: EvaluatorVariableDef[];
-    output_type: "binary" | "rating" | null;
-    scale_min: number | null;
-    scale_max: number | null;
-  };
-  const [evaluatorCatalogue, setEvaluatorCatalogue] = useState<
-    Record<string, HydratedEvaluator>
-  >({});
-
-  useEffect(() => {
-    if (!accessToken) return;
-    let cancelled = false;
-    (async () => {
-      try {
-        const data = await apiClient<
-          Array<{
-            uuid: string;
-            name: string;
-            description?: string | null;
-            slug: string | null;
-            evaluator_type?: string;
-            output_type?: "binary" | "rating";
-            live_version?: {
-              variables?: EvaluatorVariableDef[] | null;
-              output_config?: {
-                scale?: Array<{ value: unknown }> | null;
-              } | null;
-            } | null;
-          }>
-        >("/evaluators?include_defaults=true", accessToken);
-        if (cancelled) return;
-        const next: Record<string, HydratedEvaluator> = {};
-        for (const e of Array.isArray(data) ? data : []) {
-          const scale = e.live_version?.output_config?.scale ?? [];
-          const numericValues = scale
-            .map((s) =>
-              typeof s.value === "number"
-                ? s.value
-                : typeof s.value === "boolean"
-                  ? s.value
-                    ? 1
-                    : 0
-                  : Number(s.value),
-            )
-            .filter((n) => Number.isFinite(n));
-          next[e.uuid] = {
-            uuid: e.uuid,
-            name: e.name,
-            description: e.description ?? null,
-            slug: e.slug,
-            variables: Array.isArray(e.live_version?.variables)
-              ? (e.live_version!.variables as EvaluatorVariableDef[])
-              : [],
-            output_type: e.output_type ?? null,
-            scale_min:
-              e.output_type === "rating" && numericValues.length > 0
-                ? Math.min(...numericValues)
-                : null,
-            scale_max:
-              e.output_type === "rating" && numericValues.length > 0
-                ? Math.max(...numericValues)
-                : null,
-          };
-        }
-        setEvaluatorCatalogue(next);
-      } catch {
-        // best-effort hydration; dialog will fall back to defaults
-      }
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, [accessToken]);
+  // GET /annotation-tasks/{uuid} now returns each linked evaluator with
+  // its live-version metadata (variables, output_type, scale, slug,
+  // description) inlined, so we no longer need a separate
+  // /evaluators?include_defaults=true catalogue fetch on this page.
 
   const editingItem = items.find((i) => i.uuid === editLlmItemUuid) ?? null;
   const editingPayload = (editingItem?.payload ?? null) as Record<
@@ -1359,17 +1289,16 @@ function LabellingTaskPageInner() {
   ): AttachedEvaluatorInit[] => {
     const linked = task?.evaluators ?? [];
     return linked.map((ev) => {
-      const hydrated = evaluatorCatalogue[ev.uuid];
       const saved = savedValues[ev.uuid] ?? null;
-      let variables: EvaluatorVariableDef[] = hydrated?.variables ?? [];
+      let variables: EvaluatorVariableDef[] = ev.variables ?? [];
       if (variables.length === 0 && saved && Object.keys(saved).length > 0) {
         variables = Object.keys(saved).map((name) => ({ name }));
       }
       return {
         evaluator_uuid: ev.uuid,
-        name: hydrated?.name ?? ev.name,
-        description: hydrated?.description ?? null,
-        slug: hydrated?.slug ?? null,
+        name: ev.name,
+        description: ev.description ?? null,
+        slug: ev.slug ?? null,
         variables,
         variable_values: saved,
       };
@@ -2944,16 +2873,13 @@ function LabellingTaskPageInner() {
           isOpen={bulkUploadSttOpen}
           accessToken={accessToken}
           taskUuid={uuid}
-          linkedEvaluators={(task?.evaluators ?? []).map((e) => {
-            const hydrated = evaluatorCatalogue[e.uuid];
-            return {
-              uuid: e.uuid,
-              name: hydrated?.name ?? e.name,
-              output_type: hydrated?.output_type ?? null,
-              scale_min: hydrated?.scale_min ?? null,
-              scale_max: hydrated?.scale_max ?? null,
-            };
-          })}
+          linkedEvaluators={(task?.evaluators ?? []).map((e) => ({
+            uuid: e.uuid,
+            name: e.name,
+            output_type: e.output_type ?? null,
+            scale_min: typeof e.scale_min === "number" ? e.scale_min : null,
+            scale_max: typeof e.scale_max === "number" ? e.scale_max : null,
+          }))}
           onClose={() => setBulkUploadSttOpen(false)}
           onSuccess={async (count, withAnnotations) => {
             setBulkUploadSttOpen(false);
@@ -2970,16 +2896,13 @@ function LabellingTaskPageInner() {
           isOpen={bulkUploadSimulationOpen}
           accessToken={accessToken}
           taskUuid={uuid}
-          linkedEvaluators={(task?.evaluators ?? []).map((e) => {
-            const hydrated = evaluatorCatalogue[e.uuid];
-            return {
-              uuid: e.uuid,
-              name: hydrated?.name ?? e.name,
-              output_type: hydrated?.output_type ?? null,
-              scale_min: hydrated?.scale_min ?? null,
-              scale_max: hydrated?.scale_max ?? null,
-            };
-          })}
+          linkedEvaluators={(task?.evaluators ?? []).map((e) => ({
+            uuid: e.uuid,
+            name: e.name,
+            output_type: e.output_type ?? null,
+            scale_min: typeof e.scale_min === "number" ? e.scale_min : null,
+            scale_max: typeof e.scale_max === "number" ? e.scale_max : null,
+          }))}
           onClose={() => setBulkUploadSimulationOpen(false)}
           onSuccess={async (count, withAnnotations) => {
             setBulkUploadSimulationOpen(false);
@@ -2996,18 +2919,15 @@ function LabellingTaskPageInner() {
           isOpen={bulkUploadLlmOpen}
           accessToken={accessToken}
           taskUuid={uuid}
-          linkedEvaluators={(task?.evaluators ?? []).map((e) => {
-            const hydrated = evaluatorCatalogue[e.uuid];
-            return {
-              uuid: e.uuid,
-              name: hydrated?.name ?? e.name,
-              slug: hydrated?.slug ?? null,
-              variables: hydrated?.variables ?? [],
-              output_type: hydrated?.output_type ?? null,
-              scale_min: hydrated?.scale_min ?? null,
-              scale_max: hydrated?.scale_max ?? null,
-            };
-          })}
+          linkedEvaluators={(task?.evaluators ?? []).map((e) => ({
+            uuid: e.uuid,
+            name: e.name,
+            slug: e.slug ?? null,
+            variables: e.variables ?? [],
+            output_type: e.output_type ?? null,
+            scale_min: typeof e.scale_min === "number" ? e.scale_min : null,
+            scale_max: typeof e.scale_max === "number" ? e.scale_max : null,
+          }))}
           onClose={() => setBulkUploadLlmOpen(false)}
           onSuccess={async (count, withAnnotations) => {
             setBulkUploadLlmOpen(false);

--- a/src/app/human-labelling/tasks/[uuid]/page.tsx
+++ b/src/app/human-labelling/tasks/[uuid]/page.tsx
@@ -1249,6 +1249,9 @@ function LabellingTaskPageInner() {
     description?: string | null;
     slug: string | null;
     variables: EvaluatorVariableDef[];
+    output_type: "binary" | "rating" | null;
+    scale_min: number | null;
+    scale_max: number | null;
   };
   const [evaluatorCatalogue, setEvaluatorCatalogue] = useState<
     Record<string, HydratedEvaluator>
@@ -1266,12 +1269,30 @@ function LabellingTaskPageInner() {
             description?: string | null;
             slug: string | null;
             evaluator_type?: string;
-            live_version?: { variables?: EvaluatorVariableDef[] | null } | null;
+            output_type?: "binary" | "rating";
+            live_version?: {
+              variables?: EvaluatorVariableDef[] | null;
+              output_config?: {
+                scale?: Array<{ value: unknown }> | null;
+              } | null;
+            } | null;
           }>
         >("/evaluators?include_defaults=true", accessToken);
         if (cancelled) return;
         const next: Record<string, HydratedEvaluator> = {};
         for (const e of Array.isArray(data) ? data : []) {
+          const scale = e.live_version?.output_config?.scale ?? [];
+          const numericValues = scale
+            .map((s) =>
+              typeof s.value === "number"
+                ? s.value
+                : typeof s.value === "boolean"
+                  ? s.value
+                    ? 1
+                    : 0
+                  : Number(s.value),
+            )
+            .filter((n) => Number.isFinite(n));
           next[e.uuid] = {
             uuid: e.uuid,
             name: e.name,
@@ -1280,6 +1301,15 @@ function LabellingTaskPageInner() {
             variables: Array.isArray(e.live_version?.variables)
               ? (e.live_version!.variables as EvaluatorVariableDef[])
               : [],
+            output_type: e.output_type ?? null,
+            scale_min:
+              e.output_type === "rating" && numericValues.length > 0
+                ? Math.min(...numericValues)
+                : null,
+            scale_max:
+              e.output_type === "rating" && numericValues.length > 0
+                ? Math.max(...numericValues)
+                : null,
           };
         }
         setEvaluatorCatalogue(next);
@@ -2914,11 +2944,22 @@ function LabellingTaskPageInner() {
           isOpen={bulkUploadSttOpen}
           accessToken={accessToken}
           taskUuid={uuid}
+          linkedEvaluators={(task?.evaluators ?? []).map((e) => {
+            const hydrated = evaluatorCatalogue[e.uuid];
+            return {
+              uuid: e.uuid,
+              name: hydrated?.name ?? e.name,
+              output_type: hydrated?.output_type ?? null,
+              scale_min: hydrated?.scale_min ?? null,
+              scale_max: hydrated?.scale_max ?? null,
+            };
+          })}
           onClose={() => setBulkUploadSttOpen(false)}
-          onSuccess={async (count) => {
+          onSuccess={async (count, withAnnotations) => {
             setBulkUploadSttOpen(false);
             handleTabChange("items");
             await fetchTask();
+            if (withAnnotations) await fetchTaskSummary();
             toast.success(`Added ${count} ${count === 1 ? "item" : "items"}`);
           }}
         />
@@ -2929,11 +2970,22 @@ function LabellingTaskPageInner() {
           isOpen={bulkUploadSimulationOpen}
           accessToken={accessToken}
           taskUuid={uuid}
+          linkedEvaluators={(task?.evaluators ?? []).map((e) => {
+            const hydrated = evaluatorCatalogue[e.uuid];
+            return {
+              uuid: e.uuid,
+              name: hydrated?.name ?? e.name,
+              output_type: hydrated?.output_type ?? null,
+              scale_min: hydrated?.scale_min ?? null,
+              scale_max: hydrated?.scale_max ?? null,
+            };
+          })}
           onClose={() => setBulkUploadSimulationOpen(false)}
-          onSuccess={async (count) => {
+          onSuccess={async (count, withAnnotations) => {
             setBulkUploadSimulationOpen(false);
             handleTabChange("items");
             await fetchTask();
+            if (withAnnotations) await fetchTaskSummary();
             toast.success(`Added ${count} ${count === 1 ? "item" : "items"}`);
           }}
         />
@@ -2951,13 +3003,17 @@ function LabellingTaskPageInner() {
               name: hydrated?.name ?? e.name,
               slug: hydrated?.slug ?? null,
               variables: hydrated?.variables ?? [],
+              output_type: hydrated?.output_type ?? null,
+              scale_min: hydrated?.scale_min ?? null,
+              scale_max: hydrated?.scale_max ?? null,
             };
           })}
           onClose={() => setBulkUploadLlmOpen(false)}
-          onSuccess={async (count) => {
+          onSuccess={async (count, withAnnotations) => {
             setBulkUploadLlmOpen(false);
             handleTabChange("items");
             await fetchTask();
+            if (withAnnotations) await fetchTaskSummary();
             toast.success(`Added ${count} ${count === 1 ? "item" : "items"}`);
           }}
         />

--- a/src/app/human-labelling/tasks/[uuid]/page.tsx
+++ b/src/app/human-labelling/tasks/[uuid]/page.tsx
@@ -2131,7 +2131,7 @@ function LabellingTaskPageInner() {
                             selectedItems={summaryEvaluatorFilter}
                             onSelectionChange={setSummaryEvaluatorFilter}
                             placeholder="All evaluators"
-                            searchPlaceholder="Search evaluators..."
+                            searchPlaceholder="Search evaluators"
                           />
                         </div>
                         <Tooltip content="Show results for only the live versions of each evaluator. Toggle to see the results for all versions.">

--- a/src/app/stt/new/page.tsx
+++ b/src/app/stt/new/page.tsx
@@ -25,27 +25,62 @@ function NewSTTEvaluationPageInner() {
         className="flex items-center justify-center w-8 h-8 rounded-md hover:bg-muted transition-colors cursor-pointer"
         title="Back to STT evaluations"
       >
-        <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-          <path strokeLinecap="round" strokeLinejoin="round" d="M15.75 19.5L8.25 12l7.5-7.5" />
+        <svg
+          className="w-5 h-5"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+          strokeWidth={2}
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M15.75 19.5L8.25 12l7.5-7.5"
+          />
         </svg>
       </button>
       <span className="text-base font-semibold text-foreground">Back</span>
       <div className="w-px h-5 bg-border mx-1" />
       {isEvaluating ? (
         <div className="flex items-center gap-2 h-8 px-3 text-sm text-muted-foreground">
-          <svg className="w-3.5 h-3.5 animate-spin" fill="none" viewBox="0 0 24 24">
-            <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
-            <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
+          <svg
+            className="w-3.5 h-3.5 animate-spin"
+            fill="none"
+            viewBox="0 0 24 24"
+          >
+            <circle
+              className="opacity-25"
+              cx="12"
+              cy="12"
+              r="10"
+              stroke="currentColor"
+              strokeWidth="4"
+            />
+            <path
+              className="opacity-75"
+              fill="currentColor"
+              d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+            />
           </svg>
-          Evaluating…
+          Evaluating
         </div>
       ) : (
         <button
           onClick={() => evaluateRef.current?.()}
           className="h-8 px-4 rounded-md text-sm font-medium bg-foreground text-background hover:opacity-90 transition-opacity cursor-pointer flex items-center gap-1.5"
         >
-          <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-            <path strokeLinecap="round" strokeLinejoin="round" d="M5.25 5.653c0-.856.917-1.398 1.667-.986l11.54 6.348a1.125 1.125 0 010 1.971l-11.54 6.347a1.125 1.125 0 01-1.667-.986V5.653z" />
+          <svg
+            className="w-3.5 h-3.5"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            strokeWidth={2}
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              d="M5.25 5.653c0-.856.917-1.398 1.667-.986l11.54 6.348a1.125 1.125 0 010 1.971l-11.54 6.347a1.125 1.125 0 01-1.667-.986V5.653z"
+            />
           </svg>
           Evaluate
         </button>

--- a/src/app/stt/page.tsx
+++ b/src/app/stt/page.tsx
@@ -123,9 +123,7 @@ function STTPageInner() {
 
         const datasetIds = [
           ...new Set(
-            fetchedJobs
-              .filter((j) => j.dataset_id)
-              .map((j) => j.dataset_id!),
+            fetchedJobs.filter((j) => j.dataset_id).map((j) => j.dataset_id!),
           ),
         ];
         const validDatasetIds = new Set<string>();
@@ -235,7 +233,10 @@ function STTPageInner() {
         {/* Tab Bar */}
         <div className="flex gap-1 border-b border-border">
           <button
-            onClick={() => { setActiveTab("evaluations"); router.replace("/stt", { scroll: false }); }}
+            onClick={() => {
+              setActiveTab("evaluations");
+              router.replace("/stt", { scroll: false });
+            }}
             className={`px-4 py-2 text-sm font-medium transition-colors cursor-pointer border-b-2 -mb-px ${
               activeTab === "evaluations"
                 ? "border-foreground text-foreground"
@@ -245,7 +246,10 @@ function STTPageInner() {
             Evaluations
           </button>
           <button
-            onClick={() => { setActiveTab("datasets"); router.replace("/stt?tab=datasets", { scroll: false }); }}
+            onClick={() => {
+              setActiveTab("datasets");
+              router.replace("/stt?tab=datasets", { scroll: false });
+            }}
             className={`px-4 py-2 text-sm font-medium transition-colors cursor-pointer border-b-2 -mb-px ${
               activeTab === "datasets"
                 ? "border-foreground text-foreground"
@@ -326,7 +330,8 @@ function STTPageInner() {
             ) : (
               <>
                 <p className="text-sm text-muted-foreground mb-3">
-                  {jobs.length} {jobs.length === 1 ? "evaluation" : "evaluations"}
+                  {jobs.length}{" "}
+                  {jobs.length === 1 ? "evaluation" : "evaluations"}
                 </p>
                 {/* Mobile Sort Button */}
                 <div className="flex justify-end md:hidden mb-3">
@@ -711,7 +716,8 @@ function STTPageInner() {
             ) : (
               <>
                 <p className="text-sm text-muted-foreground mb-3">
-                  {datasets.length} {datasets.length === 1 ? "dataset" : "datasets"}
+                  {datasets.length}{" "}
+                  {datasets.length === 1 ? "dataset" : "datasets"}
                 </p>
                 <div className="border border-border rounded-xl overflow-hidden">
                   {/* Table Header */}
@@ -724,59 +730,59 @@ function STTPageInner() {
                     </div>
                     <div className="text-sm font-medium text-muted-foreground">
                       Evals
+                    </div>
+                    <div className="text-sm font-medium text-muted-foreground">
+                      Updated
+                    </div>
+                    <div />
                   </div>
-                  <div className="text-sm font-medium text-muted-foreground">
-                    Updated
-                  </div>
-                  <div />
-                </div>
-                {datasets.map((dataset) => (
-                  <div
-                    key={dataset.uuid}
-                    onClick={() => router.push(`/datasets/${dataset.uuid}`)}
-                    className="flex flex-col md:grid md:grid-cols-[2fr_80px_80px_1fr_40px] gap-1 md:gap-4 px-4 py-3 border-b border-border last:border-b-0 hover:bg-muted/20 transition-colors cursor-pointer items-center"
-                  >
-                    <div className="text-sm font-medium text-foreground">
-                      {dataset.name}
-                    </div>
-                    <div className="text-sm text-muted-foreground">
-                      {dataset.item_count}
-                    </div>
-                    <div className="text-sm text-muted-foreground">
-                      {dataset.eval_count}
-                    </div>
-                    <div className="text-sm text-muted-foreground">
-                      {dataset.updated_at
-                        ? formatDate(dataset.updated_at)
-                        : "—"}
-                    </div>
-                    <div className="flex justify-end">
-                      <button
-                        title="Delete dataset"
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          setDeleteDatasetId(dataset.uuid);
-                        }}
-                        className="p-1.5 rounded hover:bg-muted/50 text-muted-foreground hover:text-red-500 transition-colors cursor-pointer"
-                      >
-                        <svg
-                          className="w-3.5 h-3.5"
-                          fill="none"
-                          viewBox="0 0 24 24"
-                          stroke="currentColor"
-                          strokeWidth={2}
+                  {datasets.map((dataset) => (
+                    <div
+                      key={dataset.uuid}
+                      onClick={() => router.push(`/datasets/${dataset.uuid}`)}
+                      className="flex flex-col md:grid md:grid-cols-[2fr_80px_80px_1fr_40px] gap-1 md:gap-4 px-4 py-3 border-b border-border last:border-b-0 hover:bg-muted/20 transition-colors cursor-pointer items-center"
+                    >
+                      <div className="text-sm font-medium text-foreground">
+                        {dataset.name}
+                      </div>
+                      <div className="text-sm text-muted-foreground">
+                        {dataset.item_count}
+                      </div>
+                      <div className="text-sm text-muted-foreground">
+                        {dataset.eval_count}
+                      </div>
+                      <div className="text-sm text-muted-foreground">
+                        {dataset.updated_at
+                          ? formatDate(dataset.updated_at)
+                          : "—"}
+                      </div>
+                      <div className="flex justify-end">
+                        <button
+                          title="Delete dataset"
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            setDeleteDatasetId(dataset.uuid);
+                          }}
+                          className="p-1.5 rounded hover:bg-muted/50 text-muted-foreground hover:text-red-500 transition-colors cursor-pointer"
                         >
-                          <path
-                            strokeLinecap="round"
-                            strokeLinejoin="round"
-                            d="M14.74 9l-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 01-2.244 2.077H8.084a2.25 2.25 0 01-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 00-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 013.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 00-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 00-7.5 0"
-                          />
-                        </svg>
-                      </button>
+                          <svg
+                            className="w-3.5 h-3.5"
+                            fill="none"
+                            viewBox="0 0 24 24"
+                            stroke="currentColor"
+                            strokeWidth={2}
+                          >
+                            <path
+                              strokeLinecap="round"
+                              strokeLinejoin="round"
+                              d="M14.74 9l-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 01-2.244 2.077H8.084a2.25 2.25 0 01-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 00-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 013.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 00-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 00-7.5 0"
+                            />
+                          </svg>
+                        </button>
+                      </div>
                     </div>
-                  </div>
-                ))}
-              </div>
+                  ))}
+                </div>
               </>
             )}
           </>
@@ -829,7 +835,7 @@ function STTPageInner() {
                 disabled={!newDatasetName.trim() || isCreating}
                 className="h-9 px-4 rounded-md text-sm font-medium bg-foreground text-background hover:opacity-90 transition-opacity cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
               >
-                {isCreating ? "Creating…" : "Create"}
+                {isCreating ? "Creating" : "Create"}
               </button>
             </div>
           </div>

--- a/src/app/tts/new/page.tsx
+++ b/src/app/tts/new/page.tsx
@@ -25,27 +25,62 @@ function NewTTSEvaluationPageInner() {
         className="flex items-center justify-center w-8 h-8 rounded-md hover:bg-muted transition-colors cursor-pointer"
         title="Back to TTS evaluations"
       >
-        <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-          <path strokeLinecap="round" strokeLinejoin="round" d="M15.75 19.5L8.25 12l7.5-7.5" />
+        <svg
+          className="w-5 h-5"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+          strokeWidth={2}
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M15.75 19.5L8.25 12l7.5-7.5"
+          />
         </svg>
       </button>
       <span className="text-base font-semibold text-foreground">Back</span>
       <div className="w-px h-5 bg-border mx-1" />
       {isEvaluating ? (
         <div className="flex items-center gap-2 h-8 px-3 text-sm text-muted-foreground">
-          <svg className="w-3.5 h-3.5 animate-spin" fill="none" viewBox="0 0 24 24">
-            <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
-            <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
+          <svg
+            className="w-3.5 h-3.5 animate-spin"
+            fill="none"
+            viewBox="0 0 24 24"
+          >
+            <circle
+              className="opacity-25"
+              cx="12"
+              cy="12"
+              r="10"
+              stroke="currentColor"
+              strokeWidth="4"
+            />
+            <path
+              className="opacity-75"
+              fill="currentColor"
+              d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+            />
           </svg>
-          Evaluating…
+          Evaluating
         </div>
       ) : (
         <button
           onClick={() => evaluateRef.current?.()}
           className="h-8 px-4 rounded-md text-sm font-medium bg-foreground text-background hover:opacity-90 transition-opacity cursor-pointer flex items-center gap-1.5"
         >
-          <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-            <path strokeLinecap="round" strokeLinejoin="round" d="M5.25 5.653c0-.856.917-1.398 1.667-.986l11.54 6.348a1.125 1.125 0 010 1.971l-11.54 6.347a1.125 1.125 0 01-1.667-.986V5.653z" />
+          <svg
+            className="w-3.5 h-3.5"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            strokeWidth={2}
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              d="M5.25 5.653c0-.856.917-1.398 1.667-.986l11.54 6.348a1.125 1.125 0 010 1.971l-11.54 6.347a1.125 1.125 0 01-1.667-.986V5.653z"
+            />
           </svg>
           Evaluate
         </button>

--- a/src/app/tts/page.tsx
+++ b/src/app/tts/page.tsx
@@ -232,7 +232,10 @@ function TTSPageInner() {
         {/* Tab Bar */}
         <div className="flex gap-1 border-b border-border">
           <button
-            onClick={() => { setActiveTab("evaluations"); router.replace("/tts", { scroll: false }); }}
+            onClick={() => {
+              setActiveTab("evaluations");
+              router.replace("/tts", { scroll: false });
+            }}
             className={`px-4 py-2 text-sm font-medium transition-colors cursor-pointer border-b-2 -mb-px ${
               activeTab === "evaluations"
                 ? "border-foreground text-foreground"
@@ -242,7 +245,10 @@ function TTSPageInner() {
             Evaluations
           </button>
           <button
-            onClick={() => { setActiveTab("datasets"); router.replace("/tts?tab=datasets", { scroll: false }); }}
+            onClick={() => {
+              setActiveTab("datasets");
+              router.replace("/tts?tab=datasets", { scroll: false });
+            }}
             className={`px-4 py-2 text-sm font-medium transition-colors cursor-pointer border-b-2 -mb-px ${
               activeTab === "datasets"
                 ? "border-foreground text-foreground"
@@ -323,7 +329,8 @@ function TTSPageInner() {
             ) : (
               <>
                 <p className="text-sm text-muted-foreground mb-3">
-                  {jobs.length} {jobs.length === 1 ? "evaluation" : "evaluations"}
+                  {jobs.length}{" "}
+                  {jobs.length === 1 ? "evaluation" : "evaluations"}
                 </p>
                 {/* Mobile Sort Button */}
                 <div className="flex justify-end md:hidden mb-3">
@@ -708,7 +715,8 @@ function TTSPageInner() {
             ) : (
               <>
                 <p className="text-sm text-muted-foreground mb-3">
-                  {datasets.length} {datasets.length === 1 ? "dataset" : "datasets"}
+                  {datasets.length}{" "}
+                  {datasets.length === 1 ? "dataset" : "datasets"}
                 </p>
                 <div className="border border-border rounded-xl overflow-hidden">
                   {/* Table Header */}
@@ -721,59 +729,59 @@ function TTSPageInner() {
                     </div>
                     <div className="text-sm font-medium text-muted-foreground">
                       Evals
+                    </div>
+                    <div className="text-sm font-medium text-muted-foreground">
+                      Updated
+                    </div>
+                    <div />
                   </div>
-                  <div className="text-sm font-medium text-muted-foreground">
-                    Updated
-                  </div>
-                  <div />
-                </div>
-                {datasets.map((dataset) => (
-                  <div
-                    key={dataset.uuid}
-                    onClick={() => router.push(`/datasets/${dataset.uuid}`)}
-                    className="flex flex-col md:grid md:grid-cols-[2fr_80px_80px_1fr_40px] gap-1 md:gap-4 px-4 py-3 border-b border-border last:border-b-0 hover:bg-muted/20 transition-colors cursor-pointer items-center"
-                  >
-                    <div className="text-sm font-medium text-foreground">
-                      {dataset.name}
-                    </div>
-                    <div className="text-sm text-muted-foreground">
-                      {dataset.item_count}
-                    </div>
-                    <div className="text-sm text-muted-foreground">
-                      {dataset.eval_count}
-                    </div>
-                    <div className="text-sm text-muted-foreground">
-                      {dataset.updated_at
-                        ? formatDate(dataset.updated_at)
-                        : "—"}
-                    </div>
-                    <div className="flex justify-end">
-                      <button
-                        title="Delete dataset"
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          setDeleteDatasetId(dataset.uuid);
-                        }}
-                        className="p-1.5 rounded hover:bg-muted/50 text-muted-foreground hover:text-red-500 transition-colors cursor-pointer"
-                      >
-                        <svg
-                          className="w-3.5 h-3.5"
-                          fill="none"
-                          viewBox="0 0 24 24"
-                          stroke="currentColor"
-                          strokeWidth={2}
+                  {datasets.map((dataset) => (
+                    <div
+                      key={dataset.uuid}
+                      onClick={() => router.push(`/datasets/${dataset.uuid}`)}
+                      className="flex flex-col md:grid md:grid-cols-[2fr_80px_80px_1fr_40px] gap-1 md:gap-4 px-4 py-3 border-b border-border last:border-b-0 hover:bg-muted/20 transition-colors cursor-pointer items-center"
+                    >
+                      <div className="text-sm font-medium text-foreground">
+                        {dataset.name}
+                      </div>
+                      <div className="text-sm text-muted-foreground">
+                        {dataset.item_count}
+                      </div>
+                      <div className="text-sm text-muted-foreground">
+                        {dataset.eval_count}
+                      </div>
+                      <div className="text-sm text-muted-foreground">
+                        {dataset.updated_at
+                          ? formatDate(dataset.updated_at)
+                          : "—"}
+                      </div>
+                      <div className="flex justify-end">
+                        <button
+                          title="Delete dataset"
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            setDeleteDatasetId(dataset.uuid);
+                          }}
+                          className="p-1.5 rounded hover:bg-muted/50 text-muted-foreground hover:text-red-500 transition-colors cursor-pointer"
                         >
-                          <path
-                            strokeLinecap="round"
-                            strokeLinejoin="round"
-                            d="M14.74 9l-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 01-2.244 2.077H8.084a2.25 2.25 0 01-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 00-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 013.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 00-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 00-7.5 0"
-                          />
-                        </svg>
-                      </button>
+                          <svg
+                            className="w-3.5 h-3.5"
+                            fill="none"
+                            viewBox="0 0 24 24"
+                            stroke="currentColor"
+                            strokeWidth={2}
+                          >
+                            <path
+                              strokeLinecap="round"
+                              strokeLinejoin="round"
+                              d="M14.74 9l-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 01-2.244 2.077H8.084a2.25 2.25 0 01-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 00-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 013.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 00-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 00-7.5 0"
+                            />
+                          </svg>
+                        </button>
+                      </div>
                     </div>
-                  </div>
-                ))}
-              </div>
+                  ))}
+                </div>
               </>
             )}
           </>
@@ -826,7 +834,7 @@ function TTSPageInner() {
                 disabled={!newDatasetName.trim() || isCreating}
                 className="h-9 px-4 rounded-md text-sm font-medium bg-foreground text-background hover:opacity-90 transition-opacity cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
               >
-                {isCreating ? "Creating…" : "Create"}
+                {isCreating ? "Creating" : "Create"}
               </button>
             </div>
           </div>

--- a/src/components/AddTestDialog.tsx
+++ b/src/components/AddTestDialog.tsx
@@ -1476,7 +1476,7 @@ export function AddTestDialog({
                             onChange={(e) =>
                               setEvaluatorPickerSearch(e.target.value)
                             }
-                            placeholder="Search evaluators..."
+                            placeholder="Search evaluators"
                             autoFocus
                             className="w-full h-9 px-3 rounded-md text-sm bg-background text-foreground placeholder:text-muted-foreground border border-border focus:outline-none focus:ring-1 focus:ring-accent"
                           />
@@ -2287,188 +2287,197 @@ export function AddTestDialog({
                       {message.role === "tool_call" && (
                         <div className="flex w-full items-start gap-2">
                           <div className="w-1/2">
-                          <div className="bg-muted border border-border rounded-2xl p-4">
-                            <div className="flex items-center gap-2 mb-2">
-                              <svg
-                                className="w-4 h-4 text-muted-foreground"
-                                fill="none"
-                                viewBox="0 0 24 24"
-                                stroke="currentColor"
-                                strokeWidth={1.5}
-                              >
-                                <path
-                                  strokeLinecap="round"
-                                  strokeLinejoin="round"
-                                  d="M11.42 15.17L17.25 21A2.652 2.652 0 0021 17.25l-5.877-5.877M11.42 15.17l2.496-3.03c.317-.384.74-.626 1.208-.766M11.42 15.17l-4.655 5.653a2.548 2.548 0 11-3.586-3.586l6.837-5.63m5.108-.233c.55-.164 1.163-.188 1.743-.14a4.5 4.5 0 004.486-6.336l-3.276 3.277a3.004 3.004 0 01-2.25-2.25l3.276-3.276a4.5 4.5 0 00-6.336 4.486c.091 1.076-.071 2.264-.904 2.95l-.102.085m-1.745 1.437L5.909 7.5H4.5L2.25 3.75l1.5-1.5L7.5 4.5v1.409l4.26 4.26m-1.745 1.437l1.745-1.437m6.615 8.206L15.75 15.75M4.867 19.125h.008v.008h-.008v-.008z"
-                                />
-                              </svg>
-                              <span className="text-sm font-medium text-foreground">
-                                {message.toolName}
-                              </span>
-                              {message.isWebhook && (
-                                <span className="text-xs text-muted-foreground bg-background px-2 py-0.5 rounded">
-                                  Webhook
+                            <div className="bg-muted border border-border rounded-2xl p-4">
+                              <div className="flex items-center gap-2 mb-2">
+                                <svg
+                                  className="w-4 h-4 text-muted-foreground"
+                                  fill="none"
+                                  viewBox="0 0 24 24"
+                                  stroke="currentColor"
+                                  strokeWidth={1.5}
+                                >
+                                  <path
+                                    strokeLinecap="round"
+                                    strokeLinejoin="round"
+                                    d="M11.42 15.17L17.25 21A2.652 2.652 0 0021 17.25l-5.877-5.877M11.42 15.17l2.496-3.03c.317-.384.74-.626 1.208-.766M11.42 15.17l-4.655 5.653a2.548 2.548 0 11-3.586-3.586l6.837-5.63m5.108-.233c.55-.164 1.163-.188 1.743-.14a4.5 4.5 0 004.486-6.336l-3.276 3.277a3.004 3.004 0 01-2.25-2.25l3.276-3.276a4.5 4.5 0 00-6.336 4.486c.091 1.076-.071 2.264-.904 2.95l-.102.085m-1.745 1.437L5.909 7.5H4.5L2.25 3.75l1.5-1.5L7.5 4.5v1.409l4.26 4.26m-1.745 1.437l1.745-1.437m6.615 8.206L15.75 15.75M4.867 19.125h.008v.008h-.008v-.008z"
+                                  />
+                                </svg>
+                                <span className="text-sm font-medium text-foreground">
+                                  {message.toolName}
                                 </span>
-                              )}
-                            </div>
-                            {message.toolParams &&
-                              message.toolParams.length > 0 && (
-                                <div className="space-y-3 mt-3">
-                                  {/* Group parameters by type for webhook tools */}
-                                  {message.isWebhook ? (
-                                    <>
-                                      {/* Query Parameters */}
-                                      {message.toolParams.filter(
-                                        (p) => p.group === "query",
-                                      ).length > 0 && (
-                                        <div className="bg-background border border-border rounded-xl p-3">
-                                          <h5 className="text-xs font-medium text-muted-foreground mb-3 uppercase tracking-wide">
-                                            Query
-                                          </h5>
-                                          <div className="space-y-3">
-                                            {message.toolParams
-                                              .filter(
-                                                (p) => p.group === "query",
-                                              )
-                                              .map((param, idx) => {
-                                                const isEmpty =
-                                                  !param.value.trim();
-                                                const showError =
-                                                  localValidationAttempted &&
-                                                  isEmpty;
-                                                return (
-                                                  <div key={idx}>
-                                                    <label className="block text-sm font-medium text-foreground mb-1.5">
-                                                      {param.name}
-                                                    </label>
-                                                    <input
-                                                      type="text"
-                                                      value={param.value}
-                                                      onChange={(e) =>
-                                                        updateToolCallParam(
-                                                          message.id,
-                                                          param.name,
-                                                          e.target.value,
-                                                          param.group,
-                                                        )
-                                                      }
-                                                      placeholder={`Enter ${param.name}`}
-                                                      data-tool-call-id={message.id}
-                                                      className={`w-full h-10 px-3 rounded-lg text-sm bg-muted text-foreground placeholder:text-muted-foreground border focus:outline-none focus:ring-2 focus:ring-accent ${
-                                                        showError
-                                                          ? "border-red-500"
-                                                          : "border-border"
-                                                      }`}
-                                                    />
-                                                    {showError && (
-                                                      <p className="text-xs text-red-500 mt-1">
-                                                        This field cannot be
-                                                        empty
-                                                      </p>
-                                                    )}
-                                                  </div>
-                                                );
-                                              })}
-                                          </div>
-                                        </div>
-                                      )}
-                                      {/* Body Parameters */}
-                                      {message.toolParams.filter(
-                                        (p) => p.group === "body",
-                                      ).length > 0 && (
-                                        <div className="bg-background border border-border rounded-xl p-3">
-                                          <h5 className="text-xs font-medium text-muted-foreground mb-3 uppercase tracking-wide">
-                                            Body
-                                          </h5>
-                                          <div className="space-y-3">
-                                            {message.toolParams
-                                              .filter((p) => p.group === "body")
-                                              .map((param, idx) => {
-                                                const isEmpty =
-                                                  !param.value.trim();
-                                                const showError =
-                                                  localValidationAttempted &&
-                                                  isEmpty;
-                                                return (
-                                                  <div key={idx}>
-                                                    <label className="block text-sm font-medium text-foreground mb-1.5">
-                                                      {param.name}
-                                                    </label>
-                                                    <input
-                                                      type="text"
-                                                      value={param.value}
-                                                      onChange={(e) =>
-                                                        updateToolCallParam(
-                                                          message.id,
-                                                          param.name,
-                                                          e.target.value,
-                                                          param.group,
-                                                        )
-                                                      }
-                                                      placeholder={`Enter ${param.name}`}
-                                                      data-tool-call-id={message.id}
-                                                      className={`w-full h-10 px-3 rounded-lg text-sm bg-muted text-foreground placeholder:text-muted-foreground border focus:outline-none focus:ring-2 focus:ring-accent ${
-                                                        showError
-                                                          ? "border-red-500"
-                                                          : "border-border"
-                                                      }`}
-                                                    />
-                                                    {showError && (
-                                                      <p className="text-xs text-red-500 mt-1">
-                                                        This field cannot be
-                                                        empty
-                                                      </p>
-                                                    )}
-                                                  </div>
-                                                );
-                                              })}
-                                          </div>
-                                        </div>
-                                      )}
-                                    </>
-                                  ) : (
-                                    /* Regular tool parameters */
-                                    <div className="space-y-3">
-                                      {message.toolParams.map((param, idx) => {
-                                        const isEmpty = !param.value.trim();
-                                        const showError =
-                                          localValidationAttempted && isEmpty;
-                                        return (
-                                          <div key={idx}>
-                                            <label className="block text-sm font-medium text-foreground mb-1.5">
-                                              {param.name}
-                                            </label>
-                                            <input
-                                              type="text"
-                                              value={param.value}
-                                              onChange={(e) =>
-                                                updateToolCallParam(
-                                                  message.id,
-                                                  param.name,
-                                                  e.target.value,
-                                                  param.group,
+                                {message.isWebhook && (
+                                  <span className="text-xs text-muted-foreground bg-background px-2 py-0.5 rounded">
+                                    Webhook
+                                  </span>
+                                )}
+                              </div>
+                              {message.toolParams &&
+                                message.toolParams.length > 0 && (
+                                  <div className="space-y-3 mt-3">
+                                    {/* Group parameters by type for webhook tools */}
+                                    {message.isWebhook ? (
+                                      <>
+                                        {/* Query Parameters */}
+                                        {message.toolParams.filter(
+                                          (p) => p.group === "query",
+                                        ).length > 0 && (
+                                          <div className="bg-background border border-border rounded-xl p-3">
+                                            <h5 className="text-xs font-medium text-muted-foreground mb-3 uppercase tracking-wide">
+                                              Query
+                                            </h5>
+                                            <div className="space-y-3">
+                                              {message.toolParams
+                                                .filter(
+                                                  (p) => p.group === "query",
                                                 )
-                                              }
-                                              placeholder={`Enter ${param.name}`}
-                                              className={`w-full h-10 px-4 rounded-lg text-sm bg-background text-foreground placeholder:text-muted-foreground border focus:outline-none focus:ring-2 focus:ring-accent ${
-                                                showError
-                                                  ? "border-red-500"
-                                                  : "border-border"
-                                              }`}
-                                            />
-                                            {showError && (
-                                              <p className="text-xs text-red-500 mt-1">
-                                                This field cannot be empty
-                                              </p>
-                                            )}
+                                                .map((param, idx) => {
+                                                  const isEmpty =
+                                                    !param.value.trim();
+                                                  const showError =
+                                                    localValidationAttempted &&
+                                                    isEmpty;
+                                                  return (
+                                                    <div key={idx}>
+                                                      <label className="block text-sm font-medium text-foreground mb-1.5">
+                                                        {param.name}
+                                                      </label>
+                                                      <input
+                                                        type="text"
+                                                        value={param.value}
+                                                        onChange={(e) =>
+                                                          updateToolCallParam(
+                                                            message.id,
+                                                            param.name,
+                                                            e.target.value,
+                                                            param.group,
+                                                          )
+                                                        }
+                                                        placeholder={`Enter ${param.name}`}
+                                                        data-tool-call-id={
+                                                          message.id
+                                                        }
+                                                        className={`w-full h-10 px-3 rounded-lg text-sm bg-muted text-foreground placeholder:text-muted-foreground border focus:outline-none focus:ring-2 focus:ring-accent ${
+                                                          showError
+                                                            ? "border-red-500"
+                                                            : "border-border"
+                                                        }`}
+                                                      />
+                                                      {showError && (
+                                                        <p className="text-xs text-red-500 mt-1">
+                                                          This field cannot be
+                                                          empty
+                                                        </p>
+                                                      )}
+                                                    </div>
+                                                  );
+                                                })}
+                                            </div>
                                           </div>
-                                        );
-                                      })}
-                                    </div>
-                                  )}
-                                </div>
-                              )}
-                          </div>
+                                        )}
+                                        {/* Body Parameters */}
+                                        {message.toolParams.filter(
+                                          (p) => p.group === "body",
+                                        ).length > 0 && (
+                                          <div className="bg-background border border-border rounded-xl p-3">
+                                            <h5 className="text-xs font-medium text-muted-foreground mb-3 uppercase tracking-wide">
+                                              Body
+                                            </h5>
+                                            <div className="space-y-3">
+                                              {message.toolParams
+                                                .filter(
+                                                  (p) => p.group === "body",
+                                                )
+                                                .map((param, idx) => {
+                                                  const isEmpty =
+                                                    !param.value.trim();
+                                                  const showError =
+                                                    localValidationAttempted &&
+                                                    isEmpty;
+                                                  return (
+                                                    <div key={idx}>
+                                                      <label className="block text-sm font-medium text-foreground mb-1.5">
+                                                        {param.name}
+                                                      </label>
+                                                      <input
+                                                        type="text"
+                                                        value={param.value}
+                                                        onChange={(e) =>
+                                                          updateToolCallParam(
+                                                            message.id,
+                                                            param.name,
+                                                            e.target.value,
+                                                            param.group,
+                                                          )
+                                                        }
+                                                        placeholder={`Enter ${param.name}`}
+                                                        data-tool-call-id={
+                                                          message.id
+                                                        }
+                                                        className={`w-full h-10 px-3 rounded-lg text-sm bg-muted text-foreground placeholder:text-muted-foreground border focus:outline-none focus:ring-2 focus:ring-accent ${
+                                                          showError
+                                                            ? "border-red-500"
+                                                            : "border-border"
+                                                        }`}
+                                                      />
+                                                      {showError && (
+                                                        <p className="text-xs text-red-500 mt-1">
+                                                          This field cannot be
+                                                          empty
+                                                        </p>
+                                                      )}
+                                                    </div>
+                                                  );
+                                                })}
+                                            </div>
+                                          </div>
+                                        )}
+                                      </>
+                                    ) : (
+                                      /* Regular tool parameters */
+                                      <div className="space-y-3">
+                                        {message.toolParams.map(
+                                          (param, idx) => {
+                                            const isEmpty = !param.value.trim();
+                                            const showError =
+                                              localValidationAttempted &&
+                                              isEmpty;
+                                            return (
+                                              <div key={idx}>
+                                                <label className="block text-sm font-medium text-foreground mb-1.5">
+                                                  {param.name}
+                                                </label>
+                                                <input
+                                                  type="text"
+                                                  value={param.value}
+                                                  onChange={(e) =>
+                                                    updateToolCallParam(
+                                                      message.id,
+                                                      param.name,
+                                                      e.target.value,
+                                                      param.group,
+                                                    )
+                                                  }
+                                                  placeholder={`Enter ${param.name}`}
+                                                  className={`w-full h-10 px-4 rounded-lg text-sm bg-background text-foreground placeholder:text-muted-foreground border focus:outline-none focus:ring-2 focus:ring-accent ${
+                                                    showError
+                                                      ? "border-red-500"
+                                                      : "border-border"
+                                                  }`}
+                                                />
+                                                {showError && (
+                                                  <p className="text-xs text-red-500 mt-1">
+                                                    This field cannot be empty
+                                                  </p>
+                                                )}
+                                              </div>
+                                            );
+                                          },
+                                        )}
+                                      </div>
+                                    )}
+                                  </div>
+                                )}
+                            </div>
                           </div>
                           {showInlineDelete && (
                             <button
@@ -2927,7 +2936,6 @@ export function AddTestDialog({
               </div>
             )}
           </div>
-
         </div>
       </div>
     </div>

--- a/src/components/BulkUploadTestsModal.tsx
+++ b/src/components/BulkUploadTestsModal.tsx
@@ -7,6 +7,12 @@ import { useAccessToken } from "@/hooks";
 import Papa from "papaparse";
 import JSZip from "jszip";
 import { MultiAgentPicker } from "@/components/AgentPicker";
+import { MultiSelectPicker } from "@/components/MultiSelectPicker";
+import {
+  ChatHistoryPreview,
+  ConversationFormatDetails,
+  type TurnObject,
+} from "@/components/human-labelling/bulk-upload-shared";
 import type { EvaluatorRefPayload } from "@/components/AddTestDialog";
 import type { AvailableTool } from "@/components/ToolPicker";
 import { INBUILT_TOOLS } from "@/constants/inbuilt-tools";
@@ -46,125 +52,71 @@ type BulkUploadTestsModalProps = {
   onSuccess: () => void;
 };
 
-// The default LLM next-reply evaluator (the one that exposes a single
-// `criteria` variable). Resolved by stable backend slug so it survives
-// rename. Used as the implicit target when the CSV's `evaluators` cell is a
-// plain string instead of a JSON array.
-const DEFAULT_NEXT_REPLY_EVALUATOR_SLUG = "default-llm-next-reply";
+// Column header for an evaluator variable in the response-type CSV. We
+// use a flat "EvalName/varName" naming scheme — one column per variable,
+// across all selected evaluators — so users can edit values directly
+// instead of hand-authoring JSON.
+function variableColumnName(evalName: string, varName: string): string {
+  return `${evalName}/${varName}`;
+}
 
-const SAMPLE_NEXT_REPLY_BASIC_CSV = `name,conversation_history,evaluators
-"Greeting test","[{""role"":""assistant"",""content"":""Hello, how can I help you today?""},{""role"":""user"",""content"":""What is your return policy?""}]","The agent should clearly explain the return policy in a helpful and friendly tone"
-"Billing question","[{""role"":""user"",""content"":""I was charged twice for my order""}]","The agent should apologize and offer to investigate the duplicate charge"`;
+function csvEscape(s: string): string {
+  return `"${s.replace(/"/g, '""')}"`;
+}
 
-const SAMPLE_NEXT_REPLY_ADVANCED_CSV = `name,conversation_history,evaluators
-"Greeting test","[{""role"":""assistant"",""content"":""Hello, how can I help you today?""},{""role"":""user"",""content"":""What is your return policy?""}]","[{""name"":""Correctness"",""variables"":{""criteria"":""The agent should clearly explain the return policy in a helpful and friendly tone""}},{""name"":""Helpfulness""}]"
-"Billing question","[{""role"":""user"",""content"":""I was charged twice for my order""}]","[{""name"":""Correctness"",""variables"":{""criteria"":""The agent should apologize and offer to investigate the duplicate charge""}},{""name"":""Helpfulness""}]"`;
+// Build the response-type sample CSV against the user's selected
+// evaluators. Always produces `name` + `conversation_history` columns,
+// then one column per variable across all selected evaluators (in the
+// order the user picked them). Evaluators with no variables don't add
+// any columns — they still get attached to every test on submit.
+function buildResponseSampleCsv(selected: LLMEvaluatorOption[]): string {
+  const variableColumns: { evalName: string; varName: string }[] = [];
+  for (const e of selected) {
+    for (const v of e.variables) {
+      variableColumns.push({ evalName: e.name, varName: v.name });
+    }
+  }
+
+  const rows = [
+    {
+      name: "Greeting test",
+      conversation: [
+        { role: "assistant", content: "Hello, how can I help you today?" },
+        { role: "user", content: "What is your return policy?" },
+      ],
+      sampleValue:
+        "The agent should clearly explain the return policy in a helpful and friendly tone",
+    },
+    {
+      name: "Billing question",
+      conversation: [
+        { role: "user", content: "I was charged twice for my order" },
+      ],
+      sampleValue:
+        "The agent should apologize and offer to investigate the duplicate charge",
+    },
+  ];
+
+  const headerCells = [
+    "name",
+    "conversation_history",
+    ...variableColumns.map((c) =>
+      csvEscape(variableColumnName(c.evalName, c.varName)),
+    ),
+  ];
+  const lines = rows.map((r) =>
+    [
+      csvEscape(r.name),
+      csvEscape(JSON.stringify(r.conversation)),
+      ...variableColumns.map(() => csvEscape(r.sampleValue)),
+    ].join(","),
+  );
+  return `${headerCells.join(",")}\n${lines.join("\n")}\n`;
+}
 
 const SAMPLE_TOOL_CALL_CSV = `name,conversation_history,tool_calls
 "Book room test","[{""role"":""user"",""content"":""I want to book room 101 for tomorrow""}]","[{""tool"":""book_room"",""arguments"":{""room"":""101""},""accept_any_arguments"":false}]"
 "Weather lookup","[{""role"":""assistant"",""content"":""How can I help?""},{""role"":""user"",""content"":""What is the weather in Bangalore?""}]","[{""tool"":""get_weather"",""arguments"":{},""accept_any_arguments"":true}]"`;
-
-const NEXT_REPLY_README = `BULK UPLOAD - NEXT REPLY TESTS
-================================
-
-This ZIP contains two sample CSV files for bulk uploading "Next Reply" tests:
-
-  - sample_next_reply_tests_basic.csv
-      Use a plain-text criteria string in the "evaluators" column. This is
-      the simplest format and is equivalent to attaching the default LLM
-      next-reply evaluator (the one with a single "criteria" variable) to
-      every test, with that string filled in as the criteria.
-
-  - sample_next_reply_tests_advanced.csv
-      Use a JSON array in the "evaluators" column to attach one or more
-      evaluators to each test. Use this format when you want to attach
-      evaluators other than the default one, attach multiple evaluators to
-      every test, or fill in custom variable values.
-
-Each row in either CSV creates one test. The CSV must have the following
-columns:
-
-
-COLUMNS
--------
-
-1. name
-   A unique name for the test. This must be different from every other test
-   in the CSV and from any test you have already created.
-   Example: "Greeting test"
-
-2. conversation_history
-   A JSON array of chat messages in OpenAI's chat format. This represents
-   the conversation that has happened so far, before the agent's next reply
-   is evaluated. Each message is an object with a "role" and "content" field.
-
-   Supported roles:
-     - "user"       — A message from the end user
-     - "assistant"  — A message from the agent
-
-   The conversation should end with a user message, since the test evaluates
-   the agent's next reply after this conversation.
-
-   Example:
-     [
-       {"role": "assistant", "content": "Hello, how can I help you today?"},
-       {"role": "user", "content": "What is your return policy?"}
-     ]
-
-   In CSV, JSON must be enclosed in double quotes, and any double quotes
-   inside the JSON must be escaped by doubling them (""). See the sample
-   CSVs for the correct format.
-
-3. evaluators
-   The evaluator(s) to attach to this test. The cell accepts EITHER a
-   plain-text criteria string OR a JSON array of evaluator objects.
-
-   FORMAT A — plain-text criteria (basic CSV):
-     A plain-text description of what the agent's response should contain
-     or how it should behave in order to pass the test. The default LLM
-     next-reply evaluator will be attached to every test, and this string
-     will be used as the value of its "criteria" variable.
-     Example: "The agent should clearly explain the return policy in a
-     helpful and friendly tone"
-
-   FORMAT B — JSON array of evaluators (advanced CSV):
-     A JSON array of objects, where each object describes one evaluator to
-     attach to the test. Each object has the following fields:
-
-       - "name" (required, string)
-         The exact name of an evaluator that already exists in the
-         Evaluators tab (either a default evaluator or one you created).
-         If the name does not match an existing evaluator, the upload is
-         rejected with an error.
-
-       - "variables" (required if the evaluator declares variables, object)
-         An object mapping each of the evaluator's variable names to the
-         value to use for this test. EVERY variable declared by the
-         evaluator must be present and have a non-empty value. For
-         evaluators with no variables, pass an empty object ({}) or omit
-         the field.
-
-     Example (one evaluator with a "criteria" variable plus another with
-     no variables):
-       [
-         {
-           "name": "Correctness",
-           "variables": {
-             "criteria": "The agent should clearly explain the return policy"
-           }
-         },
-         {"name": "Helpfulness"}
-       ]
-
-   IMPORTANT — all rows must use the same set of evaluators. The variable
-   VALUES can vary per row, but the list of evaluator names attached to
-   each test must be identical across the entire CSV. If the rows attach
-   different evaluators, the upload is rejected with an error.
-
-   In CSV, JSON must be enclosed in double quotes, and any double quotes
-   inside the JSON must be escaped by doubling them (""). See the advanced
-   sample CSV for the correct format.
-`;
 
 const TOOL_CALL_README = `BULK UPLOAD - TOOL CALL TESTS
 ==============================
@@ -242,6 +194,7 @@ export function BulkUploadTestsModal({
   const backendAccessToken = useAccessToken();
   const fileInputRef = useRef<HTMLInputElement>(null);
   const assignAgentsSectionRef = useRef<HTMLDivElement>(null);
+  const dialogBodyRef = useRef<HTMLDivElement>(null);
 
   const [testType, setTestType] = useState<TestType | null>(null);
   const isResponseType = testType === "response";
@@ -265,13 +218,29 @@ export function BulkUploadTestsModal({
   // estate, and the user can re-open it manually via the toggle.
   const [formatHelpOpen, setFormatHelpOpen] = useState(true);
 
-  // LLM evaluators (defaults + user-owned) available to the tenant — needed
-  // to resolve names from the CSV's `evaluators` column to UUIDs and to
-  // validate that every variable declared by the evaluator is filled in.
-  // Only fetched / used for next-reply tests; tool-call uploads ignore it.
+  // LLM evaluators (defaults + user-owned) available to the tenant —
+  // populates the picker and gives us the variable definitions we need to
+  // build the per-variable CSV columns. Only fetched / used for next-reply
+  // tests; tool-call uploads ignore it.
   const [availableLLMEvaluators, setAvailableLLMEvaluators] = useState<
     LLMEvaluatorOption[]
   >([]);
+  // Evaluators the user has picked up-front for this batch. `selected…`
+  // tracks the live picker state so check-marks update immediately;
+  // `committed…` only updates once the picker dropdown closes, so the
+  // sections below the picker (sample CSV format, helper text, parsing)
+  // don't reflow under the open dropdown while the user is still
+  // checking and unchecking items.
+  const [selectedEvaluators, setSelectedEvaluators] = useState<
+    LLMEvaluatorOption[]
+  >([]);
+  const [committedEvaluators, setCommittedEvaluators] = useState<
+    LLMEvaluatorOption[]
+  >([]);
+  // Tracks whether the picker dropdown is currently open. When closed,
+  // `onSelectionChange` (e.g. clicking the X on a selected pill) should
+  // commit immediately, mirroring the close-dropdown commit path.
+  const [pickerOpen, setPickerOpen] = useState(false);
   const [evaluatorsLoading, setEvaluatorsLoading] = useState(false);
   const [evaluatorsFetched, setEvaluatorsFetched] = useState(false);
   const [evaluatorsFetchError, setEvaluatorsFetchError] = useState<
@@ -301,6 +270,8 @@ export function BulkUploadTestsModal({
       setUploadError(null);
       setUploadWarnings(null);
       setAvailableLLMEvaluators([]);
+      setSelectedEvaluators([]);
+      setCommittedEvaluators([]);
       setEvaluatorsLoading(false);
       setEvaluatorsFetched(false);
       setEvaluatorsFetchError(null);
@@ -472,15 +443,6 @@ export function BulkUploadTestsModal({
     setFormatHelpOpen(parsedTests.length === 0);
   }, [parsedTests.length]);
 
-  // UUID of the default LLM next-reply evaluator (a.k.a. "Correctness"),
-  // resolved from the fetched evaluators list by stable slug. Undefined
-  // until the response-type fetch lands, or if the tenant has removed the
-  // evaluator — the helper text falls back to plain styling in that case
-  // rather than rendering a broken link.
-  const correctnessEvaluatorUuid = availableLLMEvaluators.find(
-    (e) => e.slug === DEFAULT_NEXT_REPLY_EVALUATOR_SLUG,
-  )?.uuid;
-
   // Lookup set of every tool name the platform recognises for this tenant:
   // the names of all custom tools (from `GET /tools`) plus the ids of every
   // inbuilt tool (e.g. `end_call`). Tool-call CSV entries whose `tool` value
@@ -493,210 +455,66 @@ export function BulkUploadTestsModal({
     return names;
   }, [availableTools]);
 
-  // The set of evaluators attached to every parsed next-reply test.
-  // Parser validation guarantees these are identical across rows, so we
-  // read from the first row and use it as the canonical list for the
-  // preview's pill chips and per-evaluator-with-variables column headers.
-  // We hydrate `name` + `variables` by looking up each ref's UUID in the
-  // already-fetched LLM evaluators list (the lookup is what was used for
-  // CSV-side validation in the first place, so it's guaranteed to hit).
-  const previewEvaluators = useMemo(() => {
-    if (!isResponseType || parsedTests.length === 0) return [];
-    const refs = parsedTests[0].evaluators ?? [];
-    return refs
-      .map((ref) => {
-        const ev = availableLLMEvaluators.find(
-          (e) => e.uuid === ref.evaluator_uuid,
-        );
-        if (!ev) return null;
-        return { uuid: ev.uuid, name: ev.name, variables: ev.variables };
-      })
-      .filter((x): x is NonNullable<typeof x> => x !== null);
-  }, [isResponseType, parsedTests, availableLLMEvaluators]);
+  // Evaluators to render in the preview's pill row and per-variable
+  // column headers. Sourced directly from the user's up-front pick — the
+  // CSV doesn't carry an evaluator list anymore.
+  // Commit a new evaluator selection: update committed snapshot, drop
+  // any uploaded CSV (its columns no longer match), and scroll the
+  // dialog so the freshly-revealed/updated helper + dropzone come into
+  // view. Called both when the picker dropdown closes and when the user
+  // removes a selected pill via its X (which fires while the dropdown
+  // is closed).
+  const commitEvaluatorSelection = (next: LLMEvaluatorOption[]) => {
+    const sameAsCommitted =
+      next.length === committedEvaluators.length &&
+      next.every((e, i) => e.uuid === committedEvaluators[i]?.uuid);
+    if (!sameAsCommitted) {
+      setCommittedEvaluators(next);
+      setCsvFile(null);
+      setParsedTests([]);
+      setParseError(null);
+      setUploadError(null);
+      setPendingFile(null);
+      if (fileInputRef.current) fileInputRef.current.value = "";
+    }
+    // Always scroll — even if selection didn't change, the user closed
+    // the dropdown and the sections below should come into view.
+    requestAnimationFrame(() => {
+      const el = dialogBodyRef.current;
+      if (el) {
+        el.scrollTo({ top: el.scrollHeight, behavior: "smooth" });
+      }
+    });
+  };
 
   const downloadSampleCsv = async () => {
     if (!testType) return;
 
-    const zip = new JSZip();
     if (isResponseType) {
-      // Next-reply uploads ship two sample CSVs side-by-side: a "basic"
-      // file using a plain-string `evaluators` cell (the default LLM
-      // next-reply evaluator with a `criteria` variable) and an "advanced"
-      // file demonstrating the JSON-array form for attaching multiple
-      // evaluators / custom variables. README explains both.
-      zip.file(
-        "sample_next_reply_tests_basic.csv",
-        SAMPLE_NEXT_REPLY_BASIC_CSV,
-      );
-      zip.file(
-        "sample_next_reply_tests_advanced.csv",
-        SAMPLE_NEXT_REPLY_ADVANCED_CSV,
-      );
-      zip.file("README.txt", NEXT_REPLY_README);
-    } else {
-      zip.file("sample_tool_call_tests.csv", SAMPLE_TOOL_CALL_CSV);
-      zip.file("README.txt", TOOL_CALL_README);
+      // Single-CSV download tailored to the user's selected evaluators.
+      const csv = buildResponseSampleCsv(committedEvaluators);
+      const blob = new Blob([csv], { type: "text/csv" });
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement("a");
+      link.href = url;
+      link.download = "sample_next_reply_tests.csv";
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+      URL.revokeObjectURL(url);
+      return;
     }
 
+    const zip = new JSZip();
+    zip.file("sample_tool_call_tests.csv", SAMPLE_TOOL_CALL_CSV);
+    zip.file("README.txt", TOOL_CALL_README);
     const blob = await zip.generateAsync({ type: "blob" });
     const url = URL.createObjectURL(blob);
     const link = document.createElement("a");
     link.href = url;
-    link.download = isResponseType
-      ? "sample_next_reply_tests.zip"
-      : "sample_tool_call_tests.zip";
+    link.download = "sample_tool_call_tests.zip";
     link.click();
     URL.revokeObjectURL(url);
-  };
-
-  // Resolve a single row's `evaluators` cell into the API-shaped
-  // EvaluatorRefPayload[] that the backend expects per test. Accepts either:
-  //   - a plain-text string  → attaches the default LLM next-reply evaluator
-  //                            with that string as the `criteria` variable
-  //   - a JSON array of {name, variables?} → looks each entry up by name in
-  //                            the tenant's evaluator list and validates that
-  //                            every declared variable is filled in
-  // Returns either the resolved refs or a list of human-readable errors
-  // (prefixed by the caller with the row number).
-  const resolveEvaluatorsCell = (
-    cell: string,
-    evaluators: LLMEvaluatorOption[],
-  ): { refs: EvaluatorRefPayload[]; errors: string[] } => {
-    const trimmed = cell.trim();
-    const errors: string[] = [];
-
-    // JSON-array form is detected by leading `[`. Anything else is treated as
-    // a plain criteria string, even if it happens to be parseable as some
-    // other JSON value (a bare number, "true", etc.) — this avoids surprising
-    // users whose criteria string starts with a digit or quote.
-    if (trimmed.startsWith("[")) {
-      let parsed: unknown;
-      try {
-        parsed = JSON.parse(trimmed);
-      } catch {
-        return {
-          refs: [],
-          errors: ["evaluators is not valid JSON"],
-        };
-      }
-      if (!Array.isArray(parsed)) {
-        return {
-          refs: [],
-          errors: ["evaluators must be a JSON array"],
-        };
-      }
-      if (parsed.length === 0) {
-        return {
-          refs: [],
-          errors: ["evaluators array must contain at least one evaluator"],
-        };
-      }
-
-      const refs: EvaluatorRefPayload[] = [];
-      const seenUuids = new Set<string>();
-      parsed.forEach((entry, i) => {
-        const label = `evaluator #${i + 1}`;
-        if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
-          errors.push(`${label}: must be a JSON object`);
-          return;
-        }
-        const obj = entry as Record<string, unknown>;
-        const name = typeof obj.name === "string" ? obj.name.trim() : "";
-        if (!name) {
-          errors.push(`${label}: missing "name"`);
-          return;
-        }
-
-        const evaluator = evaluators.find((e) => e.name === name);
-        if (!evaluator) {
-          errors.push(
-            `evaluator "${name}" does not exist in your Evaluators tab`,
-          );
-          return;
-        }
-        if (seenUuids.has(evaluator.uuid)) {
-          errors.push(`evaluator "${name}" listed more than once`);
-          return;
-        }
-        seenUuids.add(evaluator.uuid);
-
-        // `variables` may be omitted entirely for evaluators that declare
-        // none; for those that do, every declared name must have a
-        // non-empty string value.
-        let providedVars: Record<string, unknown> = {};
-        if (obj.variables !== undefined && obj.variables !== null) {
-          if (
-            typeof obj.variables !== "object" ||
-            Array.isArray(obj.variables)
-          ) {
-            errors.push(`evaluator "${name}": "variables" must be an object`);
-            return;
-          }
-          providedVars = obj.variables as Record<string, unknown>;
-        }
-
-        const expectedNames = evaluator.variables.map((v) => v.name);
-        const variableValues: Record<string, string> = {};
-        const missing: string[] = [];
-        for (const v of evaluator.variables) {
-          const raw = providedVars[v.name];
-          if (typeof raw !== "string" || !raw.trim()) {
-            missing.push(v.name);
-            continue;
-          }
-          variableValues[v.name] = raw;
-        }
-        if (missing.length > 0) {
-          errors.push(
-            `evaluator "${name}": missing variable value(s) for ${missing
-              .map((n) => `"${n}"`)
-              .join(", ")}`,
-          );
-        }
-        const extras = Object.keys(providedVars).filter(
-          (k) => !expectedNames.includes(k),
-        );
-        if (extras.length > 0) {
-          errors.push(
-            `evaluator "${name}": unknown variable(s) ${extras
-              .map((n) => `"${n}"`)
-              .join(", ")}`,
-          );
-        }
-
-        const ref: EvaluatorRefPayload = { evaluator_uuid: evaluator.uuid };
-        if (evaluator.variables.length > 0) {
-          ref.variable_values = variableValues;
-        }
-        refs.push(ref);
-      });
-
-      return { refs, errors };
-    }
-
-    // Plain-string form → default LLM next-reply evaluator with the string
-    // as its `criteria` variable. We resolve by stable slug because the
-    // evaluator's `name` is tenant-mutable.
-    const correctness = evaluators.find(
-      (e) => e.slug === DEFAULT_NEXT_REPLY_EVALUATOR_SLUG,
-    );
-    if (!correctness) {
-      return {
-        refs: [],
-        errors: [
-          `default LLM next-reply evaluator (slug "${DEFAULT_NEXT_REPLY_EVALUATOR_SLUG}") was not found — add it to your evaluators or use the JSON-array form`,
-        ],
-      };
-    }
-    return {
-      refs: [
-        {
-          evaluator_uuid: correctness.uuid,
-          variable_values: { criteria: trimmed },
-        },
-      ],
-      errors: [],
-    };
   };
 
   const handleFileChange = (file: File | null) => {
@@ -752,17 +570,35 @@ export function BulkUploadTestsModal({
           return;
         }
 
-        const requiredColumns = isResponseType
-          ? ["name", "conversation_history", "evaluators"]
-          : ["name", "conversation_history", "tool_calls"];
-
         const headers = Object.keys(data[0]);
-        const missingColumns = requiredColumns.filter(
-          (col) => !headers.includes(col),
-        );
+        const baseColumns = isResponseType
+          ? ["name", "conversation_history"]
+          : ["name", "conversation_history", "tool_calls"];
+        const variableColumns: {
+          evaluator: LLMEvaluatorOption;
+          varName: string;
+          header: string;
+        }[] = [];
+        if (isResponseType) {
+          for (const e of committedEvaluators) {
+            for (const v of e.variables) {
+              variableColumns.push({
+                evaluator: e,
+                varName: v.name,
+                header: variableColumnName(e.name, v.name),
+              });
+            }
+          }
+        }
+        const missingColumns = [
+          ...baseColumns.filter((col) => !headers.includes(col)),
+          ...variableColumns
+            .filter((c) => !headers.includes(c.header))
+            .map((c) => c.header),
+        ];
         if (missingColumns.length > 0) {
           setParseError(
-            `Missing required columns: ${missingColumns.join(", ")}`,
+            `Missing required columns: ${missingColumns.join(", ")}. Download the sample CSV above for the exact format.`,
           );
           return;
         }
@@ -780,10 +616,6 @@ export function BulkUploadTestsModal({
 
         const errors: string[] = [];
         const tests: ParsedTest[] = [];
-        // Tracks the canonical sorted list of evaluator UUIDs from the first
-        // successfully-parsed response row, so we can flag any subsequent
-        // row whose evaluator set differs.
-        let referenceEvaluatorUuids: string[] | null = null;
         // Collected across all rows for tool-call uploads so we can show
         // a single clear "these tools don't exist on the platform — add
         // them under Tools first" guidance message above the per-row
@@ -818,39 +650,40 @@ export function BulkUploadTestsModal({
           }
 
           if (isResponseType) {
-            if (!row.evaluators?.trim()) {
-              errors.push(`Row ${rowNum}: missing evaluators`);
-              return;
-            }
-
-            const { refs, errors: rowErrors } = resolveEvaluatorsCell(
-              row.evaluators,
-              availableLLMEvaluators,
-            );
-            if (rowErrors.length > 0) {
-              for (const err of rowErrors) {
-                errors.push(`Row ${rowNum}: ${err}`);
+            // Build the EvaluatorRefPayload[] from the user's selected
+            // evaluators. Variable values come from the per-variable
+            // columns; evaluators with no variables get attached without
+            // a `variable_values` field.
+            const refs: EvaluatorRefPayload[] = [];
+            let rowFailed = false;
+            for (const e of committedEvaluators) {
+              const ref: EvaluatorRefPayload = { evaluator_uuid: e.uuid };
+              if (e.variables.length > 0) {
+                const variableValues: Record<string, string> = {};
+                const missing: string[] = [];
+                for (const v of e.variables) {
+                  const header = variableColumnName(e.name, v.name);
+                  const raw = (row[header] ?? "").trim();
+                  if (!raw) {
+                    missing.push(header);
+                    continue;
+                  }
+                  variableValues[v.name] = raw;
+                }
+                if (missing.length > 0) {
+                  errors.push(
+                    `Row ${rowNum}: missing value(s) for ${missing
+                      .map((m) => `"${m}"`)
+                      .join(", ")}`,
+                  );
+                  rowFailed = true;
+                  break;
+                }
+                ref.variable_values = variableValues;
               }
-              return;
+              refs.push(ref);
             }
-
-            const sortedUuids = refs
-              .map((r) => r.evaluator_uuid)
-              .slice()
-              .sort();
-            if (referenceEvaluatorUuids === null) {
-              referenceEvaluatorUuids = sortedUuids;
-            } else if (
-              sortedUuids.length !== referenceEvaluatorUuids.length ||
-              sortedUuids.some(
-                (uuid, i) => uuid !== referenceEvaluatorUuids![i],
-              )
-            ) {
-              errors.push(
-                `Row ${rowNum}: evaluators don't match the first row — all rows must attach the same set of evaluators`,
-              );
-              return;
-            }
+            if (rowFailed) return;
 
             tests.push({
               name: row.name.trim(),
@@ -920,9 +753,7 @@ export function BulkUploadTestsModal({
           // clear guidance line so the user immediately knows what to
           // do: add the missing tools under the Tools tab and re-upload.
           if (unknownToolNames.size > 0) {
-            const list = [...unknownToolNames]
-              .map((t) => `"${t}"`)
-              .join(", ");
+            const list = [...unknownToolNames].map((t) => `"${t}"`).join(", ");
             const oneTool = unknownToolNames.size === 1;
             setParseError(
               `${oneTool ? "A tool" : "One or more tools"} referenced in your CSV ${
@@ -1126,9 +957,7 @@ export function BulkUploadTestsModal({
     }
     if (toolCalls.length === 0) {
       return (
-        <span className="italic text-red-500">
-          empty tool_calls array
-        </span>
+        <span className="italic text-red-500">empty tool_calls array</span>
       );
     }
 
@@ -1236,42 +1065,6 @@ export function BulkUploadTestsModal({
     );
   };
 
-  // Render one cell of the per-evaluator-with-variables column. If the
-  // evaluator has a single variable (the common case — e.g. Correctness's
-  // `criteria`) we just dump the value. With multiple variables we prefix
-  // each value with a tiny monospace `varName:` label so the user can tell
-  // which variable's value is which.
-  const renderEvaluatorVariableCell = (
-    test: ParsedTest,
-    evaluator: { uuid: string; variables: EvaluatorVariableDef[] },
-  ) => {
-    const ref = test.evaluators?.find(
-      (r) => r.evaluator_uuid === evaluator.uuid,
-    );
-    const values = ref?.variable_values ?? {};
-    if (evaluator.variables.length === 1) {
-      const v = evaluator.variables[0];
-      return (
-        <div className="line-clamp-4 whitespace-pre-wrap break-words">
-          {values[v.name] ?? ""}
-        </div>
-      );
-    }
-    return (
-      <div className="space-y-1.5">
-        {evaluator.variables.map((v) => (
-          <div key={v.name}>
-            <code className="text-[10px] font-mono text-muted-foreground block">
-              {v.name}
-            </code>
-            <span className="line-clamp-3 whitespace-pre-wrap break-words">
-              {values[v.name] ?? ""}
-            </span>
-          </div>
-        ))}
-      </div>
-    );
-  };
 
   if (!isOpen) return null;
 
@@ -1284,7 +1077,7 @@ export function BulkUploadTestsModal({
 
       <div
         className={`relative w-full mx-4 bg-background rounded-2xl shadow-2xl border border-border flex flex-col max-h-[85vh] transition-[max-width] duration-300 ease-out ${
-          parsedTests.length > 0 ? "max-w-5xl" : "max-w-xl"
+          parsedTests.length > 0 ? "max-w-[80vw]" : "max-w-[50vw]"
         }`}
       >
         {/* Header */}
@@ -1313,7 +1106,10 @@ export function BulkUploadTestsModal({
         </div>
 
         {/* Content */}
-        <div className="flex-1 overflow-y-auto px-6 py-5 space-y-6">
+        <div
+          ref={dialogBodyRef}
+          className="flex-1 overflow-y-auto px-6 py-5 space-y-6"
+        >
           {/* Step 1: Test Type */}
           <div>
             <label className="block text-sm font-medium text-foreground mb-3">
@@ -1329,6 +1125,8 @@ export function BulkUploadTestsModal({
                   setParseError(null);
                   setUploadError(null);
                   setPendingFile(null);
+                  setSelectedEvaluators([]);
+                  setCommittedEvaluators([]);
                   if (fileInputRef.current) fileInputRef.current.value = "";
                 }}
                 className={`px-4 py-2 text-sm font-medium transition-colors cursor-pointer ${
@@ -1348,6 +1146,8 @@ export function BulkUploadTestsModal({
                   setParseError(null);
                   setUploadError(null);
                   setPendingFile(null);
+                  setSelectedEvaluators([]);
+                  setCommittedEvaluators([]);
                   if (fileInputRef.current) fileInputRef.current.value = "";
                 }}
                 className={`px-4 py-2 text-sm font-medium transition-colors cursor-pointer border-l border-border ${
@@ -1361,34 +1161,72 @@ export function BulkUploadTestsModal({
             </div>
           </div>
 
-          {/* Step 2: CSV Upload (only if type selected) */}
-          {testType && (
+          {/* Step 1.5: Evaluator picker — response uploads only.
+              The CSV format depends on which evaluators (and which of
+              their variables) the user wants to attach, so we ask for
+              that up-front and don't show the upload section until at
+              least one evaluator is picked. */}
+          {isResponseType && (
             <div>
-              <div className="flex items-center justify-between mb-3">
-                <label className="block text-sm font-medium text-foreground">
-                  Upload CSV
-                </label>
-                <button
-                  onClick={downloadSampleCsv}
-                  className="h-9 px-3 rounded-md text-xs font-medium border border-border bg-muted/40 text-foreground hover:bg-muted hover:border-foreground/30 transition-colors cursor-pointer flex items-center gap-1.5 shadow-sm"
-                >
-                  <svg
-                    className="w-4 h-4"
-                    fill="none"
-                    viewBox="0 0 24 24"
-                    stroke="currentColor"
-                    strokeWidth={2}
-                  >
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5M16.5 12L12 16.5m0 0L7.5 12m4.5 4.5V3"
-                    />
-                  </svg>
-                  Download sample CSV
-                </button>
-              </div>
+              <label className="block text-sm font-medium text-foreground mb-2">
+                Select evaluators to attach
+              </label>
+              <p className="text-xs text-muted-foreground mb-3">
+                These evaluators will be attached to every test in this upload.
+                Variables they declare become CSV columns.
+              </p>
+              {evaluatorsFetchError && (
+                <p className="text-xs text-red-500 mb-2">
+                  Failed to load evaluators: {evaluatorsFetchError}. Refresh and
+                  try again.
+                </p>
+              )}
+              <MultiSelectPicker
+                items={availableLLMEvaluators.map((e) => ({
+                  uuid: e.uuid,
+                  name: e.name,
+                }))}
+                selectedItems={selectedEvaluators.map((e) => ({
+                  uuid: e.uuid,
+                  name: e.name,
+                }))}
+                onSelectionChange={(items) => {
+                  const next = items
+                    .map((i) =>
+                      availableLLMEvaluators.find((e) => e.uuid === i.uuid),
+                    )
+                    .filter((e): e is LLMEvaluatorOption => e !== undefined);
+                  setSelectedEvaluators(next);
+                  // While the dropdown is open we defer; selection stays
+                  // "live" only in the trigger pills and dropdown checks.
+                  // When the dropdown is closed, the only way to change
+                  // selection is removing a pill via its X — commit
+                  // immediately so the sections below reflect the
+                  // change.
+                  if (pickerOpen) return;
+                  commitEvaluatorSelection(next);
+                }}
+                onOpenChange={(open) => {
+                  setPickerOpen(open);
+                  if (open) return;
+                  commitEvaluatorSelection(selectedEvaluators);
+                }}
+                placeholder={
+                  evaluatorsLoading
+                    ? "Loading evaluators"
+                    : "Select one or more evaluators"
+                }
+                searchPlaceholder="Search evaluators"
+                isLoading={evaluatorsLoading}
+                disabled={evaluatorsLoading || !!evaluatorsFetchError}
+              />
+            </div>
+          )}
 
+          {/* Step 2: CSV Upload (only after type + (for response) at least
+              one evaluator are picked) */}
+          {testType && (!isResponseType || committedEvaluators.length > 0) && (
+            <div>
               {/* Format description — once a CSV has parsed successfully
                   it auto-collapses so the preview owns the screen, but
                   remains togglable via the disclosure button below. */}
@@ -1421,126 +1259,100 @@ export function BulkUploadTestsModal({
               )}
               {formatHelpOpen &&
                 (isResponseType ? (
-                <div className="text-xs text-muted-foreground mb-3 leading-relaxed space-y-2">
-                  <p>Your CSV needs three columns per row:</p>
-                  <ul className="list-disc pl-5 space-y-1.5">
-                    <li>
-                      <code className="font-mono text-foreground">name</code> —
-                      a unique test name
-                    </li>
-                    <li>
-                      <code className="font-mono text-foreground">
-                        conversation_history
-                      </code>{" "}
-                      — JSON array of OpenAI-format chat messages
-                    </li>
-                    <li>
-                      <code className="font-mono text-foreground">
-                        evaluators
-                      </code>{" "}
-                      — accepts either:
-                      <ul className="list-disc pl-5 mt-1.5 space-y-1.5">
-                        <li>
-                          A plain criteria string — attaches the default{" "}
-                          {correctnessEvaluatorUuid ? (
+                  <div className="text-xs text-muted-foreground mb-3 leading-relaxed space-y-2">
+                    <p>Upload a CSV with the following columns:</p>
+                    <ul className="list-disc pl-5 space-y-1.5">
+                      <li>
+                        <code className="font-mono text-foreground">name</code>{" "}
+                        — a unique test name
+                      </li>
+                      <li>
+                        <code className="font-mono text-foreground">
+                          conversation_history
+                        </code>{" "}
+                        — JSON array representing a conversation that an
+                        agent needs to respond to.
+                        <ConversationFormatDetails
+                          example={
+                            '[{"role":"user","content":"What is your return policy?"},{"role":"assistant","content":"You can return any item within 30 days."},{"role":"user","content":"What about defective items?"}]'
+                          }
+                        />
+                      </li>
+                      {committedEvaluators.flatMap((e) =>
+                        e.variables.map((v) => (
+                          <li key={`${e.uuid}-${v.name}`}>
+                            <code className="font-mono text-foreground">
+                              {variableColumnName(e.name, v.name)}
+                            </code>
+                            {v.description ? ` — ${v.description}` : ""} (used
+                            for{" "}
                             <Link
-                              href={`/evaluators/${correctnessEvaluatorUuid}`}
+                              href={`/evaluators/${e.uuid}`}
                               target="_blank"
                               rel="noopener noreferrer"
-                              className={HELPER_LINK_CLASS}
+                              className="inline-flex items-center px-1.5 py-0.5 rounded-full bg-accent text-accent-foreground text-[10px] font-medium hover:opacity-80 transition-opacity cursor-pointer"
                             >
-                              Correctness
+                              {e.name}
                             </Link>
-                          ) : (
-                            <span className="text-foreground">Correctness</span>
-                          )}{" "}
-                          evaluator with that string as its{" "}
-                          <code className="font-mono text-foreground">
-                            criteria
-                          </code>{" "}
-                          variable.
-                        </li>
-                        <li>
-                          A JSON array like{" "}
-                          <code className="font-mono text-foreground">
-                            {`[{"name":"...","variables":{...}}]`}
-                          </code>{" "}
-                          to attach one or more evaluators by name with their
-                          variable values.
-                        </li>
-                      </ul>
-                    </li>
-                  </ul>
-                  <p>
-                    Evaluators must already exist in the{" "}
-                    <Link
-                      href="/evaluators"
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className={HELPER_LINK_CLASS}
-                    >
-                      Evaluators
-                    </Link>{" "}
-                    tab, every variable they declare must be filled, and all
-                    rows must use the same set of evaluators (variable values
-                    can differ per row).
-                  </p>
-                  <p>
-                    Download the sample CSV ZIP for basic and advanced examples
-                    plus a README with the full format.
-                  </p>
-                </div>
-              ) : (
-                <div className="text-xs text-muted-foreground mb-3 leading-relaxed space-y-2">
-                  <p>Your CSV needs three columns per row:</p>
-                  <ul className="list-disc pl-5 space-y-1.5">
-                    <li>
-                      <code className="font-mono text-foreground">name</code> —
-                      a unique test name
-                    </li>
-                    <li>
-                      <code className="font-mono text-foreground">
-                        conversation_history
-                      </code>{" "}
-                      — JSON array of OpenAI-format chat messages
-                    </li>
-                    <li>
-                      <code className="font-mono text-foreground">
-                        tool_calls
-                      </code>{" "}
-                      — JSON array of expected tool-call objects, each with:
-                      <ul className="list-disc pl-5 mt-1.5 space-y-1.5">
-                        <li>
-                          <code className="font-mono text-foreground">
-                            tool
-                          </code>{" "}
-                          (required) — the tool&apos;s name
-                        </li>
-                        <li>
-                          <code className="font-mono text-foreground">
-                            arguments
-                          </code>{" "}
-                          (optional) — object of expected argument values
-                        </li>
-                        <li>
-                          <code className="font-mono text-foreground">
-                            accept_any_arguments
-                          </code>{" "}
-                          (optional) — set to{" "}
-                          <code className="font-mono text-foreground">
-                            true
-                          </code>{" "}
-                          to skip argument matching
-                        </li>
-                      </ul>
-                    </li>
-                  </ul>
-                  <p>
-                    Download the sample CSV ZIP for an example plus a README
-                    with the full format.
-                  </p>
-                </div>
-              ))}
+                            )
+                          </li>
+                        )),
+                      )}
+                    </ul>
+                  </div>
+                ) : (
+                  <div className="text-xs text-muted-foreground mb-3 leading-relaxed space-y-2">
+                    <p>Upload a CSV with the following columns:</p>
+                    <ul className="list-disc pl-5 space-y-1.5">
+                      <li>
+                        <code className="font-mono text-foreground">name</code>{" "}
+                        — a unique test name
+                      </li>
+                      <li>
+                        <code className="font-mono text-foreground">
+                          conversation_history
+                        </code>{" "}
+                        — JSON array representing a conversation that an
+                        agent needs to respond to.
+                        <ConversationFormatDetails
+                          example={
+                            '[{"role":"user","content":"What is your return policy?"},{"role":"assistant","content":"You can return any item within 30 days."},{"role":"user","content":"What about defective items?"}]'
+                          }
+                        />
+                      </li>
+                      <li>
+                        <code className="font-mono text-foreground">
+                          tool_calls
+                        </code>{" "}
+                        — JSON array of expected tool-call objects, each with:
+                        <ul className="list-disc pl-5 mt-1.5 space-y-1.5">
+                          <li>
+                            <code className="font-mono text-foreground">
+                              tool
+                            </code>{" "}
+                            (required) — the tool&apos;s name
+                          </li>
+                          <li>
+                            <code className="font-mono text-foreground">
+                              arguments
+                            </code>{" "}
+                            (optional) — object of expected argument values
+                          </li>
+                          <li>
+                            <code className="font-mono text-foreground">
+                              accept_any_arguments
+                            </code>{" "}
+                            (optional) — set to{" "}
+                            <code className="font-mono text-foreground">
+                              true
+                            </code>{" "}
+                            to skip argument matching
+                          </li>
+                        </ul>
+                      </li>
+                    </ul>
+                  </div>
+                ))}
 
               {/* Backing-fetch failures are the only state worth
                   surfacing — loading happens silently in the background,
@@ -1656,53 +1468,182 @@ export function BulkUploadTestsModal({
                 </div>
               )}
 
-              {/* Evaluator pills — response uploads only. Rendered as a
-                  standalone row OUTSIDE the parsed-preview card so it
-                  reads as metadata about the upload (which evaluators
-                  every row shares) rather than a header strip stuck to
-                  the table. The pill set is identical for every row
-                  (parser validation guarantees it), so we render them
-                  once and link each to its evaluator detail page. */}
-              {parsedTests.length > 0 &&
-                isResponseType &&
-                previewEvaluators.length > 0 && (
-                  <div className="mt-4">
-                    <h4 className="text-sm font-semibold text-foreground mb-2">
-                      Evaluators
-                    </h4>
-                    <div className="flex items-center gap-1.5 flex-wrap">
-                      {previewEvaluators.map((ev) => (
-                        <Link
-                          key={ev.uuid}
-                          href={`/evaluators/${ev.uuid}`}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium border border-border bg-background text-foreground hover:bg-muted transition-colors"
-                        >
-                          {ev.name}
-                          <svg
-                            className="w-3 h-3 text-muted-foreground"
-                            fill="none"
-                            viewBox="0 0 24 24"
-                            stroke="currentColor"
-                            strokeWidth={2}
-                          >
-                            <path
-                              strokeLinecap="round"
-                              strokeLinejoin="round"
-                              d="M13.5 6H5.25A2.25 2.25 0 003 8.25v10.5A2.25 2.25 0 005.25 21h10.5A2.25 2.25 0 0018 18.75V10.5m-10.5 6L21 3m0 0h-5.25M21 3v5.25"
-                            />
-                          </svg>
-                        </Link>
-                      ))}
-                    </div>
+              {/* Sample CSV — placed below the dropzone, with a tip
+                  callout pointing at it. Hidden once a CSV has parsed
+                  so the preview owns the screen. */}
+              {parsedTests.length === 0 && (
+                <>
+                  <div className="mt-3 flex items-start gap-2 rounded-md border border-blue-500/30 bg-blue-500/10 px-3 py-2 text-xs text-foreground">
+                    <svg
+                      className="w-4 h-4 mt-0.5 shrink-0 text-blue-500"
+                      fill="none"
+                      viewBox="0 0 24 24"
+                      stroke="currentColor"
+                      strokeWidth={2}
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        d="M13 16h-1v-4h-1m1-4h.01M12 2a10 10 0 100 20 10 10 0 000-20z"
+                      />
+                    </svg>
+                    <span>
+                      <span className="font-semibold">Tip:</span>{" "}
+                      <button
+                        type="button"
+                        onClick={downloadSampleCsv}
+                        className="underline underline-offset-2 hover:opacity-80 transition-opacity cursor-pointer"
+                      >
+                        download the sample CSV
+                      </button>{" "}
+                      and edit it as a starting point
+                    </span>
                   </div>
-                )}
+                  <div className="mt-3 flex justify-end">
+                    <button
+                      onClick={downloadSampleCsv}
+                      className="h-9 px-3 rounded-md text-xs font-medium border border-border bg-muted/40 text-foreground hover:bg-muted hover:border-foreground/30 transition-colors cursor-pointer flex items-center gap-1.5 shadow-sm"
+                    >
+                      <svg
+                        className="w-4 h-4"
+                        fill="none"
+                        viewBox="0 0 24 24"
+                        stroke="currentColor"
+                        strokeWidth={2}
+                      >
+                        <path
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5M16.5 12L12 16.5m0 0L7.5 12m4.5 4.5V3"
+                        />
+                      </svg>
+                      Download sample CSV
+                    </button>
+                  </div>
+                </>
+              )}
 
               {/* Parsed Preview */}
-              {parsedTests.length > 0 && (
+              {parsedTests.length > 0 && isResponseType && (() => {
+                const variableColumns = committedEvaluators.flatMap((e) =>
+                  e.variables.map((v) => ({
+                    evaluatorUuid: e.uuid,
+                    varName: v.name,
+                    header: variableColumnName(e.name, v.name),
+                  })),
+                );
+                const gridStyle = {
+                  gridTemplateColumns: [
+                    "160px",
+                    "minmax(220px,1fr)",
+                    ...variableColumns.map(() => "minmax(220px,1fr)"),
+                  ].join(" "),
+                };
+                return (
+                  <div className="mt-3 space-y-2">
+                    <p className="text-sm font-medium text-foreground">
+                      {parsedTests.length}{" "}
+                      {parsedTests.length === 1 ? "test" : "tests"} ready to
+                      upload
+                    </p>
+                    <div className="border border-border rounded-xl overflow-hidden">
+                      <div className="overflow-x-auto">
+                        <div
+                          className="grid gap-3 px-4 py-2 border-b border-border bg-muted/30"
+                          style={gridStyle}
+                        >
+                          <div className="text-xs font-medium text-muted-foreground">
+                            Name
+                          </div>
+                          <div className="text-xs font-medium text-muted-foreground">
+                            Chat history
+                          </div>
+                          {variableColumns.map((c) => (
+                            <div
+                              key={`h-${c.evaluatorUuid}-${c.varName}`}
+                              className="text-xs font-medium text-muted-foreground font-mono truncate"
+                              title={c.header}
+                            >
+                              {c.header}
+                            </div>
+                          ))}
+                        </div>
+                        <div className="max-h-[15rem] overflow-y-auto divide-y divide-border">
+                          {parsedTests.slice(0, 50).map((test, idx) => {
+                            let turns: TurnObject[] = [];
+                            try {
+                              const parsed = JSON.parse(
+                                test.conversation_history,
+                              );
+                              if (Array.isArray(parsed)) turns = parsed;
+                            } catch {
+                              // Parsed-tests entries already passed JSON
+                              // validation; this is a defensive fallback.
+                            }
+                            const valuesByKey = new Map<string, string>();
+                            for (const ref of test.evaluators ?? []) {
+                              if (!ref.variable_values) continue;
+                              for (const [varName, value] of Object.entries(
+                                ref.variable_values,
+                              )) {
+                                valuesByKey.set(
+                                  `${ref.evaluator_uuid}/${varName}`,
+                                  value,
+                                );
+                              }
+                            }
+                            return (
+                              <div
+                                key={idx}
+                                className="grid gap-3 px-4 py-2 text-xs items-start"
+                                style={gridStyle}
+                              >
+                                <div
+                                  className="truncate text-foreground"
+                                  title={test.name}
+                                >
+                                  {test.name}
+                                </div>
+                                <div className="min-w-0">
+                                  <ChatHistoryPreview turns={turns} />
+                                </div>
+                                {variableColumns.map((c) => {
+                                  const value =
+                                    valuesByKey.get(
+                                      `${c.evaluatorUuid}/${c.varName}`,
+                                    ) ?? "";
+                                  return (
+                                    <div
+                                      key={`${idx}-${c.evaluatorUuid}-${c.varName}`}
+                                      className="min-w-0 max-h-24 overflow-y-auto pr-1 leading-snug text-foreground break-words whitespace-pre-wrap"
+                                    >
+                                      {value || (
+                                        <span className="text-muted-foreground italic">
+                                          (empty)
+                                        </span>
+                                      )}
+                                    </div>
+                                  );
+                                })}
+                              </div>
+                            );
+                          })}
+                          {parsedTests.length > 50 && (
+                            <div className="px-4 py-2 text-xs text-muted-foreground">
+                              + {parsedTests.length - 50} more rows
+                            </div>
+                          )}
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                );
+              })()}
+
+              {/* Tool-call preview keeps the existing table layout — its
+                  per-row `tool_calls` column has its own custom rendering. */}
+              {parsedTests.length > 0 && !isResponseType && (
                 <div className="mt-3 rounded-lg bg-muted/50 border border-border overflow-hidden">
-                  {/* "Found N tests" header */}
                   <div className="px-3 py-2.5 flex items-center gap-2 border-b border-border">
                     <svg
                       className="w-4 h-4 text-green-500"
@@ -1723,7 +1664,6 @@ export function BulkUploadTestsModal({
                     </span>
                   </div>
 
-                  {/* Per-test table */}
                   <div className="overflow-x-auto max-h-[420px] overflow-y-auto">
                     <table className="w-full text-xs">
                       <thead className="sticky top-0 bg-muted/80 backdrop-blur-sm">
@@ -1735,22 +1675,9 @@ export function BulkUploadTestsModal({
                           <th className="px-3 py-2 font-medium min-w-[240px]">
                             Conversation history
                           </th>
-                          {isResponseType ? (
-                            previewEvaluators
-                              .filter((ev) => ev.variables.length > 0)
-                              .map((ev) => (
-                                <th
-                                  key={ev.uuid}
-                                  className="px-3 py-2 font-medium min-w-[200px]"
-                                >
-                                  {ev.name}
-                                </th>
-                              ))
-                          ) : (
-                            <th className="px-3 py-2 font-medium min-w-[240px]">
-                              Expected tool calls
-                            </th>
-                          )}
+                          <th className="px-3 py-2 font-medium min-w-[240px]">
+                            Expected tool calls
+                          </th>
                         </tr>
                       </thead>
                       <tbody>
@@ -1770,22 +1697,9 @@ export function BulkUploadTestsModal({
                                 test.conversation_history,
                               )}
                             </td>
-                            {isResponseType ? (
-                              previewEvaluators
-                                .filter((ev) => ev.variables.length > 0)
-                                .map((ev) => (
-                                  <td
-                                    key={ev.uuid}
-                                    className="px-3 py-2 text-foreground"
-                                  >
-                                    {renderEvaluatorVariableCell(test, ev)}
-                                  </td>
-                                ))
-                            ) : (
-                              <td className="px-3 py-2 text-foreground">
-                                {renderToolCallsCell(test.tool_calls)}
-                              </td>
-                            )}
+                            <td className="px-3 py-2 text-foreground">
+                              {renderToolCallsCell(test.tool_calls)}
+                            </td>
                           </tr>
                         ))}
                       </tbody>

--- a/src/components/BulkUploadTestsModal.tsx
+++ b/src/components/BulkUploadTestsModal.tsx
@@ -1174,7 +1174,7 @@ export function BulkUploadTestsModal({
 
       <div
         className={`relative w-full mx-4 bg-background rounded-2xl shadow-2xl border border-border flex flex-col max-h-[85vh] transition-[max-width] duration-300 ease-out ${
-          parsedTests.length > 0 ? "max-w-[80vw]" : "max-w-[50vw]"
+          parsedTests.length > 0 ? "md:max-w-[80vw]" : "md:max-w-[50vw]"
         }`}
       >
         {/* Header */}

--- a/src/components/BulkUploadTestsModal.tsx
+++ b/src/components/BulkUploadTestsModal.tsx
@@ -10,7 +10,10 @@ import { MultiAgentPicker } from "@/components/AgentPicker";
 import { MultiSelectPicker } from "@/components/MultiSelectPicker";
 import {
   ChatHistoryPreview,
-  ConversationFormatDetails,
+  generateGuidelinesPdf,
+  type GuidelineColumn,
+  type GuidelineDoc,
+  type GuidelineField,
   type TurnObject,
 } from "@/components/human-labelling/bulk-upload-shared";
 import type { EvaluatorRefPayload } from "@/components/AddTestDialog";
@@ -118,6 +121,9 @@ const SAMPLE_TOOL_CALL_CSV = `name,conversation_history,tool_calls
 "Book room test","[{""role"":""user"",""content"":""I want to book room 101 for tomorrow""}]","[{""tool"":""book_room"",""arguments"":{""room"":""101""},""accept_any_arguments"":false}]"
 "Weather lookup","[{""role"":""assistant"",""content"":""How can I help?""},{""role"":""user"",""content"":""What is the weather in Bangalore?""}]","[{""tool"":""get_weather"",""arguments"":{},""accept_any_arguments"":true}]"`;
 
+// Plain-text README bundled in the tool-call sample ZIP. Mirrors the PDF
+// guidelines content but rendered as text for users who prefer reading the
+// readme alongside the sample CSV.
 const TOOL_CALL_README = `BULK UPLOAD - TOOL CALL TESTS
 ==============================
 
@@ -134,10 +140,9 @@ COLUMNS
    Example: "Book room test"
 
 2. conversation_history
-   A JSON array of chat messages in OpenAI's chat format. This represents
-   the conversation that has happened so far, before the agent's tool call
-   behavior is evaluated. Each message is an object with a "role" and
-   "content" field.
+   A JSON array of chat messages that represents the conversation that has
+   happened so far, before the agent's tool call behavior is evaluated.
+   Each message is an object with a "role" and "content" field.
 
    Supported roles:
      - "user"       — A message from the end user
@@ -151,13 +156,9 @@ COLUMNS
        {"role": "user", "content": "I want to book room 101 for tomorrow"}
      ]
 
-   In CSV, JSON must be enclosed in double quotes, and any double quotes
-   inside the JSON must be escaped by doubling them (""). See the sample
-   CSV for the correct format.
-
 3. tool_calls
    A JSON array of expected tool call objects. Each object describes a tool
-   the agent is expected to call (or not call) and what arguments to expect.
+   the agent is expected to call and what arguments to expect.
 
    Fields for each tool call object:
 
@@ -186,6 +187,32 @@ COLUMNS
        [{"tool": "get_weather", "arguments": {}, "accept_any_arguments": true}]
 `;
 
+const CONVERSATION_HISTORY_DESC =
+  'A JSON array of chat messages that represents the conversation that has happened so far, before the agent\'s response is evaluated. Each message is an object with a "role" and "content" field.\n\nrole — either "user" or "assistant"\ncontent — the message said by that role';
+
+const TOOL_CALL_FIELDS: GuidelineField[] = [
+  {
+    name: "tool",
+    meta: "(required, string)",
+    description:
+      "The name of the tool. Must match the tool name exactly as configured in your agent.",
+    example: '"book_room"',
+  },
+  {
+    name: "arguments",
+    meta: "(optional, object)",
+    description:
+      "The expected arguments the agent should pass to the tool. Each key is a parameter name and each value is the expected value. If omitted or empty ({}), arguments are not checked — equivalent to setting accept_any_arguments to true.",
+    example: '{"room": "101", "date": "tomorrow"}',
+  },
+  {
+    name: "accept_any_arguments",
+    meta: "(optional, boolean, default: false)",
+    description:
+      'If true, the test passes regardless of what arguments the agent sends to this tool. Useful when you only care that the tool was called, not what was passed. When true, the "arguments" field is ignored.',
+  },
+];
+
 export function BulkUploadTestsModal({
   isOpen,
   onClose,
@@ -211,12 +238,6 @@ export function BulkUploadTestsModal({
   const [isUploading, setIsUploading] = useState(false);
   const [uploadError, setUploadError] = useState<string | null>(null);
   const [uploadWarnings, setUploadWarnings] = useState<string[] | null>(null);
-  // Whether the CSV-format helper block above the dropzone is expanded.
-  // Starts open so first-time uploaders see the format spec, auto-collapses
-  // as soon as a CSV parses successfully (managed by the effect below) so
-  // the help doesn't compete with the parsed-tests preview for screen real
-  // estate, and the user can re-open it manually via the toggle.
-  const [formatHelpOpen, setFormatHelpOpen] = useState(true);
 
   // LLM evaluators (defaults + user-owned) available to the tenant —
   // populates the picker and gives us the variable definitions we need to
@@ -263,7 +284,6 @@ export function BulkUploadTestsModal({
       setParsedTests([]);
       setParseError(null);
       setPendingFile(null);
-      setFormatHelpOpen(true);
       setAssignToAgents(false);
       setSelectedAgentUuids([]);
       setIsUploading(false);
@@ -435,14 +455,6 @@ export function BulkUploadTestsModal({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [pendingFile, evaluatorsFetched, toolsFetched, isResponseType]);
 
-  // Auto-collapse the CSV-format helper as soon as a CSV parses
-  // successfully (so the preview owns the screen), and re-expand it once
-  // the user clears the parsed tests (back to a "first upload" state).
-  // The user can still flip it manually via the toggle either way.
-  useEffect(() => {
-    setFormatHelpOpen(parsedTests.length === 0);
-  }, [parsedTests.length]);
-
   // Lookup set of every tool name the platform recognises for this tenant:
   // the names of all custom tools (from `GET /tools`) plus the ids of every
   // inbuilt tool (e.g. `end_call`). Tool-call CSV entries whose `tool` value
@@ -485,6 +497,92 @@ export function BulkUploadTestsModal({
         el.scrollTo({ top: el.scrollHeight, behavior: "smooth" });
       }
     });
+  };
+
+  const buildGuidelines = (): GuidelineDoc => {
+    if (isResponseType) {
+      const columns: GuidelineColumn[] = [
+        { name: "name", description: "A unique test name." },
+        {
+          name: "conversation_history",
+          description: CONVERSATION_HISTORY_DESC,
+          example: `[
+  {"role": "user", "content": "What is your return policy?"},
+  {"role": "assistant", "content": "You can return any item within 30 days."}
+]`,
+        },
+      ];
+      for (const e of committedEvaluators) {
+        for (const v of e.variables) {
+          const desc = v.description ? ` — ${v.description}` : "";
+          columns.push({
+            name: variableColumnName(e.name, v.name),
+            description: `Used for the "${e.name}" evaluator${desc}`,
+          });
+        }
+      }
+      return {
+        title: "Bulk upload — Next reply tests",
+        intro:
+          "Upload a CSV with the following columns. Each row creates one test.",
+        columns,
+      };
+    }
+
+    return {
+      title: "Bulk upload — Tool call tests",
+      intro:
+        "Upload a CSV with the following columns. Each row creates one test.",
+      columns: [
+        {
+          name: "name",
+          description:
+            "A unique name for the test. This must be different from every other test in the CSV and from any test you have already created.",
+          example: '"Book room test"',
+        },
+        {
+          name: "conversation_history",
+          description: `${CONVERSATION_HISTORY_DESC}\n\nThe conversation should end with a user message, since the test evaluates which tools the agent calls after this conversation.`,
+          example: `[
+  {"role": "user", "content": "I want to book room 101 for tomorrow"}
+]`,
+        },
+        {
+          name: "tool_calls",
+          description:
+            "A JSON array of expected tool call objects. Each object describes a tool the agent is expected to call and what arguments to expect.",
+          fields: TOOL_CALL_FIELDS,
+          trailingExamples: [
+            {
+              label: "Tool should be called with specific arguments:",
+              example:
+                '[{"tool": "book_room", "arguments": {"room": "101"}, "accept_any_arguments": false}]',
+            },
+            {
+              label: "Tool should be called, any arguments accepted:",
+              example:
+                '[{"tool": "get_weather", "arguments": {}, "accept_any_arguments": true}]',
+            },
+          ],
+        },
+      ],
+    };
+  };
+
+  const downloadGuidelines = () => {
+    if (!testType) return;
+    const blob = generateGuidelinesPdf(buildGuidelines());
+    const filename = isResponseType
+      ? "next_reply_tests_csv_guidelines.pdf"
+      : "tool_call_tests_csv_guidelines.pdf";
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement("a");
+    link.href = url;
+    link.download = filename;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
   };
 
   const downloadSampleCsv = async () => {
@@ -1065,7 +1163,6 @@ export function BulkUploadTestsModal({
     );
   };
 
-
   if (!isOpen) return null;
 
   return (
@@ -1172,8 +1269,7 @@ export function BulkUploadTestsModal({
                 Select evaluators to attach
               </label>
               <p className="text-xs text-muted-foreground mb-3">
-                These evaluators will be attached to every test in this upload.
-                Variables they declare become CSV columns.
+                These evaluators will be attached to every test you upload
               </p>
               {evaluatorsFetchError && (
                 <p className="text-xs text-red-500 mb-2">
@@ -1227,132 +1323,30 @@ export function BulkUploadTestsModal({
               one evaluator are picked) */}
           {testType && (!isResponseType || committedEvaluators.length > 0) && (
             <div>
-              {/* Format description — once a CSV has parsed successfully
-                  it auto-collapses so the preview owns the screen, but
-                  remains togglable via the disclosure button below. */}
-              {parsedTests.length > 0 && (
-                <button
-                  type="button"
-                  onClick={() => setFormatHelpOpen((o) => !o)}
-                  className="mb-3 inline-flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors cursor-pointer"
-                  aria-expanded={formatHelpOpen}
-                >
-                  <svg
-                    className={`w-3.5 h-3.5 transition-transform ${
-                      formatHelpOpen ? "rotate-90" : ""
-                    }`}
-                    fill="none"
-                    viewBox="0 0 24 24"
-                    stroke="currentColor"
-                    strokeWidth={2.5}
+              {parsedTests.length === 0 && (
+                <div className="mb-3 flex flex-wrap gap-2">
+                  <button
+                    type="button"
+                    onClick={downloadGuidelines}
+                    className="h-9 px-3 rounded-md text-xs font-semibold border border-blue-500/40 bg-blue-500/15 text-blue-700 dark:text-blue-300 hover:bg-blue-500/25 hover:border-blue-500/60 transition-colors cursor-pointer flex items-center gap-1.5"
                   >
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      d="M8.25 4.5l7.5 7.5-7.5 7.5"
-                    />
-                  </svg>
-                  {formatHelpOpen
-                    ? "Hide CSV format details"
-                    : "Show CSV format details"}
-                </button>
+                    <svg
+                      className="w-4 h-4"
+                      fill="none"
+                      viewBox="0 0 24 24"
+                      stroke="currentColor"
+                      strokeWidth={2}
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5M16.5 12L12 16.5m0 0L7.5 12m4.5 4.5V3"
+                      />
+                    </svg>
+                    Download CSV format guidelines
+                  </button>
+                </div>
               )}
-              {formatHelpOpen &&
-                (isResponseType ? (
-                  <div className="text-xs text-muted-foreground mb-3 leading-relaxed space-y-2">
-                    <p>Upload a CSV with the following columns:</p>
-                    <ul className="list-disc pl-5 space-y-1.5">
-                      <li>
-                        <code className="font-mono text-foreground">name</code>{" "}
-                        — a unique test name
-                      </li>
-                      <li>
-                        <code className="font-mono text-foreground">
-                          conversation_history
-                        </code>{" "}
-                        — JSON array representing a conversation that an
-                        agent needs to respond to.
-                        <ConversationFormatDetails
-                          example={
-                            '[{"role":"user","content":"What is your return policy?"},{"role":"assistant","content":"You can return any item within 30 days."},{"role":"user","content":"What about defective items?"}]'
-                          }
-                        />
-                      </li>
-                      {committedEvaluators.flatMap((e) =>
-                        e.variables.map((v) => (
-                          <li key={`${e.uuid}-${v.name}`}>
-                            <code className="font-mono text-foreground">
-                              {variableColumnName(e.name, v.name)}
-                            </code>
-                            {v.description ? ` — ${v.description}` : ""} (used
-                            for{" "}
-                            <Link
-                              href={`/evaluators/${e.uuid}`}
-                              target="_blank"
-                              rel="noopener noreferrer"
-                              className="inline-flex items-center px-1.5 py-0.5 rounded-full bg-accent text-accent-foreground text-[10px] font-medium hover:opacity-80 transition-opacity cursor-pointer"
-                            >
-                              {e.name}
-                            </Link>
-                            )
-                          </li>
-                        )),
-                      )}
-                    </ul>
-                  </div>
-                ) : (
-                  <div className="text-xs text-muted-foreground mb-3 leading-relaxed space-y-2">
-                    <p>Upload a CSV with the following columns:</p>
-                    <ul className="list-disc pl-5 space-y-1.5">
-                      <li>
-                        <code className="font-mono text-foreground">name</code>{" "}
-                        — a unique test name
-                      </li>
-                      <li>
-                        <code className="font-mono text-foreground">
-                          conversation_history
-                        </code>{" "}
-                        — JSON array representing a conversation that an
-                        agent needs to respond to.
-                        <ConversationFormatDetails
-                          example={
-                            '[{"role":"user","content":"What is your return policy?"},{"role":"assistant","content":"You can return any item within 30 days."},{"role":"user","content":"What about defective items?"}]'
-                          }
-                        />
-                      </li>
-                      <li>
-                        <code className="font-mono text-foreground">
-                          tool_calls
-                        </code>{" "}
-                        — JSON array of expected tool-call objects, each with:
-                        <ul className="list-disc pl-5 mt-1.5 space-y-1.5">
-                          <li>
-                            <code className="font-mono text-foreground">
-                              tool
-                            </code>{" "}
-                            (required) — the tool&apos;s name
-                          </li>
-                          <li>
-                            <code className="font-mono text-foreground">
-                              arguments
-                            </code>{" "}
-                            (optional) — object of expected argument values
-                          </li>
-                          <li>
-                            <code className="font-mono text-foreground">
-                              accept_any_arguments
-                            </code>{" "}
-                            (optional) — set to{" "}
-                            <code className="font-mono text-foreground">
-                              true
-                            </code>{" "}
-                            to skip argument matching
-                          </li>
-                        </ul>
-                      </li>
-                    </ul>
-                  </div>
-                ))}
 
               {/* Backing-fetch failures are the only state worth
                   surfacing — loading happens silently in the background,
@@ -1472,173 +1466,152 @@ export function BulkUploadTestsModal({
                   callout pointing at it. Hidden once a CSV has parsed
                   so the preview owns the screen. */}
               {parsedTests.length === 0 && (
-                <>
-                  <div className="mt-3 flex items-start gap-2 rounded-md border border-blue-500/30 bg-blue-500/10 px-3 py-2 text-xs text-foreground">
-                    <svg
-                      className="w-4 h-4 mt-0.5 shrink-0 text-blue-500"
-                      fill="none"
-                      viewBox="0 0 24 24"
-                      stroke="currentColor"
-                      strokeWidth={2}
-                    >
-                      <path
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        d="M13 16h-1v-4h-1m1-4h.01M12 2a10 10 0 100 20 10 10 0 000-20z"
-                      />
-                    </svg>
-                    <span>
-                      <span className="font-semibold">Tip:</span>{" "}
-                      <button
-                        type="button"
-                        onClick={downloadSampleCsv}
-                        className="underline underline-offset-2 hover:opacity-80 transition-opacity cursor-pointer"
-                      >
-                        download the sample CSV
-                      </button>{" "}
-                      and edit it as a starting point
-                    </span>
-                  </div>
-                  <div className="mt-3 flex justify-end">
+                <div className="mt-3 flex items-start gap-2 rounded-md border border-emerald-500/30 bg-emerald-500/10 px-3 py-2 text-xs text-foreground">
+                  <svg
+                    className="w-4 h-4 mt-0.5 shrink-0 text-emerald-500"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                    strokeWidth={2}
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      d="M13 16h-1v-4h-1m1-4h.01M12 2a10 10 0 100 20 10 10 0 000-20z"
+                    />
+                  </svg>
+                  <span>
+                    <span className="font-semibold">Tip:</span>{" "}
                     <button
+                      type="button"
                       onClick={downloadSampleCsv}
-                      className="h-9 px-3 rounded-md text-xs font-medium border border-border bg-muted/40 text-foreground hover:bg-muted hover:border-foreground/30 transition-colors cursor-pointer flex items-center gap-1.5 shadow-sm"
+                      className="underline underline-offset-2 font-semibold text-emerald-700 dark:text-emerald-300 hover:opacity-80 transition-opacity cursor-pointer"
                     >
-                      <svg
-                        className="w-4 h-4"
-                        fill="none"
-                        viewBox="0 0 24 24"
-                        stroke="currentColor"
-                        strokeWidth={2}
-                      >
-                        <path
-                          strokeLinecap="round"
-                          strokeLinejoin="round"
-                          d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5M16.5 12L12 16.5m0 0L7.5 12m4.5 4.5V3"
-                        />
-                      </svg>
-                      Download sample CSV
-                    </button>
-                  </div>
-                </>
+                      download the sample CSV
+                    </button>{" "}
+                    and edit it as a starting point
+                  </span>
+                </div>
               )}
 
               {/* Parsed Preview */}
-              {parsedTests.length > 0 && isResponseType && (() => {
-                const variableColumns = committedEvaluators.flatMap((e) =>
-                  e.variables.map((v) => ({
-                    evaluatorUuid: e.uuid,
-                    varName: v.name,
-                    header: variableColumnName(e.name, v.name),
-                  })),
-                );
-                const gridStyle = {
-                  gridTemplateColumns: [
-                    "160px",
-                    "minmax(220px,1fr)",
-                    ...variableColumns.map(() => "minmax(220px,1fr)"),
-                  ].join(" "),
-                };
-                return (
-                  <div className="mt-3 space-y-2">
-                    <p className="text-sm font-medium text-foreground">
-                      {parsedTests.length}{" "}
-                      {parsedTests.length === 1 ? "test" : "tests"} ready to
-                      upload
-                    </p>
-                    <div className="border border-border rounded-xl overflow-hidden">
-                      <div className="overflow-x-auto">
-                        <div
-                          className="grid gap-3 px-4 py-2 border-b border-border bg-muted/30"
-                          style={gridStyle}
-                        >
-                          <div className="text-xs font-medium text-muted-foreground">
-                            Name
-                          </div>
-                          <div className="text-xs font-medium text-muted-foreground">
-                            Chat history
-                          </div>
-                          {variableColumns.map((c) => (
-                            <div
-                              key={`h-${c.evaluatorUuid}-${c.varName}`}
-                              className="text-xs font-medium text-muted-foreground font-mono truncate"
-                              title={c.header}
-                            >
-                              {c.header}
+              {parsedTests.length > 0 &&
+                isResponseType &&
+                (() => {
+                  const variableColumns = committedEvaluators.flatMap((e) =>
+                    e.variables.map((v) => ({
+                      evaluatorUuid: e.uuid,
+                      varName: v.name,
+                      header: variableColumnName(e.name, v.name),
+                    })),
+                  );
+                  const gridStyle = {
+                    gridTemplateColumns: [
+                      "160px",
+                      "minmax(220px,1fr)",
+                      ...variableColumns.map(() => "minmax(220px,1fr)"),
+                    ].join(" "),
+                  };
+                  return (
+                    <div className="mt-3 space-y-2">
+                      <p className="text-sm font-medium text-foreground">
+                        {parsedTests.length}{" "}
+                        {parsedTests.length === 1 ? "test" : "tests"} ready to
+                        upload
+                      </p>
+                      <div className="border border-border rounded-xl overflow-hidden">
+                        <div className="overflow-x-auto">
+                          <div
+                            className="grid gap-3 px-4 py-2 border-b border-border bg-muted/30"
+                            style={gridStyle}
+                          >
+                            <div className="text-xs font-medium text-muted-foreground">
+                              Name
                             </div>
-                          ))}
-                        </div>
-                        <div className="max-h-[15rem] overflow-y-auto divide-y divide-border">
-                          {parsedTests.slice(0, 50).map((test, idx) => {
-                            let turns: TurnObject[] = [];
-                            try {
-                              const parsed = JSON.parse(
-                                test.conversation_history,
-                              );
-                              if (Array.isArray(parsed)) turns = parsed;
-                            } catch {
-                              // Parsed-tests entries already passed JSON
-                              // validation; this is a defensive fallback.
-                            }
-                            const valuesByKey = new Map<string, string>();
-                            for (const ref of test.evaluators ?? []) {
-                              if (!ref.variable_values) continue;
-                              for (const [varName, value] of Object.entries(
-                                ref.variable_values,
-                              )) {
-                                valuesByKey.set(
-                                  `${ref.evaluator_uuid}/${varName}`,
-                                  value,
-                                );
-                              }
-                            }
-                            return (
+                            <div className="text-xs font-medium text-muted-foreground">
+                              Chat history
+                            </div>
+                            {variableColumns.map((c) => (
                               <div
-                                key={idx}
-                                className="grid gap-3 px-4 py-2 text-xs items-start"
-                                style={gridStyle}
+                                key={`h-${c.evaluatorUuid}-${c.varName}`}
+                                className="text-xs font-medium text-muted-foreground font-mono truncate"
+                                title={c.header}
                               >
-                                <div
-                                  className="truncate text-foreground"
-                                  title={test.name}
-                                >
-                                  {test.name}
-                                </div>
-                                <div className="min-w-0">
-                                  <ChatHistoryPreview turns={turns} />
-                                </div>
-                                {variableColumns.map((c) => {
-                                  const value =
-                                    valuesByKey.get(
-                                      `${c.evaluatorUuid}/${c.varName}`,
-                                    ) ?? "";
-                                  return (
-                                    <div
-                                      key={`${idx}-${c.evaluatorUuid}-${c.varName}`}
-                                      className="min-w-0 max-h-24 overflow-y-auto pr-1 leading-snug text-foreground break-words whitespace-pre-wrap"
-                                    >
-                                      {value || (
-                                        <span className="text-muted-foreground italic">
-                                          (empty)
-                                        </span>
-                                      )}
-                                    </div>
-                                  );
-                                })}
+                                {c.header}
                               </div>
-                            );
-                          })}
-                          {parsedTests.length > 50 && (
-                            <div className="px-4 py-2 text-xs text-muted-foreground">
-                              + {parsedTests.length - 50} more rows
-                            </div>
-                          )}
+                            ))}
+                          </div>
+                          <div className="max-h-[15rem] overflow-y-auto divide-y divide-border">
+                            {parsedTests.slice(0, 50).map((test, idx) => {
+                              let turns: TurnObject[] = [];
+                              try {
+                                const parsed = JSON.parse(
+                                  test.conversation_history,
+                                );
+                                if (Array.isArray(parsed)) turns = parsed;
+                              } catch {
+                                // Parsed-tests entries already passed JSON
+                                // validation; this is a defensive fallback.
+                              }
+                              const valuesByKey = new Map<string, string>();
+                              for (const ref of test.evaluators ?? []) {
+                                if (!ref.variable_values) continue;
+                                for (const [varName, value] of Object.entries(
+                                  ref.variable_values,
+                                )) {
+                                  valuesByKey.set(
+                                    `${ref.evaluator_uuid}/${varName}`,
+                                    value,
+                                  );
+                                }
+                              }
+                              return (
+                                <div
+                                  key={idx}
+                                  className="grid gap-3 px-4 py-2 text-xs items-start"
+                                  style={gridStyle}
+                                >
+                                  <div
+                                    className="truncate text-foreground"
+                                    title={test.name}
+                                  >
+                                    {test.name}
+                                  </div>
+                                  <div className="min-w-0">
+                                    <ChatHistoryPreview turns={turns} />
+                                  </div>
+                                  {variableColumns.map((c) => {
+                                    const value =
+                                      valuesByKey.get(
+                                        `${c.evaluatorUuid}/${c.varName}`,
+                                      ) ?? "";
+                                    return (
+                                      <div
+                                        key={`${idx}-${c.evaluatorUuid}-${c.varName}`}
+                                        className="min-w-0 max-h-24 overflow-y-auto pr-1 leading-snug text-foreground break-words whitespace-pre-wrap"
+                                      >
+                                        {value || (
+                                          <span className="text-muted-foreground italic">
+                                            (empty)
+                                          </span>
+                                        )}
+                                      </div>
+                                    );
+                                  })}
+                                </div>
+                              );
+                            })}
+                            {parsedTests.length > 50 && (
+                              <div className="px-4 py-2 text-xs text-muted-foreground">
+                                + {parsedTests.length - 50} more rows
+                              </div>
+                            )}
+                          </div>
                         </div>
                       </div>
                     </div>
-                  </div>
-                );
-              })()}
+                  );
+                })()}
 
               {/* Tool-call preview keeps the existing table layout — its
                   per-row `tool_calls` column has its own custom rendering. */}

--- a/src/components/MultiSelectPicker.tsx
+++ b/src/components/MultiSelectPicker.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useState, useEffect, useRef } from "react";
+import { createPortal } from "react-dom";
 
 export type PickerItem = {
   uuid: string;
@@ -18,6 +19,11 @@ type MultiSelectPickerProps = {
   isLoading?: boolean;
   className?: string;
   disabled?: boolean;
+  // Optional callback fired when the dropdown opens or closes. Lets the
+  // parent defer side effects (e.g. resetting an uploaded CSV) until the
+  // user is done picking instead of reacting to every intermediate
+  // toggle.
+  onOpenChange?: (open: boolean) => void;
 };
 
 export function MultiSelectPicker({
@@ -30,10 +36,68 @@ export function MultiSelectPicker({
   isLoading = false,
   className = "",
   disabled = false,
+  onOpenChange,
 }: MultiSelectPickerProps) {
-  const [dropdownOpen, setDropdownOpen] = useState(false);
+  const [dropdownOpen, setDropdownOpenState] = useState(false);
+  // Mirror state in a ref so the wrapper can read the previous value
+  // synchronously (without the setState updater form, which runs during
+  // render — calling parent setState from there triggers React's
+  // "Cannot update a component while rendering" warning).
+  const dropdownOpenRef = useRef(false);
+  // Keep the latest onOpenChange in a ref so handlers captured by
+  // mount-only effects (e.g. the document-level mousedown listener)
+  // call the freshest version, which closes over the parent's current
+  // selection state — not the empty initial state.
+  const onOpenChangeRef = useRef(onOpenChange);
+  useEffect(() => {
+    onOpenChangeRef.current = onOpenChange;
+  }, [onOpenChange]);
+  const setDropdownOpen = (next: boolean | ((p: boolean) => boolean)) => {
+    const prev = dropdownOpenRef.current;
+    const resolved = typeof next === "function" ? next(prev) : next;
+    if (resolved === prev) return;
+    dropdownOpenRef.current = resolved;
+    setDropdownOpenState(resolved);
+    onOpenChangeRef.current?.(resolved);
+  };
   const [searchQuery, setSearchQuery] = useState("");
   const dropdownRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLDivElement>(null);
+  const menuRef = useRef<HTMLDivElement>(null);
+  const [menuRect, setMenuRect] = useState<{
+    left: number;
+    top: number;
+    width: number;
+  } | null>(null);
+
+  // Anchor the portaled dropdown to the trigger via fixed positioning.
+  // Recompute on open, on scroll/resize, and whenever surrounding layout
+  // shifts (e.g. a parent renders a new section based on the picker's
+  // selection, pushing the trigger down) — caught via a ResizeObserver
+  // on the trigger and on document.body.
+  useEffect(() => {
+    if (!dropdownOpen) return;
+    const updateRect = () => {
+      const el = triggerRef.current;
+      if (!el) return;
+      const r = el.getBoundingClientRect();
+      setMenuRect({ left: r.left, top: r.bottom + 8, width: r.width });
+    };
+    updateRect();
+    window.addEventListener("scroll", updateRect, true);
+    window.addEventListener("resize", updateRect);
+    let observer: ResizeObserver | null = null;
+    if (typeof ResizeObserver !== "undefined") {
+      observer = new ResizeObserver(updateRect);
+      if (triggerRef.current) observer.observe(triggerRef.current);
+      if (typeof document !== "undefined") observer.observe(document.body);
+    }
+    return () => {
+      window.removeEventListener("scroll", updateRect, true);
+      window.removeEventListener("resize", updateRect);
+      observer?.disconnect();
+    };
+  }, [dropdownOpen]);
 
   const filteredItems = items.filter((item) =>
     item.name.toLowerCase().includes(searchQuery.toLowerCase())
@@ -55,15 +119,14 @@ export function MultiSelectPicker({
     onSelectionChange(selectedItems.filter((i) => i.uuid !== uuid));
   };
 
-  // Close dropdown when clicking outside
+  // Close dropdown when clicking outside. The menu now lives in a portal
+  // so we have to test against both the trigger container and the menu.
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
-      if (
-        dropdownRef.current &&
-        !dropdownRef.current.contains(event.target as Node)
-      ) {
-        setDropdownOpen(false);
-      }
+      const target = event.target as Node;
+      if (dropdownRef.current && dropdownRef.current.contains(target)) return;
+      if (menuRef.current && menuRef.current.contains(target)) return;
+      setDropdownOpen(false);
     };
 
     document.addEventListener("mousedown", handleClickOutside);
@@ -77,7 +140,7 @@ export function MultiSelectPicker({
           {label}
         </label>
       )}
-      <div className="relative">
+      <div className="relative" ref={triggerRef}>
         <div
           onClick={() => !disabled && setDropdownOpen(!dropdownOpen)}
           className={`w-full min-h-[44px] px-4 py-2 rounded-xl text-sm bg-background text-foreground border border-border transition-colors flex items-center justify-between gap-2 ${
@@ -141,9 +204,21 @@ export function MultiSelectPicker({
           )}
         </div>
 
-        {/* Dropdown */}
-        {dropdownOpen && !disabled && (
-          <div className="absolute left-0 right-0 top-full mt-2 bg-popover text-foreground border border-border rounded-xl shadow-xl z-[100] overflow-hidden">
+        {/* Dropdown — portaled to <body> with fixed positioning so it
+            escapes any ancestor `overflow: auto` (e.g. a scrolling modal
+            content area) and isn't clipped. */}
+        {dropdownOpen && !disabled && menuRect && typeof document !== "undefined" &&
+          createPortal(
+          <div
+            ref={menuRef}
+            style={{
+              position: "fixed",
+              left: menuRect.left,
+              top: menuRect.top,
+              width: menuRect.width,
+            }}
+            className="bg-popover text-foreground border border-border rounded-xl shadow-xl z-[100] overflow-hidden"
+          >
             {/* Search */}
             <div className="p-3 border-b border-border">
               <input
@@ -229,7 +304,8 @@ export function MultiSelectPicker({
                 ))
               )}
             </div>
-          </div>
+          </div>,
+          document.body,
         )}
       </div>
     </div>

--- a/src/components/human-labelling/BulkUploadLlmItemsDialog.tsx
+++ b/src/components/human-labelling/BulkUploadLlmItemsDialog.tsx
@@ -218,29 +218,19 @@ export function BulkUploadLlmItemsDialog({
     }),
   );
 
-  // Evaluator metadata (output_type) hydrates asynchronously on the parent
-  // page. Until every linked evaluator has a usable output_type the parser
-  // would silently drop those evaluators' annotation columns, so we treat
-  // the metadata as "not ready" and re-parse once it lands.
-  const annotationMetadataReady = annotationEvaluatorsMeta.every(
-    (e) => e.output_type === "binary" || e.output_type === "rating",
+  // Evaluators without a usable output_type (no live version, or live
+  // version with neither binary nor rating output) can't be annotated
+  // here — the parser would silently drop their column and produce a
+  // half-labelled batch. Block the annotation flow until that's fixed
+  // upstream rather than failing later.
+  const evaluatorsMissingOutputType = annotationEvaluatorsMeta.filter(
+    (e) => e.output_type !== "binary" && e.output_type !== "rating",
   );
 
   // Two linked evaluators with the same name would produce duplicate CSV
   // headers and PapaParse would silently overwrite one. Block the
   // annotation flow until the task admin renames one of them.
   const duplicateNames = duplicateEvaluatorNames(annotationEvaluatorsMeta);
-
-  // If the user dropped a CSV before evaluator metadata hydrated, re-run
-  // the parser as soon as it does so annotations land on every evaluator
-  // instead of being silently skipped.
-  useEffect(() => {
-    if (!uploadAnnotations || !annotationMetadataReady || !csvFile) return;
-    handleFile(csvFile);
-    // handleFile is recreated each render and reads latest state via
-    // closure; we only want this firing on the readiness flip.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [annotationMetadataReady]);
 
   const evaluatorsWithVariables = linkedEvaluators.filter(
     (e) => e.variables.length > 0,
@@ -303,9 +293,11 @@ export function BulkUploadLlmItemsDialog({
         }
 
         if (uploadAnnotations) {
-          if (!annotationMetadataReady) {
+          if (evaluatorsMissingOutputType.length > 0) {
             setParseError(
-              "Evaluator metadata is still loading. Please wait a moment and try again.",
+              `Annotation upload is unavailable: evaluator(s) ${evaluatorsMissingOutputType
+                .map((e) => `"${e.name}"`)
+                .join(", ")} have no binary/rating output configured.`,
             );
             return;
           }
@@ -468,9 +460,9 @@ export function BulkUploadLlmItemsDialog({
       setUploadError("Select an annotator before uploading.");
       return;
     }
-    if (uploadAnnotations && !annotationMetadataReady) {
+    if (uploadAnnotations && evaluatorsMissingOutputType.length > 0) {
       setUploadError(
-        "Evaluator metadata is still loading. Please wait a moment and try again.",
+        "One or more evaluators have no binary/rating output configured.",
       );
       return;
     }
@@ -750,6 +742,15 @@ export function BulkUploadLlmItemsDialog({
             on the evaluators page before uploading annotations.
           </div>
         )}
+        {uploadAnnotations && evaluatorsMissingOutputType.length > 0 && (
+          <div className="rounded-md border border-red-500/30 bg-red-500/10 p-3 text-xs text-red-600 dark:text-red-400">
+            Annotation upload isn&apos;t available — evaluator(s){" "}
+            {evaluatorsMissingOutputType
+              .map((e) => `"${e.name}"`)
+              .join(", ")}{" "}
+            have no binary/rating output configured.
+          </div>
+        )}
       </div>
     ) : null;
 
@@ -757,7 +758,8 @@ export function BulkUploadLlmItemsDialog({
     uploadAnnotations &&
     (annotatorsState.annotators.length === 0 ||
       !selectedAnnotatorId ||
-      duplicateNames.length > 0);
+      duplicateNames.length > 0 ||
+      evaluatorsMissingOutputType.length > 0);
 
   return (
     <BulkUploadDialogShell
@@ -789,7 +791,9 @@ export function BulkUploadLlmItemsDialog({
       uploadBlocked={uploadBlocked}
       hideUploadSection={
         uploadAnnotations &&
-        (!selectedAnnotatorId || duplicateNames.length > 0)
+        (!selectedAnnotatorId ||
+          duplicateNames.length > 0 ||
+          evaluatorsMissingOutputType.length > 0)
       }
     />
   );

--- a/src/components/human-labelling/BulkUploadLlmItemsDialog.tsx
+++ b/src/components/human-labelling/BulkUploadLlmItemsDialog.tsx
@@ -4,12 +4,22 @@ import { useEffect, useState } from "react";
 import Papa from "papaparse";
 import { apiClient } from "@/lib/api";
 import {
+  AnnotationOptIn,
   BulkUploadDialogShell,
   ChatHistoryPreview,
-  ConversationFormatDetails,
+  type EvaluatorMeta,
+  type GuidelineColumn,
+  type GuidelineDoc,
+  type ParsedAnnotation,
   type TurnObject,
+  buildItemAnnotationsPayload,
+  evaluatorReasoningColumn,
+  evaluatorValueColumn,
   findHeaderKey,
+  parseAnnotationCell,
   parseApiError,
+  sampleEvaluatorValue,
+  useAnnotators,
 } from "./bulk-upload-shared";
 
 type EvaluatorVariableDef = {
@@ -23,6 +33,9 @@ export type LinkedEvaluator = {
   name: string;
   slug: string | null;
   variables: EvaluatorVariableDef[];
+  output_type: "binary" | "rating" | null;
+  scale_min: number | null;
+  scale_max: number | null;
 };
 
 type EvaluatorRef = {
@@ -35,6 +48,7 @@ type ParsedItem = {
   chat_history: TurnObject[];
   agent_response: string;
   evaluators: EvaluatorRef[];
+  annotations: ParsedAnnotation[];
 };
 
 const NAME_HEADERS = ["name", "title"];
@@ -62,13 +76,19 @@ function variableColumnName(evalName: string, varName: string): string {
   return `${evalName}/${varName}`;
 }
 
-function buildSampleCsv(linked: LinkedEvaluator[]): string {
+function buildSampleCsv(
+  linked: LinkedEvaluator[],
+  includeAnnotations: boolean,
+): string {
   const fallback: LinkedEvaluator[] = [
     {
       uuid: "",
       name: "Correctness",
       slug: null,
       variables: [{ name: "criteria" }],
+      output_type: "binary",
+      scale_min: null,
+      scale_max: null,
     },
   ];
   const evaluators = linked.length > 0 ? linked : fallback;
@@ -86,6 +106,8 @@ function buildSampleCsv(linked: LinkedEvaluator[]): string {
       response: "You can return any item within 30 days for a full refund.",
       sampleVariableValue:
         "The agent should clearly explain the return policy in a helpful and friendly tone.",
+      sampleReasoning:
+        "The agent answered the policy clearly and politely.",
     },
     {
       name: "Refund flow",
@@ -94,6 +116,7 @@ function buildSampleCsv(linked: LinkedEvaluator[]): string {
         "I'm sorry to hear that. Can you confirm the order ID so I can investigate?",
       sampleVariableValue:
         "The agent should apologize for the duplicate charge and offer to investigate the order.",
+      sampleReasoning: "",
     },
   ];
 
@@ -104,6 +127,12 @@ function buildSampleCsv(linked: LinkedEvaluator[]): string {
     ...variableColumns.map((c) =>
       csvEscape(variableColumnName(c.evalName, c.varName)),
     ),
+    ...(includeAnnotations
+      ? evaluators.flatMap((e) => [
+          csvEscape(evaluatorValueColumn(e.name)),
+          csvEscape(evaluatorReasoningColumn(e.name)),
+        ])
+      : []),
   ];
   const lines = rows.map((r) =>
     [
@@ -111,6 +140,12 @@ function buildSampleCsv(linked: LinkedEvaluator[]): string {
       csvEscape(JSON.stringify(r.conversation)),
       csvEscape(r.response),
       ...variableColumns.map(() => csvEscape(r.sampleVariableValue)),
+      ...(includeAnnotations
+        ? evaluators.flatMap((e) => [
+            csvEscape(sampleEvaluatorValue(e)),
+            csvEscape(r.sampleReasoning),
+          ])
+        : []),
     ].join(","),
   );
   return `${headerCells.join(",")}\n${lines.join("\n")}\n`;
@@ -119,9 +154,7 @@ function buildSampleCsv(linked: LinkedEvaluator[]): string {
 function AgentReplyPreview({ agentResponse }: { agentResponse: string }) {
   return (
     <div className="max-h-24 overflow-y-auto pr-1 leading-snug text-foreground break-words whitespace-pre-wrap">
-      {agentResponse || (
-        <span className="text-muted-foreground italic">(empty)</span>
-      )}
+      {agentResponse}
     </div>
   );
 }
@@ -132,7 +165,7 @@ type BulkUploadLlmItemsDialogProps = {
   taskUuid: string;
   linkedEvaluators: LinkedEvaluator[];
   onClose: () => void;
-  onSuccess: (count: number) => void;
+  onSuccess: (count: number, withAnnotations: boolean) => void;
 };
 
 export function BulkUploadLlmItemsDialog({
@@ -148,17 +181,41 @@ export function BulkUploadLlmItemsDialog({
   const [parseError, setParseError] = useState<string | null>(null);
   const [isUploading, setIsUploading] = useState(false);
   const [uploadError, setUploadError] = useState<string | null>(null);
+  const [uploadAnnotations, setUploadAnnotations] = useState(false);
+  const [selectedAnnotatorId, setSelectedAnnotatorId] = useState<string | null>(
+    null,
+  );
+  const annotatorsState = useAnnotators(isOpen, accessToken);
 
   const reset = () => {
     setCsvFile(null);
     setParsedItems([]);
     setParseError(null);
     setUploadError(null);
+    setUploadAnnotations(false);
+    setSelectedAnnotatorId(null);
   };
 
   useEffect(() => {
     if (isOpen) reset();
   }, [isOpen]);
+
+  // Re-parse when the annotation toggle changes (column requirements differ).
+  useEffect(() => {
+    setParsedItems([]);
+    setParseError(null);
+    setCsvFile(null);
+  }, [uploadAnnotations]);
+
+  const annotationEvaluatorsMeta: EvaluatorMeta[] = linkedEvaluators.map(
+    (e) => ({
+      uuid: e.uuid,
+      name: e.name,
+      output_type: e.output_type,
+      scale_min: e.scale_min,
+      scale_max: e.scale_max,
+    }),
+  );
 
   const evaluatorsWithVariables = linkedEvaluators.filter(
     (e) => e.variables.length > 0,
@@ -218,6 +275,26 @@ export function BulkUploadLlmItemsDialog({
               )}. Download the sample CSV above for the exact format.`,
           );
           return;
+        }
+
+        if (uploadAnnotations) {
+          const missingAnnotationCols: string[] = [];
+          for (const meta of annotationEvaluatorsMeta) {
+            const valueHeader = evaluatorValueColumn(meta.name);
+            if (!headers.includes(valueHeader)) {
+              missingAnnotationCols.push(valueHeader);
+            }
+          }
+          if (missingAnnotationCols.length > 0) {
+            setParseError(
+              `CSV is missing annotation column(s): ${missingAnnotationCols
+                .map((c) => `"${c}"`)
+                .join(
+                  ", ",
+                )}. Download the sample CSV above for the exact format.`,
+            );
+            return;
+          }
         }
 
         const items: ParsedItem[] = [];
@@ -306,11 +383,41 @@ export function BulkUploadLlmItemsDialog({
             return;
           }
 
+          const annotations: ParsedAnnotation[] = [];
+          if (uploadAnnotations) {
+            for (const meta of annotationEvaluatorsMeta) {
+              if (meta.output_type !== "binary" && meta.output_type !== "rating")
+                continue;
+              const valueHeader = evaluatorValueColumn(meta.name);
+              const reasoningHeader = evaluatorReasoningColumn(meta.name);
+              const rawValue = (row[valueHeader] ?? "").trim();
+              const rawReasoning = (row[reasoningHeader] ?? "").trim();
+              if (!rawValue) {
+                setParseError(
+                  `Row ${i + 1}: missing value for "${valueHeader}".`,
+                );
+                return;
+              }
+              const parsed = parseAnnotationCell(rawValue, meta);
+              if ("error" in parsed) {
+                setParseError(`Row ${i + 1}: ${parsed.error}.`);
+                return;
+              }
+              annotations.push({
+                evaluator_uuid: meta.uuid,
+                output_type: meta.output_type,
+                value: parsed.value,
+                reasoning: rawReasoning,
+              });
+            }
+          }
+
           items.push({
             name,
             chat_history: turns,
             agent_response: responseRaw,
             evaluators: refs,
+            annotations,
           });
         }
 
@@ -326,36 +433,49 @@ export function BulkUploadLlmItemsDialog({
 
   const handleUpload = async () => {
     if (parsedItems.length === 0 || isUploading) return;
+    if (uploadAnnotations && !selectedAnnotatorId) {
+      setUploadError("Select an annotator before uploading.");
+      return;
+    }
     setIsUploading(true);
     setUploadError(null);
     try {
+      const itemsBody = parsedItems.map((p) => {
+        const evaluator_variables: Record<
+          string,
+          Record<string, string>
+        > = {};
+        for (const ref of p.evaluators) {
+          if (ref.variable_values) {
+            evaluator_variables[ref.evaluator_uuid] = {
+              ...ref.variable_values,
+            };
+          }
+        }
+        const annotationsObj = uploadAnnotations
+          ? buildItemAnnotationsPayload(p.annotations)
+          : undefined;
+        return {
+          payload: {
+            name: p.name,
+            chat_history: p.chat_history,
+            agent_response: p.agent_response,
+            evaluator_variables,
+          },
+          ...(annotationsObj ? { annotations: annotationsObj } : {}),
+        };
+      });
+      const anyAnnotated = itemsBody.some((it) => "annotations" in it);
       await apiClient(`/annotation-tasks/${taskUuid}/items`, accessToken, {
         method: "POST",
         body: {
-          items: parsedItems.map((p) => {
-            const evaluator_variables: Record<
-              string,
-              Record<string, string>
-            > = {};
-            for (const ref of p.evaluators) {
-              if (ref.variable_values) {
-                evaluator_variables[ref.evaluator_uuid] = {
-                  ...ref.variable_values,
-                };
-              }
-            }
-            return {
-              payload: {
-                name: p.name,
-                chat_history: p.chat_history,
-                agent_response: p.agent_response,
-                evaluator_variables,
-              },
-            };
-          }),
+          ...(anyAnnotated && selectedAnnotatorId
+            ? { annotator_id: selectedAnnotatorId }
+            : {}),
+          items: itemsBody,
         },
       });
-      onSuccess(parsedItems.length);
+      onSuccess(parsedItems.length, uploadAnnotations);
     } catch (err) {
       setUploadError(parseApiError(err, "Failed to upload items"));
     } finally {
@@ -363,50 +483,64 @@ export function BulkUploadLlmItemsDialog({
     }
   };
 
-  const helpContent = (
-    <>
-      <p>Each row creates one LLM annotation item:</p>
-      <ul className="list-disc pl-5 space-y-1.5">
-        <li>
-          <code className="font-mono text-foreground">name</code> — a unique
-          item name
-        </li>
-        <li>
-          <code className="font-mono text-foreground">conversation_history</code>{" "}
-          — JSON array representing a conversation up to (but not including)
-          the agent response being judged.
-          <ConversationFormatDetails
-            example={
-              '[{"role":"user","content":"What is your return policy?"},{"role":"assistant","content":"You can return any item within 30 days."},{"role":"user","content":"What about defective items?"}]'
-            }
-          />
-        </li>
-        <li>
-          <code className="font-mono text-foreground">agent_response</code> —
-          the agent response being judged
-        </li>
-        {evaluatorsWithVariables.flatMap((e) =>
-          e.variables.map((v) => (
-            <li key={`${e.uuid}-${v.name}`}>
-              <code className="font-mono text-foreground">
-                {variableColumnName(e.name, v.name)}
-              </code>
-              {v.description ? ` — ${v.description}` : ""} (used for{" "}
-              <a
-                href={`/evaluators/${e.uuid}`}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="inline-flex items-center px-1.5 py-0.5 rounded-full bg-accent text-accent-foreground text-[10px] font-medium hover:opacity-80 transition-opacity cursor-pointer"
-              >
-                {e.name}
-              </a>
-              )
-            </li>
-          )),
-        )}
-      </ul>
-    </>
-  );
+  const buildGuidelines = (): GuidelineDoc => {
+    const columns: GuidelineColumn[] = [
+      {
+        name: "name",
+        description: "A unique item name.",
+      },
+      {
+        name: "conversation_history",
+        description:
+          'A JSON array of chat messages that represents the conversation that has happened so far, before the agent response being judged. Each message is an object with a "role" and "content" field.\n\nrole — either "user" or "assistant"\ncontent — the message said by that role',
+        example: `[
+  {"role": "user", "content": "What is your return policy?"},
+  {"role": "assistant", "content": "You can return any item within 30 days."}
+]`,
+      },
+      {
+        name: "agent_response",
+        description: "The agent response being judged.",
+      },
+    ];
+
+    for (const e of evaluatorsWithVariables) {
+      for (const v of e.variables) {
+        const desc = v.description ? ` — ${v.description}` : "";
+        columns.push({
+          name: variableColumnName(e.name, v.name),
+          description: `Used for the "${e.name}" evaluator${desc}`,
+        });
+      }
+    }
+
+    if (uploadAnnotations && annotationEvaluatorsMeta.length > 0) {
+      for (const e of annotationEvaluatorsMeta) {
+        const range =
+          e.output_type === "binary"
+            ? "true/false"
+            : e.output_type === "rating" &&
+                typeof e.scale_min === "number" &&
+                typeof e.scale_max === "number"
+              ? `any value between ${e.scale_min}-${e.scale_max}`
+              : "value";
+        columns.push({
+          name: evaluatorValueColumn(e.name),
+          description: `Required. Value for the "${e.name}" evaluator (${range}).`,
+        });
+        columns.push({
+          name: evaluatorReasoningColumn(e.name),
+          description: `(optional) Reasoning for the value assigned to "${e.name}".`,
+        });
+      }
+    }
+
+    return {
+      title: "Bulk upload — LLM labelling items",
+      intro: "Upload a CSV with the following columns. Each row creates one LLM annotation item.",
+      columns,
+    };
+  };
 
   const variableColumns = evaluatorsWithVariables.flatMap((e) =>
     e.variables.map((v) => ({
@@ -415,6 +549,24 @@ export function BulkUploadLlmItemsDialog({
       header: variableColumnName(e.name, v.name),
     })),
   );
+  // Annotation columns shown only when uploadAnnotations is on. Two columns
+  // per evaluator (value + reasoning) so the user can verify everything in
+  // the CSV landed correctly before hitting upload.
+  const annotationColumns =
+    uploadAnnotations && annotationEvaluatorsMeta.length > 0
+      ? annotationEvaluatorsMeta.flatMap((e) => [
+          {
+            evaluatorUuid: e.uuid,
+            kind: "value" as const,
+            header: evaluatorValueColumn(e.name),
+          },
+          {
+            evaluatorUuid: e.uuid,
+            kind: "reasoning" as const,
+            header: evaluatorReasoningColumn(e.name),
+          },
+        ])
+      : [];
   // Use fixed minimum widths per column so the table can grow wider than
   // the dialog and scroll horizontally when there are many variables.
   const gridStyle = {
@@ -423,19 +575,20 @@ export function BulkUploadLlmItemsDialog({
       "minmax(220px,1fr)",
       "minmax(220px,1fr)",
       ...variableColumns.map(() => "minmax(220px,1fr)"),
+      ...annotationColumns.map(() => "minmax(180px,1fr)"),
     ].join(" "),
   };
 
   const itemsPreview = (
     <div className="space-y-2">
       <p className="text-sm font-medium text-foreground">
-        {parsedItems.length}{" "}
-        {parsedItems.length === 1 ? "item" : "items"} ready to upload
+        {parsedItems.length} {parsedItems.length === 1 ? "item" : "items"} ready
+        to upload
       </p>
       <div className="border border-border rounded-xl overflow-hidden">
-        <div className="overflow-x-auto">
+        <div className="overflow-auto max-h-[20rem]">
           <div
-            className="grid gap-3 px-4 py-2 border-b border-border bg-muted/30"
+            className="grid gap-3 px-4 py-2 border-b border-border bg-muted sticky top-0 z-10"
             style={gridStyle}
           >
             <div className="text-xs font-medium text-muted-foreground">
@@ -456,8 +609,17 @@ export function BulkUploadLlmItemsDialog({
                 {c.header}
               </div>
             ))}
+            {annotationColumns.map((c) => (
+              <div
+                key={`ah-${c.evaluatorUuid}-${c.kind}`}
+                className="text-xs font-medium text-muted-foreground font-mono truncate"
+                title={c.header}
+              >
+                {c.header}
+              </div>
+            ))}
           </div>
-          <div className="max-h-[15rem] overflow-y-auto divide-y divide-border">
+          <div className="divide-y divide-border">
             {parsedItems.slice(0, 50).map((p, idx) => {
               const valuesByKey = new Map<string, string>();
               for (const ref of p.evaluators) {
@@ -491,11 +653,30 @@ export function BulkUploadLlmItemsDialog({
                         key={`${idx}-${c.evaluatorUuid}-${c.varName}`}
                         className="min-w-0 max-h-24 overflow-y-auto pr-1 leading-snug text-foreground break-words whitespace-pre-wrap"
                       >
-                        {value || (
-                          <span className="text-muted-foreground italic">
-                            (empty)
-                          </span>
-                        )}
+                        {value}
+                      </div>
+                    );
+                  })}
+                  {annotationColumns.map((c) => {
+                    const ann = p.annotations.find(
+                      (a) => a.evaluator_uuid === c.evaluatorUuid,
+                    );
+                    const display =
+                      c.kind === "value"
+                        ? ann
+                          ? typeof ann.value === "boolean"
+                            ? ann.value
+                              ? "true"
+                              : "false"
+                            : String(ann.value)
+                          : ""
+                        : (ann?.reasoning ?? "");
+                    return (
+                      <div
+                        key={`${idx}-a-${c.evaluatorUuid}-${c.kind}`}
+                        className="min-w-0 max-h-24 overflow-y-auto pr-1 leading-snug text-foreground break-words whitespace-pre-wrap"
+                      >
+                        {display}
                       </div>
                     );
                   })}
@@ -513,13 +694,39 @@ export function BulkUploadLlmItemsDialog({
     </div>
   );
 
+  const annotationOptIn =
+    linkedEvaluators.length > 0 ? (
+      <AnnotationOptIn
+        annotators={annotatorsState.annotators}
+        loading={annotatorsState.loading}
+        error={annotatorsState.error}
+        uploadAnnotations={uploadAnnotations}
+        onToggle={setUploadAnnotations}
+        selectedAnnotatorId={selectedAnnotatorId}
+        onSelectAnnotator={setSelectedAnnotatorId}
+      />
+    ) : null;
+
+  const uploadBlocked =
+    uploadAnnotations &&
+    (annotatorsState.annotators.length === 0 || !selectedAnnotatorId);
+
   return (
     <BulkUploadDialogShell
       isOpen={isOpen}
       title="Bulk upload items"
-      buildSampleCsv={() => buildSampleCsv(linkedEvaluators)}
-      sampleFilename="sample_llm_items.csv"
-      helpContent={helpContent}
+      buildSampleCsv={() => buildSampleCsv(linkedEvaluators, uploadAnnotations)}
+      sampleFilename={() =>
+        uploadAnnotations
+          ? "sample_llm_items_with_annotations.csv"
+          : "sample_llm_items.csv"
+      }
+      buildGuidelines={buildGuidelines}
+      guidelinesFilename={() =>
+        uploadAnnotations
+          ? "llm_items_csv_guidelines_with_annotations.pdf"
+          : "llm_items_csv_guidelines.pdf"
+      }
       csvFile={csvFile}
       onFile={handleFile}
       onClear={reset}
@@ -530,6 +737,9 @@ export function BulkUploadLlmItemsDialog({
       itemsPreview={itemsPreview}
       onUpload={handleUpload}
       onClose={onClose}
+      topContent={annotationOptIn}
+      uploadBlocked={uploadBlocked}
+      hideUploadSection={uploadAnnotations && !selectedAnnotatorId}
     />
   );
 }

--- a/src/components/human-labelling/BulkUploadLlmItemsDialog.tsx
+++ b/src/components/human-labelling/BulkUploadLlmItemsDialog.tsx
@@ -217,6 +217,25 @@ export function BulkUploadLlmItemsDialog({
     }),
   );
 
+  // Evaluator metadata (output_type) hydrates asynchronously on the parent
+  // page. Until every linked evaluator has a usable output_type the parser
+  // would silently drop those evaluators' annotation columns, so we treat
+  // the metadata as "not ready" and re-parse once it lands.
+  const annotationMetadataReady = annotationEvaluatorsMeta.every(
+    (e) => e.output_type === "binary" || e.output_type === "rating",
+  );
+
+  // If the user dropped a CSV before evaluator metadata hydrated, re-run
+  // the parser as soon as it does so annotations land on every evaluator
+  // instead of being silently skipped.
+  useEffect(() => {
+    if (!uploadAnnotations || !annotationMetadataReady || !csvFile) return;
+    handleFile(csvFile);
+    // handleFile is recreated each render and reads latest state via
+    // closure; we only want this firing on the readiness flip.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [annotationMetadataReady]);
+
   const evaluatorsWithVariables = linkedEvaluators.filter(
     (e) => e.variables.length > 0,
   );
@@ -278,6 +297,12 @@ export function BulkUploadLlmItemsDialog({
         }
 
         if (uploadAnnotations) {
+          if (!annotationMetadataReady) {
+            setParseError(
+              "Evaluator metadata is still loading. Please wait a moment and try again.",
+            );
+            return;
+          }
           const missingAnnotationCols: string[] = [];
           for (const meta of annotationEvaluatorsMeta) {
             const valueHeader = evaluatorValueColumn(meta.name);
@@ -435,6 +460,12 @@ export function BulkUploadLlmItemsDialog({
     if (parsedItems.length === 0 || isUploading) return;
     if (uploadAnnotations && !selectedAnnotatorId) {
       setUploadError("Select an annotator before uploading.");
+      return;
+    }
+    if (uploadAnnotations && !annotationMetadataReady) {
+      setUploadError(
+        "Evaluator metadata is still loading. Please wait a moment and try again.",
+      );
       return;
     }
     setIsUploading(true);

--- a/src/components/human-labelling/BulkUploadLlmItemsDialog.tsx
+++ b/src/components/human-labelling/BulkUploadLlmItemsDialog.tsx
@@ -13,6 +13,7 @@ import {
   type ParsedAnnotation,
   type TurnObject,
   buildItemAnnotationsPayload,
+  duplicateEvaluatorNames,
   evaluatorReasoningColumn,
   evaluatorValueColumn,
   findHeaderKey,
@@ -224,6 +225,11 @@ export function BulkUploadLlmItemsDialog({
   const annotationMetadataReady = annotationEvaluatorsMeta.every(
     (e) => e.output_type === "binary" || e.output_type === "rating",
   );
+
+  // Two linked evaluators with the same name would produce duplicate CSV
+  // headers and PapaParse would silently overwrite one. Block the
+  // annotation flow until the task admin renames one of them.
+  const duplicateNames = duplicateEvaluatorNames(annotationEvaluatorsMeta);
 
   // If the user dropped a CSV before evaluator metadata hydrated, re-run
   // the parser as soon as it does so annotations land on every evaluator
@@ -727,20 +733,31 @@ export function BulkUploadLlmItemsDialog({
 
   const annotationOptIn =
     linkedEvaluators.length > 0 ? (
-      <AnnotationOptIn
-        annotators={annotatorsState.annotators}
-        loading={annotatorsState.loading}
-        error={annotatorsState.error}
-        uploadAnnotations={uploadAnnotations}
-        onToggle={setUploadAnnotations}
-        selectedAnnotatorId={selectedAnnotatorId}
-        onSelectAnnotator={setSelectedAnnotatorId}
-      />
+      <div className="space-y-3">
+        <AnnotationOptIn
+          annotators={annotatorsState.annotators}
+          loading={annotatorsState.loading}
+          error={annotatorsState.error}
+          uploadAnnotations={uploadAnnotations}
+          onToggle={setUploadAnnotations}
+          selectedAnnotatorId={selectedAnnotatorId}
+          onSelectAnnotator={setSelectedAnnotatorId}
+        />
+        {uploadAnnotations && duplicateNames.length > 0 && (
+          <div className="rounded-md border border-red-500/30 bg-red-500/10 p-3 text-xs text-red-600 dark:text-red-400">
+            Two or more linked evaluators share the same name (
+            {duplicateNames.map((n) => `"${n}"`).join(", ")}). Rename one
+            on the evaluators page before uploading annotations.
+          </div>
+        )}
+      </div>
     ) : null;
 
   const uploadBlocked =
     uploadAnnotations &&
-    (annotatorsState.annotators.length === 0 || !selectedAnnotatorId);
+    (annotatorsState.annotators.length === 0 ||
+      !selectedAnnotatorId ||
+      duplicateNames.length > 0);
 
   return (
     <BulkUploadDialogShell
@@ -770,7 +787,10 @@ export function BulkUploadLlmItemsDialog({
       onClose={onClose}
       topContent={annotationOptIn}
       uploadBlocked={uploadBlocked}
-      hideUploadSection={uploadAnnotations && !selectedAnnotatorId}
+      hideUploadSection={
+        uploadAnnotations &&
+        (!selectedAnnotatorId || duplicateNames.length > 0)
+      }
     />
   );
 }

--- a/src/components/human-labelling/BulkUploadLlmItemsDialog.tsx
+++ b/src/components/human-labelling/BulkUploadLlmItemsDialog.tsx
@@ -2,23 +2,15 @@
 
 import { useEffect, useState } from "react";
 import Papa from "papaparse";
-import { useHideFloatingButton } from "@/components/AppLayout";
 import { apiClient } from "@/lib/api";
 import {
-  CsvDropzone,
-  FormatHelpToggle,
+  BulkUploadDialogShell,
+  ChatHistoryPreview,
+  ConversationFormatDetails,
   type TurnObject,
   findHeaderKey,
   parseApiError,
-  roleLabel,
-  rolePillClass,
-  turnContentString,
 } from "./bulk-upload-shared";
-
-// Slug used by BulkUploadTestsModal for the plain-string evaluators
-// shortcut. We follow the same convention here so the CSV format the
-// user already knows from the Tests page works in this dialog too.
-const DEFAULT_NEXT_REPLY_EVALUATOR_SLUG = "default-llm-next-reply";
 
 type EvaluatorVariableDef = {
   name: string;
@@ -58,37 +50,39 @@ const RESPONSE_HEADERS = [
   "assistant_response",
   "ai_response",
 ];
-const EVALUATORS_HEADERS = ["evaluators"];
 
-// CSV-escape: wrap in double quotes and double any inner double quotes.
 function csvEscape(s: string): string {
   return `"${s.replace(/"/g, '""')}"`;
 }
 
-// Build a sample CSV that uses the *actual* evaluators linked to the
-// current task in JSON-array form, so users can edit one of the rows
-// instead of figuring the format out from scratch. Both rows share the
-// same evaluator set; only the variable values differ. Caller is
-// expected to guarantee `linked.length > 0` (the page disables the
-// "Bulk upload" button otherwise) — but we keep a defensive fallback so
-// this can't crash if it's invoked in an unexpected state.
+// Column header for an evaluator variable, e.g. "Correctness/criteria".
+// One column per variable per evaluator — keeps the CSV flat instead of
+// asking users to hand-author JSON in a single "evaluators" cell.
+function variableColumnName(evalName: string, varName: string): string {
+  return `${evalName}/${varName}`;
+}
+
 function buildSampleCsv(linked: LinkedEvaluator[]): string {
   const fallback: LinkedEvaluator[] = [
     {
       uuid: "",
       name: "Correctness",
-      slug: DEFAULT_NEXT_REPLY_EVALUATOR_SLUG,
+      slug: null,
       variables: [{ name: "criteria" }],
     },
   ];
   const evaluators = linked.length > 0 ? linked : fallback;
+  const variableColumns: { evalName: string; varName: string }[] = [];
+  for (const e of evaluators) {
+    for (const v of e.variables) {
+      variableColumns.push({ evalName: e.name, varName: v.name });
+    }
+  }
 
   const rows = [
     {
       name: "Greeting reply",
-      conversation: [
-        { role: "user", content: "What is your return policy?" },
-      ],
+      conversation: [{ role: "user", content: "What is your return policy?" }],
       response: "You can return any item within 30 days for a full refund.",
       sampleVariableValue:
         "The agent should clearly explain the return policy in a helpful and friendly tone.",
@@ -103,203 +97,23 @@ function buildSampleCsv(linked: LinkedEvaluator[]): string {
     },
   ];
 
-  const rowEvaluatorsCell = (rowIdx: number): string => {
-    const sampleValue = rows[rowIdx].sampleVariableValue;
-    const arr = evaluators.map((e) => {
-      if (e.variables.length === 0) return { name: e.name };
-      const variables: Record<string, string> = {};
-      for (const v of e.variables) {
-        variables[v.name] = sampleValue;
-      }
-      return { name: e.name, variables };
-    });
-    return JSON.stringify(arr);
-  };
-
-  const header = "name,conversation_history,agent_response,evaluators";
-  const lines = rows.map((r, i) =>
+  const headerCells = [
+    "name",
+    "conversation_history",
+    "agent_response",
+    ...variableColumns.map((c) =>
+      csvEscape(variableColumnName(c.evalName, c.varName)),
+    ),
+  ];
+  const lines = rows.map((r) =>
     [
       csvEscape(r.name),
       csvEscape(JSON.stringify(r.conversation)),
       csvEscape(r.response),
-      csvEscape(rowEvaluatorsCell(i)),
+      ...variableColumns.map(() => csvEscape(r.sampleVariableValue)),
     ].join(","),
   );
-  return `${header}\n${lines.join("\n")}\n`;
-}
-
-
-type BulkUploadLlmItemsDialogProps = {
-  isOpen: boolean;
-  accessToken: string;
-  taskUuid: string;
-  linkedEvaluators: LinkedEvaluator[];
-  onClose: () => void;
-  onSuccess: (count: number) => void;
-};
-
-// Resolve a row's `evaluators` cell to UUID-keyed refs, mirroring the
-// semantics of BulkUploadTestsModal but validating against the
-// evaluators linked to *this* annotation task (not the tenant-wide list).
-function resolveEvaluatorsCell(
-  cell: string,
-  linked: LinkedEvaluator[],
-): { refs: EvaluatorRef[]; errors: string[] } {
-  const trimmed = cell.trim();
-  const errors: string[] = [];
-
-  // A single-object spec (`{"name":"…","variables":{…}}`) is a common
-  // mistake — without the outer `[...]` it would otherwise silently
-  // fall through to the plain-string path below and be treated as a
-  // criteria string for the default evaluator. Reject explicitly.
-  if (trimmed.startsWith("{")) {
-    return {
-      refs: [],
-      errors: [
-        'evaluators must be a JSON array — wrap a single evaluator object in [...] (e.g. [{"name":"…","variables":{…}}])',
-      ],
-    };
-  }
-
-  if (trimmed.startsWith("[")) {
-    let parsed: unknown;
-    try {
-      parsed = JSON.parse(trimmed);
-    } catch {
-      return { refs: [], errors: ["evaluators is not valid JSON"] };
-    }
-    if (!Array.isArray(parsed)) {
-      return { refs: [], errors: ["evaluators must be a JSON array"] };
-    }
-    if (parsed.length === 0) {
-      return {
-        refs: [],
-        errors: ["evaluators array must contain at least one evaluator"],
-      };
-    }
-
-    const refs: EvaluatorRef[] = [];
-    const seenUuids = new Set<string>();
-    parsed.forEach((entry, i) => {
-      const label = `evaluator #${i + 1}`;
-      if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
-        errors.push(`${label}: must be a JSON object`);
-        return;
-      }
-      const obj = entry as Record<string, unknown>;
-      const name = typeof obj.name === "string" ? obj.name.trim() : "";
-      if (!name) {
-        errors.push(`${label}: missing "name"`);
-        return;
-      }
-      const evaluator = linked.find((e) => e.name === name);
-      if (!evaluator) {
-        errors.push(
-          `evaluator "${name}" is not linked to this task — link it first or remove it from the CSV`,
-        );
-        return;
-      }
-      if (seenUuids.has(evaluator.uuid)) {
-        errors.push(`evaluator "${name}" listed more than once`);
-        return;
-      }
-      seenUuids.add(evaluator.uuid);
-
-      let providedVars: Record<string, unknown> = {};
-      if (obj.variables !== undefined && obj.variables !== null) {
-        if (typeof obj.variables !== "object" || Array.isArray(obj.variables)) {
-          errors.push(`evaluator "${name}": "variables" must be an object`);
-          return;
-        }
-        providedVars = obj.variables as Record<string, unknown>;
-      }
-      const expectedNames = evaluator.variables.map((v) => v.name);
-      const variableValues: Record<string, string> = {};
-      const missing: string[] = [];
-      for (const v of evaluator.variables) {
-        const raw = providedVars[v.name];
-        if (typeof raw !== "string" || !raw.trim()) {
-          missing.push(v.name);
-          continue;
-        }
-        variableValues[v.name] = raw;
-      }
-      if (missing.length > 0) {
-        errors.push(
-          `evaluator "${name}": missing variable value(s) for ${missing
-            .map((n) => `"${n}"`)
-            .join(", ")}`,
-        );
-      }
-      const extras = Object.keys(providedVars).filter(
-        (k) => !expectedNames.includes(k),
-      );
-      if (extras.length > 0) {
-        errors.push(
-          `evaluator "${name}": unknown variable(s) ${extras
-            .map((n) => `"${n}"`)
-            .join(", ")}`,
-        );
-      }
-
-      const ref: EvaluatorRef = { evaluator_uuid: evaluator.uuid };
-      if (evaluator.variables.length > 0) {
-        ref.variable_values = variableValues;
-      }
-      refs.push(ref);
-    });
-    return { refs, errors };
-  }
-
-  // Plain-string form → default LLM next-reply evaluator (resolved by
-  // slug). Must be linked to this task.
-  const correctness = linked.find(
-    (e) => e.slug === DEFAULT_NEXT_REPLY_EVALUATOR_SLUG,
-  );
-  if (!correctness) {
-    return {
-      refs: [],
-      errors: [
-        `default LLM next-reply evaluator (slug "${DEFAULT_NEXT_REPLY_EVALUATOR_SLUG}") is not linked to this task — link it or use the JSON-array form`,
-      ],
-    };
-  }
-  return {
-    refs: [
-      {
-        evaluator_uuid: correctness.uuid,
-        variable_values: { criteria: trimmed },
-      },
-    ],
-    errors: [],
-  };
-}
-
-function ChatHistoryPreview({ turns }: { turns: TurnObject[] }) {
-  return (
-    <div className="max-h-24 overflow-y-auto pr-1 space-y-2">
-      {turns.map((t, i) => {
-        const role = typeof t.role === "string" ? t.role : "?";
-        const content = turnContentString(t);
-        return (
-          <div key={`h-${i}`} className="space-y-1 leading-snug">
-            <span
-              className={`inline-flex items-center text-[10px] font-semibold uppercase tracking-wide px-1.5 py-0.5 rounded ${rolePillClass(role)}`}
-            >
-              {roleLabel(role)}
-            </span>
-            <div className="text-foreground break-words whitespace-pre-wrap">
-              {content || (
-                <span className="text-muted-foreground italic">
-                  (no content)
-                </span>
-              )}
-            </div>
-          </div>
-        );
-      })}
-    </div>
-  );
+  return `${headerCells.join(",")}\n${lines.join("\n")}\n`;
 }
 
 function AgentReplyPreview({ agentResponse }: { agentResponse: string }) {
@@ -312,6 +126,15 @@ function AgentReplyPreview({ agentResponse }: { agentResponse: string }) {
   );
 }
 
+type BulkUploadLlmItemsDialogProps = {
+  isOpen: boolean;
+  accessToken: string;
+  taskUuid: string;
+  linkedEvaluators: LinkedEvaluator[];
+  onClose: () => void;
+  onSuccess: (count: number) => void;
+};
+
 export function BulkUploadLlmItemsDialog({
   isOpen,
   accessToken,
@@ -320,46 +143,26 @@ export function BulkUploadLlmItemsDialog({
   onClose,
   onSuccess,
 }: BulkUploadLlmItemsDialogProps) {
-  useHideFloatingButton(isOpen);
-
   const [csvFile, setCsvFile] = useState<File | null>(null);
   const [parsedItems, setParsedItems] = useState<ParsedItem[]>([]);
   const [parseError, setParseError] = useState<string | null>(null);
   const [isUploading, setIsUploading] = useState(false);
   const [uploadError, setUploadError] = useState<string | null>(null);
-  const [formatHelpOpen, setFormatHelpOpen] = useState(true);
 
   const reset = () => {
     setCsvFile(null);
     setParsedItems([]);
     setParseError(null);
     setUploadError(null);
-    setFormatHelpOpen(true);
   };
 
   useEffect(() => {
     if (isOpen) reset();
   }, [isOpen]);
 
-  useEffect(() => {
-    setFormatHelpOpen(parsedItems.length === 0);
-  }, [parsedItems.length]);
-
-  if (!isOpen) return null;
-
-  const downloadSampleCsv = () => {
-    const blob = new Blob([buildSampleCsv(linkedEvaluators)], {
-      type: "text/csv",
-    });
-    const url = URL.createObjectURL(blob);
-    const link = document.createElement("a");
-    link.href = url;
-    link.download = "sample_llm_items.csv";
-    document.body.appendChild(link);
-    link.click();
-    document.body.removeChild(link);
-    URL.revokeObjectURL(url);
-  };
+  const evaluatorsWithVariables = linkedEvaluators.filter(
+    (e) => e.variables.length > 0,
+  );
 
   const handleFile = (file: File | null) => {
     setUploadError(null);
@@ -376,11 +179,43 @@ export function BulkUploadLlmItemsDialog({
         const nameKey = findHeaderKey(headers, NAME_HEADERS);
         const conversationKey = findHeaderKey(headers, CONVERSATION_HEADERS);
         const responseKey = findHeaderKey(headers, RESPONSE_HEADERS);
-        const evaluatorsKey = findHeaderKey(headers, EVALUATORS_HEADERS);
 
-        if (!nameKey || !conversationKey || !responseKey || !evaluatorsKey) {
+        if (!nameKey || !conversationKey || !responseKey) {
           setParseError(
-            `CSV must include "name", "conversation_history", "agent_response" and "evaluators" columns. Found: ${headers.join(", ") || "(none)"}`,
+            `CSV must include "name", "conversation_history" and "agent_response" columns. Found: ${headers.join(", ") || "(none)"}`,
+          );
+          return;
+        }
+
+        const variableHeaderMap = new Map<
+          string,
+          { evaluator: LinkedEvaluator; varName: string; columnKey: string }[]
+        >();
+        const missingColumns: string[] = [];
+        for (const e of evaluatorsWithVariables) {
+          const slots: {
+            evaluator: LinkedEvaluator;
+            varName: string;
+            columnKey: string;
+          }[] = [];
+          for (const v of e.variables) {
+            const expected = variableColumnName(e.name, v.name);
+            const key = headers.find((h) => h === expected);
+            if (!key) {
+              missingColumns.push(expected);
+              continue;
+            }
+            slots.push({ evaluator: e, varName: v.name, columnKey: key });
+          }
+          variableHeaderMap.set(e.uuid, slots);
+        }
+        if (missingColumns.length > 0) {
+          setParseError(
+            `CSV is missing column(s) for evaluator variables: ${missingColumns
+              .map((c) => `"${c}"`)
+              .join(
+                ", ",
+              )}. Download the sample CSV above for the exact format.`,
           );
           return;
         }
@@ -392,10 +227,15 @@ export function BulkUploadLlmItemsDialog({
           const name = (row[nameKey] ?? "").trim();
           const conversationRaw = (row[conversationKey] ?? "").trim();
           const responseRaw = (row[responseKey] ?? "").trim();
-          const evaluatorsRaw = (row[evaluatorsKey] ?? "").trim();
 
-          if (!name && !conversationRaw && !responseRaw && !evaluatorsRaw)
+          const anyVariableValue = evaluatorsWithVariables.some((e) =>
+            (variableHeaderMap.get(e.uuid) ?? []).some(
+              (slot) => (row[slot.columnKey] ?? "").trim() !== "",
+            ),
+          );
+          if (!name && !conversationRaw && !responseRaw && !anyVariableValue)
             continue;
+
           if (!name) {
             setParseError(`Row ${i + 1}: "name" is required.`);
             return;
@@ -406,10 +246,6 @@ export function BulkUploadLlmItemsDialog({
           }
           if (!responseRaw) {
             setParseError(`Row ${i + 1}: "agent_response" is required.`);
-            return;
-          }
-          if (!evaluatorsRaw) {
-            setParseError(`Row ${i + 1}: "evaluators" is required.`);
             return;
           }
 
@@ -443,12 +279,30 @@ export function BulkUploadLlmItemsDialog({
           }
           const turns = conversation as TurnObject[];
 
-          const resolved = resolveEvaluatorsCell(
-            evaluatorsRaw,
-            linkedEvaluators,
-          );
-          if (resolved.errors.length > 0) {
-            setParseError(`Row ${i + 1}: ${resolved.errors[0]}`);
+          const refs: EvaluatorRef[] = [];
+          let rowError: string | null = null;
+          for (const e of evaluatorsWithVariables) {
+            const slots = variableHeaderMap.get(e.uuid) ?? [];
+            const variableValues: Record<string, string> = {};
+            for (const slot of slots) {
+              const raw = (row[slot.columnKey] ?? "").trim();
+              if (!raw) {
+                rowError = `Row ${i + 1}: missing value for "${variableColumnName(
+                  e.name,
+                  slot.varName,
+                )}".`;
+                break;
+              }
+              variableValues[slot.varName] = raw;
+            }
+            if (rowError) break;
+            refs.push({
+              evaluator_uuid: e.uuid,
+              variable_values: variableValues,
+            });
+          }
+          if (rowError) {
+            setParseError(rowError);
             return;
           }
 
@@ -456,7 +310,7 @@ export function BulkUploadLlmItemsDialog({
             name,
             chat_history: turns,
             agent_response: responseRaw,
-            evaluators: resolved.refs,
+            evaluators: refs,
           });
         }
 
@@ -509,206 +363,173 @@ export function BulkUploadLlmItemsDialog({
     }
   };
 
-  const handleClose = () => {
-    if (!isUploading) onClose();
+  const helpContent = (
+    <>
+      <p>Each row creates one LLM annotation item:</p>
+      <ul className="list-disc pl-5 space-y-1.5">
+        <li>
+          <code className="font-mono text-foreground">name</code> — a unique
+          item name
+        </li>
+        <li>
+          <code className="font-mono text-foreground">conversation_history</code>{" "}
+          — JSON array representing a conversation up to (but not including)
+          the agent response being judged.
+          <ConversationFormatDetails
+            example={
+              '[{"role":"user","content":"What is your return policy?"},{"role":"assistant","content":"You can return any item within 30 days."},{"role":"user","content":"What about defective items?"}]'
+            }
+          />
+        </li>
+        <li>
+          <code className="font-mono text-foreground">agent_response</code> —
+          the agent response being judged
+        </li>
+        {evaluatorsWithVariables.flatMap((e) =>
+          e.variables.map((v) => (
+            <li key={`${e.uuid}-${v.name}`}>
+              <code className="font-mono text-foreground">
+                {variableColumnName(e.name, v.name)}
+              </code>
+              {v.description ? ` — ${v.description}` : ""} (used for{" "}
+              <a
+                href={`/evaluators/${e.uuid}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center px-1.5 py-0.5 rounded-full bg-accent text-accent-foreground text-[10px] font-medium hover:opacity-80 transition-opacity cursor-pointer"
+              >
+                {e.name}
+              </a>
+              )
+            </li>
+          )),
+        )}
+      </ul>
+    </>
+  );
+
+  const variableColumns = evaluatorsWithVariables.flatMap((e) =>
+    e.variables.map((v) => ({
+      evaluatorUuid: e.uuid,
+      varName: v.name,
+      header: variableColumnName(e.name, v.name),
+    })),
+  );
+  // Use fixed minimum widths per column so the table can grow wider than
+  // the dialog and scroll horizontally when there are many variables.
+  const gridStyle = {
+    gridTemplateColumns: [
+      "160px",
+      "minmax(220px,1fr)",
+      "minmax(220px,1fr)",
+      ...variableColumns.map(() => "minmax(220px,1fr)"),
+    ].join(" "),
   };
 
-  return (
-    <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm p-4"
-      onClick={handleClose}
-    >
-      <div
-        className="bg-background border border-border rounded-xl shadow-2xl w-full max-w-2xl flex flex-col max-h-[90vh]"
-        onClick={(e) => e.stopPropagation()}
-      >
-        <div className="flex items-center justify-between px-6 py-4 border-b border-border">
-          <h2 className="text-lg font-semibold text-foreground">
-            Bulk upload items
-          </h2>
-          <button
-            onClick={handleClose}
-            disabled={isUploading}
-            aria-label="Close"
-            className="w-8 h-8 flex items-center justify-center rounded-lg text-muted-foreground hover:text-foreground hover:bg-muted transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+  const itemsPreview = (
+    <div className="space-y-2">
+      <p className="text-sm font-medium text-foreground">
+        {parsedItems.length}{" "}
+        {parsedItems.length === 1 ? "item" : "items"} ready to upload
+      </p>
+      <div className="border border-border rounded-xl overflow-hidden">
+        <div className="overflow-x-auto">
+          <div
+            className="grid gap-3 px-4 py-2 border-b border-border bg-muted/30"
+            style={gridStyle}
           >
-            <svg
-              className="w-5 h-5"
-              fill="none"
-              viewBox="0 0 24 24"
-              stroke="currentColor"
-              strokeWidth={2}
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                d="M6 18L18 6M6 6l12 12"
-              />
-            </svg>
-          </button>
-        </div>
-
-        <div className="flex-1 overflow-y-auto px-6 py-5 space-y-5">
-          <div>
-            <div className="flex items-center justify-between mb-3">
-              <label className="block text-sm font-medium text-foreground">
-                Upload CSV
-              </label>
-              <button
-                onClick={downloadSampleCsv}
-                className="h-9 px-3 rounded-md text-xs font-medium border border-border bg-muted/40 text-foreground hover:bg-muted hover:border-foreground/30 transition-colors cursor-pointer flex items-center gap-1.5 shadow-sm"
-              >
-                <svg
-                  className="w-4 h-4"
-                  fill="none"
-                  viewBox="0 0 24 24"
-                  stroke="currentColor"
-                  strokeWidth={2}
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5M16.5 12L12 16.5m0 0L7.5 12m4.5 4.5V3"
-                  />
-                </svg>
-                Download sample CSV
-              </button>
+            <div className="text-xs font-medium text-muted-foreground">
+              Name
             </div>
-
-            {parsedItems.length > 0 && (
-              <FormatHelpToggle
-                open={formatHelpOpen}
-                onToggle={() => setFormatHelpOpen((o) => !o)}
-              />
-            )}
-
-            {formatHelpOpen && (
-              <div className="text-xs text-muted-foreground mb-3 leading-relaxed space-y-2">
-                <p>Each row creates one LLM annotation item:</p>
-                <ul className="list-disc pl-5 space-y-1.5">
-                  <li>
-                    <code className="font-mono text-foreground">name</code> — a
-                    unique item name
-                  </li>
-                  <li>
-                    <code className="font-mono text-foreground">
-                      conversation_history
-                    </code>{" "}
-                    — JSON array representing a conversation up to (but not
-                    including) the agent response being judged. Each turn should
-                    have <code className="font-mono text-foreground">role</code>{" "}
-                    and{" "}
-                    <code className="font-mono text-foreground">content</code>{" "}
-                    fields.
-                  </li>
-                  <li>
-                    <code className="font-mono text-foreground">
-                      agent_response
-                    </code>{" "}
-                    — the agent response being judged
-                  </li>
-                  <li>
-                    <code className="font-mono text-foreground">
-                      evaluators
-                    </code>{" "}
-                    — a JSON array{" "}
-                    <code className="font-mono text-foreground">
-                      {`[{"name":"...","variables":{...}}]`}
-                    </code>{" "}
-                    attaching evaluators by name. Evaluator names must match
-                    evaluators linked to this task and if any evaluator requires
-                    variables, the{" "}
-                    <code className="font-mono text-foreground">variables</code>{" "}
-                    must be filled for each such evaluator for each row.
-                  </li>
-                </ul>
+            <div className="text-xs font-medium text-muted-foreground">
+              Chat history
+            </div>
+            <div className="text-xs font-medium text-muted-foreground">
+              AI reply
+            </div>
+            {variableColumns.map((c) => (
+              <div
+                key={`h-${c.evaluatorUuid}-${c.varName}`}
+                className="text-xs font-medium text-muted-foreground font-mono truncate"
+                title={c.header}
+              >
+                {c.header}
               </div>
-            )}
-
-            <CsvDropzone
-              csvFile={csvFile}
-              onFile={handleFile}
-              onClear={reset}
-            />
-
-            {parseError && (
-              <p className="text-xs text-red-500 mt-3">{parseError}</p>
+            ))}
+          </div>
+          <div className="max-h-[15rem] overflow-y-auto divide-y divide-border">
+            {parsedItems.slice(0, 50).map((p, idx) => {
+              const valuesByKey = new Map<string, string>();
+              for (const ref of p.evaluators) {
+                if (!ref.variable_values) continue;
+                for (const [varName, value] of Object.entries(
+                  ref.variable_values,
+                )) {
+                  valuesByKey.set(`${ref.evaluator_uuid}/${varName}`, value);
+                }
+              }
+              return (
+                <div
+                  key={idx}
+                  className="grid gap-3 px-4 py-2 text-xs items-start"
+                  style={gridStyle}
+                >
+                  <div className="truncate text-foreground" title={p.name}>
+                    {p.name}
+                  </div>
+                  <div className="min-w-0">
+                    <ChatHistoryPreview turns={p.chat_history} />
+                  </div>
+                  <div className="min-w-0">
+                    <AgentReplyPreview agentResponse={p.agent_response} />
+                  </div>
+                  {variableColumns.map((c) => {
+                    const value =
+                      valuesByKey.get(`${c.evaluatorUuid}/${c.varName}`) ?? "";
+                    return (
+                      <div
+                        key={`${idx}-${c.evaluatorUuid}-${c.varName}`}
+                        className="min-w-0 max-h-24 overflow-y-auto pr-1 leading-snug text-foreground break-words whitespace-pre-wrap"
+                      >
+                        {value || (
+                          <span className="text-muted-foreground italic">
+                            (empty)
+                          </span>
+                        )}
+                      </div>
+                    );
+                  })}
+                </div>
+              );
+            })}
+            {parsedItems.length > 50 && (
+              <div className="px-4 py-2 text-xs text-muted-foreground">
+                + {parsedItems.length - 50} more rows
+              </div>
             )}
           </div>
-
-          {parsedItems.length > 0 && (
-            <div className="space-y-2">
-              <p className="text-sm font-medium text-foreground">
-                {parsedItems.length}{" "}
-                {parsedItems.length === 1 ? "item" : "items"} ready to upload
-              </p>
-              <div className="border border-border rounded-xl overflow-hidden">
-                <div className="grid grid-cols-[160px_minmax(0,1fr)_minmax(0,1fr)] gap-3 px-4 py-2 border-b border-border bg-muted/30">
-                  <div className="text-xs font-medium text-muted-foreground">
-                    Name
-                  </div>
-                  <div className="text-xs font-medium text-muted-foreground">
-                    Chat history
-                  </div>
-                  <div className="text-xs font-medium text-muted-foreground">
-                    AI reply
-                  </div>
-                </div>
-                <div className="max-h-[15rem] overflow-y-auto divide-y divide-border">
-                  {parsedItems.slice(0, 50).map((p, idx) => (
-                    <div
-                      key={idx}
-                      className="grid grid-cols-[160px_minmax(0,1fr)_minmax(0,1fr)] gap-3 px-4 py-2 text-xs items-start"
-                    >
-                      <div className="truncate text-foreground" title={p.name}>
-                        {p.name}
-                      </div>
-                      <div className="min-w-0">
-                        <ChatHistoryPreview turns={p.chat_history} />
-                      </div>
-                      <div className="min-w-0">
-                        <AgentReplyPreview agentResponse={p.agent_response} />
-                      </div>
-                    </div>
-                  ))}
-                  {parsedItems.length > 50 && (
-                    <div className="px-4 py-2 text-xs text-muted-foreground">
-                      + {parsedItems.length - 50} more rows
-                    </div>
-                  )}
-                </div>
-              </div>
-            </div>
-          )}
-
-          {uploadError && (
-            <div className="rounded-md border border-red-500/30 bg-red-500/10 p-3 text-sm text-red-500">
-              {uploadError}
-            </div>
-          )}
-        </div>
-
-        <div className="flex items-center justify-end gap-3 px-6 py-4 border-t border-border">
-          <button
-            onClick={handleClose}
-            disabled={isUploading}
-            className="h-10 px-4 rounded-md text-sm font-medium border border-border bg-background hover:bg-muted/50 transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
-          >
-            Cancel
-          </button>
-          <button
-            onClick={handleUpload}
-            disabled={parsedItems.length === 0 || isUploading || !!parseError}
-            className="h-10 px-4 rounded-md text-sm font-medium bg-foreground text-background hover:opacity-90 transition-opacity cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
-          >
-            {isUploading
-              ? "Uploading…"
-              : parsedItems.length > 1
-                ? `Upload ${parsedItems.length} items`
-                : "Upload item"}
-          </button>
         </div>
       </div>
     </div>
+  );
+
+  return (
+    <BulkUploadDialogShell
+      isOpen={isOpen}
+      title="Bulk upload items"
+      buildSampleCsv={() => buildSampleCsv(linkedEvaluators)}
+      sampleFilename="sample_llm_items.csv"
+      helpContent={helpContent}
+      csvFile={csvFile}
+      onFile={handleFile}
+      onClear={reset}
+      parseError={parseError}
+      uploadError={uploadError}
+      isUploading={isUploading}
+      itemCount={parsedItems.length}
+      itemsPreview={itemsPreview}
+      onUpload={handleUpload}
+      onClose={onClose}
+    />
   );
 }

--- a/src/components/human-labelling/BulkUploadLlmItemsDialog.tsx
+++ b/src/components/human-labelling/BulkUploadLlmItemsDialog.tsx
@@ -227,9 +227,10 @@ export function BulkUploadLlmItemsDialog({
     (e) => e.output_type !== "binary" && e.output_type !== "rating",
   );
 
-  // Two linked evaluators with the same name would produce duplicate CSV
-  // headers and PapaParse would silently overwrite one. Block the
-  // annotation flow until the task admin renames one of them.
+  // Two linked evaluators with the same name produce duplicate CSV
+  // headers — for LLM items this also breaks the always-present
+  // `<evalName>/<varName>` variable columns, so it has to block
+  // regardless of whether the user is uploading annotations.
   const duplicateNames = duplicateEvaluatorNames(annotationEvaluatorsMeta);
 
   const evaluatorsWithVariables = linkedEvaluators.filter(
@@ -242,6 +243,14 @@ export function BulkUploadLlmItemsDialog({
     setParsedItems([]);
     setCsvFile(file);
     if (!file) return;
+    if (duplicateNames.length > 0) {
+      setParseError(
+        `Two or more linked evaluators share the same name (${duplicateNames
+          .map((n) => `"${n}"`)
+          .join(", ")}). Rename one before uploading.`,
+      );
+      return;
+    }
     Papa.parse<Record<string, string>>(file, {
       header: true,
       skipEmptyLines: true,
@@ -724,22 +733,25 @@ export function BulkUploadLlmItemsDialog({
   );
 
   const annotationOptIn =
-    linkedEvaluators.length > 0 ? (
+    linkedEvaluators.length > 0 || duplicateNames.length > 0 ? (
       <div className="space-y-3">
-        <AnnotationOptIn
-          annotators={annotatorsState.annotators}
-          loading={annotatorsState.loading}
-          error={annotatorsState.error}
-          uploadAnnotations={uploadAnnotations}
-          onToggle={setUploadAnnotations}
-          selectedAnnotatorId={selectedAnnotatorId}
-          onSelectAnnotator={setSelectedAnnotatorId}
-        />
-        {uploadAnnotations && duplicateNames.length > 0 && (
+        {linkedEvaluators.length > 0 && (
+          <AnnotationOptIn
+            annotators={annotatorsState.annotators}
+            loading={annotatorsState.loading}
+            error={annotatorsState.error}
+            uploadAnnotations={uploadAnnotations}
+            onToggle={setUploadAnnotations}
+            selectedAnnotatorId={selectedAnnotatorId}
+            onSelectAnnotator={setSelectedAnnotatorId}
+          />
+        )}
+        {duplicateNames.length > 0 && (
           <div className="rounded-md border border-red-500/30 bg-red-500/10 p-3 text-xs text-red-600 dark:text-red-400">
             Two or more linked evaluators share the same name (
-            {duplicateNames.map((n) => `"${n}"`).join(", ")}). Rename one
-            on the evaluators page before uploading annotations.
+            {duplicateNames.map((n) => `"${n}"`).join(", ")}). Their
+            variable and annotation columns would collide in the CSV —
+            rename one on the evaluators page before uploading.
           </div>
         )}
         {uploadAnnotations && evaluatorsMissingOutputType.length > 0 && (
@@ -755,11 +767,11 @@ export function BulkUploadLlmItemsDialog({
     ) : null;
 
   const uploadBlocked =
-    uploadAnnotations &&
-    (annotatorsState.annotators.length === 0 ||
-      !selectedAnnotatorId ||
-      duplicateNames.length > 0 ||
-      evaluatorsMissingOutputType.length > 0);
+    duplicateNames.length > 0 ||
+    (uploadAnnotations &&
+      (annotatorsState.annotators.length === 0 ||
+        !selectedAnnotatorId ||
+        evaluatorsMissingOutputType.length > 0));
 
   return (
     <BulkUploadDialogShell
@@ -790,10 +802,9 @@ export function BulkUploadLlmItemsDialog({
       topContent={annotationOptIn}
       uploadBlocked={uploadBlocked}
       hideUploadSection={
-        uploadAnnotations &&
-        (!selectedAnnotatorId ||
-          duplicateNames.length > 0 ||
-          evaluatorsMissingOutputType.length > 0)
+        duplicateNames.length > 0 ||
+        (uploadAnnotations &&
+          (!selectedAnnotatorId || evaluatorsMissingOutputType.length > 0))
       }
     />
   );

--- a/src/components/human-labelling/BulkUploadSimulationItemsDialog.tsx
+++ b/src/components/human-labelling/BulkUploadSimulationItemsDialog.tsx
@@ -176,6 +176,14 @@ export function BulkUploadSimulationItemsDialog({
     }),
   );
 
+  // Evaluator metadata (output_type) hydrates asynchronously on the parent
+  // page. Until every linked evaluator has a usable output_type the parser
+  // would silently drop those evaluators' annotation columns, so we treat
+  // the metadata as "not ready" and re-parse once it lands.
+  const annotationMetadataReady = annotationEvaluatorsMeta.every(
+    (e) => e.output_type === "binary" || e.output_type === "rating",
+  );
+
   const reset = () => {
     setCsvFile(null);
     setParsedItems([]);
@@ -194,6 +202,15 @@ export function BulkUploadSimulationItemsDialog({
     setParseError(null);
     setCsvFile(null);
   }, [uploadAnnotations]);
+
+  // Re-parse once evaluator metadata hydrates so annotations land on every
+  // evaluator instead of being silently skipped for ones whose output_type
+  // was still null when the user dropped the CSV.
+  useEffect(() => {
+    if (!uploadAnnotations || !annotationMetadataReady || !csvFile) return;
+    handleFile(csvFile);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [annotationMetadataReady]);
 
   const handleFile = (file: File | null) => {
     setUploadError(null);
@@ -216,6 +233,12 @@ export function BulkUploadSimulationItemsDialog({
           return;
         }
         if (uploadAnnotations) {
+          if (!annotationMetadataReady) {
+            setParseError(
+              "Evaluator metadata is still loading. Please wait a moment and try again.",
+            );
+            return;
+          }
           const missing: string[] = [];
           for (const meta of annotationEvaluatorsMeta) {
             const valueHeader = evaluatorValueColumn(meta.name);
@@ -322,6 +345,12 @@ export function BulkUploadSimulationItemsDialog({
     if (parsedItems.length === 0 || isUploading) return;
     if (uploadAnnotations && !selectedAnnotatorId) {
       setUploadError("Select an annotator before uploading.");
+      return;
+    }
+    if (uploadAnnotations && !annotationMetadataReady) {
+      setUploadError(
+        "Evaluator metadata is still loading. Please wait a moment and try again.",
+      );
       return;
     }
     setIsUploading(true);

--- a/src/components/human-labelling/BulkUploadSimulationItemsDialog.tsx
+++ b/src/components/human-labelling/BulkUploadSimulationItemsDialog.tsx
@@ -2,11 +2,10 @@
 
 import { useEffect, useState } from "react";
 import Papa from "papaparse";
-import { useHideFloatingButton } from "@/components/AppLayout";
 import { apiClient } from "@/lib/api";
 import {
-  CsvDropzone,
-  FormatHelpToggle,
+  BulkUploadDialogShell,
+  ConversationFormatDetails,
   type TurnObject,
   findHeaderKey,
   parseApiError,
@@ -41,9 +40,6 @@ type BulkUploadSimulationItemsDialogProps = {
   onSuccess: (count: number) => void;
 };
 
-// Vertical preview of a transcript: each turn rendered as a "Role" label
-// above its content. The container is sized so that ~2 turns are visible
-// at once; anything beyond that scrolls inside the cell.
 function TranscriptPreview({ turns }: { turns: TurnObject[] }) {
   return (
     <div className="max-h-24 overflow-y-auto pr-1 space-y-2">
@@ -78,44 +74,22 @@ export function BulkUploadSimulationItemsDialog({
   onClose,
   onSuccess,
 }: BulkUploadSimulationItemsDialogProps) {
-  useHideFloatingButton(isOpen);
-
   const [csvFile, setCsvFile] = useState<File | null>(null);
   const [parsedItems, setParsedItems] = useState<ParsedItem[]>([]);
   const [parseError, setParseError] = useState<string | null>(null);
   const [isUploading, setIsUploading] = useState(false);
   const [uploadError, setUploadError] = useState<string | null>(null);
-  const [formatHelpOpen, setFormatHelpOpen] = useState(true);
 
   const reset = () => {
     setCsvFile(null);
     setParsedItems([]);
     setParseError(null);
     setUploadError(null);
-    setFormatHelpOpen(true);
   };
 
   useEffect(() => {
     if (isOpen) reset();
   }, [isOpen]);
-
-  useEffect(() => {
-    setFormatHelpOpen(parsedItems.length === 0);
-  }, [parsedItems.length]);
-
-  if (!isOpen) return null;
-
-  const downloadSampleCsv = () => {
-    const blob = new Blob([SAMPLE_SIMULATION_CSV], { type: "text/csv" });
-    const url = URL.createObjectURL(blob);
-    const link = document.createElement("a");
-    link.href = url;
-    link.download = "sample_simulation_items.csv";
-    document.body.appendChild(link);
-    link.click();
-    document.body.removeChild(link);
-    URL.revokeObjectURL(url);
-  };
 
   const handleFile = (file: File | null) => {
     setUploadError(null);
@@ -214,186 +188,87 @@ export function BulkUploadSimulationItemsDialog({
     }
   };
 
-  const handleClose = () => {
-    if (!isUploading) onClose();
-  };
+  const helpContent = (
+    <>
+      <p>Each row creates one simulation item:</p>
+      <ul className="list-disc pl-5 space-y-1.5">
+        <li>
+          <code className="font-mono text-foreground">name</code> — a name for
+          the item
+        </li>
+        <li>
+          <code className="font-mono text-foreground">transcript</code> — JSON
+          array representing the full conversation.
+          <ConversationFormatDetails
+            example={
+              '[{"role":"assistant","content":"Hi, how can I help?"},{"role":"user","content":"I lost my card"},{"role":"assistant","content":"I can help block it. Can you confirm the last 4 digits?"}]'
+            }
+          />
+        </li>
+      </ul>
+    </>
+  );
 
-  return (
-    <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm p-4"
-      onClick={handleClose}
-    >
-      <div
-        className="bg-background border border-border rounded-xl shadow-2xl w-full max-w-2xl flex flex-col max-h-[90vh]"
-        onClick={(e) => e.stopPropagation()}
-      >
-        <div className="flex items-center justify-between px-6 py-4 border-b border-border">
-          <h2 className="text-lg font-semibold text-foreground">
-            Bulk upload items
-          </h2>
-          <button
-            onClick={handleClose}
-            disabled={isUploading}
-            aria-label="Close"
-            className="w-8 h-8 flex items-center justify-center rounded-lg text-muted-foreground hover:text-foreground hover:bg-muted transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
-          >
-            <svg
-              className="w-5 h-5"
-              fill="none"
-              viewBox="0 0 24 24"
-              stroke="currentColor"
-              strokeWidth={2}
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                d="M6 18L18 6M6 6l12 12"
-              />
-            </svg>
-          </button>
-        </div>
-
-        <div className="flex-1 overflow-y-auto px-6 py-5 space-y-5">
-          <div>
-            <div className="flex items-center justify-between mb-3">
-              <label className="block text-sm font-medium text-foreground">
-                Upload CSV
-              </label>
-              <button
-                type="button"
-                onClick={downloadSampleCsv}
-                className="h-9 px-3 rounded-md text-xs font-medium border border-border bg-muted/40 text-foreground hover:bg-muted hover:border-foreground/30 transition-colors cursor-pointer flex items-center gap-1.5 shadow-sm"
-              >
-                <svg
-                  className="w-4 h-4"
-                  fill="none"
-                  viewBox="0 0 24 24"
-                  stroke="currentColor"
-                  strokeWidth={2}
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5M16.5 12L12 16.5m0 0L7.5 12m4.5 4.5V3"
-                  />
-                </svg>
-                Download sample CSV
-              </button>
-            </div>
-
-            {parsedItems.length > 0 && (
-              <FormatHelpToggle
-                open={formatHelpOpen}
-                onToggle={() => setFormatHelpOpen((o) => !o)}
-              />
-            )}
-
-            {formatHelpOpen && (
-              <div className="text-xs text-muted-foreground mb-3 leading-relaxed space-y-2">
-                <p>Each row creates one simulation item:</p>
-                <ul className="list-disc pl-5 space-y-1.5">
-                  <li>
-                    <code className="font-mono text-foreground">name</code> — a
-                    name for the item
-                  </li>
-                  <li>
-                    <code className="font-mono text-foreground">
-                      transcript
-                    </code>{" "}
-                    — JSON array representing a conversation with each turn
-                    having a{" "}
-                    <code className="font-mono text-foreground">role</code> and{" "}
-                    <code className="font-mono text-foreground">content</code>{" "}
-                    fields
-                  </li>
-                </ul>
-              </div>
-            )}
-
-            <CsvDropzone
-              csvFile={csvFile}
-              onFile={handleFile}
-              onClear={reset}
-            />
-
-            {parseError && (
-              <p className="text-xs text-red-500 mt-3">{parseError}</p>
-            )}
+  const itemsPreview = (
+    <div className="space-y-2">
+      <p className="text-sm font-medium text-foreground">
+        {parsedItems.length}{" "}
+        {parsedItems.length === 1 ? "item" : "items"} ready to upload
+      </p>
+      <div className="border border-border rounded-xl overflow-hidden">
+        <div className="grid grid-cols-[180px_1fr_60px] gap-3 px-4 py-2 border-b border-border bg-muted/30">
+          <div className="text-xs font-medium text-muted-foreground">Name</div>
+          <div className="text-xs font-medium text-muted-foreground">
+            Transcript
           </div>
-
-          {parsedItems.length > 0 && (
-            <div className="space-y-2">
-              <p className="text-sm font-medium text-foreground">
-                {parsedItems.length}{" "}
-                {parsedItems.length === 1 ? "item" : "items"} ready to upload
-              </p>
-              <div className="border border-border rounded-xl overflow-hidden">
-                <div className="grid grid-cols-[180px_1fr_60px] gap-3 px-4 py-2 border-b border-border bg-muted/30">
-                  <div className="text-xs font-medium text-muted-foreground">
-                    Name
-                  </div>
-                  <div className="text-xs font-medium text-muted-foreground">
-                    Transcript
-                  </div>
-                  <div className="text-xs font-medium text-muted-foreground text-right">
-                    Turns
-                  </div>
-                </div>
-                <div className="max-h-[15rem] overflow-y-auto divide-y divide-border">
-                  {parsedItems.slice(0, 50).map((p, idx) => (
-                    <div
-                      key={idx}
-                      className="grid grid-cols-[180px_1fr_60px] gap-3 px-4 py-2 text-xs items-start"
-                    >
-                      <div className="truncate text-foreground" title={p.name}>
-                        {p.name}
-                      </div>
-                      <div className="min-w-0">
-                        <TranscriptPreview turns={p.transcript} />
-                      </div>
-                      <div className="text-right tabular-nums text-muted-foreground">
-                        {p.transcript.length}
-                      </div>
-                    </div>
-                  ))}
-                  {parsedItems.length > 50 && (
-                    <div className="px-4 py-2 text-xs text-muted-foreground">
-                      + {parsedItems.length - 50} more rows
-                    </div>
-                  )}
-                </div>
+          <div className="text-xs font-medium text-muted-foreground text-right">
+            Turns
+          </div>
+        </div>
+        <div className="max-h-[15rem] overflow-y-auto divide-y divide-border">
+          {parsedItems.slice(0, 50).map((p, idx) => (
+            <div
+              key={idx}
+              className="grid grid-cols-[180px_1fr_60px] gap-3 px-4 py-2 text-xs items-start"
+            >
+              <div className="truncate text-foreground" title={p.name}>
+                {p.name}
+              </div>
+              <div className="min-w-0">
+                <TranscriptPreview turns={p.transcript} />
+              </div>
+              <div className="text-right tabular-nums text-muted-foreground">
+                {p.transcript.length}
               </div>
             </div>
-          )}
-
-          {uploadError && (
-            <div className="rounded-md border border-red-500/30 bg-red-500/10 p-3 text-sm text-red-500">
-              {uploadError}
+          ))}
+          {parsedItems.length > 50 && (
+            <div className="px-4 py-2 text-xs text-muted-foreground">
+              + {parsedItems.length - 50} more rows
             </div>
           )}
-        </div>
-
-        <div className="flex items-center justify-end gap-3 px-6 py-4 border-t border-border">
-          <button
-            onClick={handleClose}
-            disabled={isUploading}
-            className="h-10 px-4 rounded-md text-sm font-medium border border-border bg-background hover:bg-muted/50 transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
-          >
-            Cancel
-          </button>
-          <button
-            onClick={handleUpload}
-            disabled={parsedItems.length === 0 || isUploading || !!parseError}
-            className="h-10 px-4 rounded-md text-sm font-medium bg-foreground text-background hover:opacity-90 transition-opacity cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
-          >
-            {isUploading
-              ? "Uploading…"
-              : parsedItems.length > 1
-                ? `Upload ${parsedItems.length} items`
-                : "Upload item"}
-          </button>
         </div>
       </div>
     </div>
+  );
+
+  return (
+    <BulkUploadDialogShell
+      isOpen={isOpen}
+      title="Bulk upload items"
+      buildSampleCsv={() => SAMPLE_SIMULATION_CSV}
+      sampleFilename="sample_simulation_items.csv"
+      helpContent={helpContent}
+      csvFile={csvFile}
+      onFile={handleFile}
+      onClear={reset}
+      parseError={parseError}
+      uploadError={uploadError}
+      isUploading={isUploading}
+      itemCount={parsedItems.length}
+      itemsPreview={itemsPreview}
+      onUpload={handleUpload}
+      onClose={onClose}
+    />
   );
 }

--- a/src/components/human-labelling/BulkUploadSimulationItemsDialog.tsx
+++ b/src/components/human-labelling/BulkUploadSimulationItemsDialog.tsx
@@ -4,14 +4,24 @@ import { useEffect, useState } from "react";
 import Papa from "papaparse";
 import { apiClient } from "@/lib/api";
 import {
+  AnnotationOptIn,
   BulkUploadDialogShell,
-  ConversationFormatDetails,
+  type EvaluatorMeta,
+  type GuidelineColumn,
+  type GuidelineDoc,
+  type ParsedAnnotation,
   type TurnObject,
+  buildItemAnnotationsPayload,
+  evaluatorReasoningColumn,
+  evaluatorValueColumn,
   findHeaderKey,
+  parseAnnotationCell,
   parseApiError,
   roleLabel,
   rolePillClass,
+  sampleEvaluatorValue,
   turnContentString,
+  useAnnotators,
 } from "./bulk-upload-shared";
 
 const TRANSCRIPT_HEADERS = [
@@ -22,22 +32,92 @@ const TRANSCRIPT_HEADERS = [
 ];
 const NAME_HEADERS = ["name", "title", "simulation_name"];
 
-const SAMPLE_SIMULATION_CSV = `name,transcript
-"Card lost - happy path","[{""role"":""assistant"",""content"":""Hi, how can I help?""},{""role"":""user"",""content"":""I lost my card""},{""role"":""assistant"",""content"":""I can help block it. Can you confirm the last 4 digits?""}]"
-"Refund flow","[{""role"":""user"",""content"":""I was charged twice""},{""role"":""assistant"",""content"":""I'm sorry to hear that. Let me investigate the duplicate charge for you.""}]"
-`;
+function csvEscape(s: string): string {
+  return `"${s.replace(/"/g, '""')}"`;
+}
+
+const SAMPLE_SIMULATION_BASE_ROWS: Array<{
+  name: string;
+  transcript: string;
+  reasoning: string;
+}> = [
+  {
+    name: "Card lost - happy path",
+    transcript: JSON.stringify([
+      { role: "assistant", content: "Hi, how can I help?" },
+      { role: "user", content: "I lost my card" },
+      {
+        role: "assistant",
+        content: "I can help block it. Can you confirm the last 4 digits?",
+      },
+    ]),
+    reasoning:
+      "The agent acknowledged the issue and asked the right verification question.",
+  },
+  {
+    name: "Refund flow",
+    transcript: JSON.stringify([
+      { role: "user", content: "I was charged twice" },
+      {
+        role: "assistant",
+        content:
+          "I'm sorry to hear that. Let me investigate the duplicate charge for you.",
+      },
+    ]),
+    reasoning: "",
+  },
+];
+
+function buildSampleSimulationCsv(
+  evaluators: EvaluatorMeta[],
+  includeAnnotations: boolean,
+): string {
+  const headerCells = [
+    "name",
+    "transcript",
+    ...(includeAnnotations
+      ? evaluators.flatMap((e) => [
+          csvEscape(evaluatorValueColumn(e.name)),
+          csvEscape(evaluatorReasoningColumn(e.name)),
+        ])
+      : []),
+  ];
+  const lines = SAMPLE_SIMULATION_BASE_ROWS.map((r) =>
+    [
+      csvEscape(r.name),
+      csvEscape(r.transcript),
+      ...(includeAnnotations
+        ? evaluators.flatMap((e) => [
+            csvEscape(sampleEvaluatorValue(e)),
+            csvEscape(r.reasoning),
+          ])
+        : []),
+    ].join(","),
+  );
+  return `${headerCells.join(",")}\n${lines.join("\n")}\n`;
+}
 
 type ParsedItem = {
   name: string;
   transcript: TurnObject[];
+  annotations: ParsedAnnotation[];
+};
+
+export type SimulationLinkedEvaluator = {
+  uuid: string;
+  name: string;
+  output_type: "binary" | "rating" | null;
+  scale_min: number | null;
+  scale_max: number | null;
 };
 
 type BulkUploadSimulationItemsDialogProps = {
   isOpen: boolean;
   accessToken: string;
   taskUuid: string;
+  linkedEvaluators?: SimulationLinkedEvaluator[];
   onClose: () => void;
-  onSuccess: (count: number) => void;
+  onSuccess: (count: number, withAnnotations: boolean) => void;
 };
 
 function TranscriptPreview({ turns }: { turns: TurnObject[] }) {
@@ -71,6 +151,7 @@ export function BulkUploadSimulationItemsDialog({
   isOpen,
   accessToken,
   taskUuid,
+  linkedEvaluators = [],
   onClose,
   onSuccess,
 }: BulkUploadSimulationItemsDialogProps) {
@@ -79,17 +160,40 @@ export function BulkUploadSimulationItemsDialog({
   const [parseError, setParseError] = useState<string | null>(null);
   const [isUploading, setIsUploading] = useState(false);
   const [uploadError, setUploadError] = useState<string | null>(null);
+  const [uploadAnnotations, setUploadAnnotations] = useState(false);
+  const [selectedAnnotatorId, setSelectedAnnotatorId] = useState<string | null>(
+    null,
+  );
+  const annotatorsState = useAnnotators(isOpen, accessToken);
+
+  const annotationEvaluatorsMeta: EvaluatorMeta[] = linkedEvaluators.map(
+    (e) => ({
+      uuid: e.uuid,
+      name: e.name,
+      output_type: e.output_type,
+      scale_min: e.scale_min,
+      scale_max: e.scale_max,
+    }),
+  );
 
   const reset = () => {
     setCsvFile(null);
     setParsedItems([]);
     setParseError(null);
     setUploadError(null);
+    setUploadAnnotations(false);
+    setSelectedAnnotatorId(null);
   };
 
   useEffect(() => {
     if (isOpen) reset();
   }, [isOpen]);
+
+  useEffect(() => {
+    setParsedItems([]);
+    setParseError(null);
+    setCsvFile(null);
+  }, [uploadAnnotations]);
 
   const handleFile = (file: File | null) => {
     setUploadError(null);
@@ -110,6 +214,21 @@ export function BulkUploadSimulationItemsDialog({
             `CSV must include "name" and "transcript" columns. Found: ${headers.join(", ") || "(none)"}`,
           );
           return;
+        }
+        if (uploadAnnotations) {
+          const missing: string[] = [];
+          for (const meta of annotationEvaluatorsMeta) {
+            const valueHeader = evaluatorValueColumn(meta.name);
+            if (!headers.includes(valueHeader)) missing.push(valueHeader);
+          }
+          if (missing.length > 0) {
+            setParseError(
+              `CSV is missing annotation column(s): ${missing
+                .map((c) => `"${c}"`)
+                .join(", ")}.`,
+            );
+            return;
+          }
         }
         const items: ParsedItem[] = [];
         for (let i = 0; i < results.data.length; i++) {
@@ -155,7 +274,39 @@ export function BulkUploadSimulationItemsDialog({
               return;
             }
           }
-          items.push({ name, transcript: parsed as TurnObject[] });
+          const annotations: ParsedAnnotation[] = [];
+          if (uploadAnnotations) {
+            for (const meta of annotationEvaluatorsMeta) {
+              if (meta.output_type !== "binary" && meta.output_type !== "rating")
+                continue;
+              const valueHeader = evaluatorValueColumn(meta.name);
+              const reasoningHeader = evaluatorReasoningColumn(meta.name);
+              const rawValue = (row[valueHeader] ?? "").trim();
+              const rawReasoning = (row[reasoningHeader] ?? "").trim();
+              if (!rawValue) {
+                setParseError(
+                  `Row ${i + 1}: missing value for "${valueHeader}".`,
+                );
+                return;
+              }
+              const parsedAnn = parseAnnotationCell(rawValue, meta);
+              if ("error" in parsedAnn) {
+                setParseError(`Row ${i + 1}: ${parsedAnn.error}.`);
+                return;
+              }
+              annotations.push({
+                evaluator_uuid: meta.uuid,
+                output_type: meta.output_type,
+                value: parsedAnn.value,
+                reasoning: rawReasoning,
+              });
+            }
+          }
+          items.push({
+            name,
+            transcript: parsed as TurnObject[],
+            annotations,
+          });
         }
         if (items.length === 0) {
           setParseError("No rows with a transcript were found in the CSV.");
@@ -169,18 +320,33 @@ export function BulkUploadSimulationItemsDialog({
 
   const handleUpload = async () => {
     if (parsedItems.length === 0 || isUploading) return;
+    if (uploadAnnotations && !selectedAnnotatorId) {
+      setUploadError("Select an annotator before uploading.");
+      return;
+    }
     setIsUploading(true);
     setUploadError(null);
     try {
+      const itemsBody = parsedItems.map((p) => {
+        const annotationsObj = uploadAnnotations
+          ? buildItemAnnotationsPayload(p.annotations)
+          : undefined;
+        return {
+          payload: { name: p.name, transcript: p.transcript },
+          ...(annotationsObj ? { annotations: annotationsObj } : {}),
+        };
+      });
+      const anyAnnotated = itemsBody.some((it) => "annotations" in it);
       await apiClient(`/annotation-tasks/${taskUuid}/items`, accessToken, {
         method: "POST",
         body: {
-          items: parsedItems.map((p) => ({
-            payload: { name: p.name, transcript: p.transcript },
-          })),
+          ...(anyAnnotated && selectedAnnotatorId
+            ? { annotator_id: selectedAnnotatorId }
+            : {}),
+          items: itemsBody,
         },
       });
-      onSuccess(parsedItems.length);
+      onSuccess(parsedItems.length, uploadAnnotations);
     } catch (err) {
       setUploadError(parseApiError(err, "Failed to upload items"));
     } finally {
@@ -188,77 +354,194 @@ export function BulkUploadSimulationItemsDialog({
     }
   };
 
-  const helpContent = (
-    <>
-      <p>Each row creates one simulation item:</p>
-      <ul className="list-disc pl-5 space-y-1.5">
-        <li>
-          <code className="font-mono text-foreground">name</code> — a name for
-          the item
-        </li>
-        <li>
-          <code className="font-mono text-foreground">transcript</code> — JSON
-          array representing the full conversation.
-          <ConversationFormatDetails
-            example={
-              '[{"role":"assistant","content":"Hi, how can I help?"},{"role":"user","content":"I lost my card"},{"role":"assistant","content":"I can help block it. Can you confirm the last 4 digits?"}]'
-            }
-          />
-        </li>
-      </ul>
-    </>
-  );
+  const buildGuidelines = (): GuidelineDoc => {
+    const columns: GuidelineColumn[] = [
+      {
+        name: "name",
+        description: "A name for the item.",
+      },
+      {
+        name: "transcript",
+        description:
+          'A JSON array of chat messages representing the full conversation. Each message is an object with a "role" and "content" field.\n\nrole — either "user" or "assistant"\ncontent — the message said by that role',
+        example: `[
+  {"role": "assistant", "content": "Hi, how can I help?"},
+  {"role": "user", "content": "I lost my card"}
+]`,
+      },
+    ];
+
+    if (uploadAnnotations && annotationEvaluatorsMeta.length > 0) {
+      for (const e of annotationEvaluatorsMeta) {
+        const range =
+          e.output_type === "binary"
+            ? "true/false"
+            : e.output_type === "rating" &&
+                typeof e.scale_min === "number" &&
+                typeof e.scale_max === "number"
+              ? `any value between ${e.scale_min}-${e.scale_max}`
+              : "value";
+        columns.push({
+          name: evaluatorValueColumn(e.name),
+          description: `Required. Value for the "${e.name}" evaluator (${range}).`,
+        });
+        columns.push({
+          name: evaluatorReasoningColumn(e.name),
+          description: `(optional) Reasoning for the value assigned to "${e.name}".`,
+        });
+      }
+    }
+
+    return {
+      title: "Bulk upload — Simulation labelling items",
+      intro:
+        "Upload a CSV with the following columns. Each row creates one simulation annotation item.",
+      columns,
+    };
+  };
+
+  const annotationColumns =
+    uploadAnnotations && annotationEvaluatorsMeta.length > 0
+      ? annotationEvaluatorsMeta.flatMap((e) => [
+          {
+            evaluatorUuid: e.uuid,
+            kind: "value" as const,
+            header: evaluatorValueColumn(e.name),
+          },
+          {
+            evaluatorUuid: e.uuid,
+            kind: "reasoning" as const,
+            header: evaluatorReasoningColumn(e.name),
+          },
+        ])
+      : [];
+  const simGridStyle = {
+    gridTemplateColumns: [
+      "180px",
+      "minmax(280px,1fr)",
+      "60px",
+      ...annotationColumns.map(() => "minmax(180px,1fr)"),
+    ].join(" "),
+  };
 
   const itemsPreview = (
     <div className="space-y-2">
       <p className="text-sm font-medium text-foreground">
-        {parsedItems.length}{" "}
-        {parsedItems.length === 1 ? "item" : "items"} ready to upload
+        {parsedItems.length} {parsedItems.length === 1 ? "item" : "items"} ready
+        to upload
       </p>
       <div className="border border-border rounded-xl overflow-hidden">
-        <div className="grid grid-cols-[180px_1fr_60px] gap-3 px-4 py-2 border-b border-border bg-muted/30">
-          <div className="text-xs font-medium text-muted-foreground">Name</div>
-          <div className="text-xs font-medium text-muted-foreground">
-            Transcript
-          </div>
-          <div className="text-xs font-medium text-muted-foreground text-right">
-            Turns
-          </div>
-        </div>
-        <div className="max-h-[15rem] overflow-y-auto divide-y divide-border">
-          {parsedItems.slice(0, 50).map((p, idx) => (
-            <div
-              key={idx}
-              className="grid grid-cols-[180px_1fr_60px] gap-3 px-4 py-2 text-xs items-start"
-            >
-              <div className="truncate text-foreground" title={p.name}>
-                {p.name}
-              </div>
-              <div className="min-w-0">
-                <TranscriptPreview turns={p.transcript} />
-              </div>
-              <div className="text-right tabular-nums text-muted-foreground">
-                {p.transcript.length}
-              </div>
+        <div className="overflow-auto max-h-[20rem]">
+          <div
+            className="grid gap-3 px-4 py-2 border-b border-border bg-muted sticky top-0 z-10"
+            style={simGridStyle}
+          >
+            <div className="text-xs font-medium text-muted-foreground">
+              Name
             </div>
-          ))}
-          {parsedItems.length > 50 && (
-            <div className="px-4 py-2 text-xs text-muted-foreground">
-              + {parsedItems.length - 50} more rows
+            <div className="text-xs font-medium text-muted-foreground">
+              Transcript
             </div>
-          )}
+            <div className="text-xs font-medium text-muted-foreground text-right">
+              Turns
+            </div>
+            {annotationColumns.map((c) => (
+              <div
+                key={`ah-${c.evaluatorUuid}-${c.kind}`}
+                className="text-xs font-medium text-muted-foreground font-mono truncate"
+                title={c.header}
+              >
+                {c.header}
+              </div>
+            ))}
+          </div>
+          <div className="divide-y divide-border">
+            {parsedItems.slice(0, 50).map((p, idx) => (
+              <div
+                key={idx}
+                className="grid gap-3 px-4 py-2 text-xs items-start"
+                style={simGridStyle}
+              >
+                <div className="truncate text-foreground" title={p.name}>
+                  {p.name}
+                </div>
+                <div className="min-w-0">
+                  <TranscriptPreview turns={p.transcript} />
+                </div>
+                <div className="text-right tabular-nums text-muted-foreground">
+                  {p.transcript.length}
+                </div>
+                {annotationColumns.map((c) => {
+                  const ann = p.annotations.find(
+                    (a) => a.evaluator_uuid === c.evaluatorUuid,
+                  );
+                  const display =
+                    c.kind === "value"
+                      ? ann
+                        ? typeof ann.value === "boolean"
+                          ? ann.value
+                            ? "true"
+                            : "false"
+                          : String(ann.value)
+                        : ""
+                      : (ann?.reasoning ?? "");
+                  return (
+                    <div
+                      key={`${idx}-a-${c.evaluatorUuid}-${c.kind}`}
+                      className="min-w-0 max-h-24 overflow-y-auto pr-1 leading-snug text-foreground break-words whitespace-pre-wrap"
+                    >
+                      {display}
+                    </div>
+                  );
+                })}
+              </div>
+            ))}
+            {parsedItems.length > 50 && (
+              <div className="px-4 py-2 text-xs text-muted-foreground">
+                + {parsedItems.length - 50} more rows
+              </div>
+            )}
+          </div>
         </div>
       </div>
     </div>
   );
 
+  const annotationOptIn =
+    linkedEvaluators.length > 0 ? (
+      <AnnotationOptIn
+        annotators={annotatorsState.annotators}
+        loading={annotatorsState.loading}
+        error={annotatorsState.error}
+        uploadAnnotations={uploadAnnotations}
+        onToggle={setUploadAnnotations}
+        selectedAnnotatorId={selectedAnnotatorId}
+        onSelectAnnotator={setSelectedAnnotatorId}
+      />
+    ) : null;
+
+  const uploadBlocked =
+    uploadAnnotations &&
+    (annotatorsState.annotators.length === 0 || !selectedAnnotatorId);
+
   return (
     <BulkUploadDialogShell
       isOpen={isOpen}
       title="Bulk upload items"
-      buildSampleCsv={() => SAMPLE_SIMULATION_CSV}
-      sampleFilename="sample_simulation_items.csv"
-      helpContent={helpContent}
+      buildSampleCsv={() =>
+        buildSampleSimulationCsv(annotationEvaluatorsMeta, uploadAnnotations)
+      }
+      sampleFilename={() =>
+        uploadAnnotations
+          ? "sample_simulation_items_with_annotations.csv"
+          : "sample_simulation_items.csv"
+      }
+      buildGuidelines={buildGuidelines}
+      guidelinesFilename={() =>
+        uploadAnnotations
+          ? "simulation_items_csv_guidelines_with_annotations.pdf"
+          : "simulation_items_csv_guidelines.pdf"
+      }
       csvFile={csvFile}
       onFile={handleFile}
       onClear={reset}
@@ -269,6 +552,9 @@ export function BulkUploadSimulationItemsDialog({
       itemsPreview={itemsPreview}
       onUpload={handleUpload}
       onClose={onClose}
+      topContent={annotationOptIn}
+      uploadBlocked={uploadBlocked}
+      hideUploadSection={uploadAnnotations && !selectedAnnotatorId}
     />
   );
 }

--- a/src/components/human-labelling/BulkUploadSimulationItemsDialog.tsx
+++ b/src/components/human-labelling/BulkUploadSimulationItemsDialog.tsx
@@ -177,12 +177,11 @@ export function BulkUploadSimulationItemsDialog({
     }),
   );
 
-  // Evaluator metadata (output_type) hydrates asynchronously on the parent
-  // page. Until every linked evaluator has a usable output_type the parser
-  // would silently drop those evaluators' annotation columns, so we treat
-  // the metadata as "not ready" and re-parse once it lands.
-  const annotationMetadataReady = annotationEvaluatorsMeta.every(
-    (e) => e.output_type === "binary" || e.output_type === "rating",
+  // Evaluators without a usable output_type can't be annotated here —
+  // the parser would silently drop their column and produce a half-
+  // labelled batch. Block the annotation flow rather than failing later.
+  const evaluatorsMissingOutputType = annotationEvaluatorsMeta.filter(
+    (e) => e.output_type !== "binary" && e.output_type !== "rating",
   );
 
   // Two linked evaluators sharing a name produce duplicate CSV headers
@@ -209,14 +208,6 @@ export function BulkUploadSimulationItemsDialog({
     setCsvFile(null);
   }, [uploadAnnotations]);
 
-  // Re-parse once evaluator metadata hydrates so annotations land on every
-  // evaluator instead of being silently skipped for ones whose output_type
-  // was still null when the user dropped the CSV.
-  useEffect(() => {
-    if (!uploadAnnotations || !annotationMetadataReady || !csvFile) return;
-    handleFile(csvFile);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [annotationMetadataReady]);
 
   const handleFile = (file: File | null) => {
     setUploadError(null);
@@ -239,9 +230,11 @@ export function BulkUploadSimulationItemsDialog({
           return;
         }
         if (uploadAnnotations) {
-          if (!annotationMetadataReady) {
+          if (evaluatorsMissingOutputType.length > 0) {
             setParseError(
-              "Evaluator metadata is still loading. Please wait a moment and try again.",
+              `Annotation upload is unavailable: evaluator(s) ${evaluatorsMissingOutputType
+                .map((e) => `"${e.name}"`)
+                .join(", ")} have no binary/rating output configured.`,
             );
             return;
           }
@@ -353,9 +346,9 @@ export function BulkUploadSimulationItemsDialog({
       setUploadError("Select an annotator before uploading.");
       return;
     }
-    if (uploadAnnotations && !annotationMetadataReady) {
+    if (uploadAnnotations && evaluatorsMissingOutputType.length > 0) {
       setUploadError(
-        "Evaluator metadata is still loading. Please wait a moment and try again.",
+        "One or more evaluators have no binary/rating output configured.",
       );
       return;
     }
@@ -561,6 +554,15 @@ export function BulkUploadSimulationItemsDialog({
             on the evaluators page before uploading annotations.
           </div>
         )}
+        {uploadAnnotations && evaluatorsMissingOutputType.length > 0 && (
+          <div className="rounded-md border border-red-500/30 bg-red-500/10 p-3 text-xs text-red-600 dark:text-red-400">
+            Annotation upload isn&apos;t available — evaluator(s){" "}
+            {evaluatorsMissingOutputType
+              .map((e) => `"${e.name}"`)
+              .join(", ")}{" "}
+            have no binary/rating output configured.
+          </div>
+        )}
       </div>
     ) : null;
 
@@ -568,7 +570,8 @@ export function BulkUploadSimulationItemsDialog({
     uploadAnnotations &&
     (annotatorsState.annotators.length === 0 ||
       !selectedAnnotatorId ||
-      duplicateNames.length > 0);
+      duplicateNames.length > 0 ||
+      evaluatorsMissingOutputType.length > 0);
 
   return (
     <BulkUploadDialogShell
@@ -602,7 +605,9 @@ export function BulkUploadSimulationItemsDialog({
       uploadBlocked={uploadBlocked}
       hideUploadSection={
         uploadAnnotations &&
-        (!selectedAnnotatorId || duplicateNames.length > 0)
+        (!selectedAnnotatorId ||
+          duplicateNames.length > 0 ||
+          evaluatorsMissingOutputType.length > 0)
       }
     />
   );

--- a/src/components/human-labelling/BulkUploadSimulationItemsDialog.tsx
+++ b/src/components/human-labelling/BulkUploadSimulationItemsDialog.tsx
@@ -12,6 +12,7 @@ import {
   type ParsedAnnotation,
   type TurnObject,
   buildItemAnnotationsPayload,
+  duplicateEvaluatorNames,
   evaluatorReasoningColumn,
   evaluatorValueColumn,
   findHeaderKey,
@@ -183,6 +184,11 @@ export function BulkUploadSimulationItemsDialog({
   const annotationMetadataReady = annotationEvaluatorsMeta.every(
     (e) => e.output_type === "binary" || e.output_type === "rating",
   );
+
+  // Two linked evaluators sharing a name produce duplicate CSV headers
+  // that PapaParse silently overwrites. Block the annotation flow until
+  // one is renamed.
+  const duplicateNames = duplicateEvaluatorNames(annotationEvaluatorsMeta);
 
   const reset = () => {
     setCsvFile(null);
@@ -538,20 +544,31 @@ export function BulkUploadSimulationItemsDialog({
 
   const annotationOptIn =
     linkedEvaluators.length > 0 ? (
-      <AnnotationOptIn
-        annotators={annotatorsState.annotators}
-        loading={annotatorsState.loading}
-        error={annotatorsState.error}
-        uploadAnnotations={uploadAnnotations}
-        onToggle={setUploadAnnotations}
-        selectedAnnotatorId={selectedAnnotatorId}
-        onSelectAnnotator={setSelectedAnnotatorId}
-      />
+      <div className="space-y-3">
+        <AnnotationOptIn
+          annotators={annotatorsState.annotators}
+          loading={annotatorsState.loading}
+          error={annotatorsState.error}
+          uploadAnnotations={uploadAnnotations}
+          onToggle={setUploadAnnotations}
+          selectedAnnotatorId={selectedAnnotatorId}
+          onSelectAnnotator={setSelectedAnnotatorId}
+        />
+        {uploadAnnotations && duplicateNames.length > 0 && (
+          <div className="rounded-md border border-red-500/30 bg-red-500/10 p-3 text-xs text-red-600 dark:text-red-400">
+            Two or more linked evaluators share the same name (
+            {duplicateNames.map((n) => `"${n}"`).join(", ")}). Rename one
+            on the evaluators page before uploading annotations.
+          </div>
+        )}
+      </div>
     ) : null;
 
   const uploadBlocked =
     uploadAnnotations &&
-    (annotatorsState.annotators.length === 0 || !selectedAnnotatorId);
+    (annotatorsState.annotators.length === 0 ||
+      !selectedAnnotatorId ||
+      duplicateNames.length > 0);
 
   return (
     <BulkUploadDialogShell
@@ -583,7 +600,10 @@ export function BulkUploadSimulationItemsDialog({
       onClose={onClose}
       topContent={annotationOptIn}
       uploadBlocked={uploadBlocked}
-      hideUploadSection={uploadAnnotations && !selectedAnnotatorId}
+      hideUploadSection={
+        uploadAnnotations &&
+        (!selectedAnnotatorId || duplicateNames.length > 0)
+      }
     />
   );
 }

--- a/src/components/human-labelling/BulkUploadSttItemsDialog.tsx
+++ b/src/components/human-labelling/BulkUploadSttItemsDialog.tsx
@@ -11,6 +11,7 @@ import {
   type GuidelineDoc,
   type ParsedAnnotation,
   buildItemAnnotationsPayload,
+  duplicateEvaluatorNames,
   evaluatorReasoningColumn,
   evaluatorValueColumn,
   findHeaderKey,
@@ -149,6 +150,11 @@ export function BulkUploadSttItemsDialog({
   const annotationMetadataReady = annotationEvaluatorsMeta.every(
     (e) => e.output_type === "binary" || e.output_type === "rating",
   );
+
+  // Two linked evaluators sharing a name produce duplicate CSV headers
+  // that PapaParse silently overwrites. Block the annotation flow until
+  // one is renamed.
+  const duplicateNames = duplicateEvaluatorNames(annotationEvaluatorsMeta);
 
   const reset = () => {
     setCsvFile(null);
@@ -469,20 +475,31 @@ export function BulkUploadSttItemsDialog({
 
   const annotationOptIn =
     linkedEvaluators.length > 0 ? (
-      <AnnotationOptIn
-        annotators={annotatorsState.annotators}
-        loading={annotatorsState.loading}
-        error={annotatorsState.error}
-        uploadAnnotations={uploadAnnotations}
-        onToggle={setUploadAnnotations}
-        selectedAnnotatorId={selectedAnnotatorId}
-        onSelectAnnotator={setSelectedAnnotatorId}
-      />
+      <div className="space-y-3">
+        <AnnotationOptIn
+          annotators={annotatorsState.annotators}
+          loading={annotatorsState.loading}
+          error={annotatorsState.error}
+          uploadAnnotations={uploadAnnotations}
+          onToggle={setUploadAnnotations}
+          selectedAnnotatorId={selectedAnnotatorId}
+          onSelectAnnotator={setSelectedAnnotatorId}
+        />
+        {uploadAnnotations && duplicateNames.length > 0 && (
+          <div className="rounded-md border border-red-500/30 bg-red-500/10 p-3 text-xs text-red-600 dark:text-red-400">
+            Two or more linked evaluators share the same name (
+            {duplicateNames.map((n) => `"${n}"`).join(", ")}). Rename one
+            on the evaluators page before uploading annotations.
+          </div>
+        )}
+      </div>
     ) : null;
 
   const uploadBlocked =
     uploadAnnotations &&
-    (annotatorsState.annotators.length === 0 || !selectedAnnotatorId);
+    (annotatorsState.annotators.length === 0 ||
+      !selectedAnnotatorId ||
+      duplicateNames.length > 0);
 
   return (
     <BulkUploadDialogShell
@@ -514,7 +531,10 @@ export function BulkUploadSttItemsDialog({
       onClose={onClose}
       topContent={annotationOptIn}
       uploadBlocked={uploadBlocked}
-      hideUploadSection={uploadAnnotations && !selectedAnnotatorId}
+      hideUploadSection={
+        uploadAnnotations &&
+        (!selectedAnnotatorId || duplicateNames.length > 0)
+      }
     />
   );
 }

--- a/src/components/human-labelling/BulkUploadSttItemsDialog.tsx
+++ b/src/components/human-labelling/BulkUploadSttItemsDialog.tsx
@@ -143,12 +143,11 @@ export function BulkUploadSttItemsDialog({
     }),
   );
 
-  // Evaluator metadata (output_type) hydrates asynchronously on the parent
-  // page. Until every linked evaluator has a usable output_type the parser
-  // would silently drop those evaluators' annotation columns, so we treat
-  // the metadata as "not ready" and re-parse once it lands.
-  const annotationMetadataReady = annotationEvaluatorsMeta.every(
-    (e) => e.output_type === "binary" || e.output_type === "rating",
+  // Evaluators without a usable output_type can't be annotated here —
+  // the parser would silently drop their column and produce a half-
+  // labelled batch. Block the annotation flow rather than failing later.
+  const evaluatorsMissingOutputType = annotationEvaluatorsMeta.filter(
+    (e) => e.output_type !== "binary" && e.output_type !== "rating",
   );
 
   // Two linked evaluators sharing a name produce duplicate CSV headers
@@ -175,14 +174,6 @@ export function BulkUploadSttItemsDialog({
     setCsvFile(null);
   }, [uploadAnnotations]);
 
-  // Re-parse once evaluator metadata hydrates so annotations land on every
-  // evaluator instead of being silently skipped for ones whose output_type
-  // was still null when the user dropped the CSV.
-  useEffect(() => {
-    if (!uploadAnnotations || !annotationMetadataReady || !csvFile) return;
-    handleFile(csvFile);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [annotationMetadataReady]);
 
   const handleFile = (file: File | null) => {
     setUploadError(null);
@@ -205,9 +196,11 @@ export function BulkUploadSttItemsDialog({
           return;
         }
         if (uploadAnnotations) {
-          if (!annotationMetadataReady) {
+          if (evaluatorsMissingOutputType.length > 0) {
             setParseError(
-              "Evaluator metadata is still loading. Please wait a moment and try again.",
+              `Annotation upload is unavailable: evaluator(s) ${evaluatorsMissingOutputType
+                .map((e) => `"${e.name}"`)
+                .join(", ")} have no binary/rating output configured.`,
             );
             return;
           }
@@ -287,9 +280,9 @@ export function BulkUploadSttItemsDialog({
       setUploadError("Select an annotator before uploading.");
       return;
     }
-    if (uploadAnnotations && !annotationMetadataReady) {
+    if (uploadAnnotations && evaluatorsMissingOutputType.length > 0) {
       setUploadError(
-        "Evaluator metadata is still loading. Please wait a moment and try again.",
+        "One or more evaluators have no binary/rating output configured.",
       );
       return;
     }
@@ -492,6 +485,15 @@ export function BulkUploadSttItemsDialog({
             on the evaluators page before uploading annotations.
           </div>
         )}
+        {uploadAnnotations && evaluatorsMissingOutputType.length > 0 && (
+          <div className="rounded-md border border-red-500/30 bg-red-500/10 p-3 text-xs text-red-600 dark:text-red-400">
+            Annotation upload isn&apos;t available — evaluator(s){" "}
+            {evaluatorsMissingOutputType
+              .map((e) => `"${e.name}"`)
+              .join(", ")}{" "}
+            have no binary/rating output configured.
+          </div>
+        )}
       </div>
     ) : null;
 
@@ -499,7 +501,8 @@ export function BulkUploadSttItemsDialog({
     uploadAnnotations &&
     (annotatorsState.annotators.length === 0 ||
       !selectedAnnotatorId ||
-      duplicateNames.length > 0);
+      duplicateNames.length > 0 ||
+      evaluatorsMissingOutputType.length > 0);
 
   return (
     <BulkUploadDialogShell
@@ -533,7 +536,9 @@ export function BulkUploadSttItemsDialog({
       uploadBlocked={uploadBlocked}
       hideUploadSection={
         uploadAnnotations &&
-        (!selectedAnnotatorId || duplicateNames.length > 0)
+        (!selectedAnnotatorId ||
+          duplicateNames.length > 0 ||
+          evaluatorsMissingOutputType.length > 0)
       }
     />
   );

--- a/src/components/human-labelling/BulkUploadSttItemsDialog.tsx
+++ b/src/components/human-labelling/BulkUploadSttItemsDialog.tsx
@@ -4,9 +4,20 @@ import { useEffect, useState } from "react";
 import Papa from "papaparse";
 import { apiClient } from "@/lib/api";
 import {
+  AnnotationOptIn,
   BulkUploadDialogShell,
+  type EvaluatorMeta,
+  type GuidelineColumn,
+  type GuidelineDoc,
+  type ParsedAnnotation,
+  buildItemAnnotationsPayload,
+  evaluatorReasoningColumn,
+  evaluatorValueColumn,
   findHeaderKey,
+  parseAnnotationCell,
   parseApiError,
+  sampleEvaluatorValue,
+  useAnnotators,
 } from "./bulk-upload-shared";
 
 const REFERENCE_HEADERS = [
@@ -24,29 +35,89 @@ const PREDICTED_HEADERS = [
   "hypothesis",
 ];
 
-const SAMPLE_STT_CSV = `reference_transcript,predicted_transcript
-"Hello, how are you today?","hello how are you today"
-"I would like to book a flight.","I'd like to book a flight"
-"Can you repeat that, please?","can you repeat that please"
-`;
+function csvEscape(s: string): string {
+  return `"${s.replace(/"/g, '""')}"`;
+}
+
+const SAMPLE_STT_BASE_ROWS: Array<{
+  ref: string;
+  pred: string;
+  reasoning: string;
+}> = [
+  {
+    ref: "Hello, how are you today?",
+    pred: "hello how are you today",
+    reasoning: "Punctuation is missing but the words match.",
+  },
+  {
+    ref: "I would like to book a flight.",
+    pred: "I'd like to book a flight",
+    reasoning: "",
+  },
+  {
+    ref: "Can you repeat that, please?",
+    pred: "can you repeat that please",
+    reasoning: "",
+  },
+];
+
+function buildSampleSttCsv(
+  evaluators: EvaluatorMeta[],
+  includeAnnotations: boolean,
+): string {
+  const headerCells = [
+    "reference_transcript",
+    "predicted_transcript",
+    ...(includeAnnotations
+      ? evaluators.flatMap((e) => [
+          csvEscape(evaluatorValueColumn(e.name)),
+          csvEscape(evaluatorReasoningColumn(e.name)),
+        ])
+      : []),
+  ];
+  const lines = SAMPLE_STT_BASE_ROWS.map((r) =>
+    [
+      csvEscape(r.ref),
+      csvEscape(r.pred),
+      ...(includeAnnotations
+        ? evaluators.flatMap((e) => [
+            csvEscape(sampleEvaluatorValue(e)),
+            csvEscape(r.reasoning),
+          ])
+        : []),
+    ].join(","),
+  );
+  return `${headerCells.join(",")}\n${lines.join("\n")}\n`;
+}
 
 type ParsedItem = {
   reference_transcript: string;
   predicted_transcript: string;
+  annotations: ParsedAnnotation[];
+};
+
+export type SttLinkedEvaluator = {
+  uuid: string;
+  name: string;
+  output_type: "binary" | "rating" | null;
+  scale_min: number | null;
+  scale_max: number | null;
 };
 
 type BulkUploadSttItemsDialogProps = {
   isOpen: boolean;
   accessToken: string;
   taskUuid: string;
+  linkedEvaluators?: SttLinkedEvaluator[];
   onClose: () => void;
-  onSuccess: (count: number) => void;
+  onSuccess: (count: number, withAnnotations: boolean) => void;
 };
 
 export function BulkUploadSttItemsDialog({
   isOpen,
   accessToken,
   taskUuid,
+  linkedEvaluators = [],
   onClose,
   onSuccess,
 }: BulkUploadSttItemsDialogProps) {
@@ -55,17 +126,40 @@ export function BulkUploadSttItemsDialog({
   const [parseError, setParseError] = useState<string | null>(null);
   const [isUploading, setIsUploading] = useState(false);
   const [uploadError, setUploadError] = useState<string | null>(null);
+  const [uploadAnnotations, setUploadAnnotations] = useState(false);
+  const [selectedAnnotatorId, setSelectedAnnotatorId] = useState<string | null>(
+    null,
+  );
+  const annotatorsState = useAnnotators(isOpen, accessToken);
+
+  const annotationEvaluatorsMeta: EvaluatorMeta[] = linkedEvaluators.map(
+    (e) => ({
+      uuid: e.uuid,
+      name: e.name,
+      output_type: e.output_type,
+      scale_min: e.scale_min,
+      scale_max: e.scale_max,
+    }),
+  );
 
   const reset = () => {
     setCsvFile(null);
     setParsedItems([]);
     setParseError(null);
     setUploadError(null);
+    setUploadAnnotations(false);
+    setSelectedAnnotatorId(null);
   };
 
   useEffect(() => {
     if (isOpen) reset();
   }, [isOpen]);
+
+  useEffect(() => {
+    setParsedItems([]);
+    setParseError(null);
+    setCsvFile(null);
+  }, [uploadAnnotations]);
 
   const handleFile = (file: File | null) => {
     setUploadError(null);
@@ -87,8 +181,24 @@ export function BulkUploadSttItemsDialog({
           );
           return;
         }
+        if (uploadAnnotations) {
+          const missing: string[] = [];
+          for (const meta of annotationEvaluatorsMeta) {
+            const valueHeader = evaluatorValueColumn(meta.name);
+            if (!headers.includes(valueHeader)) missing.push(valueHeader);
+          }
+          if (missing.length > 0) {
+            setParseError(
+              `CSV is missing annotation column(s): ${missing
+                .map((c) => `"${c}"`)
+                .join(", ")}.`,
+            );
+            return;
+          }
+        }
         const items: ParsedItem[] = [];
-        for (const r of results.data) {
+        for (let i = 0; i < results.data.length; i++) {
+          const r = results.data[i];
           const reference_transcript = (r[refKey] ?? "").trim();
           const predicted_transcript = (r[predKey] ?? "").trim();
           if (!reference_transcript && !predicted_transcript) continue;
@@ -98,7 +208,39 @@ export function BulkUploadSttItemsDialog({
             );
             return;
           }
-          items.push({ reference_transcript, predicted_transcript });
+          const annotations: ParsedAnnotation[] = [];
+          if (uploadAnnotations) {
+            for (const meta of annotationEvaluatorsMeta) {
+              if (meta.output_type !== "binary" && meta.output_type !== "rating")
+                continue;
+              const valueHeader = evaluatorValueColumn(meta.name);
+              const reasoningHeader = evaluatorReasoningColumn(meta.name);
+              const rawValue = (r[valueHeader] ?? "").trim();
+              const rawReasoning = (r[reasoningHeader] ?? "").trim();
+              if (!rawValue) {
+                setParseError(
+                  `Row ${i + 1}: missing value for "${valueHeader}".`,
+                );
+                return;
+              }
+              const parsed = parseAnnotationCell(rawValue, meta);
+              if ("error" in parsed) {
+                setParseError(`Row ${i + 1}: ${parsed.error}.`);
+                return;
+              }
+              annotations.push({
+                evaluator_uuid: meta.uuid,
+                output_type: meta.output_type,
+                value: parsed.value,
+                reasoning: rawReasoning,
+              });
+            }
+          }
+          items.push({
+            reference_transcript,
+            predicted_transcript,
+            annotations,
+          });
         }
         if (items.length === 0) {
           setParseError("No rows with content were found in the CSV.");
@@ -112,16 +254,36 @@ export function BulkUploadSttItemsDialog({
 
   const handleUpload = async () => {
     if (parsedItems.length === 0 || isUploading) return;
+    if (uploadAnnotations && !selectedAnnotatorId) {
+      setUploadError("Select an annotator before uploading.");
+      return;
+    }
     setIsUploading(true);
     setUploadError(null);
     try {
+      const itemsBody = parsedItems.map((p) => {
+        const annotationsObj = uploadAnnotations
+          ? buildItemAnnotationsPayload(p.annotations)
+          : undefined;
+        return {
+          payload: {
+            reference_transcript: p.reference_transcript,
+            predicted_transcript: p.predicted_transcript,
+          },
+          ...(annotationsObj ? { annotations: annotationsObj } : {}),
+        };
+      });
+      const anyAnnotated = itemsBody.some((it) => "annotations" in it);
       await apiClient(`/annotation-tasks/${taskUuid}/items`, accessToken, {
         method: "POST",
         body: {
-          items: parsedItems.map((p) => ({ payload: p })),
+          ...(anyAnnotated && selectedAnnotatorId
+            ? { annotator_id: selectedAnnotatorId }
+            : {}),
+          items: itemsBody,
         },
       });
-      onSuccess(parsedItems.length);
+      onSuccess(parsedItems.length, uploadAnnotations);
     } catch (err) {
       setUploadError(parseApiError(err, "Failed to upload items"));
     } finally {
@@ -129,71 +291,188 @@ export function BulkUploadSttItemsDialog({
     }
   };
 
-  const helpContent = (
-    <>
-      <p>Your CSV needs two columns per row:</p>
-      <ul className="list-disc pl-5 space-y-1.5">
-        <li>
-          <code className="font-mono text-foreground">reference_transcript</code>{" "}
-          — what was actually said
-        </li>
-        <li>
-          <code className="font-mono text-foreground">predicted_transcript</code>{" "}
-          — what the system transcribed
-        </li>
-      </ul>
-    </>
-  );
+  const buildGuidelines = (): GuidelineDoc => {
+    const columns: GuidelineColumn[] = [
+      {
+        name: "reference_transcript",
+        description: "What was actually said.",
+      },
+      {
+        name: "predicted_transcript",
+        description: "What the system transcribed.",
+      },
+    ];
+
+    if (uploadAnnotations && annotationEvaluatorsMeta.length > 0) {
+      for (const e of annotationEvaluatorsMeta) {
+        const range =
+          e.output_type === "binary"
+            ? "true/false"
+            : e.output_type === "rating" &&
+                typeof e.scale_min === "number" &&
+                typeof e.scale_max === "number"
+              ? `any value between ${e.scale_min}-${e.scale_max}`
+              : "value";
+        columns.push({
+          name: evaluatorValueColumn(e.name),
+          description: `Required. Value for the "${e.name}" evaluator (${range}).`,
+        });
+        columns.push({
+          name: evaluatorReasoningColumn(e.name),
+          description: `(optional) Reasoning for the value assigned to "${e.name}".`,
+        });
+      }
+    }
+
+    return {
+      title: "Bulk upload — STT labelling items",
+      intro:
+        "Upload a CSV with the following columns. Each row creates one STT annotation item.",
+      columns,
+    };
+  };
+
+  const annotationColumns =
+    uploadAnnotations && annotationEvaluatorsMeta.length > 0
+      ? annotationEvaluatorsMeta.flatMap((e) => [
+          {
+            evaluatorUuid: e.uuid,
+            kind: "value" as const,
+            header: evaluatorValueColumn(e.name),
+          },
+          {
+            evaluatorUuid: e.uuid,
+            kind: "reasoning" as const,
+            header: evaluatorReasoningColumn(e.name),
+          },
+        ])
+      : [];
+  const sttGridStyle = {
+    gridTemplateColumns: [
+      "minmax(220px,1fr)",
+      "minmax(220px,1fr)",
+      ...annotationColumns.map(() => "minmax(180px,1fr)"),
+    ].join(" "),
+  };
 
   const itemsPreview = (
     <div className="space-y-2">
       <p className="text-sm font-medium text-foreground">
-        {parsedItems.length}{" "}
-        {parsedItems.length === 1 ? "item" : "items"} ready to upload
+        {parsedItems.length} {parsedItems.length === 1 ? "item" : "items"} ready
+        to upload
       </p>
       <div className="border border-border rounded-xl overflow-hidden">
-        <div className="grid grid-cols-2 gap-3 px-4 py-2 border-b border-border bg-muted/30">
-          <div className="text-xs font-medium text-muted-foreground">
-            Reference transcript
-          </div>
-          <div className="text-xs font-medium text-muted-foreground">
-            Predicted transcript
-          </div>
-        </div>
-        <div className="max-h-64 overflow-y-auto divide-y divide-border">
-          {parsedItems.slice(0, 50).map((p, idx) => (
-            <div key={idx} className="grid grid-cols-2 gap-3 px-4 py-2 text-xs">
-              <div
-                className="truncate text-foreground"
-                title={p.reference_transcript}
-              >
-                {p.reference_transcript}
-              </div>
-              <div
-                className="truncate text-foreground"
-                title={p.predicted_transcript}
-              >
-                {p.predicted_transcript}
-              </div>
+        <div className="overflow-auto max-h-[20rem]">
+          <div
+            className="grid gap-3 px-4 py-2 border-b border-border bg-muted sticky top-0 z-10"
+            style={sttGridStyle}
+          >
+            <div className="text-xs font-medium text-muted-foreground">
+              Reference transcript
             </div>
-          ))}
-          {parsedItems.length > 50 && (
-            <div className="px-4 py-2 text-xs text-muted-foreground">
-              + {parsedItems.length - 50} more rows
+            <div className="text-xs font-medium text-muted-foreground">
+              Predicted transcript
             </div>
-          )}
+            {annotationColumns.map((c) => (
+              <div
+                key={`ah-${c.evaluatorUuid}-${c.kind}`}
+                className="text-xs font-medium text-muted-foreground font-mono truncate"
+                title={c.header}
+              >
+                {c.header}
+              </div>
+            ))}
+          </div>
+          <div className="divide-y divide-border">
+            {parsedItems.slice(0, 50).map((p, idx) => (
+              <div
+                key={idx}
+                className="grid gap-3 px-4 py-2 text-xs items-start"
+                style={sttGridStyle}
+              >
+                <div
+                  className="truncate text-foreground"
+                  title={p.reference_transcript}
+                >
+                  {p.reference_transcript}
+                </div>
+                <div
+                  className="truncate text-foreground"
+                  title={p.predicted_transcript}
+                >
+                  {p.predicted_transcript}
+                </div>
+                {annotationColumns.map((c) => {
+                  const ann = p.annotations.find(
+                    (a) => a.evaluator_uuid === c.evaluatorUuid,
+                  );
+                  const display =
+                    c.kind === "value"
+                      ? ann
+                        ? typeof ann.value === "boolean"
+                          ? ann.value
+                            ? "true"
+                            : "false"
+                          : String(ann.value)
+                        : ""
+                      : (ann?.reasoning ?? "");
+                  return (
+                    <div
+                      key={`${idx}-a-${c.evaluatorUuid}-${c.kind}`}
+                      className="min-w-0 max-h-24 overflow-y-auto pr-1 leading-snug text-foreground break-words whitespace-pre-wrap"
+                    >
+                      {display}
+                    </div>
+                  );
+                })}
+              </div>
+            ))}
+            {parsedItems.length > 50 && (
+              <div className="px-4 py-2 text-xs text-muted-foreground">
+                + {parsedItems.length - 50} more rows
+              </div>
+            )}
+          </div>
         </div>
       </div>
     </div>
   );
 
+  const annotationOptIn =
+    linkedEvaluators.length > 0 ? (
+      <AnnotationOptIn
+        annotators={annotatorsState.annotators}
+        loading={annotatorsState.loading}
+        error={annotatorsState.error}
+        uploadAnnotations={uploadAnnotations}
+        onToggle={setUploadAnnotations}
+        selectedAnnotatorId={selectedAnnotatorId}
+        onSelectAnnotator={setSelectedAnnotatorId}
+      />
+    ) : null;
+
+  const uploadBlocked =
+    uploadAnnotations &&
+    (annotatorsState.annotators.length === 0 || !selectedAnnotatorId);
+
   return (
     <BulkUploadDialogShell
       isOpen={isOpen}
       title="Bulk upload items"
-      buildSampleCsv={() => SAMPLE_STT_CSV}
-      sampleFilename="sample_stt_items.csv"
-      helpContent={helpContent}
+      buildSampleCsv={() =>
+        buildSampleSttCsv(annotationEvaluatorsMeta, uploadAnnotations)
+      }
+      sampleFilename={() =>
+        uploadAnnotations
+          ? "sample_stt_items_with_annotations.csv"
+          : "sample_stt_items.csv"
+      }
+      buildGuidelines={buildGuidelines}
+      guidelinesFilename={() =>
+        uploadAnnotations
+          ? "stt_items_csv_guidelines_with_annotations.pdf"
+          : "stt_items_csv_guidelines.pdf"
+      }
       csvFile={csvFile}
       onFile={handleFile}
       onClear={reset}
@@ -204,6 +483,9 @@ export function BulkUploadSttItemsDialog({
       itemsPreview={itemsPreview}
       onUpload={handleUpload}
       onClose={onClose}
+      topContent={annotationOptIn}
+      uploadBlocked={uploadBlocked}
+      hideUploadSection={uploadAnnotations && !selectedAnnotatorId}
     />
   );
 }

--- a/src/components/human-labelling/BulkUploadSttItemsDialog.tsx
+++ b/src/components/human-labelling/BulkUploadSttItemsDialog.tsx
@@ -142,6 +142,14 @@ export function BulkUploadSttItemsDialog({
     }),
   );
 
+  // Evaluator metadata (output_type) hydrates asynchronously on the parent
+  // page. Until every linked evaluator has a usable output_type the parser
+  // would silently drop those evaluators' annotation columns, so we treat
+  // the metadata as "not ready" and re-parse once it lands.
+  const annotationMetadataReady = annotationEvaluatorsMeta.every(
+    (e) => e.output_type === "binary" || e.output_type === "rating",
+  );
+
   const reset = () => {
     setCsvFile(null);
     setParsedItems([]);
@@ -160,6 +168,15 @@ export function BulkUploadSttItemsDialog({
     setParseError(null);
     setCsvFile(null);
   }, [uploadAnnotations]);
+
+  // Re-parse once evaluator metadata hydrates so annotations land on every
+  // evaluator instead of being silently skipped for ones whose output_type
+  // was still null when the user dropped the CSV.
+  useEffect(() => {
+    if (!uploadAnnotations || !annotationMetadataReady || !csvFile) return;
+    handleFile(csvFile);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [annotationMetadataReady]);
 
   const handleFile = (file: File | null) => {
     setUploadError(null);
@@ -182,6 +199,12 @@ export function BulkUploadSttItemsDialog({
           return;
         }
         if (uploadAnnotations) {
+          if (!annotationMetadataReady) {
+            setParseError(
+              "Evaluator metadata is still loading. Please wait a moment and try again.",
+            );
+            return;
+          }
           const missing: string[] = [];
           for (const meta of annotationEvaluatorsMeta) {
             const valueHeader = evaluatorValueColumn(meta.name);
@@ -256,6 +279,12 @@ export function BulkUploadSttItemsDialog({
     if (parsedItems.length === 0 || isUploading) return;
     if (uploadAnnotations && !selectedAnnotatorId) {
       setUploadError("Select an annotator before uploading.");
+      return;
+    }
+    if (uploadAnnotations && !annotationMetadataReady) {
+      setUploadError(
+        "Evaluator metadata is still loading. Please wait a moment and try again.",
+      );
       return;
     }
     setIsUploading(true);

--- a/src/components/human-labelling/BulkUploadSttItemsDialog.tsx
+++ b/src/components/human-labelling/BulkUploadSttItemsDialog.tsx
@@ -2,11 +2,9 @@
 
 import { useEffect, useState } from "react";
 import Papa from "papaparse";
-import { useHideFloatingButton } from "@/components/AppLayout";
 import { apiClient } from "@/lib/api";
 import {
-  CsvDropzone,
-  FormatHelpToggle,
+  BulkUploadDialogShell,
   findHeaderKey,
   parseApiError,
 } from "./bulk-upload-shared";
@@ -52,45 +50,22 @@ export function BulkUploadSttItemsDialog({
   onClose,
   onSuccess,
 }: BulkUploadSttItemsDialogProps) {
-  useHideFloatingButton(isOpen);
-
   const [csvFile, setCsvFile] = useState<File | null>(null);
   const [parsedItems, setParsedItems] = useState<ParsedItem[]>([]);
   const [parseError, setParseError] = useState<string | null>(null);
   const [isUploading, setIsUploading] = useState(false);
   const [uploadError, setUploadError] = useState<string | null>(null);
-  // Format help: open by default; auto-collapses once a CSV parses.
-  const [formatHelpOpen, setFormatHelpOpen] = useState(true);
 
   const reset = () => {
     setCsvFile(null);
     setParsedItems([]);
     setParseError(null);
     setUploadError(null);
-    setFormatHelpOpen(true);
   };
 
   useEffect(() => {
     if (isOpen) reset();
   }, [isOpen]);
-
-  useEffect(() => {
-    setFormatHelpOpen(parsedItems.length === 0);
-  }, [parsedItems.length]);
-
-  if (!isOpen) return null;
-
-  const downloadSampleCsv = () => {
-    const blob = new Blob([SAMPLE_STT_CSV], { type: "text/csv" });
-    const url = URL.createObjectURL(blob);
-    const link = document.createElement("a");
-    link.href = url;
-    link.download = "sample_stt_items.csv";
-    document.body.appendChild(link);
-    link.click();
-    document.body.removeChild(link);
-    URL.revokeObjectURL(url);
-  };
 
   const handleFile = (file: File | null) => {
     setUploadError(null);
@@ -154,184 +129,81 @@ export function BulkUploadSttItemsDialog({
     }
   };
 
-  const handleClose = () => {
-    if (!isUploading) onClose();
-  };
+  const helpContent = (
+    <>
+      <p>Your CSV needs two columns per row:</p>
+      <ul className="list-disc pl-5 space-y-1.5">
+        <li>
+          <code className="font-mono text-foreground">reference_transcript</code>{" "}
+          — what was actually said
+        </li>
+        <li>
+          <code className="font-mono text-foreground">predicted_transcript</code>{" "}
+          — what the system transcribed
+        </li>
+      </ul>
+    </>
+  );
 
-  return (
-    <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm p-4"
-      onClick={handleClose}
-    >
-      <div
-        className="bg-background border border-border rounded-xl shadow-2xl w-full max-w-2xl flex flex-col max-h-[90vh]"
-        onClick={(e) => e.stopPropagation()}
-      >
-        <div className="flex items-center justify-between px-6 py-4 border-b border-border">
-          <h2 className="text-lg font-semibold text-foreground">
-            Bulk upload items
-          </h2>
-          <button
-            onClick={handleClose}
-            disabled={isUploading}
-            aria-label="Close"
-            className="w-8 h-8 flex items-center justify-center rounded-lg text-muted-foreground hover:text-foreground hover:bg-muted transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
-          >
-            <svg
-              className="w-5 h-5"
-              fill="none"
-              viewBox="0 0 24 24"
-              stroke="currentColor"
-              strokeWidth={2}
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                d="M6 18L18 6M6 6l12 12"
-              />
-            </svg>
-          </button>
-        </div>
-
-        <div className="flex-1 overflow-y-auto px-6 py-5 space-y-5">
-          <div>
-            <div className="flex items-center justify-between mb-3">
-              <label className="block text-sm font-medium text-foreground">
-                Upload CSV
-              </label>
-              <button
-                type="button"
-                onClick={downloadSampleCsv}
-                className="h-9 px-3 rounded-md text-xs font-medium border border-border bg-muted/40 text-foreground hover:bg-muted hover:border-foreground/30 transition-colors cursor-pointer flex items-center gap-1.5 shadow-sm"
-              >
-                <svg
-                  className="w-4 h-4"
-                  fill="none"
-                  viewBox="0 0 24 24"
-                  stroke="currentColor"
-                  strokeWidth={2}
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5M16.5 12L12 16.5m0 0L7.5 12m4.5 4.5V3"
-                  />
-                </svg>
-                Download sample CSV
-              </button>
-            </div>
-
-            {parsedItems.length > 0 && (
-              <FormatHelpToggle
-                open={formatHelpOpen}
-                onToggle={() => setFormatHelpOpen((o) => !o)}
-              />
-            )}
-
-            {formatHelpOpen && (
-              <div className="text-xs text-muted-foreground mb-3 leading-relaxed space-y-2">
-                <p>Your CSV needs two columns per row:</p>
-                <ul className="list-disc pl-5 space-y-1.5">
-                  <li>
-                    <code className="font-mono text-foreground">
-                      reference_transcript
-                    </code>{" "}
-                    — what was actually said
-                  </li>
-                  <li>
-                    <code className="font-mono text-foreground">
-                      predicted_transcript
-                    </code>{" "}
-                    — what the system transcribed
-                  </li>
-                </ul>
-              </div>
-            )}
-
-            <CsvDropzone
-              csvFile={csvFile}
-              onFile={handleFile}
-              onClear={reset}
-            />
-
-            {parseError && (
-              <p className="text-xs text-red-500 mt-3">{parseError}</p>
-            )}
+  const itemsPreview = (
+    <div className="space-y-2">
+      <p className="text-sm font-medium text-foreground">
+        {parsedItems.length}{" "}
+        {parsedItems.length === 1 ? "item" : "items"} ready to upload
+      </p>
+      <div className="border border-border rounded-xl overflow-hidden">
+        <div className="grid grid-cols-2 gap-3 px-4 py-2 border-b border-border bg-muted/30">
+          <div className="text-xs font-medium text-muted-foreground">
+            Reference transcript
           </div>
-
-          {parsedItems.length > 0 && (
-            <div className="space-y-2">
-              <p className="text-sm font-medium text-foreground">
-                {parsedItems.length}{" "}
-                {parsedItems.length === 1 ? "item" : "items"} ready to upload
-              </p>
-              <div className="border border-border rounded-xl overflow-hidden">
-                <div className="grid grid-cols-2 gap-3 px-4 py-2 border-b border-border bg-muted/30">
-                  <div className="text-xs font-medium text-muted-foreground">
-                    Reference transcript
-                  </div>
-                  <div className="text-xs font-medium text-muted-foreground">
-                    Predicted transcript
-                  </div>
-                </div>
-                <div className="max-h-64 overflow-y-auto divide-y divide-border">
-                  {parsedItems.slice(0, 50).map((p, idx) => (
-                    <div
-                      key={idx}
-                      className="grid grid-cols-2 gap-3 px-4 py-2 text-xs"
-                    >
-                      <div
-                        className="truncate text-foreground"
-                        title={p.reference_transcript}
-                      >
-                        {p.reference_transcript}
-                      </div>
-                      <div
-                        className="truncate text-foreground"
-                        title={p.predicted_transcript}
-                      >
-                        {p.predicted_transcript}
-                      </div>
-                    </div>
-                  ))}
-                  {parsedItems.length > 50 && (
-                    <div className="px-4 py-2 text-xs text-muted-foreground">
-                      + {parsedItems.length - 50} more rows
-                    </div>
-                  )}
-                </div>
+          <div className="text-xs font-medium text-muted-foreground">
+            Predicted transcript
+          </div>
+        </div>
+        <div className="max-h-64 overflow-y-auto divide-y divide-border">
+          {parsedItems.slice(0, 50).map((p, idx) => (
+            <div key={idx} className="grid grid-cols-2 gap-3 px-4 py-2 text-xs">
+              <div
+                className="truncate text-foreground"
+                title={p.reference_transcript}
+              >
+                {p.reference_transcript}
+              </div>
+              <div
+                className="truncate text-foreground"
+                title={p.predicted_transcript}
+              >
+                {p.predicted_transcript}
               </div>
             </div>
-          )}
-
-          {uploadError && (
-            <div className="rounded-md border border-red-500/30 bg-red-500/10 p-3 text-sm text-red-500">
-              {uploadError}
+          ))}
+          {parsedItems.length > 50 && (
+            <div className="px-4 py-2 text-xs text-muted-foreground">
+              + {parsedItems.length - 50} more rows
             </div>
           )}
-        </div>
-
-        <div className="flex items-center justify-end gap-3 px-6 py-4 border-t border-border">
-          <button
-            onClick={handleClose}
-            disabled={isUploading}
-            className="h-10 px-4 rounded-md text-sm font-medium border border-border bg-background hover:bg-muted/50 transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
-          >
-            Cancel
-          </button>
-          <button
-            onClick={handleUpload}
-            disabled={parsedItems.length === 0 || isUploading || !!parseError}
-            className="h-10 px-4 rounded-md text-sm font-medium bg-foreground text-background hover:opacity-90 transition-opacity cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
-          >
-            {isUploading
-              ? "Uploading…"
-              : parsedItems.length > 1
-                ? `Upload ${parsedItems.length} items`
-                : "Upload item"}
-          </button>
         </div>
       </div>
     </div>
+  );
+
+  return (
+    <BulkUploadDialogShell
+      isOpen={isOpen}
+      title="Bulk upload items"
+      buildSampleCsv={() => SAMPLE_STT_CSV}
+      sampleFilename="sample_stt_items.csv"
+      helpContent={helpContent}
+      csvFile={csvFile}
+      onFile={handleFile}
+      onClear={reset}
+      parseError={parseError}
+      uploadError={uploadError}
+      isUploading={isUploading}
+      itemCount={parsedItems.length}
+      itemsPreview={itemsPreview}
+      onUpload={handleUpload}
+      onClose={onClose}
+    />
   );
 }

--- a/src/components/human-labelling/bulk-upload-shared.tsx
+++ b/src/components/human-labelling/bulk-upload-shared.tsx
@@ -1,7 +1,11 @@
 "use client";
 
 import React, { useEffect, useState } from "react";
+import Link from "next/link";
+import { jsPDF } from "jspdf";
 import { useHideFloatingButton } from "@/components/AppLayout";
+import { SingleSelectPicker } from "@/components/SingleSelectPicker";
+import { apiClient } from "@/lib/api";
 
 // ─── Shared types ─────────────────────────────────────────────────────────
 
@@ -11,6 +15,311 @@ export type TurnObject = {
   tool_calls?: unknown;
   [key: string]: unknown;
 };
+
+// Minimal evaluator description used by the bulk upload dialogs to render
+// per-evaluator value/reasoning columns in the helper text and sample CSV
+// (when the user opts into pre-filling annotations).
+export type EvaluatorMeta = {
+  uuid: string;
+  name: string;
+  output_type: "binary" | "rating" | null;
+  scale_min: number | null;
+  scale_max: number | null;
+};
+
+export type Annotator = { uuid: string; name: string };
+
+// Per-evaluator annotation parsed from a CSV row. Reasoning is always a
+// string (empty string when no reasoning column / cell). The value field
+// holds either a boolean (binary evaluators) or a number (rating).
+export type ParsedAnnotation = {
+  evaluator_uuid: string;
+  output_type: "binary" | "rating";
+  value: boolean | number;
+  reasoning: string;
+};
+
+// Per-evaluator annotation payload as the backend expects it for a single
+// item: an object keyed by evaluator UUID. The shape is uniform across
+// every output_type — `{ value, reasoning }` — and the bulk endpoint
+// rejects any other key (e.g. `pass`) with 400.
+export type ItemAnnotationsPayload = Record<
+  string,
+  { value: boolean | number; reasoning: string }
+>;
+
+// Build the per-item annotations payload from parsed cells. Returns
+// `undefined` when no evaluator cells were filled in for the row, so the
+// caller can omit `annotations` for that item entirely.
+export function buildItemAnnotationsPayload(
+  parsed: ParsedAnnotation[],
+): ItemAnnotationsPayload | undefined {
+  if (parsed.length === 0) return undefined;
+  const out: ItemAnnotationsPayload = {};
+  for (const a of parsed) {
+    out[a.evaluator_uuid] = {
+      value: a.value,
+      reasoning: a.reasoning,
+    };
+  }
+  return out;
+}
+
+// CSV column header for an evaluator's value column.
+export function evaluatorValueColumn(evalName: string): string {
+  return evalName;
+}
+
+// CSV column header for an evaluator's reasoning column.
+export function evaluatorReasoningColumn(evalName: string): string {
+  return `${evalName}/reasoning`;
+}
+
+// Sample value to render in the sample CSV's evaluator value column.
+// Binary → "true"; rating → midpoint of [min,max] (rounded).
+export function sampleEvaluatorValue(e: EvaluatorMeta): string {
+  if (e.output_type === "binary") return "true";
+  if (
+    e.output_type === "rating" &&
+    typeof e.scale_min === "number" &&
+    typeof e.scale_max === "number"
+  ) {
+    const mid = Math.round((e.scale_min + e.scale_max) / 2);
+    return String(mid);
+  }
+  return "";
+}
+
+// Parse an annotation cell value against the evaluator's output type. Returns
+// the typed value or an error message.
+export function parseAnnotationCell(
+  raw: string,
+  e: EvaluatorMeta,
+): { value: boolean | number } | { error: string } {
+  const trimmed = raw.trim();
+  if (e.output_type === "binary") {
+    const lower = trimmed.toLowerCase();
+    if (["true", "pass", "1", "yes"].includes(lower)) return { value: true };
+    if (["false", "fail", "0", "no"].includes(lower)) return { value: false };
+    return {
+      error: `expected "true"/"pass" or "false"/"fail" for binary evaluator "${e.name}"`,
+    };
+  }
+  if (e.output_type === "rating") {
+    const num = Number(trimmed);
+    if (!Number.isFinite(num)) {
+      return {
+        error: `expected a number for rating evaluator "${e.name}"`,
+      };
+    }
+    if (
+      typeof e.scale_min === "number" &&
+      typeof e.scale_max === "number" &&
+      (num < e.scale_min || num > e.scale_max)
+    ) {
+      return {
+        error: `value ${num} is outside the ${e.scale_min}–${e.scale_max} range for "${e.name}"`,
+      };
+    }
+    return { value: num };
+  }
+  return { error: `unsupported evaluator type for "${e.name}"` };
+}
+
+// ─── Annotator picker ─────────────────────────────────────────────────────
+
+// Loads annotators from the backend; surfaces a loading / empty / error
+// state. Returns helpers for use inside a bulk-upload dialog.
+export function useAnnotators(
+  isOpen: boolean,
+  accessToken: string,
+): {
+  annotators: Annotator[];
+  loading: boolean;
+  error: string | null;
+} {
+  const [annotators, setAnnotators] = useState<Annotator[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!isOpen || !accessToken) return;
+    let cancelled = false;
+    (async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const data = await apiClient<Annotator[]>("/annotators", accessToken);
+        if (!cancelled) setAnnotators(Array.isArray(data) ? data : []);
+      } catch (err) {
+        if (!cancelled)
+          setError(parseApiError(err, "Failed to load annotators"));
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [isOpen, accessToken]);
+
+  return { annotators, loading, error };
+}
+
+type AnnotationOptInProps = {
+  annotators: Annotator[];
+  loading: boolean;
+  error: string | null;
+  uploadAnnotations: boolean;
+  onToggle: (next: boolean) => void;
+  selectedAnnotatorId: string | null;
+  onSelectAnnotator: (uuid: string | null) => void;
+};
+
+// Renders the "Upload annotations too?" yes/no choice and, when yes,
+// either a single-select annotator picker, an empty state with a link to
+// add annotators, or load/error feedback. Used at the top of every bulk
+// upload items dialog when the parent task has linked evaluators.
+export function AnnotationOptIn({
+  annotators,
+  loading,
+  error,
+  uploadAnnotations,
+  onToggle,
+  selectedAnnotatorId,
+  onSelectAnnotator,
+}: AnnotationOptInProps) {
+  return (
+    <div className="space-y-3">
+      <div>
+        <label className="block text-sm font-medium text-foreground mb-2">
+          Do you want to upload existing human labels?
+        </label>
+
+        <div className="flex rounded-lg border border-border overflow-hidden w-fit">
+          <button
+            type="button"
+            onClick={() => onToggle(false)}
+            className={`px-4 py-2 text-sm font-medium transition-colors cursor-pointer ${
+              !uploadAnnotations
+                ? "bg-foreground text-background"
+                : "bg-background text-muted-foreground hover:text-foreground hover:bg-muted"
+            }`}
+          >
+            No
+          </button>
+          <button
+            type="button"
+            onClick={() => onToggle(true)}
+            className={`px-4 py-2 text-sm font-medium transition-colors cursor-pointer border-l border-border ${
+              uploadAnnotations
+                ? "bg-foreground text-background"
+                : "bg-background text-muted-foreground hover:text-foreground hover:bg-muted"
+            }`}
+          >
+            Yes
+          </button>
+        </div>
+      </div>
+
+      {uploadAnnotations && (
+        <div>
+          <label className="block text-sm font-medium text-foreground mb-2">
+            Select annotator
+          </label>
+          {loading ? (
+            <p className="text-xs text-muted-foreground">Loading annotators…</p>
+          ) : error ? (
+            <p className="text-xs text-red-500">{error}</p>
+          ) : annotators.length === 0 ? (
+            <div className="rounded-md border border-amber-500/30 bg-amber-500/10 p-3 text-xs text-foreground">
+              No annotators exist yet.{" "}
+              <Link
+                href="/human-labelling?tab=annotators"
+                className="underline underline-offset-2 hover:opacity-80 transition-opacity"
+              >
+                Add an annotator
+              </Link>{" "}
+              to your account first.
+            </div>
+          ) : (
+            <SingleSelectPicker<Annotator>
+              items={annotators}
+              selectedId={selectedAnnotatorId}
+              onSelect={(a) => onSelectAnnotator(a.uuid)}
+              getId={(a) => a.uuid}
+              ariaLabel="Select annotator"
+              placeholder="Select an annotator"
+              className="w-full"
+              matchesSearch={(a, q) =>
+                a.name.toLowerCase().includes(q.toLowerCase())
+              }
+              searchPlaceholder="Search annotators"
+              renderTrigger={(a) => (
+                <span className="text-sm text-foreground">
+                  {a ? a.name : "Select an annotator"}
+                </span>
+              )}
+              renderOption={(a) => (
+                <span className="text-sm text-foreground">{a.name}</span>
+              )}
+            />
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// Helper text bullet list describing the evaluator value and reasoning
+// columns that appear when the user opts into uploading annotations.
+export function EvaluatorAnnotationColumnsHelp({
+  evaluators,
+}: {
+  evaluators: EvaluatorMeta[];
+}) {
+  return (
+    <>
+      {evaluators.map((e) => {
+        const range =
+          e.output_type === "binary"
+            ? "true/false"
+            : e.output_type === "rating" &&
+                typeof e.scale_min === "number" &&
+                typeof e.scale_max === "number"
+              ? `any value between ${e.scale_min}-${e.scale_max}`
+              : "value";
+        const pill = (
+          <Link
+            href={`/evaluators/${e.uuid}`}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center px-1.5 py-0.5 rounded-full bg-accent text-accent-foreground text-[10px] font-medium hover:opacity-80 transition-opacity cursor-pointer"
+          >
+            {e.name}
+          </Link>
+        );
+        return (
+          <React.Fragment key={e.uuid}>
+            <li>
+              <code className="font-mono text-foreground">
+                {evaluatorValueColumn(e.name)}
+              </code>{" "}
+              — value for {pill} evaluator ({range})
+            </li>
+            <li>
+              <code className="font-mono text-foreground">
+                {evaluatorReasoningColumn(e.name)}
+              </code>{" "}
+              — (optional) reasoning for the value assigned to the {pill}{" "}
+              evaluator
+            </li>
+          </React.Fragment>
+        );
+      })}
+    </>
+  );
+}
 
 // ─── Shared helpers ───────────────────────────────────────────────────────
 
@@ -227,11 +536,7 @@ export function ChatHistoryPreview({ turns }: { turns: TurnObject[] }) {
 // bulk-upload dialog that takes a conversation/transcript JSON column so
 // the explanation stays consistent and out of the way until the user
 // asks for it.
-export function ConversationFormatDetails({
-  example,
-}: {
-  example: string;
-}) {
+export function ConversationFormatDetails({ example }: { example: string }) {
   const [open, setOpen] = useState(false);
   return (
     <div className="mt-1">
@@ -262,7 +567,9 @@ export function ConversationFormatDetails({
           <ul className="list-disc pl-5 mt-1 space-y-0.5">
             <li>
               <code className="font-mono text-foreground">role</code> — either{" "}
-              <code className="font-mono text-foreground">&quot;user&quot;</code>{" "}
+              <code className="font-mono text-foreground">
+                &quot;user&quot;
+              </code>{" "}
               or{" "}
               <code className="font-mono text-foreground">
                 &quot;assistant&quot;
@@ -299,6 +606,187 @@ export function downloadCsvBlob(csv: string, filename: string): void {
   URL.revokeObjectURL(url);
 }
 
+// ─── Guidelines PDF ───────────────────────────────────────────────────────
+
+// Structured representation of CSV format guidelines that we render to a
+// nicely-formatted PDF for download. Each column documents one CSV column;
+// `fields` describes nested object fields (used for tool_calls).
+export type GuidelineField = {
+  name: string;
+  meta?: string;
+  description: string;
+  example?: string;
+};
+
+export type GuidelineColumn = {
+  name: string;
+  description: string;
+  example?: string;
+  fields?: GuidelineField[];
+  trailingExamples?: { label: string; example: string }[];
+};
+
+export type GuidelineDoc = {
+  title: string;
+  intro?: string;
+  columns: GuidelineColumn[];
+};
+
+export function generateGuidelinesPdf(doc: GuidelineDoc): Blob {
+  const pdf = new jsPDF({ unit: "pt", format: "a4" });
+  const pageW = pdf.internal.pageSize.getWidth();
+  const pageH = pdf.internal.pageSize.getHeight();
+  const M = 56;
+  const textW = pageW - 2 * M;
+  let y = M;
+
+  const ensure = (needed: number) => {
+    if (y + needed > pageH - M) {
+      pdf.addPage();
+      y = M;
+    }
+  };
+
+  const writeText = (
+    text: string,
+    opts: {
+      size?: number;
+      style?: "normal" | "bold" | "italic";
+      font?: "helvetica" | "courier";
+      color?: [number, number, number];
+      indent?: number;
+      lineGap?: number;
+    } = {},
+  ) => {
+    const size = opts.size ?? 11;
+    const style = opts.style ?? "normal";
+    const font = opts.font ?? "helvetica";
+    const indent = opts.indent ?? 0;
+    const lineH = size * 1.35;
+    pdf.setFont(font, style);
+    pdf.setFontSize(size);
+    pdf.setTextColor(...(opts.color ?? [30, 30, 30]));
+    const lines = pdf.splitTextToSize(text, textW - indent);
+    for (const line of lines) {
+      ensure(lineH);
+      pdf.text(line, M + indent, y + size);
+      y += lineH;
+    }
+    if (opts.lineGap) y += opts.lineGap;
+  };
+
+  const writeCodeBlock = (code: string, indent = 0) => {
+    const size = 9;
+    const lineH = size * 1.4;
+    pdf.setFont("courier", "normal");
+    pdf.setFontSize(size);
+    // Split on hard newlines first so we preserve the author's line breaks
+    // and indentation, then word-wrap each segment to the block width.
+    const wrapW = textW - indent - 16;
+    const lines: string[] = [];
+    for (const raw of code.split("\n")) {
+      const wrapped = pdf.splitTextToSize(raw, wrapW) as string[];
+      if (wrapped.length === 0) lines.push("");
+      else lines.push(...wrapped);
+    }
+    const padY = 6;
+    const blockH = lines.length * lineH + padY * 2;
+    ensure(blockH + 4);
+    pdf.setFillColor(245, 246, 248);
+    pdf.setDrawColor(225, 228, 232);
+    pdf.roundedRect(M + indent, y, textW - indent, blockH, 4, 4, "FD");
+    pdf.setTextColor(40, 50, 70);
+    let yy = y + padY;
+    for (const line of lines) {
+      pdf.text(line, M + indent + 8, yy + size);
+      yy += lineH;
+    }
+    y += blockH + 8;
+  };
+
+  // Title
+  writeText(doc.title, { size: 22, style: "bold", color: [20, 20, 20] });
+  // Underline accent
+  pdf.setDrawColor(220, 224, 230);
+  pdf.setLineWidth(0.8);
+  pdf.line(M, y + 2, M + textW, y + 2);
+  y += 14;
+
+  if (doc.intro) {
+    writeText(doc.intro, { size: 11, color: [70, 75, 85], lineGap: 6 });
+  }
+
+  for (const col of doc.columns) {
+    ensure(40);
+    writeText(col.name, {
+      size: 13,
+      style: "bold",
+      font: "courier",
+      color: [20, 35, 90],
+      lineGap: 2,
+    });
+    writeText(col.description, {
+      size: 11,
+      color: [40, 45, 55],
+      indent: 12,
+      lineGap: 4,
+    });
+    if (col.example) {
+      writeCodeBlock(col.example, 12);
+    }
+    if (col.fields) {
+      for (const f of col.fields) {
+        ensure(30);
+        const header = f.meta ? `${f.name}  ${f.meta}` : f.name;
+        writeText(header, {
+          size: 11,
+          style: "bold",
+          font: "courier",
+          color: [60, 60, 80],
+          indent: 12,
+          lineGap: 1,
+        });
+        writeText(f.description, {
+          size: 10.5,
+          color: [55, 60, 70],
+          indent: 24,
+          lineGap: 3,
+        });
+        if (f.example) {
+          writeCodeBlock(f.example, 24);
+        }
+      }
+    }
+    if (col.trailingExamples) {
+      for (const ex of col.trailingExamples) {
+        ensure(30);
+        writeText(ex.label, {
+          size: 10.5,
+          style: "italic",
+          color: [80, 85, 95],
+          indent: 12,
+          lineGap: 1,
+        });
+        writeCodeBlock(ex.example, 12);
+      }
+    }
+    y += 6;
+  }
+
+  return pdf.output("blob");
+}
+
+function downloadBlob(blob: Blob, filename: string): void {
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = filename;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(url);
+}
+
 // Shared shell for the three bulk-upload dialogs (LLM / STT / Simulation).
 // Owns the modal chrome, header, footer, dropzone, format-help toggle, tip
 // callout, and sample-CSV download wiring. Each dialog supplies its own
@@ -307,8 +795,11 @@ type BulkUploadDialogShellProps = {
   isOpen: boolean;
   title: string;
   buildSampleCsv: () => string;
-  sampleFilename: string;
-  helpContent: React.ReactNode;
+  sampleFilename: string | (() => string);
+  // Structured CSV format guidelines, rendered to a styled PDF for the
+  // "Download CSV format guidelines" button.
+  buildGuidelines: () => GuidelineDoc;
+  guidelinesFilename?: string | (() => string);
   csvFile: File | null;
   onFile: (file: File | null) => void;
   onClear: () => void;
@@ -319,6 +810,19 @@ type BulkUploadDialogShellProps = {
   itemsPreview: React.ReactNode;
   onUpload: () => void;
   onClose: () => void;
+  // Optional content rendered above the CSV upload section. Used by the
+  // labelling-task dialogs to ask the user up-front whether they want to
+  // also pre-fill annotations and to pick the annotator.
+  topContent?: React.ReactNode;
+  // When set, blocks the Upload button. Used together with topContent to
+  // gate uploads on incomplete top-level prerequisites (e.g. annotator not
+  // yet picked).
+  uploadBlocked?: boolean;
+  // When set, hides the entire CSV upload section (guidelines, dropzone,
+  // tip, items preview, footer Upload button). Used to keep the dialog
+  // focused on a top-level prerequisite — e.g. picking an annotator —
+  // before exposing the rest of the flow.
+  hideUploadSection?: boolean;
 };
 
 export function BulkUploadDialogShell({
@@ -326,7 +830,8 @@ export function BulkUploadDialogShell({
   title,
   buildSampleCsv,
   sampleFilename,
-  helpContent,
+  buildGuidelines,
+  guidelinesFilename = "csv_format_guidelines.pdf",
   csvFile,
   onFile,
   onClear,
@@ -337,20 +842,27 @@ export function BulkUploadDialogShell({
   itemsPreview,
   onUpload,
   onClose,
+  topContent,
+  uploadBlocked,
+  hideUploadSection,
 }: BulkUploadDialogShellProps) {
   useHideFloatingButton(isOpen);
-  const [formatHelpOpen, setFormatHelpOpen] = useState(true);
-
-  // Auto-collapse the help block once a CSV has parsed; re-open if the
-  // user clears it.
-  useEffect(() => {
-    setFormatHelpOpen(itemCount === 0);
-  }, [itemCount]);
 
   if (!isOpen) return null;
 
   const downloadSample = () =>
-    downloadCsvBlob(buildSampleCsv(), sampleFilename);
+    downloadCsvBlob(
+      buildSampleCsv(),
+      typeof sampleFilename === "function" ? sampleFilename() : sampleFilename,
+    );
+
+  const downloadGuidelines = () =>
+    downloadBlob(
+      generateGuidelinesPdf(buildGuidelines()),
+      typeof guidelinesFilename === "function"
+        ? guidelinesFilename()
+        : guidelinesFilename,
+    );
 
   const handleClose = () => {
     if (!isUploading) onClose();
@@ -363,7 +875,7 @@ export function BulkUploadDialogShell({
     >
       <div
         className={`bg-background border border-border rounded-xl shadow-2xl w-full flex flex-col max-h-[90vh] transition-[max-width] duration-200 ${
-          itemCount > 0 ? "max-w-[80vw]" : "max-w-[50vw]"
+          itemCount > 0 ? "max-w-[80vw]" : "max-w-[37.5vw]"
         }`}
         onClick={(e) => e.stopPropagation()}
       >
@@ -392,50 +904,40 @@ export function BulkUploadDialogShell({
         </div>
 
         <div className="flex-1 overflow-y-auto px-6 py-5 space-y-5">
+          {topContent}
+          {!hideUploadSection && (
           <div>
-            <div className="flex items-center justify-between mb-3">
-              <label className="block text-sm font-medium text-foreground">
-                Upload CSV
-              </label>
-              <button
-                type="button"
-                onClick={downloadSample}
-                className="h-9 px-3 rounded-md text-xs font-medium border border-border bg-muted/40 text-foreground hover:bg-muted hover:border-foreground/30 transition-colors cursor-pointer flex items-center gap-1.5 shadow-sm"
-              >
-                <svg
-                  className="w-4 h-4"
-                  fill="none"
-                  viewBox="0 0 24 24"
-                  stroke="currentColor"
-                  strokeWidth={2}
+            {itemCount === 0 && (
+              <div className="mb-3 flex flex-wrap gap-2">
+                <button
+                  type="button"
+                  onClick={downloadGuidelines}
+                  className="h-9 px-3 rounded-md text-xs font-semibold border border-blue-500/40 bg-blue-500/15 text-blue-700 dark:text-blue-300 hover:bg-blue-500/25 hover:border-blue-500/60 transition-colors cursor-pointer flex items-center gap-1.5"
                 >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5M16.5 12L12 16.5m0 0L7.5 12m4.5 4.5V3"
-                  />
-                </svg>
-                Download sample CSV
-              </button>
-            </div>
-
-            {itemCount > 0 && (
-              <FormatHelpToggle
-                open={formatHelpOpen}
-                onToggle={() => setFormatHelpOpen((o) => !o)}
-              />
-            )}
-
-            {formatHelpOpen && (
-              <div className="text-xs text-muted-foreground mb-3 leading-relaxed space-y-2">
-                {helpContent}
+                  <svg
+                    className="w-4 h-4"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                    strokeWidth={2}
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5M16.5 12L12 16.5m0 0L7.5 12m4.5 4.5V3"
+                    />
+                  </svg>
+                  Download CSV format guidelines
+                </button>
               </div>
             )}
 
-            {formatHelpOpen && (
-              <div className="mb-3 flex items-start gap-2 rounded-md border border-blue-500/30 bg-blue-500/10 px-3 py-2 text-xs text-foreground">
+            <CsvDropzone csvFile={csvFile} onFile={onFile} onClear={onClear} />
+
+            {itemCount === 0 && (
+              <div className="mt-3 flex items-start gap-2 rounded-md border border-emerald-500/30 bg-emerald-500/10 px-3 py-2 text-xs text-foreground">
                 <svg
-                  className="w-4 h-4 mt-0.5 shrink-0 text-blue-500"
+                  className="w-4 h-4 mt-0.5 shrink-0 text-emerald-500"
                   fill="none"
                   viewBox="0 0 24 24"
                   stroke="currentColor"
@@ -452,7 +954,7 @@ export function BulkUploadDialogShell({
                   <button
                     type="button"
                     onClick={downloadSample}
-                    className="underline underline-offset-2 hover:opacity-80 transition-opacity cursor-pointer"
+                    className="underline underline-offset-2 font-semibold text-emerald-700 dark:text-emerald-300 hover:opacity-80 transition-opacity cursor-pointer"
                   >
                     download the sample CSV
                   </button>{" "}
@@ -461,16 +963,15 @@ export function BulkUploadDialogShell({
               </div>
             )}
 
-            <CsvDropzone csvFile={csvFile} onFile={onFile} onClear={onClear} />
-
             {parseError && (
               <p className="text-xs text-red-500 mt-3">{parseError}</p>
             )}
           </div>
+          )}
 
-          {itemCount > 0 && itemsPreview}
+          {!hideUploadSection && itemCount > 0 && itemsPreview}
 
-          {uploadError && (
+          {!hideUploadSection && uploadError && (
             <div className="rounded-md border border-red-500/30 bg-red-500/10 p-3 text-sm text-red-500">
               {uploadError}
             </div>
@@ -485,9 +986,12 @@ export function BulkUploadDialogShell({
           >
             Cancel
           </button>
+          {!hideUploadSection && (
           <button
             onClick={onUpload}
-            disabled={itemCount === 0 || isUploading || !!parseError}
+            disabled={
+              itemCount === 0 || isUploading || !!parseError || !!uploadBlocked
+            }
             className="h-10 px-4 rounded-md text-sm font-medium bg-foreground text-background hover:opacity-90 transition-opacity cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
           >
             {isUploading
@@ -496,6 +1000,7 @@ export function BulkUploadDialogShell({
                 ? `Upload ${itemCount} items`
                 : "Upload item"}
           </button>
+          )}
         </div>
       </div>
     </div>

--- a/src/components/human-labelling/bulk-upload-shared.tsx
+++ b/src/components/human-labelling/bulk-upload-shared.tsx
@@ -65,14 +65,33 @@ export function buildItemAnnotationsPayload(
   return out;
 }
 
-// CSV column header for an evaluator's value column.
+// CSV column header for an evaluator's value column. We namespace under
+// `<evalName>/value` (not just `<evalName>`) so the header can't collide
+// with reserved item columns like `name`, `agent_response`, or
+// `conversation_history`.
 export function evaluatorValueColumn(evalName: string): string {
-  return evalName;
+  return `${evalName}/value`;
 }
 
 // CSV column header for an evaluator's reasoning column.
 export function evaluatorReasoningColumn(evalName: string): string {
   return `${evalName}/reasoning`;
+}
+
+// Returns the names that appear more than once in `evaluators`, so the
+// caller can refuse to render the annotation flow when two linked
+// evaluators share a name (which would produce duplicate CSV headers
+// that PapaParse silently overwrites). Empty list = safe to proceed.
+export function duplicateEvaluatorNames(
+  evaluators: { name: string }[],
+): string[] {
+  const seen = new Map<string, number>();
+  for (const e of evaluators) {
+    seen.set(e.name, (seen.get(e.name) ?? 0) + 1);
+  }
+  return Array.from(seen.entries())
+    .filter(([, n]) => n > 1)
+    .map(([name]) => name);
 }
 
 // Sample value to render in the sample CSV's evaluator value column.
@@ -875,7 +894,7 @@ export function BulkUploadDialogShell({
     >
       <div
         className={`bg-background border border-border rounded-xl shadow-2xl w-full flex flex-col max-h-[90vh] transition-[max-width] duration-200 ${
-          itemCount > 0 ? "max-w-[80vw]" : "max-w-[37.5vw]"
+          itemCount > 0 ? "md:max-w-[80vw]" : "md:max-w-[37.5vw]"
         }`}
         onClick={(e) => e.stopPropagation()}
       >

--- a/src/components/human-labelling/bulk-upload-shared.tsx
+++ b/src/components/human-labelling/bulk-upload-shared.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import React from "react";
+import React, { useEffect, useState } from "react";
+import { useHideFloatingButton } from "@/components/AppLayout";
 
 // ─── Shared types ─────────────────────────────────────────────────────────
 
@@ -110,10 +111,10 @@ export function CsvDropzone({
       onDragOver={(e) => e.preventDefault()}
       onDrop={handleDrop}
       onClick={() => inputRef.current?.click()}
-      className={`border-2 border-dashed rounded-xl p-8 text-center transition-colors cursor-pointer ${
+      className={`border-2 border-dashed rounded-xl text-center transition-colors cursor-pointer ${
         csvFile
-          ? "border-foreground/30 bg-muted/30"
-          : "border-border hover:border-muted-foreground"
+          ? "border-foreground/30 bg-muted/30 py-3 px-4"
+          : "border-border hover:border-muted-foreground p-8"
       }`}
     >
       <input
@@ -186,6 +187,317 @@ export function CsvDropzone({
           <p className="text-xs text-muted-foreground mt-1">{helperText}</p>
         </>
       )}
+    </div>
+  );
+}
+
+// Vertical preview of a conversation/transcript: each turn rendered as a
+// "Role" pill above its content. Sized so ~2 turns are visible at once;
+// anything beyond that scrolls inside the cell. Shared across the bulk
+// upload dialogs so chat history rendering is identical everywhere.
+export function ChatHistoryPreview({ turns }: { turns: TurnObject[] }) {
+  return (
+    <div className="max-h-24 overflow-y-auto pr-1 space-y-2">
+      {turns.map((t, i) => {
+        const role = typeof t.role === "string" ? t.role : "?";
+        const content = turnContentString(t);
+        return (
+          <div key={`h-${i}`} className="space-y-1 leading-snug">
+            <span
+              className={`inline-flex items-center text-[10px] font-semibold uppercase tracking-wide px-1.5 py-0.5 rounded ${rolePillClass(role)}`}
+            >
+              {roleLabel(role)}
+            </span>
+            <div className="text-foreground break-words whitespace-pre-wrap">
+              {content || (
+                <span className="text-muted-foreground italic">
+                  (no content)
+                </span>
+              )}
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+// "View more" toggle that reveals the role/content schema and a
+// copy-pasteable example for a conversation column. Reused across every
+// bulk-upload dialog that takes a conversation/transcript JSON column so
+// the explanation stays consistent and out of the way until the user
+// asks for it.
+export function ConversationFormatDetails({
+  example,
+}: {
+  example: string;
+}) {
+  const [open, setOpen] = useState(false);
+  return (
+    <div className="mt-1">
+      <button
+        type="button"
+        onClick={() => setOpen((o) => !o)}
+        className="inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors cursor-pointer"
+        aria-expanded={open}
+      >
+        <svg
+          className={`w-3 h-3 transition-transform ${open ? "rotate-90" : ""}`}
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+          strokeWidth={2.5}
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M8.25 4.5l7.5 7.5-7.5 7.5"
+          />
+        </svg>
+        {open ? "View less" : "View more"}
+      </button>
+      {open && (
+        <>
+          <div className="mt-1.5">Each turn must have:</div>
+          <ul className="list-disc pl-5 mt-1 space-y-0.5">
+            <li>
+              <code className="font-mono text-foreground">role</code> — either{" "}
+              <code className="font-mono text-foreground">&quot;user&quot;</code>{" "}
+              or{" "}
+              <code className="font-mono text-foreground">
+                &quot;assistant&quot;
+              </code>
+            </li>
+            <li>
+              <code className="font-mono text-foreground">content</code> — the
+              actual message said by that role
+            </li>
+          </ul>
+          <div className="mt-1.5">
+            Example:{" "}
+            <code className="font-mono text-foreground break-all">
+              {example}
+            </code>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
+// Trigger a CSV download from a string. Used by the dialog shell for the
+// "Download sample CSV" button and the inline tip link.
+export function downloadCsvBlob(csv: string, filename: string): void {
+  const blob = new Blob([csv], { type: "text/csv" });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = filename;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(url);
+}
+
+// Shared shell for the three bulk-upload dialogs (LLM / STT / Simulation).
+// Owns the modal chrome, header, footer, dropzone, format-help toggle, tip
+// callout, and sample-CSV download wiring. Each dialog supplies its own
+// help body, parsing/upload logic, and items preview.
+type BulkUploadDialogShellProps = {
+  isOpen: boolean;
+  title: string;
+  buildSampleCsv: () => string;
+  sampleFilename: string;
+  helpContent: React.ReactNode;
+  csvFile: File | null;
+  onFile: (file: File | null) => void;
+  onClear: () => void;
+  parseError: string | null;
+  uploadError: string | null;
+  isUploading: boolean;
+  itemCount: number;
+  itemsPreview: React.ReactNode;
+  onUpload: () => void;
+  onClose: () => void;
+};
+
+export function BulkUploadDialogShell({
+  isOpen,
+  title,
+  buildSampleCsv,
+  sampleFilename,
+  helpContent,
+  csvFile,
+  onFile,
+  onClear,
+  parseError,
+  uploadError,
+  isUploading,
+  itemCount,
+  itemsPreview,
+  onUpload,
+  onClose,
+}: BulkUploadDialogShellProps) {
+  useHideFloatingButton(isOpen);
+  const [formatHelpOpen, setFormatHelpOpen] = useState(true);
+
+  // Auto-collapse the help block once a CSV has parsed; re-open if the
+  // user clears it.
+  useEffect(() => {
+    setFormatHelpOpen(itemCount === 0);
+  }, [itemCount]);
+
+  if (!isOpen) return null;
+
+  const downloadSample = () =>
+    downloadCsvBlob(buildSampleCsv(), sampleFilename);
+
+  const handleClose = () => {
+    if (!isUploading) onClose();
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm p-4"
+      onClick={handleClose}
+    >
+      <div
+        className={`bg-background border border-border rounded-xl shadow-2xl w-full flex flex-col max-h-[90vh] transition-[max-width] duration-200 ${
+          itemCount > 0 ? "max-w-[80vw]" : "max-w-[50vw]"
+        }`}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-center justify-between px-6 py-4 border-b border-border">
+          <h2 className="text-lg font-semibold text-foreground">{title}</h2>
+          <button
+            onClick={handleClose}
+            disabled={isUploading}
+            aria-label="Close"
+            className="w-8 h-8 flex items-center justify-center rounded-lg text-muted-foreground hover:text-foreground hover:bg-muted transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            <svg
+              className="w-5 h-5"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              strokeWidth={2}
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M6 18L18 6M6 6l12 12"
+              />
+            </svg>
+          </button>
+        </div>
+
+        <div className="flex-1 overflow-y-auto px-6 py-5 space-y-5">
+          <div>
+            <div className="flex items-center justify-between mb-3">
+              <label className="block text-sm font-medium text-foreground">
+                Upload CSV
+              </label>
+              <button
+                type="button"
+                onClick={downloadSample}
+                className="h-9 px-3 rounded-md text-xs font-medium border border-border bg-muted/40 text-foreground hover:bg-muted hover:border-foreground/30 transition-colors cursor-pointer flex items-center gap-1.5 shadow-sm"
+              >
+                <svg
+                  className="w-4 h-4"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                  strokeWidth={2}
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5M16.5 12L12 16.5m0 0L7.5 12m4.5 4.5V3"
+                  />
+                </svg>
+                Download sample CSV
+              </button>
+            </div>
+
+            {itemCount > 0 && (
+              <FormatHelpToggle
+                open={formatHelpOpen}
+                onToggle={() => setFormatHelpOpen((o) => !o)}
+              />
+            )}
+
+            {formatHelpOpen && (
+              <div className="text-xs text-muted-foreground mb-3 leading-relaxed space-y-2">
+                {helpContent}
+              </div>
+            )}
+
+            {formatHelpOpen && (
+              <div className="mb-3 flex items-start gap-2 rounded-md border border-blue-500/30 bg-blue-500/10 px-3 py-2 text-xs text-foreground">
+                <svg
+                  className="w-4 h-4 mt-0.5 shrink-0 text-blue-500"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                  strokeWidth={2}
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    d="M13 16h-1v-4h-1m1-4h.01M12 2a10 10 0 100 20 10 10 0 000-20z"
+                  />
+                </svg>
+                <span>
+                  <span className="font-semibold">Tip:</span>{" "}
+                  <button
+                    type="button"
+                    onClick={downloadSample}
+                    className="underline underline-offset-2 hover:opacity-80 transition-opacity cursor-pointer"
+                  >
+                    download the sample CSV
+                  </button>{" "}
+                  and edit it as a starting point
+                </span>
+              </div>
+            )}
+
+            <CsvDropzone csvFile={csvFile} onFile={onFile} onClear={onClear} />
+
+            {parseError && (
+              <p className="text-xs text-red-500 mt-3">{parseError}</p>
+            )}
+          </div>
+
+          {itemCount > 0 && itemsPreview}
+
+          {uploadError && (
+            <div className="rounded-md border border-red-500/30 bg-red-500/10 p-3 text-sm text-red-500">
+              {uploadError}
+            </div>
+          )}
+        </div>
+
+        <div className="flex items-center justify-end gap-3 px-6 py-4 border-t border-border">
+          <button
+            onClick={handleClose}
+            disabled={isUploading}
+            className="h-10 px-4 rounded-md text-sm font-medium border border-border bg-background hover:bg-muted/50 transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={onUpload}
+            disabled={itemCount === 0 || isUploading || !!parseError}
+            className="h-10 px-4 rounded-md text-sm font-medium bg-foreground text-background hover:opacity-90 transition-opacity cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {isUploading
+              ? "Uploading"
+              : itemCount > 1
+                ? `Upload ${itemCount} items`
+                : "Upload item"}
+          </button>
+        </div>
+      </div>
     </div>
   );
 }

--- a/src/lib/exportTestResults.ts
+++ b/src/lib/exportTestResults.ts
@@ -66,7 +66,7 @@ function isToolCallTest(
 // Multi-line text dump of the agent's tool calls for tool-call tests.
 // One block per call (`Tool: <name>` + `Arguments: <json>`), blocks
 // separated by a blank line. Routes through `normalizeToolCall` so the
-// historical `{name, arguments}` / `{tool, arguments}` / `{function: …}`
+// historical `{name, arguments}` / `{tool, arguments}` / `{function: ...}`
 // shapes all render consistently.
 function toolCallsCell(output: TestCaseOutput | null | undefined): string {
   if (!output?.tool_calls || output.tool_calls.length === 0) return "";
@@ -82,7 +82,7 @@ function toolCallsCell(output: TestCaseOutput | null | undefined): string {
 
 // Multi-line text dump of the per-evaluator verdicts for response tests.
 // One block per evaluator: `<name>: <verdict>`, optional `Variables:` list
-// (one indented line per `{{var}}: <value>`), and `Reasoning: …` line.
+// (one indented line per `{{var}}: <value>`), and `Reasoning: ...` line.
 // Falls back to the top-level `reasoning` string for legacy response
 // snapshots that pre-date the `judge_results` rollout (rendered as a
 // single un-keyed reasoning block).


### PR DESCRIPTION
Fix #59 
Fix #60 
Fix #61 

## Summary

- CSV format guidelines now download as a styled PDF (jsPDF) instead of plain text, with pretty-printed `conversation_history` examples (one turn per line). Applies to LLM/Simulation/STT labelling-item dialogs and the next-reply/tool-call tests modal.
- Reworked the human-annotation bulk upload flow:
  - Evaluator value cells are now **required** (CSV guidelines + parser updated).
  - Parsed-items preview shows every annotation column (value + reasoning) per evaluator, in a single sticky-header `overflow:auto` table so both axes scroll together.
  - Empty preview cells render blank instead of "(empty)".
  - Annotator picker uses `SingleSelectPicker` at full width.
  - The whole upload section (guidelines button, dropzone, tip, items preview, footer Upload) stays hidden until an annotator is selected when "upload annotations" is on.
- Fixed bulk-annotation API: send `{ value, reasoning }` for every `output_type`. The binary branch previously sent `{ pass, reasoning }`, which the endpoint now rejects with 400.
- Refresh `/summary` after a bulk upload **only when annotations were uploaded**, so the per-item "View results" button enables right away without an extra round-trip on plain item uploads.
- Copy cleanup across all guidelines: dropped "OpenAI's chat format", the JSON quoting warning, and the `REQUIRED COLUMNS` / `EVALUATOR VARIABLE COLUMNS` / `ANNOTATION COLUMNS` headings; `conversation_history` description is consistent between next-reply and tool-call docs.

## Test plan

- [ ] Open each bulk-upload dialog (LLM, Simulation, STT items + Next-reply, Tool-call tests) and click "Download CSV format guidelines" — verify PDF renders with title, intro, monospace column headers, code blocks, and pretty-printed JSON examples.
- [ ] On a labelling task with linked evaluators, toggle "upload annotations" → Yes; confirm the rest of the dialog stays hidden until an annotator is picked from the dropdown.
- [ ] Upload a CSV with all evaluator columns filled — preview shows value + reasoning columns per evaluator and scrolls as one unit.
- [ ] Upload a CSV with a missing value cell — parser reports `Row N: missing value for "<column>"` and blocks the upload.
- [ ] Bulk upload with annotations on a binary evaluator → backend accepts (no 400 on the `value` key) and the per-item "View results" button enables without a manual refresh.
- [ ] Bulk upload **without** annotations → no extra `/summary` call fires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)