### PR TITLE
Bulk upload: annotated-check highlighting + overview table column fix

### DIFF
--- a/src/app/evaluators/[uuid]/page.tsx
+++ b/src/app/evaluators/[uuid]/page.tsx
@@ -474,7 +474,7 @@ export default function EvaluatorDetailPage() {
       <div className="space-y-4 md:space-y-6 py-4 md:py-6">
         {/* Back */}
         <button
-          onClick={() => router.push("/evaluators")}
+          onClick={() => router.back()}
           className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors cursor-pointer"
         >
           <svg
@@ -521,7 +521,7 @@ export default function EvaluatorDetailPage() {
               {error ?? "Evaluator not found"}
             </p>
             <button
-              onClick={() => router.push("/evaluators")}
+              onClick={() => router.back()}
               className="text-sm md:text-base text-muted-foreground hover:text-foreground transition-colors cursor-pointer"
             >
               Back to evaluators

--- a/src/app/human-labelling/jobs/[token]/page.tsx
+++ b/src/app/human-labelling/jobs/[token]/page.tsx
@@ -109,7 +109,7 @@ export default function AdminAnnotateJobPage() {
           </>
         )}
 
-        <div className="border border-border rounded-xl overflow-hidden">
+        <div className="border border-border rounded-xl [overflow:clip]">
           <AnnotationJobView
             token={token}
             mode="admin"

--- a/src/app/human-labelling/tasks/[uuid]/evaluator-runs/[runUuid]/page.tsx
+++ b/src/app/human-labelling/tasks/[uuid]/evaluator-runs/[runUuid]/page.tsx
@@ -569,8 +569,8 @@ export default function EvaluatorRunDetailPage() {
               versionLabels={versionLabels}
             />
 
-            <div className="border border-border rounded-xl overflow-hidden">
-              <div className="flex flex-col flex-1 min-h-0">
+            <div className="border border-border rounded-xl [overflow:clip]">
+              <div className="flex flex-col">
                 <header className="border-b border-border px-4 md:px-6 py-3 flex items-center justify-center gap-2">
                   <button
                     onClick={() =>
@@ -596,9 +596,10 @@ export default function EvaluatorRunDetailPage() {
                   </button>
                 </header>
 
-                <div className="flex flex-col md:flex-row min-h-0">
-                  <aside className="w-full md:w-20 border-b md:border-b-0 md:border-r border-border bg-muted/20 overflow-y-auto">
-                    <div className="p-2 md:p-3 grid grid-cols-8 md:grid-cols-1 gap-2">
+                <div className="flex flex-col md:flex-row">
+                  {/* Mobile: horizontal scrolling strip */}
+                  <div className="md:hidden w-full max-h-32 border-b border-border bg-muted/20 overflow-y-auto">
+                    <div className="p-2 grid grid-cols-8 gap-2">
                       {itemsForRun.map((it, i) => {
                         const done = itemDone(it.uuid);
                         const isCurrent = i === safeIndex;
@@ -620,9 +621,36 @@ export default function EvaluatorRunDetailPage() {
                         );
                       })}
                     </div>
-                  </aside>
+                  </div>
+                  {/* Desktop: sidebar whose height is defined by the main pane, not its own content */}
+                  <div className="hidden md:block relative w-20 flex-shrink-0 border-r border-border bg-muted/20">
+                    <div className="absolute inset-0 overflow-y-auto">
+                      <div className="p-3 grid grid-cols-1 gap-2">
+                        {itemsForRun.map((it, i) => {
+                          const done = itemDone(it.uuid);
+                          const isCurrent = i === safeIndex;
+                          return (
+                            <button
+                              key={it.uuid}
+                              onClick={() => setCurrentIndex(i)}
+                              title={`Item ${i + 1}${done ? " (completed)" : ""}`}
+                              className={`h-10 w-full rounded-md border text-sm font-medium transition-colors cursor-pointer flex items-center justify-center ${
+                                isCurrent
+                                  ? "border-foreground bg-foreground text-background"
+                                  : done
+                                    ? "border-blue-200 bg-blue-100 text-blue-700 dark:border-blue-500/30 dark:bg-blue-500/20 dark:text-blue-400"
+                                    : "border-border bg-background text-foreground hover:bg-muted/50"
+                              }`}
+                            >
+                              {i + 1}
+                            </button>
+                          );
+                        })}
+                      </div>
+                    </div>
+                  </div>
 
-                  <main className="flex-1 overflow-y-auto">
+                  <main className="flex-1">
                     {!currentItem ? (
                       <div className="flex items-center justify-center h-full p-8 text-sm text-muted-foreground">
                         No items in this run.
@@ -1105,7 +1133,7 @@ function HumanAgreementSummary({
           annotations on the same items
         </p>
       </div>
-      <div className="flex flex-wrap items-stretch gap-3">
+      <div className="flex items-stretch gap-3 overflow-x-auto pb-1">
         {evaluators.map((ev) => {
           const row = agreementById.get(ev.evaluator_id);
           if (!row) return null;

--- a/src/app/human-labelling/tasks/[uuid]/page.tsx
+++ b/src/app/human-labelling/tasks/[uuid]/page.tsx
@@ -500,6 +500,7 @@ function ItemRowActions({
   onDelete,
   onViewResults,
   onLabel,
+  onEdit,
   onEvaluate,
   isResultsOpen,
   viewResultsDisabled,
@@ -509,6 +510,7 @@ function ItemRowActions({
   onDelete: (uuid: string) => void | Promise<void>;
   onViewResults: (uuid: string) => void;
   onLabel?: (uuid: string) => void;
+  onEdit?: (uuid: string) => void;
   onEvaluate?: (uuid: string) => void;
   isResultsOpen?: boolean;
   viewResultsDisabled?: boolean;
@@ -527,6 +529,16 @@ function ItemRowActions({
           className="h-8 px-3 rounded-md text-sm font-medium bg-foreground text-background hover:opacity-90 transition-opacity cursor-pointer"
         >
           Label
+        </button>
+      )}
+      {onEdit && (
+        <button
+          type="button"
+          onClick={() => onEdit(itemUuid)}
+          aria-label="Edit"
+          className="h-8 px-3 rounded-md text-sm font-medium border border-border bg-background hover:bg-muted/50 transition-colors cursor-pointer"
+        >
+          Edit
         </button>
       )}
       {onEvaluate && (
@@ -810,6 +822,7 @@ function LabellingTaskPageInner() {
   const [deleteSelectedOpen, setDeleteSelectedOpen] = useState(false);
   const [deletingSelected, setDeletingSelected] = useState(false);
   const [editSttItemsOpen, setEditSttItemsOpen] = useState(false);
+  const [editSttSingleItemUuid, setEditSttSingleItemUuid] = useState<string | null>(null);
   const [editLlmItemUuid, setEditLlmItemUuid] = useState<string | null>(null);
   const [editLlmItemName, setEditLlmItemName] = useState("");
   const [savingLlmItem, setSavingLlmItem] = useState(false);
@@ -1887,17 +1900,17 @@ function LabellingTaskPageInner() {
                   const annotators = taskSummary.annotators ?? [];
                   const evaluators = taskSummary.evaluators ?? [];
                   const summaryTaskType = taskSummary.task_type;
-                  const itemColumns =
-                    summaryTaskType === "stt"
-                      ? [
-                          { key: "ref", label: "Reference transcript" },
-                          { key: "pred", label: "Predicted transcript" },
-                        ]
-                      : [{ key: "name", label: "Name" }];
-                  const itemColTpl = itemColumns
-                    .map(() => "minmax(180px,1.4fr)")
-                    .join(" ");
-                  const evalColTpl = "minmax(180px,1fr) 170px 170px 140px";
+                  const itemColumns = [{ key: "name", label: "Name" }];
+                  const itemColTpl = "200px";
+                  const longestEvalName =
+                    evaluators.length > 0
+                      ? Math.max(...evaluators.map((e) => e.name.length))
+                      : 0;
+                  const evalNameColPx = Math.max(
+                    120,
+                    Math.ceil(longestEvalName * 6.5 + 60),
+                  );
+                  const evalColTpl = `${evalNameColPx}px 170px 170px 140px`;
                   const annotatorColTpl =
                     annotators.length > 0
                       ? annotators.map(() => "120px").join(" ")
@@ -1910,17 +1923,6 @@ function LabellingTaskPageInner() {
                     payload: Record<string, unknown> | null,
                   ): string[] => {
                     const p = payload ?? {};
-                    if (summaryTaskType === "stt") {
-                      const ref =
-                        typeof p.reference_transcript === "string"
-                          ? (p.reference_transcript as string)
-                          : "";
-                      const pred =
-                        typeof p.predicted_transcript === "string"
-                          ? (p.predicted_transcript as string)
-                          : "";
-                      return [ref || "—", pred || "—"];
-                    }
                     const name =
                       typeof p.name === "string" ? (p.name as string) : "";
                     return [name || "—"];
@@ -2284,14 +2286,6 @@ function LabellingTaskPageInner() {
                     >
                       Clear
                     </button>
-                    {taskType === "stt" && (
-                      <button
-                        onClick={() => setEditSttItemsOpen(true)}
-                        className="h-8 px-3 rounded-md text-sm font-medium border border-border bg-background hover:bg-muted/50 transition-colors cursor-pointer"
-                      >
-                        Edit
-                      </button>
-                    )}
                     <button
                       onClick={() => setDeleteSelectedOpen(true)}
                       className="h-8 px-3 rounded-md text-sm font-medium border border-red-500/30 bg-red-500/10 text-red-500 hover:bg-red-500/20 transition-colors cursor-pointer"
@@ -2348,7 +2342,7 @@ function LabellingTaskPageInner() {
 
               {taskType === "stt" ? (
                 <div className="border border-border rounded-xl overflow-hidden">
-                  <div className="grid grid-cols-[40px_minmax(0,1fr)_minmax(0,1fr)_440px] gap-4 px-4 py-2 border-b border-border bg-muted/30 items-center">
+                  <div className="grid grid-cols-[40px_minmax(0,0.6fr)_minmax(0,1fr)_minmax(0,1fr)_440px] gap-4 px-4 py-2 border-b border-border bg-muted/30 items-center">
                     <input
                       type="checkbox"
                       checked={allSelected}
@@ -2359,6 +2353,9 @@ function LabellingTaskPageInner() {
                       aria-label="Select all"
                       className="w-4 h-4 cursor-pointer accent-foreground"
                     />
+                    <div className="text-sm font-medium text-muted-foreground">
+                      Name
+                    </div>
                     <div className="text-sm font-medium text-muted-foreground">
                       Reference transcript
                     </div>
@@ -2371,6 +2368,7 @@ function LabellingTaskPageInner() {
                   </div>
                   {items.map((item) => {
                     const p = (item.payload ?? {}) as Record<string, unknown>;
+                    const name = typeof p.name === "string" ? p.name : "";
                     const ref =
                       typeof p.reference_transcript === "string"
                         ? p.reference_transcript
@@ -2384,7 +2382,7 @@ function LabellingTaskPageInner() {
                     return (
                       <Fragment key={item.uuid}>
                         <div
-                          className={`grid grid-cols-[40px_minmax(0,1fr)_minmax(0,1fr)_440px] gap-4 px-4 py-3 border-b border-border last:border-b-0 transition-colors items-center ${
+                          className={`grid grid-cols-[40px_minmax(0,0.6fr)_minmax(0,1fr)_minmax(0,1fr)_440px] gap-4 px-4 py-3 border-b border-border last:border-b-0 transition-colors items-center ${
                             isSelected ? "bg-muted/30" : "hover:bg-muted/20"
                           }`}
                         >
@@ -2395,6 +2393,9 @@ function LabellingTaskPageInner() {
                             aria-label={`Select item ${item.id}`}
                             className="w-4 h-4 cursor-pointer accent-foreground"
                           />
+                          <p className="text-sm text-foreground line-clamp-2">
+                            {name || "—"}
+                          </p>
                           <p className="text-sm text-foreground line-clamp-2">
                             {ref || "—"}
                           </p>
@@ -2415,6 +2416,10 @@ function LabellingTaskPageInner() {
                               } else {
                                 toggleItem(uuid);
                               }
+                            }}
+                            onEdit={(uuid) => {
+                              setEditSttSingleItemUuid(uuid);
+                              setEditSttItemsOpen(true);
                             }}
                             onEvaluate={(uuid) => {
                               if (items.length === 1) {
@@ -2496,6 +2501,7 @@ function LabellingTaskPageInner() {
                                 toggleItem(uuid);
                               }
                             }}
+                            onEdit={(uuid) => setEditLlmItemUuid(uuid)}
                             onEvaluate={(uuid) => {
                               if (items.length === 1) {
                                 setSelectedItemIds(new Set([uuid]));
@@ -2896,6 +2902,7 @@ function LabellingTaskPageInner() {
             body: {
               items: rows.map((r) => ({
                 payload: {
+                  ...(r.name ? { name: r.name } : {}),
                   reference_transcript: r.actual_transcript,
                   predicted_transcript: r.predicted_transcript,
                 },
@@ -2912,11 +2919,16 @@ function LabellingTaskPageInner() {
         isOpen={editSttItemsOpen}
         mode="edit"
         initialRows={items
-          .filter((it) => selectedItemIds.has(it.uuid))
+          .filter((it) =>
+            editSttSingleItemUuid
+              ? it.uuid === editSttSingleItemUuid
+              : selectedItemIds.has(it.uuid),
+          )
           .map((it) => {
             const p = (it.payload ?? {}) as Record<string, unknown>;
             return {
               uuid: it.uuid,
+              name: typeof p.name === "string" ? p.name : "",
               actual:
                 typeof p.reference_transcript === "string"
                   ? p.reference_transcript
@@ -2927,7 +2939,7 @@ function LabellingTaskPageInner() {
                   : "",
             };
           })}
-        onClose={() => setEditSttItemsOpen(false)}
+        onClose={() => { setEditSttItemsOpen(false); setEditSttSingleItemUuid(null); }}
         onSubmit={async (rows) => {
           if (!accessToken) return;
           await apiClient<{ updated_count: number }>(
@@ -2941,6 +2953,7 @@ function LabellingTaskPageInner() {
                   .map((r) => ({
                     uuid: r.uuid,
                     payload: {
+                      ...(r.name ? { name: r.name } : {}),
                       reference_transcript: r.actual_transcript,
                       predicted_transcript: r.predicted_transcript,
                     },
@@ -2950,6 +2963,7 @@ function LabellingTaskPageInner() {
           );
           await fetchTask();
           setEditSttItemsOpen(false);
+          setEditSttSingleItemUuid(null);
           setSelectedItemIds(new Set());
         }}
       />

--- a/src/app/human-labelling/tasks/[uuid]/page.tsx
+++ b/src/app/human-labelling/tasks/[uuid]/page.tsx
@@ -1844,7 +1844,7 @@ function LabellingTaskPageInner() {
                     closely each evaluator aligns with humans
                   </p>
                 </div>
-                <div className="flex flex-wrap items-stretch gap-3">
+                <div className="flex items-stretch gap-3 overflow-x-auto pb-1">
                   <AgreementStatCard
                     staticPillText="Annotator agreement"
                     value={

--- a/src/app/human-labelling/tasks/[uuid]/page.tsx
+++ b/src/app/human-labelling/tasks/[uuid]/page.tsx
@@ -1899,7 +1899,6 @@ function LabellingTaskPageInner() {
               : (() => {
                   const annotators = taskSummary.annotators ?? [];
                   const evaluators = taskSummary.evaluators ?? [];
-                  const summaryTaskType = taskSummary.task_type;
                   const itemColumns = [{ key: "name", label: "Name" }];
                   const itemColTpl = "200px";
                   const longestEvalName =

--- a/src/components/evaluators/VersionCard.tsx
+++ b/src/components/evaluators/VersionCard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 type ScaleEntry = {
   value: boolean | number | string;
@@ -46,6 +46,10 @@ export function VersionCard({
   const [promptVisible, setPromptVisible] = useState(isLive || isDefault);
   const [copied, setCopied] = useState(false);
 
+  useEffect(() => {
+    setPromptVisible(isLive || isDefault);
+  }, [isLive, isDefault]);
+
   function handleCopy() {
     navigator.clipboard.writeText(version.system_prompt).then(() => {
       setCopied(true);
@@ -62,9 +66,9 @@ export function VersionCard({
       }
     >
       <div className="flex items-start justify-between gap-3 flex-wrap">
-        <div className="flex items-center gap-2 flex-wrap min-w-0">
+        <div className="flex flex-col gap-1 min-w-0">
           {!isDefault && (
-            <>
+            <div className="flex items-center gap-2 flex-wrap">
               <span className="inline-flex items-center px-2 py-0.5 rounded-md text-xs font-semibold bg-muted text-foreground">
                 v{version.version_number}
               </span>
@@ -73,14 +77,14 @@ export function VersionCard({
                   Current
                 </span>
               )}
-            </>
+            </div>
           )}
           <code className="text-xs md:text-sm font-mono text-muted-foreground truncate">
             {version.judge_model}
           </code>
         </div>
         {!isDefault && (
-          <div className="flex items-center gap-3 flex-shrink-0">
+          <div className="flex items-center gap-2 flex-shrink-0">
             {!isLive && (
               <button
                 onClick={() => onSetLive(version.uuid)}
@@ -90,40 +94,38 @@ export function VersionCard({
                 {isSettingLive ? "Marking..." : "Mark as current"}
               </button>
             )}
-            <span className="text-xs text-muted-foreground whitespace-nowrap">
-              {formatDateTime(version.created_at)}
-            </span>
+            <button
+              onClick={() => setPromptVisible((v) => !v)}
+              className="h-9 px-3 rounded-md text-xs md:text-sm font-semibold border border-violet-500/40 bg-violet-500/10 text-violet-700 hover:bg-violet-500/20 dark:text-violet-300 dark:border-violet-400/40 dark:bg-violet-500/15 dark:hover:bg-violet-500/25 transition-colors cursor-pointer flex items-center gap-1.5"
+            >
+              {promptVisible ? (
+                <>
+                  <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M3.98 8.223A10.477 10.477 0 001.934 12C3.226 16.338 7.244 19.5 12 19.5c.993 0 1.953-.138 2.863-.395M6.228 6.228A10.45 10.45 0 0112 4.5c4.756 0 8.773 3.162 10.065 7.498a10.523 10.523 0 01-4.293 5.774M6.228 6.228L3 3m3.228 3.228l3.65 3.65m7.894 7.894L21 21m-3.228-3.228l-3.65-3.65m0 0a3 3 0 10-4.243-4.243m4.242 4.242L9.88 9.88" />
+                  </svg>
+                  Hide prompt
+                </>
+              ) : (
+                <>
+                  <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M2.036 12.322a1.012 1.012 0 010-.639C3.423 7.51 7.36 4.5 12 4.5c4.638 0 8.573 3.007 9.963 7.178.07.207.07.431 0 .639C20.577 16.49 16.64 19.5 12 19.5c-4.638 0-8.573-3.007-9.963-7.178z" />
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+                  </svg>
+                  Show prompt
+                </>
+              )}
+            </button>
           </div>
         )}
       </div>
 
-      <div className="space-y-2">
+      {promptVisible && <div className="space-y-2">
         <div className="flex items-center justify-between gap-2">
-          <button
-            onClick={() => setPromptVisible((v) => !v)}
-            className="flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors cursor-pointer"
-          >
-            {promptVisible ? (
-              <>
-                <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-                  <path strokeLinecap="round" strokeLinejoin="round" d="M3.98 8.223A10.477 10.477 0 001.934 12C3.226 16.338 7.244 19.5 12 19.5c.993 0 1.953-.138 2.863-.395M6.228 6.228A10.45 10.45 0 0112 4.5c4.756 0 8.773 3.162 10.065 7.498a10.523 10.523 0 01-4.293 5.774M6.228 6.228L3 3m3.228 3.228l3.65 3.65m7.894 7.894L21 21m-3.228-3.228l-3.65-3.65m0 0a3 3 0 10-4.243-4.243m4.242 4.242L9.88 9.88" />
-                </svg>
-                Hide prompt
-              </>
-            ) : (
-              <>
-                <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-                  <path strokeLinecap="round" strokeLinejoin="round" d="M2.036 12.322a1.012 1.012 0 010-.639C3.423 7.51 7.36 4.5 12 4.5c4.638 0 8.573 3.007 9.963 7.178.07.207.07.431 0 .639C20.577 16.49 16.64 19.5 12 19.5c-4.638 0-8.573-3.007-9.963-7.178z" />
-                  <path strokeLinecap="round" strokeLinejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
-                </svg>
-                View prompt
-              </>
-            )}
-          </button>
-          {promptVisible && (
+          <span className="text-xs font-medium text-muted-foreground uppercase tracking-wide">Prompt</span>
+          {(
             <button
               onClick={handleCopy}
-              className="flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors cursor-pointer"
+              className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-md text-xs font-medium border border-border bg-muted/40 text-foreground hover:bg-muted transition-colors cursor-pointer"
             >
               {copied ? (
                 <>
@@ -143,12 +145,10 @@ export function VersionCard({
             </button>
           )}
         </div>
-        {promptVisible && (
-          <pre className="border border-border rounded-md p-3 md:p-4 bg-muted/10 text-sm text-foreground whitespace-pre-wrap font-mono leading-relaxed overflow-x-auto">
-            {version.system_prompt}
-          </pre>
-        )}
-      </div>
+        <pre className="border border-border rounded-md p-3 md:p-4 bg-muted/10 text-sm text-foreground whitespace-pre-wrap font-mono leading-relaxed overflow-x-auto">
+          {version.system_prompt}
+        </pre>
+      </div>}
 
       {version.variables?.length ? (
         <div className="space-y-2">

--- a/src/components/evaluators/VersionCard.tsx
+++ b/src/components/evaluators/VersionCard.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { useState } from "react";
+
 type ScaleEntry = {
   value: boolean | number | string;
   name: string;
@@ -41,6 +43,16 @@ export function VersionCard({
   onSetLive,
   formatDateTime,
 }: VersionCardProps) {
+  const [promptVisible, setPromptVisible] = useState(isLive || isDefault);
+  const [copied, setCopied] = useState(false);
+
+  function handleCopy() {
+    navigator.clipboard.writeText(version.system_prompt).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    });
+  }
+
   return (
     <div
       className={
@@ -85,9 +97,58 @@ export function VersionCard({
         )}
       </div>
 
-      <pre className="border border-border rounded-md p-3 md:p-4 bg-muted/10 text-sm text-foreground whitespace-pre-wrap font-mono leading-relaxed overflow-x-auto">
-        {version.system_prompt}
-      </pre>
+      <div className="space-y-2">
+        <div className="flex items-center justify-between gap-2">
+          <button
+            onClick={() => setPromptVisible((v) => !v)}
+            className="flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors cursor-pointer"
+          >
+            {promptVisible ? (
+              <>
+                <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M3.98 8.223A10.477 10.477 0 001.934 12C3.226 16.338 7.244 19.5 12 19.5c.993 0 1.953-.138 2.863-.395M6.228 6.228A10.45 10.45 0 0112 4.5c4.756 0 8.773 3.162 10.065 7.498a10.523 10.523 0 01-4.293 5.774M6.228 6.228L3 3m3.228 3.228l3.65 3.65m7.894 7.894L21 21m-3.228-3.228l-3.65-3.65m0 0a3 3 0 10-4.243-4.243m4.242 4.242L9.88 9.88" />
+                </svg>
+                Hide prompt
+              </>
+            ) : (
+              <>
+                <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M2.036 12.322a1.012 1.012 0 010-.639C3.423 7.51 7.36 4.5 12 4.5c4.638 0 8.573 3.007 9.963 7.178.07.207.07.431 0 .639C20.577 16.49 16.64 19.5 12 19.5c-4.638 0-8.573-3.007-9.963-7.178z" />
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+                </svg>
+                View prompt
+              </>
+            )}
+          </button>
+          {promptVisible && (
+            <button
+              onClick={handleCopy}
+              className="flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors cursor-pointer"
+            >
+              {copied ? (
+                <>
+                  <svg className="w-3.5 h-3.5 text-emerald-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M4.5 12.75l6 6 9-13.5" />
+                  </svg>
+                  <span className="text-emerald-500">Copied</span>
+                </>
+              ) : (
+                <>
+                  <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M15.666 3.888A2.25 2.25 0 0013.5 2.25h-3c-1.03 0-1.9.693-2.166 1.638m7.332 0c.055.194.084.4.084.612v0a.75.75 0 01-.75.75H9a.75.75 0 01-.75-.75v0c0-.212.03-.418.084-.612m7.332 0c.646.049 1.288.11 1.927.184 1.1.128 1.907 1.077 1.907 2.185V19.5a2.25 2.25 0 01-2.25 2.25H6.75A2.25 2.25 0 014.5 19.5V6.257c0-1.108.806-2.057 1.907-2.185a48.208 48.208 0 011.927-.184" />
+                  </svg>
+                  Copy
+                </>
+              )}
+            </button>
+          )}
+        </div>
+        {promptVisible && (
+          <pre className="border border-border rounded-md p-3 md:p-4 bg-muted/10 text-sm text-foreground whitespace-pre-wrap font-mono leading-relaxed overflow-x-auto">
+            {version.system_prompt}
+          </pre>
+        )}
+      </div>
 
       {version.variables?.length ? (
         <div className="space-y-2">

--- a/src/components/human-labelling/AddSttItemsDialog.tsx
+++ b/src/components/human-labelling/AddSttItemsDialog.tsx
@@ -6,12 +6,14 @@ import { useHideFloatingButton } from "@/components/AppLayout";
 type SttRowDraft = {
   id: string;
   uuid?: string; // present in edit mode; undefined for new rows
+  name: string;
   actual: string;
   predicted: string;
 };
 
 export type SttItemRowSubmission = {
   uuid?: string;
+  name: string;
   actual_transcript: string;
   predicted_transcript: string;
 };
@@ -19,16 +21,69 @@ export type SttItemRowSubmission = {
 type AddSttItemsDialogProps = {
   isOpen: boolean;
   mode?: "add" | "edit";
-  initialRows?: { uuid: string; actual: string; predicted: string }[];
+  initialRows?: {
+    uuid: string;
+    name: string;
+    actual: string;
+    predicted: string;
+  }[];
   onClose: () => void;
   onSubmit: (rows: SttItemRowSubmission[]) => Promise<void> | void;
 };
+
+function humaniseDetailObject(detail: {
+  code?: string;
+  conflicting_names?: string[];
+}): string | null {
+  const names = detail.conflicting_names ?? [];
+  const fmt =
+    names.length === 0
+      ? null
+      : names.length === 1
+        ? `"${names[0]}"`
+        : names.map((n) => `"${n}"`).join(", ");
+
+  if (detail.code === "ITEM_NAME_CONFLICT") {
+    return fmt
+      ? names.length === 1
+        ? `An item named ${fmt} already exists in this task.`
+        : `Items with these names already exist in this task: ${fmt}.`
+      : "One or more item names already exist in this task.";
+  }
+  if (detail.code === "ITEM_NAME_DUPLICATE_IN_REQUEST") {
+    return fmt
+      ? names.length === 1
+        ? `Duplicate name in your request: ${fmt}.`
+        : `Duplicate names in your request: ${fmt}.`
+      : "Your request contains duplicate item names.";
+  }
+  return null;
+}
+
+function extractApiError(err: unknown, fallback: string): string {
+  if (!(err instanceof Error)) return fallback;
+  const m = err.message.match(/Request failed: \d+ - (.+)$/s);
+  if (m) {
+    try {
+      const parsed = JSON.parse(m[1]);
+      if (parsed?.detail && typeof parsed.detail === "object") {
+        const msg = humaniseDetailObject(parsed.detail);
+        if (msg) return msg;
+      }
+    } catch {
+      /* ignore */
+    }
+    return m[1];
+  }
+  return err.message || fallback;
+}
 
 const newRow = (): SttRowDraft => ({
   id:
     typeof crypto !== "undefined" && "randomUUID" in crypto
       ? crypto.randomUUID()
       : `${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  name: "",
   actual: "",
   predicted: "",
 });
@@ -49,6 +104,7 @@ export function AddSttItemsDialog({
       ? initialRows.map((r) => ({
           id: r.uuid,
           uuid: r.uuid,
+          name: r.name,
           actual: r.actual,
           predicted: r.predicted,
         }))
@@ -66,6 +122,7 @@ export function AddSttItemsDialog({
           ? initialRows.map((r) => ({
               id: r.uuid,
               uuid: r.uuid,
+              name: r.name,
               actual: r.actual,
               predicted: r.predicted,
             }))
@@ -94,10 +151,11 @@ export function AddSttItemsDialog({
   const validRows: SttItemRowSubmission[] = rows
     .map((r) => ({
       uuid: r.uuid,
+      name: r.name.trim(),
       actual_transcript: r.actual.trim(),
       predicted_transcript: r.predicted.trim(),
     }))
-    .filter((r) => r.actual_transcript && r.predicted_transcript);
+    .filter((r) => r.name && r.actual_transcript && r.predicted_transcript);
 
   const handleClose = () => {
     if (!submitting) {
@@ -114,11 +172,10 @@ export function AddSttItemsDialog({
       await onSubmit(validRows);
     } catch (err) {
       setError(
-        err instanceof Error
-          ? err.message
-          : isEdit
-            ? "Failed to save items"
-            : "Failed to add items",
+        extractApiError(
+          err,
+          isEdit ? "Failed to save items" : "Failed to add items",
+        ),
       );
     } finally {
       setSubmitting(false);
@@ -131,7 +188,7 @@ export function AddSttItemsDialog({
       onClick={handleClose}
     >
       <div
-        className="bg-background border border-border rounded-xl w-full max-w-3xl shadow-2xl flex flex-col max-h-[90vh]"
+        className="bg-background border border-border rounded-xl w-full max-w-4xl shadow-2xl flex flex-col max-h-[90vh]"
         onClick={(e) => e.stopPropagation()}
       >
         <div className="flex items-start justify-between gap-3 px-5 md:px-6 py-4 border-b border-border">
@@ -141,7 +198,7 @@ export function AddSttItemsDialog({
             </h2>
             <p className="text-xs md:text-sm text-muted-foreground mt-1">
               {isEdit
-                ? "Update the reference and predicted transcripts for each row"
+                ? "Update the name, reference, and predicted transcripts for each row"
                 : "Annotators will compare the predicted transcript against the reference"}
             </p>
           </div>
@@ -168,7 +225,10 @@ export function AddSttItemsDialog({
 
         <div className="flex-1 overflow-y-auto p-4 md:p-6 space-y-2">
           {/* Column headers (shown once) */}
-          <div className="grid grid-cols-[1fr_1fr_28px] gap-2 px-1 pb-1">
+          <div className="grid grid-cols-[1fr_2fr_2fr_28px] gap-2 px-1 pb-1">
+            <div className="text-xs font-medium text-muted-foreground">
+              Name
+            </div>
             <div className="text-xs font-medium text-muted-foreground">
               Reference transcript
             </div>
@@ -181,8 +241,16 @@ export function AddSttItemsDialog({
           {rows.map((row, idx) => (
             <div
               key={row.id}
-              className="grid grid-cols-[1fr_1fr_28px] gap-2 items-center"
+              className="grid grid-cols-[1fr_2fr_2fr_28px] gap-2 items-center"
             >
+              <input
+                type="text"
+                value={row.name}
+                onChange={(e) => updateRow(row.id, { name: e.target.value })}
+                placeholder="e.g. Clip 1"
+                disabled={submitting}
+                className="w-full h-9 px-3 rounded-md text-sm border border-border bg-background text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-accent disabled:opacity-50"
+              />
               <input
                 type="text"
                 value={row.actual}

--- a/src/components/human-labelling/AddSttItemsDialog.tsx
+++ b/src/components/human-labelling/AddSttItemsDialog.tsx
@@ -62,7 +62,7 @@ function humaniseDetailObject(detail: {
 
 function extractApiError(err: unknown, fallback: string): string {
   if (!(err instanceof Error)) return fallback;
-  const m = err.message.match(/Request failed: \d+ - (.+)$/s);
+  const m = err.message.match(/Request failed: \d+ - ([\s\S]+)$/);
   if (m) {
     try {
       const parsed = JSON.parse(m[1]);

--- a/src/components/human-labelling/AddSttItemsDialog.tsx
+++ b/src/components/human-labelling/AddSttItemsDialog.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { useHideFloatingButton } from "@/components/AppLayout";
+import { humaniseDetailObject } from "./bulk-upload-shared";
 
 type SttRowDraft = {
   id: string;
@@ -30,35 +31,6 @@ type AddSttItemsDialogProps = {
   onClose: () => void;
   onSubmit: (rows: SttItemRowSubmission[]) => Promise<void> | void;
 };
-
-function humaniseDetailObject(detail: {
-  code?: string;
-  conflicting_names?: string[];
-}): string | null {
-  const names = detail.conflicting_names ?? [];
-  const fmt =
-    names.length === 0
-      ? null
-      : names.length === 1
-        ? `"${names[0]}"`
-        : names.map((n) => `"${n}"`).join(", ");
-
-  if (detail.code === "ITEM_NAME_CONFLICT") {
-    return fmt
-      ? names.length === 1
-        ? `An item named ${fmt} already exists in this task.`
-        : `Items with these names already exist in this task: ${fmt}.`
-      : "One or more item names already exist in this task.";
-  }
-  if (detail.code === "ITEM_NAME_DUPLICATE_IN_REQUEST") {
-    return fmt
-      ? names.length === 1
-        ? `Duplicate name in your request: ${fmt}.`
-        : `Duplicate names in your request: ${fmt}.`
-      : "Your request contains duplicate item names.";
-  }
-  return null;
-}
 
 function extractApiError(err: unknown, fallback: string): string {
   if (!(err instanceof Error)) return fallback;

--- a/src/components/human-labelling/AgreementStatCard.tsx
+++ b/src/components/human-labelling/AgreementStatCard.tsx
@@ -32,7 +32,7 @@ export function AgreementStatCard(
 ) {
   const { value, valueClassName = "" } = props;
   return (
-    <div className="border border-border rounded-lg px-4 py-3 bg-background min-w-[160px]">
+    <div className="border border-border rounded-lg px-4 py-3 bg-background min-w-[160px] shrink-0">
       {"staticPillText" in props ? (
         <span
           className={`${agreementStatPillBase} cursor-default`}

--- a/src/components/human-labelling/AnnotationJobView.tsx
+++ b/src/components/human-labelling/AnnotationJobView.tsx
@@ -611,9 +611,10 @@ function AnnotateView({
         </div>
       )}
 
-      <div className="flex-1 flex flex-col md:flex-row min-h-0">
-        <aside className="w-full md:w-20 max-h-32 md:max-h-none border-b md:border-b-0 md:border-r border-border bg-muted/20 overflow-y-auto">
-          <div className="p-2 md:p-3 grid grid-cols-8 md:grid-cols-1 gap-2">
+      <div className={`flex-1 flex flex-col md:flex-row ${fillViewport ? "min-h-0" : ""}`}>
+        {/* Mobile: horizontal scrolling strip */}
+        <div className="md:hidden w-full max-h-32 border-b border-border bg-muted/20 overflow-y-auto">
+          <div className="p-2 grid grid-cols-8 gap-2">
             {items.map((it, i) => {
               const done = itemCompleted(it.uuid);
               const isCurrent = i === currentIndex;
@@ -635,9 +636,36 @@ function AnnotateView({
               );
             })}
           </div>
-        </aside>
+        </div>
+        {/* Desktop: sidebar whose height is defined by the main pane, not its own content */}
+        <div className={`hidden md:block relative w-20 flex-shrink-0 border-r border-border bg-muted/20 ${fillViewport ? "" : ""}`}>
+          <div className="absolute inset-0 overflow-y-auto">
+            <div className="p-3 grid grid-cols-1 gap-2">
+              {items.map((it, i) => {
+                const done = itemCompleted(it.uuid);
+                const isCurrent = i === currentIndex;
+                return (
+                  <button
+                    key={it.uuid}
+                    onClick={() => onJumpTo(i)}
+                    title={`Item ${i + 1}${done ? " (completed)" : ""}`}
+                    className={`h-10 w-full rounded-md border text-sm font-medium transition-colors cursor-pointer flex items-center justify-center ${
+                      isCurrent
+                        ? "border-foreground bg-foreground text-background"
+                        : done
+                          ? "border-blue-200 bg-blue-100 text-blue-700 dark:border-blue-500/30 dark:bg-blue-500/20 dark:text-blue-400"
+                          : "border-border bg-background text-foreground hover:bg-muted/50"
+                    }`}
+                  >
+                    {i + 1}
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+        </div>
 
-        <main className="flex-1 min-h-0 flex flex-col md:flex-row overflow-y-auto md:overflow-hidden">
+        <main className={`flex-1 flex flex-col md:flex-row ${fillViewport ? "min-h-0 overflow-y-auto md:overflow-hidden" : ""}`}>
           {!currentItem ? (
             <div className="flex items-center justify-center h-full p-8 text-sm text-muted-foreground w-full">
               No items in this job.

--- a/src/components/human-labelling/AnnotationJobView.tsx
+++ b/src/components/human-labelling/AnnotationJobView.tsx
@@ -638,7 +638,7 @@ function AnnotateView({
           </div>
         </div>
         {/* Desktop: sidebar whose height is defined by the main pane, not its own content */}
-        <div className={`hidden md:block relative w-20 flex-shrink-0 border-r border-border bg-muted/20 ${fillViewport ? "" : ""}`}>
+        <div className="hidden md:block relative w-20 flex-shrink-0 border-r border-border bg-muted/20">
           <div className="absolute inset-0 overflow-y-auto">
             <div className="p-3 grid grid-cols-1 gap-2">
               {items.map((it, i) => {

--- a/src/components/human-labelling/BulkUploadSttItemsDialog.tsx
+++ b/src/components/human-labelling/BulkUploadSttItemsDialog.tsx
@@ -254,9 +254,9 @@ export function BulkUploadSttItemsDialog({
         const nameKey = findHeaderKey(headers, NAME_HEADERS);
         const refKey = findHeaderKey(headers, REFERENCE_HEADERS);
         const predKey = findHeaderKey(headers, PREDICTED_HEADERS);
-        if (!refKey || !predKey) {
+        if (!nameKey || !refKey || !predKey) {
           setParseError(
-            `CSV must include "reference_transcript" and "predicted_transcript" columns. Found: ${headers.join(", ") || "(none)"}`,
+            `CSV must include "name", "reference_transcript" and "predicted_transcript" columns. Found: ${headers.join(", ") || "(none)"}`,
           );
           return;
         }
@@ -286,13 +286,17 @@ export function BulkUploadSttItemsDialog({
         const items: ParsedItem[] = [];
         for (let i = 0; i < results.data.length; i++) {
           const r = results.data[i];
-          const name = nameKey ? (r[nameKey] ?? "").trim() : "";
+          const name = (r[nameKey] ?? "").trim();
           const reference_transcript = (r[refKey] ?? "").trim();
           const predicted_transcript = (r[predKey] ?? "").trim();
-          if (!reference_transcript && !predicted_transcript) continue;
+          if (!name && !reference_transcript && !predicted_transcript) continue;
+          if (!name) {
+            setParseError(`Row ${i + 1}: "name" is required.`);
+            return;
+          }
           if (!reference_transcript || !predicted_transcript) {
             setParseError(
-              "Every row must have both a reference and a predicted transcript.",
+              `Row ${i + 1}: both "reference_transcript" and "predicted_transcript" are required.`,
             );
             return;
           }
@@ -365,7 +369,7 @@ export function BulkUploadSttItemsDialog({
           : undefined;
         return {
           payload: {
-            ...(p.name ? { name: p.name } : {}),
+            name: p.name,
             reference_transcript: p.reference_transcript,
             predicted_transcript: p.predicted_transcript,
           },
@@ -394,7 +398,7 @@ export function BulkUploadSttItemsDialog({
     const columns: GuidelineColumn[] = [
       {
         name: "name",
-        description: "(optional) A display name or label for the item.",
+        description: "Required. A unique name for the item.",
       },
       {
         name: "reference_transcript",

--- a/src/components/human-labelling/BulkUploadSttItemsDialog.tsx
+++ b/src/components/human-labelling/BulkUploadSttItemsDialog.tsx
@@ -21,6 +21,7 @@ import {
   useAnnotators,
 } from "./bulk-upload-shared";
 
+const NAME_HEADERS = ["name", "title", "label", "item_name"];
 const REFERENCE_HEADERS = [
   "reference_transcript",
   "reference",
@@ -41,21 +42,25 @@ function csvEscape(s: string): string {
 }
 
 const SAMPLE_STT_BASE_ROWS: Array<{
+  name: string;
   ref: string;
   pred: string;
   reasoning: string;
 }> = [
   {
+    name: "Greeting",
     ref: "Hello, how are you today?",
     pred: "hello how are you today",
     reasoning: "Punctuation is missing but the words match.",
   },
   {
+    name: "Flight booking",
     ref: "I would like to book a flight.",
     pred: "I'd like to book a flight",
     reasoning: "",
   },
   {
+    name: "Repeat request",
     ref: "Can you repeat that, please?",
     pred: "can you repeat that please",
     reasoning: "",
@@ -67,6 +72,7 @@ function buildSampleSttCsv(
   includeAnnotations: boolean,
 ): string {
   const headerCells = [
+    "name",
     "reference_transcript",
     "predicted_transcript",
     ...(includeAnnotations
@@ -78,6 +84,7 @@ function buildSampleSttCsv(
   ];
   const lines = SAMPLE_STT_BASE_ROWS.map((r) =>
     [
+      csvEscape(r.name),
       csvEscape(r.ref),
       csvEscape(r.pred),
       ...(includeAnnotations
@@ -92,9 +99,16 @@ function buildSampleSttCsv(
 }
 
 type ParsedItem = {
+  name: string;
   reference_transcript: string;
   predicted_transcript: string;
   annotations: ParsedAnnotation[];
+};
+
+type AnnotatedCheckResult = {
+  all_new: boolean;
+  existing_with_annotations: { index: number; name: string }[];
+  existing_without_annotations: { index: number; name: string }[];
 };
 
 export type SttLinkedEvaluator = {
@@ -131,6 +145,9 @@ export function BulkUploadSttItemsDialog({
   const [selectedAnnotatorId, setSelectedAnnotatorId] = useState<string | null>(
     null,
   );
+  const [annotatedCheck, setAnnotatedCheck] =
+    useState<AnnotatedCheckResult | null>(null);
+  const [annotatedCheckLoading, setAnnotatedCheckLoading] = useState(false);
   const annotatorsState = useAnnotators(isOpen, accessToken);
 
   const annotationEvaluatorsMeta: EvaluatorMeta[] = linkedEvaluators.map(
@@ -162,6 +179,8 @@ export function BulkUploadSttItemsDialog({
     setUploadError(null);
     setUploadAnnotations(false);
     setSelectedAnnotatorId(null);
+    setAnnotatedCheck(null);
+    setAnnotatedCheckLoading(false);
   };
 
   useEffect(() => {
@@ -172,8 +191,53 @@ export function BulkUploadSttItemsDialog({
     setParsedItems([]);
     setParseError(null);
     setCsvFile(null);
+    setAnnotatedCheck(null);
   }, [uploadAnnotations]);
 
+  useEffect(() => {
+    if (
+      !uploadAnnotations ||
+      !selectedAnnotatorId ||
+      parsedItems.length === 0
+    ) {
+      setAnnotatedCheck(null);
+      setAnnotatedCheckLoading(false);
+      return;
+    }
+    let cancelled = false;
+    (async () => {
+      setAnnotatedCheckLoading(true);
+      setAnnotatedCheck(null);
+      try {
+        const result = await apiClient<AnnotatedCheckResult>(
+          `/annotation-tasks/${taskUuid}/items/annotated-check`,
+          accessToken,
+          {
+            method: "POST",
+            body: {
+              annotator_id: selectedAnnotatorId,
+              names: parsedItems.map((p) => p.name),
+            },
+          },
+        );
+        if (!cancelled) setAnnotatedCheck(result);
+      } catch {
+        // Don't block the upload if the check fails — just hide the warnings.
+        if (!cancelled) setAnnotatedCheck(null);
+      } finally {
+        if (!cancelled) setAnnotatedCheckLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    uploadAnnotations,
+    selectedAnnotatorId,
+    parsedItems,
+    taskUuid,
+    accessToken,
+  ]);
 
   const handleFile = (file: File | null) => {
     setUploadError(null);
@@ -187,6 +251,7 @@ export function BulkUploadSttItemsDialog({
       transformHeader: (h) => h.trim(),
       complete: (results) => {
         const headers = results.meta.fields ?? [];
+        const nameKey = findHeaderKey(headers, NAME_HEADERS);
         const refKey = findHeaderKey(headers, REFERENCE_HEADERS);
         const predKey = findHeaderKey(headers, PREDICTED_HEADERS);
         if (!refKey || !predKey) {
@@ -221,6 +286,7 @@ export function BulkUploadSttItemsDialog({
         const items: ParsedItem[] = [];
         for (let i = 0; i < results.data.length; i++) {
           const r = results.data[i];
+          const name = nameKey ? (r[nameKey] ?? "").trim() : "";
           const reference_transcript = (r[refKey] ?? "").trim();
           const predicted_transcript = (r[predKey] ?? "").trim();
           if (!reference_transcript && !predicted_transcript) continue;
@@ -233,7 +299,10 @@ export function BulkUploadSttItemsDialog({
           const annotations: ParsedAnnotation[] = [];
           if (uploadAnnotations) {
             for (const meta of annotationEvaluatorsMeta) {
-              if (meta.output_type !== "binary" && meta.output_type !== "rating")
+              if (
+                meta.output_type !== "binary" &&
+                meta.output_type !== "rating"
+              )
                 continue;
               const valueHeader = evaluatorValueColumn(meta.name);
               const reasoningHeader = evaluatorReasoningColumn(meta.name);
@@ -259,6 +328,7 @@ export function BulkUploadSttItemsDialog({
             }
           }
           items.push({
+            name,
             reference_transcript,
             predicted_transcript,
             annotations,
@@ -295,6 +365,7 @@ export function BulkUploadSttItemsDialog({
           : undefined;
         return {
           payload: {
+            ...(p.name ? { name: p.name } : {}),
             reference_transcript: p.reference_transcript,
             predicted_transcript: p.predicted_transcript,
           },
@@ -321,6 +392,10 @@ export function BulkUploadSttItemsDialog({
 
   const buildGuidelines = (): GuidelineDoc => {
     const columns: GuidelineColumn[] = [
+      {
+        name: "name",
+        description: "(optional) A display name or label for the item.",
+      },
       {
         name: "reference_transcript",
         description: "What was actually said.",
@@ -377,98 +452,170 @@ export function BulkUploadSttItemsDialog({
       : [];
   const sttGridStyle = {
     gridTemplateColumns: [
+      "minmax(80px, 140px)",
       "minmax(120px, 200px)",
       "minmax(120px, 200px)",
       ...annotationColumns.map((c) =>
-        c.kind === "value"
-          ? "minmax(64px, 88px)"
-          : "minmax(100px, 176px)",
+        c.kind === "value" ? "minmax(64px, 88px)" : "minmax(100px, 176px)",
       ),
     ].join(" "),
   };
 
+  const existingNoAnnotationIndices = new Set(
+    annotatedCheck?.existing_without_annotations.map((e) => e.index) ?? [],
+  );
+  const existingWithAnnotationIndices = new Set(
+    annotatedCheck?.existing_with_annotations.map((e) => e.index) ?? [],
+  );
+
   const itemsPreview = (
     <div className="space-y-2">
-      <p className="text-sm font-medium text-foreground">
-        {parsedItems.length} {parsedItems.length === 1 ? "item" : "items"} ready
-        to upload
-      </p>
+      <div className="flex items-center justify-between gap-2">
+        <p className="text-sm font-medium text-foreground">
+          {parsedItems.length} {parsedItems.length === 1 ? "item" : "items"}{" "}
+          ready to upload
+        </p>
+        {annotatedCheckLoading && (
+          <span className="text-xs text-muted-foreground flex items-center gap-1.5">
+            <svg
+              className="w-3.5 h-3.5 animate-spin"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              strokeWidth={2}
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M16.023 9.348h4.992v-.001M2.985 19.644v-4.992m0 0h4.992m-4.993 0 3.181 3.183a8.25 8.25 0 0 0 13.803-3.7M4.031 9.865a8.25 8.25 0 0 1 13.803-3.7l3.181 3.182m0-4.991v4.99"
+              />
+            </svg>
+            Checking for existing items…
+          </span>
+        )}
+      </div>
       <div className="border border-border rounded-xl overflow-hidden">
         <div className="overflow-auto max-h-[20rem]">
           <div className="min-w-max">
-          <div
-            className="grid gap-2 px-3 py-2 border-b border-border bg-muted sticky top-0 z-10"
-            style={sttGridStyle}
-          >
-            <div className="text-xs font-medium text-muted-foreground">
-              Reference transcript
-            </div>
-            <div className="text-xs font-medium text-muted-foreground">
-              Predicted transcript
-            </div>
-            {annotationColumns.map((c) => (
-              <div
-                key={`ah-${c.evaluatorUuid}-${c.kind}`}
-                className="text-xs font-medium text-muted-foreground font-mono truncate"
-                title={c.header}
-              >
-                {c.header}
+            <div
+              className="grid gap-2 px-3 py-2 border-b border-border bg-muted sticky top-0 z-10"
+              style={sttGridStyle}
+            >
+              <div className="text-xs font-medium text-muted-foreground">
+                Name
               </div>
-            ))}
-          </div>
-          <div className="divide-y divide-border">
-            {parsedItems.slice(0, 50).map((p, idx) => (
-              <div
-                key={idx}
-                className="grid gap-2 px-3 py-2 text-xs items-start"
-                style={sttGridStyle}
-              >
+              <div className="text-xs font-medium text-muted-foreground">
+                Reference transcript
+              </div>
+              <div className="text-xs font-medium text-muted-foreground">
+                Predicted transcript
+              </div>
+              {annotationColumns.map((c) => (
                 <div
-                  className="truncate text-foreground"
-                  title={p.reference_transcript}
+                  key={`ah-${c.evaluatorUuid}-${c.kind}`}
+                  className="text-xs font-medium text-muted-foreground font-mono truncate"
+                  title={c.header}
                 >
-                  {p.reference_transcript}
+                  {c.header}
                 </div>
-                <div
-                  className="truncate text-foreground"
-                  title={p.predicted_transcript}
-                >
-                  {p.predicted_transcript}
-                </div>
-                {annotationColumns.map((c) => {
-                  const ann = p.annotations.find(
-                    (a) => a.evaluator_uuid === c.evaluatorUuid,
-                  );
-                  const display =
-                    c.kind === "value"
-                      ? ann
-                        ? typeof ann.value === "boolean"
-                          ? ann.value
-                            ? "true"
-                            : "false"
-                          : String(ann.value)
-                        : ""
-                      : (ann?.reasoning ?? "");
-                  return (
-                    <div
-                      key={`${idx}-a-${c.evaluatorUuid}-${c.kind}`}
-                      className="min-w-0 max-h-24 overflow-y-auto pr-1 leading-snug text-foreground break-words whitespace-pre-wrap"
-                    >
-                      {display}
+              ))}
+            </div>
+            <div className="divide-y divide-border">
+              {parsedItems.slice(0, 50).map((p, idx) => {
+                const isExistingNoAnnotation =
+                  existingNoAnnotationIndices.has(idx);
+                const isExistingWithAnnotation =
+                  existingWithAnnotationIndices.has(idx);
+                const rowBg = isExistingWithAnnotation
+                  ? "bg-red-500/10"
+                  : isExistingNoAnnotation
+                    ? "bg-amber-500/10"
+                    : "";
+                return (
+                  <div
+                    key={idx}
+                    className={`grid gap-2 px-3 py-2 text-xs items-start ${rowBg}`}
+                    style={sttGridStyle}
+                  >
+                    <div className="truncate text-foreground" title={p.name}>
+                      {p.name || (
+                        <span className="text-muted-foreground">—</span>
+                      )}
                     </div>
-                  );
-                })}
-              </div>
-            ))}
-            {parsedItems.length > 50 && (
-              <div className="px-4 py-2 text-xs text-muted-foreground">
-                + {parsedItems.length - 50} more rows
-              </div>
-            )}
-          </div>
+                    <div
+                      className="truncate text-foreground"
+                      title={p.reference_transcript}
+                    >
+                      {p.reference_transcript}
+                    </div>
+                    <div
+                      className="truncate text-foreground"
+                      title={p.predicted_transcript}
+                    >
+                      {p.predicted_transcript}
+                    </div>
+                    {annotationColumns.map((c) => {
+                      const ann = p.annotations.find(
+                        (a) => a.evaluator_uuid === c.evaluatorUuid,
+                      );
+                      const display =
+                        c.kind === "value"
+                          ? ann
+                            ? typeof ann.value === "boolean"
+                              ? ann.value
+                                ? "true"
+                                : "false"
+                              : String(ann.value)
+                            : ""
+                          : (ann?.reasoning ?? "");
+                      return (
+                        <div
+                          key={`${idx}-a-${c.evaluatorUuid}-${c.kind}`}
+                          className="min-w-0 max-h-24 overflow-y-auto pr-1 leading-snug text-foreground break-words whitespace-pre-wrap"
+                        >
+                          {display}
+                        </div>
+                      );
+                    })}
+                  </div>
+                );
+              })}
+              {parsedItems.length > 50 && (
+                <div className="px-4 py-2 text-xs text-muted-foreground">
+                  + {parsedItems.length - 50} more rows
+                </div>
+              )}
+            </div>
           </div>
         </div>
       </div>
+      {existingNoAnnotationIndices.size > 0 && (
+        <div className="flex items-start gap-2 rounded-md border border-amber-500/30 bg-amber-500/10 px-3 py-2.5 text-xs text-foreground">
+          <span className="mt-0.5 shrink-0 inline-block w-2.5 h-2.5 rounded-sm bg-amber-500/60" />
+          <span>
+            Rows highlighted in{" "}
+            <span className="font-semibold text-amber-700 dark:text-amber-400">
+              amber
+            </span>{" "}
+            match names of existing items — annotations will be attached to
+            those existing items. The original item remains unchanged.
+          </span>
+        </div>
+      )}
+      {existingWithAnnotationIndices.size > 0 && (
+        <div className="flex items-start gap-2 rounded-md border border-red-500/30 bg-red-500/10 px-3 py-2.5 text-xs text-foreground">
+          <span className="mt-0.5 shrink-0 inline-block w-2.5 h-2.5 rounded-sm bg-red-500/60" />
+          <span>
+            Rows highlighted in{" "}
+            <span className="font-semibold text-red-700 dark:text-red-400">
+              red
+            </span>{" "}
+            match names of existing items that already have annotations from
+            this annotator — those annotations will be replaced with the new
+            ones. The original item remains unchanged.
+          </span>
+        </div>
+      )}
     </div>
   );
 
@@ -487,16 +634,14 @@ export function BulkUploadSttItemsDialog({
         {uploadAnnotations && duplicateNames.length > 0 && (
           <div className="rounded-md border border-red-500/30 bg-red-500/10 p-3 text-xs text-red-600 dark:text-red-400">
             Two or more linked evaluators share the same name (
-            {duplicateNames.map((n) => `"${n}"`).join(", ")}). Rename one
-            on the evaluators page before uploading annotations.
+            {duplicateNames.map((n) => `"${n}"`).join(", ")}). Rename one on the
+            evaluators page before uploading annotations.
           </div>
         )}
         {uploadAnnotations && evaluatorsMissingOutputType.length > 0 && (
           <div className="rounded-md border border-red-500/30 bg-red-500/10 p-3 text-xs text-red-600 dark:text-red-400">
             Annotation upload isn&apos;t available — evaluator(s){" "}
-            {evaluatorsMissingOutputType
-              .map((e) => `"${e.name}"`)
-              .join(", ")}{" "}
+            {evaluatorsMissingOutputType.map((e) => `"${e.name}"`).join(", ")}{" "}
             have no binary/rating output configured.
           </div>
         )}

--- a/src/components/human-labelling/bulk-upload-shared.tsx
+++ b/src/components/human-labelling/bulk-upload-shared.tsx
@@ -342,7 +342,7 @@ export function EvaluatorAnnotationColumnsHelp({
 
 // ─── Shared helpers ───────────────────────────────────────────────────────
 
-function humaniseDetailObject(detail: {
+export function humaniseDetailObject(detail: {
   code?: string;
   conflicting_names?: string[];
 }): string | null {

--- a/src/components/human-labelling/bulk-upload-shared.tsx
+++ b/src/components/human-labelling/bulk-upload-shared.tsx
@@ -342,13 +342,45 @@ export function EvaluatorAnnotationColumnsHelp({
 
 // ─── Shared helpers ───────────────────────────────────────────────────────
 
+function humaniseDetailObject(detail: {
+  code?: string;
+  conflicting_names?: string[];
+}): string | null {
+  const names = detail.conflicting_names ?? [];
+  const fmt =
+    names.length === 0
+      ? null
+      : names.length === 1
+        ? `"${names[0]}"`
+        : names.map((n) => `"${n}"`).join(", ");
+
+  if (detail.code === "ITEM_NAME_CONFLICT") {
+    return fmt
+      ? names.length === 1
+        ? `An item named ${fmt} already exists in this task.`
+        : `Items with these names already exist in this task: ${fmt}.`
+      : "One or more item names already exist in this task.";
+  }
+  if (detail.code === "ITEM_NAME_DUPLICATE_IN_REQUEST") {
+    return fmt
+      ? names.length === 1
+        ? `Duplicate name in your request: ${fmt}.`
+        : `Duplicate names in your request: ${fmt}.`
+      : "Your request contains duplicate item names.";
+  }
+  return null;
+}
+
 export function parseApiError(err: unknown, fallback: string): string {
   if (!(err instanceof Error)) return fallback;
   const m = err.message.match(/Request failed: \d+ - (.+)$/);
   if (m) {
     try {
       const parsed = JSON.parse(m[1]);
-      if (parsed && typeof parsed.detail === "string") return parsed.detail;
+      if (parsed?.detail && typeof parsed.detail === "object") {
+        const msg = humaniseDetailObject(parsed.detail);
+        if (msg) return msg;
+      }
     } catch {
       // not JSON — fall through to the captured message
     }
@@ -925,16 +957,42 @@ export function BulkUploadDialogShell({
         <div className="flex-1 overflow-y-auto px-6 py-5 space-y-5">
           {topContent}
           {!hideUploadSection && (
-          <div>
-            {itemCount === 0 && (
-              <div className="mb-3 flex flex-wrap gap-2">
-                <button
-                  type="button"
-                  onClick={downloadGuidelines}
-                  className="h-9 px-3 rounded-md text-xs font-semibold border border-blue-500/40 bg-blue-500/15 text-blue-700 dark:text-blue-300 hover:bg-blue-500/25 hover:border-blue-500/60 transition-colors cursor-pointer flex items-center gap-1.5"
-                >
+            <div>
+              {itemCount === 0 && (
+                <div className="mb-3 flex flex-wrap gap-2">
+                  <button
+                    type="button"
+                    onClick={downloadGuidelines}
+                    className="h-9 px-3 rounded-md text-xs font-semibold border border-blue-500/40 bg-blue-500/15 text-blue-700 dark:text-blue-300 hover:bg-blue-500/25 hover:border-blue-500/60 transition-colors cursor-pointer flex items-center gap-1.5"
+                  >
+                    <svg
+                      className="w-4 h-4"
+                      fill="none"
+                      viewBox="0 0 24 24"
+                      stroke="currentColor"
+                      strokeWidth={2}
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5M16.5 12L12 16.5m0 0L7.5 12m4.5 4.5V3"
+                      />
+                    </svg>
+                    Download CSV format guidelines
+                  </button>
+                </div>
+              )}
+
+              <CsvDropzone
+                csvFile={csvFile}
+                onFile={onFile}
+                onClear={onClear}
+              />
+
+              {itemCount === 0 && (
+                <div className="mt-3 flex items-start gap-2 rounded-md border border-emerald-500/30 bg-emerald-500/10 px-3 py-2 text-xs text-foreground">
                   <svg
-                    className="w-4 h-4"
+                    className="w-4 h-4 mt-0.5 shrink-0 text-emerald-500"
                     fill="none"
                     viewBox="0 0 24 24"
                     stroke="currentColor"
@@ -943,49 +1001,27 @@ export function BulkUploadDialogShell({
                     <path
                       strokeLinecap="round"
                       strokeLinejoin="round"
-                      d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5M16.5 12L12 16.5m0 0L7.5 12m4.5 4.5V3"
+                      d="M13 16h-1v-4h-1m1-4h.01M12 2a10 10 0 100 20 10 10 0 000-20z"
                     />
                   </svg>
-                  Download CSV format guidelines
-                </button>
-              </div>
-            )}
+                  <span>
+                    <span className="font-semibold">Tip:</span>{" "}
+                    <button
+                      type="button"
+                      onClick={downloadSample}
+                      className="underline underline-offset-2 font-semibold text-emerald-700 dark:text-emerald-300 hover:opacity-80 transition-opacity cursor-pointer"
+                    >
+                      download the sample CSV
+                    </button>{" "}
+                    and edit it as a starting point
+                  </span>
+                </div>
+              )}
 
-            <CsvDropzone csvFile={csvFile} onFile={onFile} onClear={onClear} />
-
-            {itemCount === 0 && (
-              <div className="mt-3 flex items-start gap-2 rounded-md border border-emerald-500/30 bg-emerald-500/10 px-3 py-2 text-xs text-foreground">
-                <svg
-                  className="w-4 h-4 mt-0.5 shrink-0 text-emerald-500"
-                  fill="none"
-                  viewBox="0 0 24 24"
-                  stroke="currentColor"
-                  strokeWidth={2}
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    d="M13 16h-1v-4h-1m1-4h.01M12 2a10 10 0 100 20 10 10 0 000-20z"
-                  />
-                </svg>
-                <span>
-                  <span className="font-semibold">Tip:</span>{" "}
-                  <button
-                    type="button"
-                    onClick={downloadSample}
-                    className="underline underline-offset-2 font-semibold text-emerald-700 dark:text-emerald-300 hover:opacity-80 transition-opacity cursor-pointer"
-                  >
-                    download the sample CSV
-                  </button>{" "}
-                  and edit it as a starting point
-                </span>
-              </div>
-            )}
-
-            {parseError && (
-              <p className="text-xs text-red-500 mt-3">{parseError}</p>
-            )}
-          </div>
+              {parseError && (
+                <p className="text-xs text-red-500 mt-3">{parseError}</p>
+              )}
+            </div>
           )}
 
           {!hideUploadSection && itemCount > 0 && itemsPreview}
@@ -1006,19 +1042,22 @@ export function BulkUploadDialogShell({
             Cancel
           </button>
           {!hideUploadSection && (
-          <button
-            onClick={onUpload}
-            disabled={
-              itemCount === 0 || isUploading || !!parseError || !!uploadBlocked
-            }
-            className="h-10 px-4 rounded-md text-sm font-medium bg-foreground text-background hover:opacity-90 transition-opacity cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
-          >
-            {isUploading
-              ? "Uploading"
-              : itemCount > 1
-                ? `Upload ${itemCount} items`
-                : "Upload item"}
-          </button>
+            <button
+              onClick={onUpload}
+              disabled={
+                itemCount === 0 ||
+                isUploading ||
+                !!parseError ||
+                !!uploadBlocked
+              }
+              className="h-10 px-4 rounded-md text-sm font-medium bg-foreground text-background hover:opacity-90 transition-opacity cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {isUploading
+                ? "Uploading"
+                : itemCount > 1
+                  ? `Upload ${itemCount} items`
+                  : "Upload item"}
+            </button>
           )}
         </div>
       </div>

--- a/src/components/human-labelling/bulk-upload-shared.tsx
+++ b/src/components/human-labelling/bulk-upload-shared.tsx
@@ -377,6 +377,7 @@ export function parseApiError(err: unknown, fallback: string): string {
   if (m) {
     try {
       const parsed = JSON.parse(m[1]);
+      if (typeof parsed?.detail === "string") return parsed.detail;
       if (parsed?.detail && typeof parsed.detail === "object") {
         const msg = humaniseDetailObject(parsed.detail);
         if (msg) return msg;

--- a/src/components/human-labelling/item-panes/SttItemPane.tsx
+++ b/src/components/human-labelling/item-panes/SttItemPane.tsx
@@ -5,6 +5,8 @@ export function SttItemPane({
 }: {
   payload: Record<string, unknown>;
 }) {
+  const name =
+    typeof payload.name === "string" ? (payload.name as string) : "";
   const reference =
     typeof payload.reference_transcript === "string"
       ? (payload.reference_transcript as string)
@@ -15,6 +17,9 @@ export function SttItemPane({
       : "";
   return (
     <div className="space-y-4">
+      {name && (
+        <p className="text-sm font-semibold text-foreground">{name}</p>
+      )}
       <Section
         title="Reference transcript"
         subtitle="What the speaker actually said"


### PR DESCRIPTION
## Summary

- **Bulk upload STT items — annotated-check**: After a CSV is parsed with annotations enabled, calls the new `POST /annotation-tasks/{uuid}/items/annotated-check` endpoint to identify rows whose item names already exist in the task. Rows where the item exists but has no annotation from the selected annotator are highlighted **amber**; rows where an annotation already exists and will be replaced are highlighted **red**. A spinner shows while the check is in flight. Two banner messages below the preview explain each color. The check re-runs automatically when the annotator selection changes. Failures are swallowed silently so they never block the upload.
- **Overview tab — evaluator column width**: Fixed column misalignment caused by `max-content` on the evaluator column. Since each row is its own CSS grid container, `max-content` sized each row independently. Now computes a fixed pixel width from the longest evaluator name in the dataset and uses that for all rows, so all columns stay aligned.
- **AddSttItemsDialog — regex ES2018 flag**: Removed the `/s` (dotAll) flag from a regex that was causing a TypeScript build error (`es2018` target required). Replaced with `[\s\S]+` which is equivalent and compatible with all targets.

## Reviewer notes

- The annotated-check call is fire-and-forget from the UX perspective — if the endpoint is unavailable, no warning banners appear and the upload proceeds normally.
- The evaluator column width uses `charCount * 6.5 + 60` px (min 120 px) — a rough approximation for `text-xs`. If fonts change this may need tuning.