### PR TITLE
Tests tab create/edit, type filter, run subset, STT/TTS export, tool-call verdict

### DIFF
--- a/src/app/human-alignment/tasks/[uuid]/evaluator-runs/[runUuid]/page.tsx
+++ b/src/app/human-alignment/tasks/[uuid]/evaluator-runs/[runUuid]/page.tsx
@@ -565,16 +565,21 @@ export default function EvaluatorRunDetailPage() {
                   </button>
                 )}
                 {job.status === "completed" && itemsForRun.length > 0 && (
+                  /* Tinted teal styling matches `ExportResultsButton` and
+                     `ExportZipButton` so the export affordance reads the
+                     same on every results page. Stays inline (not the
+                     shared component) because the XLSX builder is
+                     page-specific. */
                   <button
                     type="button"
                     onClick={handleExport}
                     disabled={exporting}
                     title="Download spreadsheet (XLSX)"
-                    className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-[13px] font-medium bg-foreground text-background shadow-sm hover:opacity-90 transition-opacity cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+                    className="flex items-center gap-2 h-8 px-2 md:px-3 rounded-lg text-xs md:text-sm font-medium border cursor-pointer transition-colors disabled:opacity-50 disabled:cursor-not-allowed bg-teal-500/12 border-teal-500/45 text-teal-950 dark:text-teal-100 hover:bg-teal-500/22 dark:hover:bg-teal-500/18"
                   >
                     {exporting ? (
                       <svg
-                        className="w-3.5 h-3.5 shrink-0 animate-spin"
+                        className="w-4 h-4 animate-spin"
                         fill="none"
                         viewBox="0 0 24 24"
                       >
@@ -594,7 +599,7 @@ export default function EvaluatorRunDetailPage() {
                       </svg>
                     ) : (
                       <svg
-                        className="w-3.5 h-3.5 shrink-0"
+                        className="w-4 h-4"
                         fill="none"
                         viewBox="0 0 24 24"
                         stroke="currentColor"
@@ -603,7 +608,7 @@ export default function EvaluatorRunDetailPage() {
                         <path
                           strokeLinecap="round"
                           strokeLinejoin="round"
-                          d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4"
+                          d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5M16.5 12L12 16.5m0 0L7.5 12m4.5 4.5V3"
                         />
                       </svg>
                     )}

--- a/src/app/human-alignment/tasks/[uuid]/evaluator-runs/[runUuid]/page.tsx
+++ b/src/app/human-alignment/tasks/[uuid]/evaluator-runs/[runUuid]/page.tsx
@@ -539,16 +539,13 @@ export default function EvaluatorRunDetailPage() {
             versionLabels={versionLabels}
             linkEvaluators
             actionsSlot={
+              /* Button order is fixed across all results pages so users
+                 build the same muscle memory: Re-run (leftmost, page-
+                 specific action), then Export results, then Share. The
+                 Export ↔ Share ordering matches TestRunnerDialog,
+                 BenchmarkResultsDialog, and the auth/public STT & TTS
+                 pages. */
               <div className="flex items-center gap-2 flex-wrap">
-                {job.status === "completed" && accessToken && (
-                  <ShareButton
-                    entityType="annotation-evaluator-run"
-                    entityId={`${taskUuid}:${runUuid}`}
-                    accessToken={accessToken}
-                    initialIsPublic={job.is_public ?? false}
-                    initialShareToken={job.share_token ?? null}
-                  />
-                )}
                 {accessToken && rerunItemIds.length > 0 && (
                   <button
                     type="button"
@@ -614,6 +611,15 @@ export default function EvaluatorRunDetailPage() {
                     )}
                     {exporting ? "Exporting…" : "Export results"}
                   </button>
+                )}
+                {job.status === "completed" && accessToken && (
+                  <ShareButton
+                    entityType="annotation-evaluator-run"
+                    entityId={`${taskUuid}:${runUuid}`}
+                    accessToken={accessToken}
+                    initialIsPublic={job.is_public ?? false}
+                    initialShareToken={job.share_token ?? null}
+                  />
                 )}
               </div>
             }

--- a/src/app/public/stt/[token]/page.tsx
+++ b/src/app/public/stt/[token]/page.tsx
@@ -206,7 +206,6 @@ export default function PublicSTTPage() {
                   getRows={() => {
                     const columns: ExportColumn[] = [
                       { key: "provider", header: "Provider" },
-                      { key: "row", header: "Row" },
                       { key: "reference_text", header: "Reference text" },
                       { key: "predicted_text", header: "Predicted text" },
                       { key: "wer", header: "WER" },
@@ -220,7 +219,6 @@ export default function PublicSTTPage() {
                       for (const r of pr.results ?? []) {
                         const row: Record<string, unknown> = {
                           provider: getProviderLabel(pr.provider),
-                          row: r.id,
                           reference_text: r.gt,
                           predicted_text: r.pred,
                           wer: r.wer,

--- a/src/app/public/stt/[token]/page.tsx
+++ b/src/app/public/stt/[token]/page.tsx
@@ -14,6 +14,11 @@ import {
   ratingRange,
   type STTEvaluatorColumn,
 } from "@/components/eval-details";
+import { readEvaluatorCell } from "@/components/eval-details/EvaluatorScoreCell";
+import {
+  ExportResultsButton,
+  type ExportColumn,
+} from "@/components/ExportResultsButton";
 import {
   getPublicDefaultEvaluator,
   type PublicDefaultEvaluator,
@@ -190,6 +195,64 @@ export default function PublicSTTPage() {
       <div className="space-y-4 md:space-y-6">
         {data.provider_results && data.provider_results.length > 0 && (
           <>
+            {/* Actions row — Export results, matching the auth STT page.
+                Built at click time so it reflects the latest fetched state. */}
+            {data.provider_results.some(
+              (pr) => (pr.results?.length ?? 0) > 0,
+            ) && (
+              <div className="flex items-center justify-end">
+                <ExportResultsButton
+                  filename={`stt-results-${data.task_id}`}
+                  getRows={() => {
+                    const columns: ExportColumn[] = [
+                      { key: "provider", header: "Provider" },
+                      { key: "row", header: "Row" },
+                      { key: "reference_text", header: "Reference text" },
+                      { key: "predicted_text", header: "Predicted text" },
+                      { key: "wer", header: "WER" },
+                      ...evaluatorColumns.map((c) => ({
+                        key: c.key,
+                        header: c.label,
+                      })),
+                    ];
+                    const rows: Record<string, unknown>[] = [];
+                    for (const pr of data.provider_results ?? []) {
+                      for (const r of pr.results ?? []) {
+                        const row: Record<string, unknown> = {
+                          provider: getProviderLabel(pr.provider),
+                          row: r.id,
+                          reference_text: r.gt,
+                          predicted_text: r.pred,
+                          wer: r.wer,
+                        };
+                        for (const c of evaluatorColumns) {
+                          const { score, error } = readEvaluatorCell(
+                            r as unknown as Record<string, unknown>,
+                            c,
+                          );
+                          if (error || score === undefined) {
+                            row[c.key] = "";
+                            continue;
+                          }
+                          if (c.outputType === "binary") {
+                            const norm = score.toLowerCase();
+                            row[c.key] =
+                              norm === "true" || norm === "1"
+                                ? "true"
+                                : "false";
+                          } else {
+                            const n = parseFloat(score);
+                            row[c.key] = Number.isFinite(n) ? n : score;
+                          }
+                        }
+                        rows.push(row);
+                      }
+                    }
+                    return { columns, rows };
+                  }}
+                />
+              </div>
+            )}
             {/* Tab Nav */}
             <div className="flex gap-2 border-b border-border">
               {(["leaderboard", "outputs", "about"] as const).map((tab) => (

--- a/src/app/public/tts/[token]/page.tsx
+++ b/src/app/public/tts/[token]/page.tsx
@@ -206,7 +206,6 @@ export default function PublicTTSPage() {
                   getContents={() => {
                     const columns: ExportColumn[] = [
                       { key: "provider", header: "Provider" },
-                      { key: "row", header: "Row" },
                       { key: "audio_name", header: "Audio name" },
                       { key: "text", header: "Text" },
                       ...evaluatorColumns.map((c) => ({
@@ -238,7 +237,6 @@ export default function PublicTTSPage() {
                           : "";
                         const row: Record<string, unknown> = {
                           provider: getProviderLabel(pr.provider),
-                          row: r.id,
                           audio_name: audioName,
                           text: r.text,
                         };

--- a/src/app/public/tts/[token]/page.tsx
+++ b/src/app/public/tts/[token]/page.tsx
@@ -14,6 +14,9 @@ import {
   ratingRange,
   type TTSEvaluatorColumn,
 } from "@/components/eval-details";
+import { readEvaluatorCell } from "@/components/eval-details/EvaluatorScoreCell";
+import { ExportZipButton } from "@/components/ExportZipButton";
+import type { ExportColumn } from "@/components/ExportResultsButton";
 import {
   getPublicDefaultEvaluator,
   type PublicDefaultEvaluator,
@@ -192,6 +195,87 @@ export default function PublicTTSPage() {
       <div className="space-y-4 md:space-y-6">
         {data.provider_results && data.provider_results.length > 0 && (
           <>
+            {/* Actions row — Export results as a zip (results.csv + an
+                audios/ folder), matching the auth TTS page. */}
+            {data.provider_results.some(
+              (pr) => (pr.results?.length ?? 0) > 0,
+            ) && (
+              <div className="flex items-center justify-end">
+                <ExportZipButton
+                  filename={`tts-results-${data.dataset_name ?? data.task_id}`}
+                  getContents={() => {
+                    const columns: ExportColumn[] = [
+                      { key: "provider", header: "Provider" },
+                      { key: "row", header: "Row" },
+                      { key: "audio_name", header: "Audio name" },
+                      { key: "text", header: "Text" },
+                      ...evaluatorColumns.map((c) => ({
+                        key: c.key,
+                        header: c.label,
+                      })),
+                    ];
+                    const rows: Record<string, unknown>[] = [];
+                    const files: { path: string; url: string }[] = [];
+                    for (const pr of data.provider_results ?? []) {
+                      for (const r of pr.results ?? []) {
+                        const ext = (() => {
+                          try {
+                            const u = new URL(
+                              r.audio_path,
+                              window.location.origin,
+                            );
+                            const m = u.pathname.match(/\.([a-z0-9]+)$/i);
+                            return m ? m[1].toLowerCase() : "wav";
+                          } catch {
+                            const m = r.audio_path.match(
+                              /\.([a-z0-9]+)(?:\?|$)/i,
+                            );
+                            return m ? m[1].toLowerCase() : "wav";
+                          }
+                        })();
+                        const audioName = r.audio_path
+                          ? `${pr.provider}_${r.id}.${ext}`
+                          : "";
+                        const row: Record<string, unknown> = {
+                          provider: getProviderLabel(pr.provider),
+                          row: r.id,
+                          audio_name: audioName,
+                          text: r.text,
+                        };
+                        for (const c of evaluatorColumns) {
+                          const { score, error } = readEvaluatorCell(
+                            r as unknown as Record<string, unknown>,
+                            c,
+                          );
+                          if (error || score === undefined) {
+                            row[c.key] = "";
+                            continue;
+                          }
+                          if (c.outputType === "binary") {
+                            const norm = score.toLowerCase();
+                            row[c.key] =
+                              norm === "true" || norm === "1"
+                                ? "true"
+                                : "false";
+                          } else {
+                            const n = parseFloat(score);
+                            row[c.key] = Number.isFinite(n) ? n : score;
+                          }
+                        }
+                        rows.push(row);
+                        if (audioName && r.audio_path) {
+                          files.push({
+                            path: `audios/${audioName}`,
+                            url: r.audio_path,
+                          });
+                        }
+                      }
+                    }
+                    return { csv: { columns, rows }, files };
+                  }}
+                />
+              </div>
+            )}
             {/* Tab Nav */}
             <div className="flex gap-2 border-b border-border">
               {(["leaderboard", "outputs", "about"] as const).map((tab) => (

--- a/src/app/stt/[uuid]/page.tsx
+++ b/src/app/stt/[uuid]/page.tsx
@@ -23,6 +23,7 @@ import {
   getFirstSTTEmptyPredictionIndex,
   type STTEvaluatorColumn,
 } from "@/components/eval-details";
+import { readEvaluatorCell } from "@/components/eval-details/EvaluatorScoreCell";
 import { useSidebarState } from "@/lib/sidebar";
 import { getDataset } from "@/lib/datasets";
 import { ShareButton } from "@/components/ShareButton";
@@ -764,20 +765,28 @@ export default function STTEvaluationDetailPage() {
                             predicted_text: r.pred,
                             wer: r.wer,
                           };
+                          // Read via `readEvaluatorCell` so the refreshed
+                          // `evaluator_outputs[<uuid>]` shape is preferred
+                          // over the legacy flat scoreField. Matches what
+                          // STTResultsTable renders on screen.
                           for (const c of evaluatorColumns) {
-                            const raw = r[c.scoreField ?? c.key];
-                            if (raw === undefined || raw === null) {
+                            const { score, error } = readEvaluatorCell(
+                              r as unknown as Record<string, unknown>,
+                              c,
+                            );
+                            if (error || score === undefined) {
                               row[c.key] = "";
                               continue;
                             }
-                            const s = String(raw);
                             if (c.outputType === "binary") {
                               // Mirrors EvaluatorScoreCell: "true"/"1" → Pass.
                               row[c.key] =
-                                s === "true" || s === "1" ? "true" : "false";
+                                score === "true" || score === "1"
+                                  ? "true"
+                                  : "false";
                             } else {
-                              const n = parseFloat(s);
-                              row[c.key] = Number.isFinite(n) ? n : s;
+                              const n = parseFloat(score);
+                              row[c.key] = Number.isFinite(n) ? n : score;
                             }
                           }
                           rows.push(row);

--- a/src/app/stt/[uuid]/page.tsx
+++ b/src/app/stt/[uuid]/page.tsx
@@ -735,7 +735,6 @@ export default function STTEvaluationDetailPage() {
                     getRows={() => {
                       const columns: ExportColumn[] = [
                         { key: "provider", header: "Provider" },
-                        { key: "row", header: "Row" },
                         { key: "reference_text", header: "Reference text" },
                         { key: "predicted_text", header: "Predicted text" },
                         { key: "wer", header: "WER" },
@@ -750,7 +749,6 @@ export default function STTEvaluationDetailPage() {
                         for (const r of pr.results ?? []) {
                           const row: Record<string, unknown> = {
                             provider: getProviderLabel(pr.provider),
-                            row: r.id,
                             reference_text: r.gt,
                             predicted_text: r.pred,
                             wer: r.wer,

--- a/src/app/stt/[uuid]/page.tsx
+++ b/src/app/stt/[uuid]/page.tsx
@@ -719,19 +719,9 @@ export default function STTEvaluationDetailPage() {
               {evaluationResult.status !== "done" && (
                 <StatusBadge status={evaluationResult.status} showSpinner />
               )}
-              {/* Sharing only makes sense once the run is complete — earlier
-                  state changes too quickly and a shared link would render
-                  partial results. */}
-              {evaluationResult.status === "done" && backendAccessToken && (
-                <ShareButton
-                  entityType="stt"
-                  entityId={taskId}
-                  accessToken={backendAccessToken}
-                  initialIsPublic={evaluationResult.is_public ?? false}
-                  initialShareToken={evaluationResult.share_token ?? null}
-                />
-              )}
-              {/* Export per-row results to CSV. One row per (provider, row);
+              {/* Export per-row results to CSV. Placed before Share so the
+                  Export ↔ Share button order matches TestRunnerDialog /
+                  BenchmarkResultsDialog. One row per (provider, row);
                   columns: reference / predicted text, WER, and one column
                   per attached evaluator (binary → "true"/"false", rating →
                   raw numeric score). Built at click time so it reflects
@@ -779,9 +769,12 @@ export default function STTEvaluationDetailPage() {
                               continue;
                             }
                             if (c.outputType === "binary") {
-                              // Mirrors EvaluatorScoreCell: "true"/"1" → Pass.
+                              // Mirrors EvaluatorScoreCell: lowercase the
+                              // raw string before comparing so judges that
+                              // emit "True"/"TRUE" still register as Pass.
+                              const norm = score.toLowerCase();
                               row[c.key] =
-                                score === "true" || score === "1"
+                                norm === "true" || norm === "1"
                                   ? "true"
                                   : "false";
                             } else {
@@ -796,6 +789,18 @@ export default function STTEvaluationDetailPage() {
                     }}
                   />
                 )}
+              {/* Sharing only makes sense once the run is complete — earlier
+                  state changes too quickly and a shared link would render
+                  partial results. */}
+              {evaluationResult.status === "done" && backendAccessToken && (
+                <ShareButton
+                  entityType="stt"
+                  entityId={taskId}
+                  accessToken={backendAccessToken}
+                  initialIsPublic={evaluationResult.is_public ?? false}
+                  initialShareToken={evaluationResult.share_token ?? null}
+                />
+              )}
               {evaluationResult.status === "failed" &&
                 backendAccessToken &&
                 evaluationResult.dataset_id && (

--- a/src/app/stt/[uuid]/page.tsx
+++ b/src/app/stt/[uuid]/page.tsx
@@ -21,6 +21,7 @@ import {
 import { useSidebarState } from "@/lib/sidebar";
 import { getDataset } from "@/lib/datasets";
 import { ShareButton } from "@/components/ShareButton";
+import { ExportResultsButton, ExportColumn } from "@/components/ExportResultsButton";
 import { DeleteConfirmationDialog } from "@/components/DeleteConfirmationDialog";
 import { retryEvaluation } from "@/lib/retryEvaluation";
 import {
@@ -722,6 +723,63 @@ export default function STTEvaluationDetailPage() {
                     initialShareToken={evaluationResult.share_token ?? null}
                   />
                 )}
+                {/* Export per-row results to CSV. One row per (provider, row);
+                    columns: reference / predicted text, WER, and one column
+                    per attached evaluator (binary → "true"/"false", rating →
+                    raw numeric score). Built at click time so it reflects
+                    the latest state if the user re-runs the page. */}
+                {evaluationResult.status === "done" &&
+                  (evaluationResult.provider_results ?? []).some(
+                    (pr) => (pr.results?.length ?? 0) > 0,
+                  ) && (
+                    <ExportResultsButton
+                      filename={`stt-results-${evaluationResult.dataset_name ?? taskId}`}
+                      getRows={() => {
+                        const columns: ExportColumn[] = [
+                          { key: "provider", header: "Provider" },
+                          { key: "row", header: "Row" },
+                          { key: "reference_text", header: "Reference text" },
+                          { key: "predicted_text", header: "Predicted text" },
+                          { key: "wer", header: "WER" },
+                          ...evaluatorColumns.map((c) => ({
+                            key: c.key,
+                            header: c.label,
+                          })),
+                        ];
+                        const rows: Record<string, unknown>[] = [];
+                        for (const pr of evaluationResult.provider_results ??
+                          []) {
+                          for (const r of pr.results ?? []) {
+                            const row: Record<string, unknown> = {
+                              provider: getProviderLabel(pr.provider),
+                              row: r.id,
+                              reference_text: r.gt,
+                              predicted_text: r.pred,
+                              wer: r.wer,
+                            };
+                            for (const c of evaluatorColumns) {
+                              const raw = r[c.scoreField ?? c.key];
+                              if (raw === undefined || raw === null) {
+                                row[c.key] = "";
+                                continue;
+                              }
+                              const s = String(raw);
+                              if (c.outputType === "binary") {
+                                // Mirrors EvaluatorScoreCell: "true"/"1" → Pass.
+                                row[c.key] =
+                                  s === "true" || s === "1" ? "true" : "false";
+                              } else {
+                                const n = parseFloat(s);
+                                row[c.key] = Number.isFinite(n) ? n : s;
+                              }
+                            }
+                            rows.push(row);
+                          }
+                        }
+                        return { columns, rows };
+                      }}
+                    />
+                  )}
                 {evaluationResult.status === "failed" &&
                   backendAccessToken &&
                   evaluationResult.dataset_id && (

--- a/src/app/tests/page.tsx
+++ b/src/app/tests/page.tsx
@@ -24,7 +24,10 @@ import {
 import { BulkUploadTestsModal } from "@/components/BulkUploadTestsModal";
 import { useSidebarState } from "@/lib/sidebar";
 import { POLLING_INTERVAL_MS } from "@/constants/polling";
-import { readNameConflictMessage } from "@/lib/parseBackendError";
+import {
+  readBulkNameConflictMessage,
+  readNameConflictMessage,
+} from "@/lib/parseBackendError";
 
 // Hydrated evaluator row as returned by GET /tests / GET /tests/{uuid}.evaluators[].
 // `uuid` is the evaluator's id (used as `evaluator_uuid` when writing back).
@@ -587,7 +590,8 @@ function LLMPageInner() {
     }
   };
 
-  // Create test via POST API
+  // Create test via POST /tests/bulk (used for both single and bulk flows for
+  // a consistent backend contract — see also BulkUploadTestsModal).
   const createTest = async (
     config: TestConfig,
     evaluators: EvaluatorRefPayload[]
@@ -604,30 +608,33 @@ function LLMPageInner() {
         throw new Error("BACKEND_URL environment variable is not set");
       }
 
-      // Only attach `evaluators` for next-reply tests. Tool-invocation tests
-      // don't carry evaluators and must not have their links touched server-side.
-      const body: {
+      const isResponse = config.evaluation.type === "response";
+      const testItem: {
         name: string;
-        type: "response" | "tool_call";
-        config: TestConfig;
+        conversation_history: TestConfig["history"];
         evaluators?: EvaluatorRefPayload[];
+        tool_calls?: NonNullable<TestConfig["evaluation"]["tool_calls"]>;
       } = {
         name: newTestName.trim(),
-        type: config.evaluation.type,
-        config: config,
+        conversation_history: config.history,
       };
-      if (config.evaluation.type === "response") {
-        body.evaluators = evaluators;
+      if (isResponse) {
+        testItem.evaluators = evaluators;
+      } else {
+        testItem.tool_calls = config.evaluation.tool_calls ?? [];
       }
 
-      const response = await fetch(`${backendUrl}/tests`, {
+      const response = await fetch(`${backendUrl}/tests/bulk`, {
         method: "POST",
         headers: {
           accept: "application/json",
           "Content-Type": "application/json",
           Authorization: `Bearer ${backendAccessToken}`,
         },
-        body: JSON.stringify(body),
+        body: JSON.stringify({
+          type: config.evaluation.type,
+          tests: [testItem],
+        }),
       });
 
       if (response.status === 401) {
@@ -636,7 +643,10 @@ function LLMPageInner() {
       }
 
       if (!response.ok) {
-        const conflict = await readNameConflictMessage(response);
+        // Bulk endpoint returns 400 (not 409) for name conflicts. Route the
+        // duplicate-name case to the inline name-field error slot so it
+        // matches the single-test create UX users expect.
+        const conflict = await readBulkNameConflictMessage(response);
         if (conflict) {
           setNameConflictError(conflict);
           setIsCreating(false);

--- a/src/app/tests/page.tsx
+++ b/src/app/tests/page.tsx
@@ -887,7 +887,12 @@ function LLMPageInner() {
               Create and manage tests to evaluate your LLM
             </p>
           </div>
-          {activeTab === "tests" && (
+          {/* Top-right action area. Hidden when the library is fully empty
+              — in that case the placeholder card below renders the
+              Create test / Bulk upload buttons instead, since there are
+              no tests to manage and no bulk-delete / search context that
+              would put the action buttons up here. */}
+          {activeTab === "tests" && !testsLoading && tests.length > 0 && (
             <div className="flex items-center gap-2">
               {selectedTestUuids.size > 0 && (
                 <button
@@ -897,9 +902,11 @@ function LLMPageInner() {
                   Delete selected ({selectedTestUuids.size})
                 </button>
               )}
+              {/* Same tinted styling as the agent page's Tests tab:
+                  Create test → emerald, Bulk upload → orange. */}
               <button
                 onClick={() => setBulkUploadOpen(true)}
-                className="h-9 md:h-10 px-4 rounded-md text-sm md:text-base font-medium border border-border bg-background text-foreground hover:bg-muted/50 transition-colors cursor-pointer flex-shrink-0"
+                className="h-9 md:h-10 px-3 md:px-4 rounded-md text-sm md:text-base font-medium border cursor-pointer transition-colors flex-shrink-0 bg-orange-500/12 border-orange-500/45 text-orange-950 dark:text-orange-100 hover:bg-orange-500/22 dark:hover:bg-orange-500/18"
               >
                 Bulk upload
               </button>
@@ -908,9 +915,9 @@ function LLMPageInner() {
                   resetForm();
                   setAddTestSidebarOpen(true);
                 }}
-                className="h-9 md:h-10 px-4 rounded-md text-sm md:text-base font-medium bg-foreground text-background hover:opacity-90 transition-opacity cursor-pointer flex-shrink-0"
+                className="h-9 md:h-10 px-3 md:px-4 rounded-md text-sm md:text-base font-medium border cursor-pointer transition-colors flex-shrink-0 bg-emerald-500/12 border-emerald-500/45 text-emerald-950 dark:text-emerald-100 hover:bg-emerald-500/22 dark:hover:bg-emerald-500/18"
               >
-                Add test
+                Create test
               </button>
             </div>
           )}
@@ -1029,15 +1036,30 @@ function LLMPageInner() {
                 ? "No tests match your search"
                 : "You haven't created any tests yet"}
             </p>
-            <button
-              onClick={() => {
-                resetForm();
-                setAddTestSidebarOpen(true);
-              }}
-              className="h-9 md:h-10 px-4 rounded-md text-sm md:text-base font-medium border border-border bg-background hover:bg-muted/50 transition-colors cursor-pointer"
-            >
-              Add test
-            </button>
+            {/* When the library is truly empty (no search filter), show
+                both create affordances inline — the top-right area is
+                hidden in that case so this is the only entry point.
+                When the empty state is search-driven, render no button
+                (the user can clear the search). */}
+            {!searchQuery && (
+              <div className="flex flex-wrap items-center justify-center gap-2 md:gap-3">
+                <button
+                  onClick={() => {
+                    resetForm();
+                    setAddTestSidebarOpen(true);
+                  }}
+                  className="h-9 md:h-10 px-3 md:px-4 rounded-md text-sm md:text-base font-medium border cursor-pointer transition-colors bg-emerald-500/12 border-emerald-500/45 text-emerald-950 dark:text-emerald-100 hover:bg-emerald-500/22 dark:hover:bg-emerald-500/18"
+                >
+                  Create test
+                </button>
+                <button
+                  onClick={() => setBulkUploadOpen(true)}
+                  className="h-9 md:h-10 px-3 md:px-4 rounded-md text-sm md:text-base font-medium border cursor-pointer transition-colors bg-orange-500/12 border-orange-500/45 text-orange-950 dark:text-orange-100 hover:bg-orange-500/22 dark:hover:bg-orange-500/18"
+                >
+                  Bulk upload
+                </button>
+              </div>
+            )}
           </div>
         ) : (
           <>

--- a/src/app/tests/page.tsx
+++ b/src/app/tests/page.tsx
@@ -643,12 +643,14 @@ function LLMPageInner() {
       }
 
       if (!response.ok) {
-        // Bulk endpoint returns 400 (not 409) for name conflicts. Route the
-        // duplicate-name case to the inline name-field error slot so it
-        // matches the single-test create UX users expect.
+        // Bulk endpoint returns 400 (not 409) for name conflicts. Route
+        // the duplicate-name case to the inline name-field error slot
+        // with a friendly fixed message, matching the agent-create UX
+        // (the backend's verbatim "Test names already exist: <name>" is
+        // awkward for a single-test dialog).
         const conflict = await readBulkNameConflictMessage(response);
         if (conflict) {
-          setNameConflictError(conflict);
+          setNameConflictError("A test with this name already exists");
           setIsCreating(false);
           return;
         }
@@ -809,7 +811,7 @@ function LLMPageInner() {
       if (!response.ok) {
         const conflict = await readNameConflictMessage(response);
         if (conflict) {
-          setNameConflictError(conflict);
+          setNameConflictError("A test with this name already exists");
           setIsCreating(false);
           return;
         }

--- a/src/app/tts/[uuid]/page.tsx
+++ b/src/app/tts/[uuid]/page.tsx
@@ -21,6 +21,7 @@ import {
   ratingRange,
   type TTSEvaluatorColumn,
 } from "@/components/eval-details";
+import { readEvaluatorCell } from "@/components/eval-details/EvaluatorScoreCell";
 import { useSidebarState } from "@/lib/sidebar";
 import { getDataset } from "@/lib/datasets";
 import { ShareButton } from "@/components/ShareButton";
@@ -791,19 +792,27 @@ export default function TTSEvaluationDetailPage() {
                             audio_name: audioName,
                             text: r.text,
                           };
+                          // Read via `readEvaluatorCell` so the refreshed
+                          // `evaluator_outputs[<uuid>]` shape is preferred
+                          // over the legacy flat scoreField. Matches what
+                          // TTSResultsTable renders on screen.
                           for (const c of evaluatorColumns) {
-                            const raw = r[c.scoreField ?? c.key];
-                            if (raw === undefined || raw === null) {
+                            const { score, error } = readEvaluatorCell(
+                              r as unknown as Record<string, unknown>,
+                              c,
+                            );
+                            if (error || score === undefined) {
                               row[c.key] = "";
                               continue;
                             }
-                            const s = String(raw);
                             if (c.outputType === "binary") {
                               row[c.key] =
-                                s === "true" || s === "1" ? "true" : "false";
+                                score === "true" || score === "1"
+                                  ? "true"
+                                  : "false";
                             } else {
-                              const n = parseFloat(s);
-                              row[c.key] = Number.isFinite(n) ? n : s;
+                              const n = parseFloat(score);
+                              row[c.key] = Number.isFinite(n) ? n : score;
                             }
                           }
                           rows.push(row);

--- a/src/app/tts/[uuid]/page.tsx
+++ b/src/app/tts/[uuid]/page.tsx
@@ -725,24 +725,14 @@ export default function TTSEvaluationDetailPage() {
               {evaluationResult.status !== "done" && (
                 <StatusBadge status={evaluationResult.status} showSpinner />
               )}
-              {/* Sharing only makes sense once the run is complete — earlier
-                  state changes too quickly and a shared link would render
-                  partial results. */}
-              {evaluationResult.status === "done" && backendAccessToken && (
-                <ShareButton
-                  entityType="tts"
-                  entityId={taskId}
-                  accessToken={backendAccessToken}
-                  initialIsPublic={evaluationResult.is_public ?? false}
-                  initialShareToken={evaluationResult.share_token ?? null}
-                />
-              )}
               {/* Export per-row results as a zip containing `results.csv`
                   (row id, audio_name, evaluator scores — same convention
                   as the STT CSV) and an `audios/` folder of every
                   synthesized clip. Each audio is named
                   `<provider>_<row>.<ext>` so the audio_name CSV column
-                  points directly at the file inside the zip. */}
+                  points directly at the file inside the zip. Placed
+                  before Share so the Export ↔ Share ordering matches
+                  TestRunnerDialog / BenchmarkResultsDialog / STT. */}
               {evaluationResult.status === "done" &&
                 (evaluationResult.provider_results ?? []).some(
                   (pr) => (pr.results?.length ?? 0) > 0,
@@ -806,8 +796,12 @@ export default function TTSEvaluationDetailPage() {
                               continue;
                             }
                             if (c.outputType === "binary") {
+                              // Mirrors EvaluatorScoreCell: lowercase the
+                              // raw string before comparing so judges that
+                              // emit "True"/"TRUE" still register as Pass.
+                              const norm = score.toLowerCase();
                               row[c.key] =
-                                score === "true" || score === "1"
+                                norm === "true" || norm === "1"
                                   ? "true"
                                   : "false";
                             } else {
@@ -831,6 +825,18 @@ export default function TTSEvaluationDetailPage() {
                     }}
                   />
                 )}
+              {/* Sharing only makes sense once the run is complete — earlier
+                  state changes too quickly and a shared link would render
+                  partial results. */}
+              {evaluationResult.status === "done" && backendAccessToken && (
+                <ShareButton
+                  entityType="tts"
+                  entityId={taskId}
+                  accessToken={backendAccessToken}
+                  initialIsPublic={evaluationResult.is_public ?? false}
+                  initialShareToken={evaluationResult.share_token ?? null}
+                />
+              )}
               {evaluationResult.status === "failed" &&
                 backendAccessToken &&
                 evaluationResult.dataset_id && (

--- a/src/app/tts/[uuid]/page.tsx
+++ b/src/app/tts/[uuid]/page.tsx
@@ -19,6 +19,8 @@ import {
 import { useSidebarState } from "@/lib/sidebar";
 import { getDataset } from "@/lib/datasets";
 import { ShareButton } from "@/components/ShareButton";
+import { ExportZipButton } from "@/components/ExportZipButton";
+import type { ExportColumn } from "@/components/ExportResultsButton";
 import { DeleteConfirmationDialog } from "@/components/DeleteConfirmationDialog";
 import { retryEvaluation } from "@/lib/retryEvaluation";
 import {
@@ -727,6 +729,92 @@ export default function TTSEvaluationDetailPage() {
                     initialShareToken={evaluationResult.share_token ?? null}
                   />
                 )}
+                {/* Export per-row results as a zip containing `results.csv`
+                    (row id, audio_name, evaluator scores — same convention
+                    as the STT CSV) and an `audios/` folder of every
+                    synthesized clip. Each audio is named
+                    `<provider>_<row>.<ext>` so the audio_name CSV column
+                    points directly at the file inside the zip. */}
+                {evaluationResult.status === "done" &&
+                  (evaluationResult.provider_results ?? []).some(
+                    (pr) => (pr.results?.length ?? 0) > 0,
+                  ) && (
+                    <ExportZipButton
+                      filename={`tts-results-${evaluationResult.dataset_name ?? taskId}`}
+                      getContents={() => {
+                        const columns: ExportColumn[] = [
+                          { key: "provider", header: "Provider" },
+                          { key: "row", header: "Row" },
+                          { key: "audio_name", header: "Audio name" },
+                          { key: "text", header: "Text" },
+                          ...evaluatorColumns.map((c) => ({
+                            key: c.key,
+                            header: c.label,
+                          })),
+                        ];
+                        const rows: Record<string, unknown>[] = [];
+                        const files: { path: string; url: string }[] = [];
+                        for (const pr of evaluationResult.provider_results ??
+                          []) {
+                          for (const r of pr.results ?? []) {
+                            // audio_path is rendered as <audio src=...> on the
+                            // page, so it's already a fetchable URL. Use the
+                            // path's extension if present; fall back to `.wav`
+                            // (the backend's default container) when the URL
+                            // has no extension or has querystring noise.
+                            const ext = (() => {
+                              try {
+                                const u = new URL(
+                                  r.audio_path,
+                                  window.location.origin,
+                                );
+                                const m = u.pathname.match(/\.([a-z0-9]+)$/i);
+                                return m ? m[1].toLowerCase() : "wav";
+                              } catch {
+                                const m = r.audio_path.match(/\.([a-z0-9]+)(?:\?|$)/i);
+                                return m ? m[1].toLowerCase() : "wav";
+                              }
+                            })();
+                            const audioName = r.audio_path
+                              ? `${pr.provider}_${r.id}.${ext}`
+                              : "";
+                            const row: Record<string, unknown> = {
+                              provider: getProviderLabel(pr.provider),
+                              row: r.id,
+                              audio_name: audioName,
+                              text: r.text,
+                            };
+                            for (const c of evaluatorColumns) {
+                              const raw = r[c.scoreField ?? c.key];
+                              if (raw === undefined || raw === null) {
+                                row[c.key] = "";
+                                continue;
+                              }
+                              const s = String(raw);
+                              if (c.outputType === "binary") {
+                                row[c.key] =
+                                  s === "true" || s === "1" ? "true" : "false";
+                              } else {
+                                const n = parseFloat(s);
+                                row[c.key] = Number.isFinite(n) ? n : s;
+                              }
+                            }
+                            rows.push(row);
+                            if (audioName && r.audio_path) {
+                              files.push({
+                                path: `audios/${audioName}`,
+                                url: r.audio_path,
+                              });
+                            }
+                          }
+                        }
+                        return {
+                          csv: { columns, rows },
+                          files,
+                        };
+                      }}
+                    />
+                  )}
                 {evaluationResult.status === "failed" &&
                   backendAccessToken &&
                   evaluationResult.dataset_id && (

--- a/src/app/tts/[uuid]/page.tsx
+++ b/src/app/tts/[uuid]/page.tsx
@@ -742,7 +742,6 @@ export default function TTSEvaluationDetailPage() {
                     getContents={() => {
                       const columns: ExportColumn[] = [
                         { key: "provider", header: "Provider" },
-                        { key: "row", header: "Row" },
                         { key: "audio_name", header: "Audio name" },
                         { key: "text", header: "Text" },
                         ...evaluatorColumns.map((c) => ({
@@ -778,7 +777,6 @@ export default function TTSEvaluationDetailPage() {
                             : "";
                           const row: Record<string, unknown> = {
                             provider: getProviderLabel(pr.provider),
-                            row: r.id,
                             audio_name: audioName,
                             text: r.text,
                           };

--- a/src/components/AddTestDialog.tsx
+++ b/src/components/AddTestDialog.tsx
@@ -2125,13 +2125,16 @@ export function AddTestDialog({
                   Create conversation context starting with
                 </p>
 
+                {/* Conversation starter buttons. Semantic tint per role so
+                    they match the per-row +-menu items below — agent = sky,
+                    user = amber. */}
                 <div className="flex items-center gap-3">
                   <button
                     onClick={() => addChatMessage("agent")}
-                    className="px-4 py-2.5 rounded-xl border border-border bg-transparent text-foreground hover:bg-muted transition-colors cursor-pointer flex items-center gap-2"
+                    className="px-4 py-2.5 rounded-xl border cursor-pointer transition-colors flex items-center gap-2 bg-sky-500/12 border-sky-500/45 text-sky-950 dark:text-sky-100 hover:bg-sky-500/22 dark:hover:bg-sky-500/18"
                   >
                     <svg
-                      className="w-5 h-5 text-muted-foreground"
+                      className="w-5 h-5"
                       fill="none"
                       viewBox="0 0 24 24"
                       stroke="currentColor"
@@ -2147,10 +2150,10 @@ export function AddTestDialog({
                   </button>
                   <button
                     onClick={() => addChatMessage("user")}
-                    className="px-4 py-2.5 rounded-xl border border-border bg-transparent text-foreground hover:bg-muted transition-colors cursor-pointer flex items-center gap-2"
+                    className="px-4 py-2.5 rounded-xl border cursor-pointer transition-colors flex items-center gap-2 bg-amber-500/12 border-amber-500/45 text-amber-950 dark:text-amber-100 hover:bg-amber-500/22 dark:hover:bg-amber-500/18"
                   >
                     <svg
-                      className="w-5 h-5 text-muted-foreground"
+                      className="w-5 h-5"
                       fill="none"
                       viewBox="0 0 24 24"
                       stroke="currentColor"
@@ -2223,7 +2226,7 @@ export function AddTestDialog({
                           const inlineDeleteBtn = showInlineDelete ? (
                             <button
                               onClick={() => removeChatMessage(message.id)}
-                              className="w-8 h-8 flex-shrink-0 rounded-lg border border-border flex items-center justify-center text-muted-foreground hover:text-red-400 hover:border-red-400/50 transition-colors cursor-pointer"
+                              className="w-8 h-8 flex-shrink-0 rounded-lg border flex items-center justify-center cursor-pointer transition-colors bg-red-500/10 border-red-500/40 text-red-500 hover:bg-red-500/20 hover:border-red-500/60"
                               title="Remove message"
                             >
                               <svg
@@ -2495,7 +2498,7 @@ export function AddTestDialog({
                           {showInlineDelete && (
                             <button
                               onClick={() => removeChatMessage(message.id)}
-                              className="w-8 h-8 flex-shrink-0 rounded-lg border border-border flex items-center justify-center text-muted-foreground hover:text-red-400 hover:border-red-400/50 transition-colors cursor-pointer"
+                              className="w-8 h-8 flex-shrink-0 rounded-lg border flex items-center justify-center cursor-pointer transition-colors bg-red-500/10 border-red-500/40 text-red-500 hover:bg-red-500/20 hover:border-red-500/60"
                               title="Remove message"
                             >
                               <svg
@@ -2622,7 +2625,7 @@ export function AddTestDialog({
                                       !addMessageDropdownOpen,
                                     )
                                   }
-                                  className="w-8 h-8 rounded-lg border border-border flex items-center justify-center text-muted-foreground hover:text-foreground hover:border-muted-foreground transition-colors cursor-pointer"
+                                  className="w-8 h-8 rounded-lg border flex items-center justify-center cursor-pointer transition-colors bg-emerald-500/12 border-emerald-500/45 text-emerald-700 dark:text-emerald-300 hover:bg-emerald-500/22 dark:hover:bg-emerald-500/18"
                                   title="Add message"
                                 >
                                   <svg
@@ -2660,15 +2663,20 @@ export function AddTestDialog({
                                             : "left-0 bottom-full mb-2"
                                       }`}
                                     >
+                                      {/* Semantic hue per message kind so
+                                          options at a glance map to the
+                                          chat-bubble role. User = amber
+                                          (human/warm), Agent = sky (AI),
+                                          Tool call = violet (action). */}
                                       <button
                                         onClick={() => {
                                           addChatMessage("user");
                                           setAddMessageDropdownOpen(false);
                                         }}
-                                        className="w-full px-3 py-1.5 flex items-center gap-2 text-foreground hover:bg-muted transition-colors cursor-pointer"
+                                        className="w-full px-3 py-1.5 flex items-center gap-2 text-amber-700 dark:text-amber-200 hover:bg-amber-500/15 transition-colors cursor-pointer"
                                       >
                                         <svg
-                                          className="w-4 h-4 text-muted-foreground"
+                                          className="w-4 h-4"
                                           fill="none"
                                           viewBox="0 0 24 24"
                                           stroke="currentColor"
@@ -2689,10 +2697,10 @@ export function AddTestDialog({
                                           addChatMessage("agent");
                                           setAddMessageDropdownOpen(false);
                                         }}
-                                        className="w-full px-3 py-1.5 flex items-center gap-2 text-foreground hover:bg-muted transition-colors cursor-pointer"
+                                        className="w-full px-3 py-1.5 flex items-center gap-2 text-sky-700 dark:text-sky-200 hover:bg-sky-500/15 transition-colors cursor-pointer"
                                       >
                                         <svg
-                                          className="w-4 h-4 text-muted-foreground"
+                                          className="w-4 h-4"
                                           fill="none"
                                           viewBox="0 0 24 24"
                                           stroke="currentColor"
@@ -2713,10 +2721,10 @@ export function AddTestDialog({
                                           setAddMessageDropdownOpen(false);
                                           setToolCallDropdownOpen(true);
                                         }}
-                                        className="w-full px-3 py-1.5 flex items-center gap-2 text-foreground hover:bg-muted transition-colors cursor-pointer"
+                                        className="w-full px-3 py-1.5 flex items-center gap-2 text-violet-700 dark:text-violet-200 hover:bg-violet-500/15 transition-colors cursor-pointer"
                                       >
                                         <svg
-                                          className="w-4 h-4 text-muted-foreground"
+                                          className="w-4 h-4"
                                           fill="none"
                                           viewBox="0 0 24 24"
                                           stroke="currentColor"

--- a/src/components/AddTestDialog.tsx
+++ b/src/components/AddTestDialog.tsx
@@ -1452,11 +1452,14 @@ export function AddTestDialog({
                             disabled={
                               evaluatorsLoading || isLoading || noOptionsLeft
                             }
-                            className={`px-3 py-1.5 text-sm font-medium bg-background text-foreground rounded-lg hover:bg-muted transition-colors cursor-pointer border border-border disabled:opacity-50 disabled:cursor-not-allowed ${
+                            // Tinted violet so the action stands out from
+                            // the neutral form chrome around it. Validation
+                            // error state overrides border/text to red.
+                            className={`px-3 py-1.5 text-sm font-medium rounded-lg border cursor-pointer transition-colors disabled:opacity-50 disabled:cursor-not-allowed bg-violet-500/12 border-violet-500/45 text-violet-950 dark:text-violet-100 hover:bg-violet-500/22 dark:hover:bg-violet-500/18 ${
                               localValidationAttempted &&
                               activeTab === "next-reply" &&
                               attachedEvaluators.length === 0
-                                ? "border-red-500 text-red-400"
+                                ? "!border-red-500 !text-red-500 !bg-red-500/10"
                                 : ""
                             }`}
                           >

--- a/src/components/AddTestDialog.tsx
+++ b/src/components/AddTestDialog.tsx
@@ -2653,7 +2653,7 @@ export function AddTestDialog({
                                       }
                                     />
                                     <div
-                                      className={`absolute bg-background border border-border rounded-lg shadow-xl z-[200] overflow-hidden py-1 whitespace-nowrap ${
+                                      className={`absolute bg-background border border-border rounded-lg shadow-xl z-[200] overflow-hidden whitespace-nowrap ${
                                         message.role === "user"
                                           ? chatMessages.length <= 2
                                             ? "right-0 top-10"
@@ -2663,11 +2663,12 @@ export function AddTestDialog({
                                             : "left-0 bottom-full mb-2"
                                       }`}
                                     >
-                                      {/* Semantic hue per message kind,
-                                          rendered as a tinted row chip so
-                                          each option reads as its own
-                                          coloured cell. Cyan for Agent
-                                          tool call keeps it visually
+                                      {/* Three clearly separated hues so
+                                          adjacent rows don't read as the
+                                          same family: amber (warm yellow)
+                                          for User, sky (cool blue) for
+                                          Agent, fuchsia (pink-magenta)
+                                          for Agent tool call — also
                                           distinct from the violet
                                           "Add evaluator" button above. */}
                                       <button
@@ -2723,7 +2724,7 @@ export function AddTestDialog({
                                           setAddMessageDropdownOpen(false);
                                           setToolCallDropdownOpen(true);
                                         }}
-                                        className="w-full px-3 py-1.5 flex items-center gap-2 transition-colors cursor-pointer bg-cyan-500/15 text-cyan-900 dark:bg-cyan-500/20 dark:text-cyan-100 hover:bg-cyan-500/25 dark:hover:bg-cyan-500/30"
+                                        className="w-full px-3 py-1.5 flex items-center gap-2 transition-colors cursor-pointer bg-fuchsia-500/15 text-fuchsia-900 dark:bg-fuchsia-500/20 dark:text-fuchsia-100 hover:bg-fuchsia-500/25 dark:hover:bg-fuchsia-500/30"
                                       >
                                         <svg
                                           className="w-4 h-4"

--- a/src/components/AddTestDialog.tsx
+++ b/src/components/AddTestDialog.tsx
@@ -2591,7 +2591,7 @@ export function AddTestDialog({
                           isLastNonToolResponse && (
                             <button
                               onClick={() => removeChatMessage(message.id)}
-                              className="w-8 h-8 rounded-lg border border-border flex items-center justify-center text-muted-foreground hover:text-red-400 hover:border-red-400/50 transition-colors cursor-pointer"
+                              className="w-8 h-8 rounded-lg border flex items-center justify-center cursor-pointer transition-colors bg-red-500/10 border-red-500/40 text-red-500 hover:bg-red-500/20 hover:border-red-500/60"
                               title="Remove message"
                             >
                               <svg
@@ -2663,17 +2663,19 @@ export function AddTestDialog({
                                             : "left-0 bottom-full mb-2"
                                       }`}
                                     >
-                                      {/* Semantic hue per message kind so
-                                          options at a glance map to the
-                                          chat-bubble role. User = amber
-                                          (human/warm), Agent = sky (AI),
-                                          Tool call = violet (action). */}
+                                      {/* Semantic hue per message kind,
+                                          rendered as a tinted row chip so
+                                          each option reads as its own
+                                          coloured cell. Cyan for Agent
+                                          tool call keeps it visually
+                                          distinct from the violet
+                                          "Add evaluator" button above. */}
                                       <button
                                         onClick={() => {
                                           addChatMessage("user");
                                           setAddMessageDropdownOpen(false);
                                         }}
-                                        className="w-full px-3 py-1.5 flex items-center gap-2 text-amber-700 dark:text-amber-200 hover:bg-amber-500/15 transition-colors cursor-pointer"
+                                        className="w-full px-3 py-1.5 flex items-center gap-2 transition-colors cursor-pointer bg-amber-500/15 text-amber-900 dark:bg-amber-500/20 dark:text-amber-100 hover:bg-amber-500/25 dark:hover:bg-amber-500/30"
                                       >
                                         <svg
                                           className="w-4 h-4"
@@ -2697,7 +2699,7 @@ export function AddTestDialog({
                                           addChatMessage("agent");
                                           setAddMessageDropdownOpen(false);
                                         }}
-                                        className="w-full px-3 py-1.5 flex items-center gap-2 text-sky-700 dark:text-sky-200 hover:bg-sky-500/15 transition-colors cursor-pointer"
+                                        className="w-full px-3 py-1.5 flex items-center gap-2 transition-colors cursor-pointer bg-sky-500/15 text-sky-900 dark:bg-sky-500/20 dark:text-sky-100 hover:bg-sky-500/25 dark:hover:bg-sky-500/30"
                                       >
                                         <svg
                                           className="w-4 h-4"
@@ -2721,7 +2723,7 @@ export function AddTestDialog({
                                           setAddMessageDropdownOpen(false);
                                           setToolCallDropdownOpen(true);
                                         }}
-                                        className="w-full px-3 py-1.5 flex items-center gap-2 text-violet-700 dark:text-violet-200 hover:bg-violet-500/15 transition-colors cursor-pointer"
+                                        className="w-full px-3 py-1.5 flex items-center gap-2 transition-colors cursor-pointer bg-cyan-500/15 text-cyan-900 dark:bg-cyan-500/20 dark:text-cyan-100 hover:bg-cyan-500/25 dark:hover:bg-cyan-500/30"
                                       >
                                         <svg
                                           className="w-4 h-4"

--- a/src/components/AddTestDialog.tsx
+++ b/src/components/AddTestDialog.tsx
@@ -2302,6 +2302,33 @@ export function AddTestDialog({
                       {/* Tool Call Display */}
                       {message.role === "tool_call" && (
                         <div className="flex w-full items-start gap-2">
+                          {/* Delete button on the LEFT of the tool-call card
+                              so it aligns with how previous agent message
+                              rows place it (tool calls are always an agent
+                              action, never a user one). Rendered first in
+                              source order so flexbox lays it out at the
+                              start of the row. */}
+                          {showInlineDelete && (
+                            <button
+                              onClick={() => removeChatMessage(message.id)}
+                              className="w-8 h-8 flex-shrink-0 rounded-lg border flex items-center justify-center cursor-pointer transition-colors bg-red-500/10 border-red-500/40 text-red-500 hover:bg-red-500/20 hover:border-red-500/60"
+                              title="Remove message"
+                            >
+                              <svg
+                                className="w-4 h-4"
+                                fill="none"
+                                viewBox="0 0 24 24"
+                                stroke="currentColor"
+                                strokeWidth={2}
+                              >
+                                <path
+                                  strokeLinecap="round"
+                                  strokeLinejoin="round"
+                                  d="M14.74 9l-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 01-2.244 2.077H8.084a2.25 2.25 0 01-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 00-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 013.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 00-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 00-7.5 0"
+                                />
+                              </svg>
+                            </button>
+                          )}
                           <div className="w-1/2">
                             <div className="bg-muted border border-border rounded-2xl p-4">
                               <div className="flex items-center gap-2 mb-2">
@@ -2495,27 +2522,6 @@ export function AddTestDialog({
                                 )}
                             </div>
                           </div>
-                          {showInlineDelete && (
-                            <button
-                              onClick={() => removeChatMessage(message.id)}
-                              className="w-8 h-8 flex-shrink-0 rounded-lg border flex items-center justify-center cursor-pointer transition-colors bg-red-500/10 border-red-500/40 text-red-500 hover:bg-red-500/20 hover:border-red-500/60"
-                              title="Remove message"
-                            >
-                              <svg
-                                className="w-4 h-4"
-                                fill="none"
-                                viewBox="0 0 24 24"
-                                stroke="currentColor"
-                                strokeWidth={2}
-                              >
-                                <path
-                                  strokeLinecap="round"
-                                  strokeLinejoin="round"
-                                  d="M14.74 9l-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 01-2.244 2.077H8.084a2.25 2.25 0 01-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 00-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 013.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 00-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 00-7.5 0"
-                                />
-                              </svg>
-                            </button>
-                          )}
                         </div>
                       )}
 

--- a/src/components/BulkUploadTestsModal.tsx
+++ b/src/components/BulkUploadTestsModal.tsx
@@ -52,6 +52,13 @@ type BulkUploadTestsModalProps = {
   isOpen: boolean;
   onClose: () => void;
   onSuccess: () => void;
+  /**
+   * If set, the modal is locked to this agent: the "Assign tests to agents"
+   * picker is hidden and `agent_uuids: [lockedAgentUuid]` is sent with the
+   * upload so the new tests auto-attach to the agent the user came from.
+   * Used by the agent page's Tests tab.
+   */
+  lockedAgentUuid?: string;
 };
 
 // Column header for an evaluator variable in the response-type CSV. We
@@ -150,6 +157,7 @@ export function BulkUploadTestsModal({
   isOpen,
   onClose,
   onSuccess,
+  lockedAgentUuid,
 }: BulkUploadTestsModalProps) {
   const backendAccessToken = useAccessToken();
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -854,7 +862,9 @@ export function BulkUploadTestsModal({
         tests: typeof tests;
         agent_uuids?: string[];
       } = { type: testType, tests };
-      if (assignToAgents && selectedAgentUuids.length > 0) {
+      if (lockedAgentUuid) {
+        body.agent_uuids = [lockedAgentUuid];
+      } else if (assignToAgents && selectedAgentUuids.length > 0) {
         body.agent_uuids = selectedAgentUuids;
       }
 
@@ -1612,8 +1622,9 @@ export function BulkUploadTestsModal({
             </div>
           )}
 
-          {/* Step 3: Assign to Agents (optional) */}
-          {testType && parsedTests.length > 0 && (
+          {/* Step 3: Assign to Agents (optional, hidden when modal is
+              locked to a specific agent — see lockedAgentUuid prop). */}
+          {testType && parsedTests.length > 0 && !lockedAgentUuid && (
             <div ref={assignAgentsSectionRef}>
               <div className="flex items-center gap-3 mb-3">
                 <button
@@ -1707,7 +1718,9 @@ export function BulkUploadTestsModal({
                   disabled={
                     isUploading ||
                     parsedTests.length === 0 ||
-                    (assignToAgents && selectedAgentUuids.length === 0)
+                    (!lockedAgentUuid &&
+                      assignToAgents &&
+                      selectedAgentUuids.length === 0)
                   }
                   className="h-10 px-5 rounded-lg text-sm font-medium bg-foreground text-background hover:opacity-90 transition-opacity cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2"
                 >

--- a/src/components/BulkUploadTestsModal.tsx
+++ b/src/components/BulkUploadTestsModal.tsx
@@ -1146,12 +1146,15 @@ export function BulkUploadTestsModal({
           ref={dialogBodyRef}
           className="flex-1 overflow-y-auto px-6 py-5 space-y-6"
         >
-          {/* Step 1: Test Type */}
+          {/* Step 1: Test Type — two side-by-side option cards so the
+              one-line description sits next to each title, helping the
+              user pick before clicking. Selected card uses the same
+              filled-foreground look the old segmented toggle had. */}
           <div>
             <label className="block text-sm font-medium text-foreground mb-3">
               Select the type of test
             </label>
-            <div className="flex rounded-lg border border-border overflow-hidden w-fit">
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 w-full max-w-2xl">
               <button
                 type="button"
                 onClick={() => {
@@ -1165,13 +1168,23 @@ export function BulkUploadTestsModal({
                   setCommittedEvaluators([]);
                   if (fileInputRef.current) fileInputRef.current.value = "";
                 }}
-                className={`px-4 py-2 text-sm font-medium transition-colors cursor-pointer ${
+                className={`text-left px-4 py-3 rounded-lg border transition-colors cursor-pointer ${
                   isResponseType
-                    ? "bg-foreground text-background"
-                    : "bg-background text-muted-foreground hover:text-foreground hover:bg-muted"
+                    ? "bg-foreground text-background border-foreground"
+                    : "bg-background border-border hover:bg-muted/50"
                 }`}
               >
-                Next Reply
+                <div className="text-sm font-medium mb-0.5">Next Reply</div>
+                <div
+                  className={`text-xs leading-snug ${
+                    isResponseType
+                      ? "text-background/80"
+                      : "text-muted-foreground"
+                  }`}
+                >
+                  Grade the agent&apos;s text reply to the last user message
+                  against your evaluators.
+                </div>
               </button>
               <button
                 type="button"
@@ -1186,13 +1199,23 @@ export function BulkUploadTestsModal({
                   setCommittedEvaluators([]);
                   if (fileInputRef.current) fileInputRef.current.value = "";
                 }}
-                className={`px-4 py-2 text-sm font-medium transition-colors cursor-pointer border-l border-border ${
+                className={`text-left px-4 py-3 rounded-lg border transition-colors cursor-pointer ${
                   testType === "tool_call"
-                    ? "bg-foreground text-background"
-                    : "bg-background text-muted-foreground hover:text-foreground hover:bg-muted"
+                    ? "bg-foreground text-background border-foreground"
+                    : "bg-background border-border hover:bg-muted/50"
                 }`}
               >
-                Tool Call
+                <div className="text-sm font-medium mb-0.5">Tool Call</div>
+                <div
+                  className={`text-xs leading-snug ${
+                    testType === "tool_call"
+                      ? "text-background/80"
+                      : "text-muted-foreground"
+                  }`}
+                >
+                  Check which tool the agent invokes and the arguments it
+                  passes.
+                </div>
               </button>
             </div>
           </div>

--- a/src/components/BulkUploadTestsModal.tsx
+++ b/src/components/BulkUploadTestsModal.tsx
@@ -1182,8 +1182,8 @@ export function BulkUploadTestsModal({
                       : "text-muted-foreground"
                   }`}
                 >
-                  Grade the agent&apos;s text reply to the last user message
-                  against your evaluators.
+                  Evaluate the agent&apos;s response given a conversation
+                  history
                 </div>
               </button>
               <button
@@ -1213,8 +1213,8 @@ export function BulkUploadTestsModal({
                       : "text-muted-foreground"
                   }`}
                 >
-                  Check which tool the agent invokes and the arguments it
-                  passes.
+                  Check whether the agent invokes the correct tool with the
+                  correct arguments
                 </div>
               </button>
             </div>

--- a/src/components/ExportResultsButton.tsx
+++ b/src/components/ExportResultsButton.tsx
@@ -41,7 +41,7 @@ export function ExportResultsButton({
   filename,
   getRows,
   disabled,
-  label = "Export",
+  label = "Export results",
   className,
 }: ExportResultsButtonProps) {
   const handleClick = () => {

--- a/src/components/ExportZipButton.tsx
+++ b/src/components/ExportZipButton.tsx
@@ -65,7 +65,7 @@ export function ExportZipButton({
   filename,
   getContents,
   disabled,
-  label = "Export",
+  label = "Export results",
   className,
 }: ExportZipButtonProps) {
   const [isExporting, setIsExporting] = useState(false);

--- a/src/components/ExportZipButton.tsx
+++ b/src/components/ExportZipButton.tsx
@@ -1,0 +1,166 @@
+"use client";
+
+import React, { useState } from "react";
+import JSZip from "jszip";
+import type { ExportColumn } from "@/components/ExportResultsButton";
+
+export type ExportZipFile = {
+  /** Path inside the zip, e.g. `audios/openai_42.mp3`. */
+  path: string;
+  /** Absolute URL the browser can `fetch()` directly. */
+  url: string;
+};
+
+type ExportZipButtonProps = {
+  filename: string;
+  /**
+   * Builds the zip's contents at click time so it always reflects the latest
+   * state. Return an empty `rows` array to disable the download.
+   *
+   * - `csv`: written to the zip's root as `results.csv` using the same
+   *   formula-injection-safe escape rules as `ExportResultsButton`.
+   * - `files`: external assets fetched and added at their `path` in the zip.
+   *   Failures are logged and surfaced as `<path>.error.txt` so the user has
+   *   a record without the whole download blowing up.
+   */
+  getContents: () => {
+    csv: { columns: ExportColumn[]; rows: Record<string, unknown>[] };
+    files: ExportZipFile[];
+  };
+  disabled?: boolean;
+  label?: string;
+  className?: string;
+};
+
+function escapeCell(value: unknown): string {
+  if (value === null || value === undefined) return "";
+  const raw =
+    typeof value === "string"
+      ? value
+      : typeof value === "object"
+        ? JSON.stringify(value)
+        : String(value);
+
+  // Prevent spreadsheet apps from interpreting exported user-controlled
+  // values as formulas when a CSV is opened in Excel/Sheets.
+  const s = /^[=+\-@\t\r]/.test(raw) ? `'${raw}` : raw;
+  if (s.includes(",") || s.includes('"') || s.includes("\n") || s.includes("\r")) {
+    return `"${s.replace(/"/g, '""')}"`;
+  }
+  return s;
+}
+
+function buildCsv(
+  columns: ExportColumn[],
+  rows: Record<string, unknown>[],
+): string {
+  const lines = [
+    columns.map((c) => escapeCell(c.header)).join(","),
+    ...rows.map((r) => columns.map((c) => escapeCell(r[c.key])).join(",")),
+  ];
+  return lines.join("\n");
+}
+
+export function ExportZipButton({
+  filename,
+  getContents,
+  disabled,
+  label = "Export",
+  className,
+}: ExportZipButtonProps) {
+  const [isExporting, setIsExporting] = useState(false);
+
+  const handleClick = async () => {
+    if (isExporting) return;
+    const { csv, files } = getContents();
+    if (csv.rows.length === 0 && files.length === 0) return;
+
+    setIsExporting(true);
+    try {
+      const zip = new JSZip();
+      zip.file("results.csv", buildCsv(csv.columns, csv.rows));
+
+      // Fetch each asset in parallel. Use Promise.allSettled so one
+      // 404 / network error doesn't kill the whole export.
+      const fetched = await Promise.allSettled(
+        files.map(async (f) => {
+          const res = await fetch(f.url);
+          if (!res.ok) {
+            throw new Error(`HTTP ${res.status} for ${f.url}`);
+          }
+          const blob = await res.blob();
+          return { path: f.path, blob };
+        }),
+      );
+      fetched.forEach((result, i) => {
+        if (result.status === "fulfilled") {
+          zip.file(result.value.path, result.value.blob);
+        } else {
+          const file = files[i];
+          const message =
+            result.reason instanceof Error
+              ? result.reason.message
+              : String(result.reason);
+          console.error(`Export: failed to fetch ${file.url}`, result.reason);
+          zip.file(`${file.path}.error.txt`, message);
+        }
+      });
+
+      const blob = await zip.generateAsync({ type: "blob" });
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement("a");
+      link.href = url;
+      link.download = `${filename}.zip`;
+      link.style.visibility = "hidden";
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+      URL.revokeObjectURL(url);
+    } finally {
+      setIsExporting(false);
+    }
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      disabled={disabled || isExporting}
+      title="Export results as a zip"
+      className={`flex items-center gap-2 h-8 px-2 md:px-3 rounded-lg text-xs md:text-sm font-medium border cursor-pointer transition-colors disabled:opacity-50 disabled:cursor-not-allowed bg-teal-500/12 border-teal-500/45 text-teal-950 dark:text-teal-100 hover:bg-teal-500/22 dark:hover:bg-teal-500/18 ${className ?? ""}`}
+    >
+      {isExporting ? (
+        <svg className="w-4 h-4 animate-spin" fill="none" viewBox="0 0 24 24">
+          <circle
+            className="opacity-25"
+            cx="12"
+            cy="12"
+            r="10"
+            stroke="currentColor"
+            strokeWidth="4"
+          />
+          <path
+            className="opacity-75"
+            fill="currentColor"
+            d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+          />
+        </svg>
+      ) : (
+        <svg
+          className="w-4 h-4"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+          strokeWidth={2}
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5M16.5 12L12 16.5m0 0L7.5 12m4.5 4.5V3"
+          />
+        </svg>
+      )}
+      {isExporting ? "Exporting…" : label}
+    </button>
+  );
+}

--- a/src/components/agent-tabs/TestsTabContent.tsx
+++ b/src/components/agent-tabs/TestsTabContent.tsx
@@ -1409,16 +1409,107 @@ export function TestsTabContent({
 
   return (
     <div className="flex flex-col">
-      {/* Header with Add button - only show when there are tests */}
+      {/* Header — only shown when the agent has at least one test
+          attached. Split into two groups: page-level "act on the tests"
+          actions (Run all / Compare models) on the left, and "add more
+          tests" actions (Add / Create / Bulk upload) on the right.
+          Multi-select bulk actions (Run / Remove / Delete subset) live
+          above the table in their own toolbar, not here. */}
       {agentTests.length > 0 && (
         <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-3 mb-4">
+          {/* Left group: act-on-the-tests buttons. */}
           <div className="flex flex-wrap items-center gap-2 md:gap-3">
-            {/* Multi-select bulk-action toolbar lives right above the
-                table (further down in this component), modelled on the
-                same pattern used by the labelling task's items table.
-                The header here keeps just the Add / Create / Bulk /
-                Run-all / Compare actions, independent of selection
-                state. */}
+            {/* Run all tests — sky tint, "play" semantic. */}
+            <div className="relative group/runall">
+              <button
+                onClick={() => {
+                  if (isConnectionUnverified) return;
+                  if (agentTests.length > maxRowsPerEval) {
+                    showLimitToast(
+                      `You can only run up to ${maxRowsPerEval} tests at a time.`,
+                    );
+                    return;
+                  }
+                  setTestsToRun(agentTests);
+                  setRunAllLinked(true);
+                  setTestRunnerOpen(true);
+                }}
+                disabled={isConnectionUnverified}
+                className={`h-9 md:h-10 px-3 md:px-4 rounded-md text-sm md:text-base font-medium border transition-colors flex items-center gap-2 bg-sky-500/12 border-sky-500/45 text-sky-950 dark:text-sky-100 ${
+                  isConnectionUnverified
+                    ? "opacity-50 cursor-not-allowed"
+                    : "hover:bg-sky-500/22 dark:hover:bg-sky-500/18 cursor-pointer"
+                }`}
+              >
+                <svg
+                  className="w-4 h-4"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                  strokeWidth={2}
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    d="M5.25 5.653c0-.856.917-1.398 1.667-.986l11.54 6.348a1.125 1.125 0 010 1.971l-11.54 6.347a1.125 1.125 0 01-1.667-.985V5.653z"
+                  />
+                </svg>
+                <span className="hidden sm:inline">Run all tests</span>
+                <span className="sm:hidden">Run all</span>
+              </button>
+              {isConnectionUnverified && (
+                <div className="absolute left-1/2 -translate-x-1/2 bottom-full mb-2 px-3 py-1.5 bg-foreground text-background text-xs rounded-lg shadow-lg opacity-0 group-hover/runall:opacity-100 pointer-events-none transition-opacity whitespace-nowrap z-50">
+                  Verify agent connection first
+                </div>
+              )}
+            </div>
+
+            {/* Compare models — amber tint, "analyse" semantic. */}
+            <div className="relative group/compare">
+              <button
+                onClick={() => {
+                  if (isConnectionUnverified || isBenchmarkDisabled) return;
+                  setBenchmarkDialogOpen(true);
+                }}
+                disabled={isConnectionUnverified || isBenchmarkDisabled}
+                className={`h-9 md:h-10 px-3 md:px-4 rounded-md text-sm md:text-base font-medium border transition-colors flex items-center gap-2 bg-amber-500/12 border-amber-500/45 text-amber-950 dark:text-amber-100 ${
+                  isConnectionUnverified || isBenchmarkDisabled
+                    ? "opacity-50 cursor-not-allowed"
+                    : "hover:bg-amber-500/22 dark:hover:bg-amber-500/18 cursor-pointer"
+                }`}
+              >
+                <svg
+                  className="w-4 h-4"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                  strokeWidth={2}
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    d="M3.75 3v11.25A2.25 2.25 0 006 16.5h2.25M3.75 3h-1.5m1.5 0h16.5m0 0h1.5m-1.5 0v11.25A2.25 2.25 0 0118 16.5h-2.25m-7.5 0h7.5m-7.5 0l-1 3m8.5-3l1 3m0 0l.5 1.5m-.5-1.5h-9.5m0 0l-.5 1.5m.75-9l3-3 2.148 2.148A12.061 12.061 0 0116.5 7.605"
+                  />
+                </svg>
+                <span className="hidden sm:inline">Compare models</span>
+                <span className="sm:hidden">Compare</span>
+              </button>
+              {isConnectionUnverified && (
+                <div className="absolute left-1/2 -translate-x-1/2 bottom-full mb-2 px-3 py-1.5 bg-foreground text-background text-xs rounded-lg shadow-lg opacity-0 group-hover/compare:opacity-100 pointer-events-none transition-opacity whitespace-nowrap z-50">
+                  Verify agent connection first
+                </div>
+              )}
+              {!isConnectionUnverified && isBenchmarkDisabled && (
+                <div className="absolute left-1/2 -translate-x-1/2 bottom-full mb-2 px-3 py-1.5 bg-foreground text-background text-xs rounded-lg shadow-lg opacity-0 group-hover/compare:opacity-100 pointer-events-none transition-opacity whitespace-nowrap z-50">
+                  You have turned off benchmarking models in connection settings
+                  — turn it on to enable this
+                </div>
+              )}
+            </div>
+          </div>
+
+          {/* Right group: add-more-tests buttons. */}
+          <div className="flex flex-wrap items-center gap-2 md:gap-3">
             <div className="relative" ref={dropdownRef}>
               <button
                 onClick={() => setShowTestDropdown(!showTestDropdown)}
@@ -1524,93 +1615,6 @@ export function TestsTabContent({
             </div>
             {/* Create test / Bulk upload (new tests, auto-attached to this agent) */}
             {renderNewTestButtons()}
-            {/* Run all tests */}
-            <div className="relative group/runall">
-              <button
-                onClick={() => {
-                  if (isConnectionUnverified) return;
-                  if (agentTests.length > maxRowsPerEval) {
-                    showLimitToast(
-                      `You can only run up to ${maxRowsPerEval} tests at a time.`,
-                    );
-                    return;
-                  }
-                  setTestsToRun(agentTests);
-                  setRunAllLinked(true);
-                  setTestRunnerOpen(true);
-                }}
-                disabled={isConnectionUnverified}
-                className={`h-9 md:h-10 px-3 md:px-4 rounded-md text-sm md:text-base font-medium border border-border bg-background transition-colors flex items-center gap-2 ${
-                  isConnectionUnverified
-                    ? "opacity-50 cursor-not-allowed"
-                    : "hover:bg-muted/50 cursor-pointer"
-                }`}
-              >
-                <svg
-                  className="w-4 h-4"
-                  fill="none"
-                  viewBox="0 0 24 24"
-                  stroke="currentColor"
-                  strokeWidth={2}
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    d="M5.25 5.653c0-.856.917-1.398 1.667-.986l11.54 6.348a1.125 1.125 0 010 1.971l-11.54 6.347a1.125 1.125 0 01-1.667-.985V5.653z"
-                  />
-                </svg>
-                <span className="hidden sm:inline">Run all tests</span>
-                <span className="sm:hidden">Run all</span>
-              </button>
-              {isConnectionUnverified && (
-                <div className="absolute left-1/2 -translate-x-1/2 bottom-full mb-2 px-3 py-1.5 bg-foreground text-background text-xs rounded-lg shadow-lg opacity-0 group-hover/runall:opacity-100 pointer-events-none transition-opacity whitespace-nowrap z-50">
-                  Verify agent connection first
-                </div>
-              )}
-            </div>
-
-            {/* Compare models */}
-            <div className="relative group/compare">
-              <button
-                onClick={() => {
-                  if (isConnectionUnverified || isBenchmarkDisabled) return;
-                  setBenchmarkDialogOpen(true);
-                }}
-                disabled={isConnectionUnverified || isBenchmarkDisabled}
-                className={`h-9 md:h-10 px-3 md:px-4 rounded-md text-sm md:text-base font-medium border border-border bg-background transition-colors flex items-center gap-2 ${
-                  isConnectionUnverified || isBenchmarkDisabled
-                    ? "opacity-50 cursor-not-allowed"
-                    : "hover:bg-muted/50 cursor-pointer"
-                }`}
-              >
-                <svg
-                  className="w-4 h-4"
-                  fill="none"
-                  viewBox="0 0 24 24"
-                  stroke="currentColor"
-                  strokeWidth={2}
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    d="M3.75 3v11.25A2.25 2.25 0 006 16.5h2.25M3.75 3h-1.5m1.5 0h16.5m0 0h1.5m-1.5 0v11.25A2.25 2.25 0 0118 16.5h-2.25m-7.5 0h7.5m-7.5 0l-1 3m8.5-3l1 3m0 0l.5 1.5m-.5-1.5h-9.5m0 0l-.5 1.5m.75-9l3-3 2.148 2.148A12.061 12.061 0 0116.5 7.605"
-                  />
-                </svg>
-                <span className="hidden sm:inline">Compare models</span>
-                <span className="sm:hidden">Compare</span>
-              </button>
-              {isConnectionUnverified && (
-                <div className="absolute left-1/2 -translate-x-1/2 bottom-full mb-2 px-3 py-1.5 bg-foreground text-background text-xs rounded-lg shadow-lg opacity-0 group-hover/compare:opacity-100 pointer-events-none transition-opacity whitespace-nowrap z-50">
-                  Verify agent connection first
-                </div>
-              )}
-              {!isConnectionUnverified && isBenchmarkDisabled && (
-                <div className="absolute left-1/2 -translate-x-1/2 bottom-full mb-2 px-3 py-1.5 bg-foreground text-background text-xs rounded-lg shadow-lg opacity-0 group-hover/compare:opacity-100 pointer-events-none transition-opacity whitespace-nowrap z-50">
-                  You have turned off benchmarking models in connection settings
-                  — turn it on to enable this
-                </div>
-              )}
-            </div>
           </div>
         </div>
       )}

--- a/src/components/agent-tabs/TestsTabContent.tsx
+++ b/src/components/agent-tabs/TestsTabContent.tsx
@@ -1156,12 +1156,12 @@ export function TestsTabContent({
   // Share/Public/Copy-link (purple/blue/amber) and Export (teal) actions.
   //
   //   Add test (attach existing) → indigo
-  //   Create test               → pink
+  //   Create test               → emerald (pink read as "danger" — swapped)
   //   Bulk upload               → orange
   const ADD_TEST_BUTTON_CLASS =
     "h-9 md:h-10 px-3 md:px-4 rounded-md text-sm md:text-base font-medium border cursor-pointer transition-colors bg-indigo-500/12 border-indigo-500/45 text-indigo-950 dark:text-indigo-100 hover:bg-indigo-500/22 dark:hover:bg-indigo-500/18";
   const CREATE_TEST_BUTTON_CLASS =
-    "h-9 md:h-10 px-3 md:px-4 rounded-md text-sm md:text-base font-medium border cursor-pointer transition-colors bg-pink-500/12 border-pink-500/45 text-pink-950 dark:text-pink-100 hover:bg-pink-500/22 dark:hover:bg-pink-500/18";
+    "h-9 md:h-10 px-3 md:px-4 rounded-md text-sm md:text-base font-medium border cursor-pointer transition-colors bg-emerald-500/12 border-emerald-500/45 text-emerald-950 dark:text-emerald-100 hover:bg-emerald-500/22 dark:hover:bg-emerald-500/18";
   const BULK_UPLOAD_BUTTON_CLASS =
     "h-9 md:h-10 px-3 md:px-4 rounded-md text-sm md:text-base font-medium border cursor-pointer transition-colors bg-orange-500/12 border-orange-500/45 text-orange-950 dark:text-orange-100 hover:bg-orange-500/22 dark:hover:bg-orange-500/18";
 

--- a/src/components/agent-tabs/TestsTabContent.tsx
+++ b/src/components/agent-tabs/TestsTabContent.tsx
@@ -8,8 +8,20 @@ import { DeleteConfirmationDialog } from "@/components/DeleteConfirmationDialog"
 import { TestRunnerDialog } from "@/components/TestRunnerDialog";
 import { BenchmarkDialog } from "@/components/BenchmarkDialog";
 import { BenchmarkResultsDialog } from "@/components/BenchmarkResultsDialog";
+import {
+  AddTestDialog,
+  TestConfig,
+  EvaluatorRefPayload,
+  AttachedEvaluatorInit,
+  EvaluatorVariableDef,
+} from "@/components/AddTestDialog";
+import { BulkUploadTestsModal } from "@/components/BulkUploadTestsModal";
 import { POLLING_INTERVAL_MS } from "@/constants/polling";
 import { showLimitToast } from "@/constants/limits";
+import {
+  readBulkNameConflictMessage,
+  readNameConflictMessage,
+} from "@/lib/parseBackendError";
 
 type TestData = {
   uuid: string;
@@ -19,6 +31,20 @@ type TestData = {
   config: Record<string, any>;
   created_at: string;
   updated_at: string;
+};
+
+// Shape returned by GET /tests/{uuid} — same as TestData but with hydrated
+// evaluators (joined rows from get_evaluators_for_test()). Used by the
+// open-for-edit flow to seed the AddTestDialog.
+type TestDetail = TestData & {
+  evaluators?: Array<{
+    uuid: string;
+    name: string;
+    description?: string | null;
+    slug: string | null;
+    variables?: EvaluatorVariableDef[] | null;
+    variable_values?: Record<string, string> | null;
+  }> | null;
 };
 
 type TestRunResult = {
@@ -152,7 +178,44 @@ export function TestsTabContent({
   const [showTestDropdown, setShowTestDropdown] = useState(false);
   const [searchQuery, setSearchQuery] = useState("");
   const [testsSearchQuery, setTestsSearchQuery] = useState("");
+  // Filter the agent's tests by test type. "all" shows both kinds; "response"
+  // is Next Reply, "tool_call" is Tool Call. The "select all" checkbox keys
+  // off `filteredAgentTests`, so this filter also narrows what gets selected.
+  const [typeFilter, setTypeFilter] = useState<"all" | "response" | "tool_call">(
+    "all",
+  );
   const dropdownRef = useRef<HTMLDivElement>(null);
+
+  // Create-test dialog state (single test created in-place from the agent
+  // page; submits via POST /tests/bulk with agent_uuids so the new test is
+  // auto-attached to this agent in one call).
+  const [createDialogOpen, setCreateDialogOpen] = useState(false);
+  const [newTestName, setNewTestName] = useState("");
+  const [validationAttempted, setValidationAttempted] = useState(false);
+  const [isCreating, setIsCreating] = useState(false);
+  const [createError, setCreateError] = useState<string | null>(null);
+  const [nameConflictError, setNameConflictError] = useState<string | null>(
+    null,
+  );
+
+  // Bulk-upload modal state (CSV upload; locked to this agent).
+  const [bulkUploadOpen, setBulkUploadOpen] = useState(false);
+
+  // Open/edit-test state. When `editingTestUuid` is set, the AddTestDialog is
+  // in edit mode: it submits via PUT /tests/{uuid}. Otherwise (and when
+  // createDialogOpen is true) it's in create mode and submits via the bulk
+  // endpoint with agent_uuids: [agentUuid].
+  const [editingTestUuid, setEditingTestUuid] = useState<string | null>(null);
+  const [isLoadingTest, setIsLoadingTest] = useState(false);
+  const [initialTab, setInitialTab] = useState<
+    "next-reply" | "tool-invocation" | undefined
+  >(undefined);
+  const [initialConfig, setInitialConfig] = useState<TestConfig | undefined>(
+    undefined,
+  );
+  const [initialEvaluators, setInitialEvaluators] = useState<
+    AttachedEvaluatorInit[] | undefined
+  >(undefined);
 
   // Selection state for bulk operations
   const [selectedTestUuids, setSelectedTestUuids] = useState<Set<string>>(
@@ -220,55 +283,57 @@ export function TestsTabContent({
     pastRunsRef.current = pastRuns;
   }, [pastRuns]);
 
-  // Fetch tests attached to this agent
-  useEffect(() => {
-    const fetchAgentTests = async () => {
-      if (!backendAccessToken) return;
+  // Fetch tests attached to this agent. Exposed as a callback so the
+  // create/bulk-upload flows below can refresh the list after the bulk API
+  // auto-attaches new tests to this agent.
+  const fetchAgentTests = useCallback(async () => {
+    if (!backendAccessToken) return;
 
-      try {
-        setAgentTestsLoading(true);
-        setAgentTestsError(null);
-        const backendUrl = process.env.NEXT_PUBLIC_BACKEND_URL;
-        if (!backendUrl) {
-          throw new Error("BACKEND_URL environment variable is not set");
-        }
-
-        const response = await fetch(
-          `${backendUrl}/agent-tests/agent/${agentUuid}/tests`,
-          {
-            method: "GET",
-            headers: {
-              accept: "application/json",
-              Authorization: `Bearer ${backendAccessToken}`,
-            },
-          },
-        );
-
-        if (response.status === 401) {
-          await signOut({ callbackUrl: "/login" });
-          return;
-        }
-
-        if (!response.ok) {
-          throw new Error("Failed to fetch agent tests");
-        }
-
-        const data: TestData[] = await response.json();
-        setAgentTests(data);
-      } catch (err) {
-        console.error("Error fetching agent tests:", err);
-        setAgentTestsError(
-          err instanceof Error ? err.message : "Failed to load agent tests",
-        );
-      } finally {
-        setAgentTestsLoading(false);
+    try {
+      setAgentTestsLoading(true);
+      setAgentTestsError(null);
+      const backendUrl = process.env.NEXT_PUBLIC_BACKEND_URL;
+      if (!backendUrl) {
+        throw new Error("BACKEND_URL environment variable is not set");
       }
-    };
 
+      const response = await fetch(
+        `${backendUrl}/agent-tests/agent/${agentUuid}/tests`,
+        {
+          method: "GET",
+          headers: {
+            accept: "application/json",
+            Authorization: `Bearer ${backendAccessToken}`,
+          },
+        },
+      );
+
+      if (response.status === 401) {
+        await signOut({ callbackUrl: "/login" });
+        return;
+      }
+
+      if (!response.ok) {
+        throw new Error("Failed to fetch agent tests");
+      }
+
+      const data: TestData[] = await response.json();
+      setAgentTests(data);
+    } catch (err) {
+      console.error("Error fetching agent tests:", err);
+      setAgentTestsError(
+        err instanceof Error ? err.message : "Failed to load agent tests",
+      );
+    } finally {
+      setAgentTestsLoading(false);
+    }
+  }, [agentUuid, backendAccessToken]);
+
+  useEffect(() => {
     if (agentUuid && backendAccessToken) {
       fetchAgentTests();
     }
-  }, [agentUuid, backendAccessToken]);
+  }, [agentUuid, backendAccessToken, fetchAgentTests]);
 
   // Fetch all available tests when dropdown opens
   useEffect(() => {
@@ -517,15 +582,18 @@ export function TestsTabContent({
         test.description.toLowerCase().includes(searchQuery.toLowerCase())),
   );
 
-  // Filter agent tests based on search query
-  const filteredAgentTests = agentTests.filter(
-    (test) =>
-      test.name.toLowerCase().includes(testsSearchQuery.toLowerCase()) ||
-      (test.description &&
-        test.description
-          .toLowerCase()
-          .includes(testsSearchQuery.toLowerCase())),
-  );
+  // Filter agent tests by search query AND test type. Both filters apply
+  // together (AND). The type filter also constrains the select-all checkbox
+  // since it operates on `filteredAgentTests`.
+  const filteredAgentTests = agentTests.filter((test) => {
+    if (typeFilter !== "all" && test.type !== typeFilter) return false;
+    const q = testsSearchQuery.toLowerCase();
+    if (!q) return true;
+    return (
+      test.name.toLowerCase().includes(q) ||
+      (test.description ? test.description.toLowerCase().includes(q) : false)
+    );
+  });
 
   // Add test to agent
   const handleSelectTest = async (test: TestData) => {
@@ -563,6 +631,242 @@ export function TestsTabContent({
       setSearchQuery("");
     } catch (err) {
       console.error("Error adding test to agent:", err);
+    }
+  };
+
+  // Create a single test in-place from this agent's Tests tab and
+  // auto-attach it to the agent in one call by going through the bulk
+  // endpoint with `agent_uuids: [agentUuid]`. The bulk API atomically
+  // creates the test and best-effort links it to the agent (per
+  // .cursor/rules/app-details.md); partial-link failures surface as
+  // `warnings` in the response, which we treat as a soft success.
+  const createTestForAgent = async (
+    config: TestConfig,
+    evaluators: EvaluatorRefPayload[],
+  ) => {
+    setValidationAttempted(true);
+    if (!newTestName.trim()) return;
+
+    try {
+      setIsCreating(true);
+      setCreateError(null);
+      setNameConflictError(null);
+      const backendUrl = process.env.NEXT_PUBLIC_BACKEND_URL;
+      if (!backendUrl) {
+        throw new Error("BACKEND_URL environment variable is not set");
+      }
+
+      const isResponse = config.evaluation.type === "response";
+      const testItem: {
+        name: string;
+        conversation_history: TestConfig["history"];
+        evaluators?: EvaluatorRefPayload[];
+        tool_calls?: NonNullable<TestConfig["evaluation"]["tool_calls"]>;
+      } = {
+        name: newTestName.trim(),
+        conversation_history: config.history,
+      };
+      if (isResponse) {
+        testItem.evaluators = evaluators;
+      } else {
+        testItem.tool_calls = config.evaluation.tool_calls ?? [];
+      }
+
+      const response = await fetch(`${backendUrl}/tests/bulk`, {
+        method: "POST",
+        headers: {
+          accept: "application/json",
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${backendAccessToken}`,
+        },
+        body: JSON.stringify({
+          type: config.evaluation.type,
+          tests: [testItem],
+          agent_uuids: [agentUuid],
+        }),
+      });
+
+      if (response.status === 401) {
+        await signOut({ callbackUrl: "/login" });
+        return;
+      }
+
+      if (!response.ok) {
+        const conflict = await readBulkNameConflictMessage(response);
+        if (conflict) {
+          setNameConflictError(conflict);
+          setIsCreating(false);
+          return;
+        }
+        throw new Error("Failed to create test");
+      }
+
+      // Refresh the agent's test list so the new test appears immediately.
+      await fetchAgentTests();
+      setNewTestName("");
+      setValidationAttempted(false);
+      setCreateDialogOpen(false);
+    } catch (err) {
+      console.error("Error creating test:", err);
+      setCreateError(
+        err instanceof Error ? err.message : "Failed to create test",
+      );
+    } finally {
+      setIsCreating(false);
+    }
+  };
+
+  // Reset all edit/create-related state. Called when closing the dialog.
+  const resetTestDialog = () => {
+    setEditingTestUuid(null);
+    setIsLoadingTest(false);
+    setInitialTab(undefined);
+    setInitialConfig(undefined);
+    setInitialEvaluators(undefined);
+    setNewTestName("");
+    setValidationAttempted(false);
+    setCreateError(null);
+    setNameConflictError(null);
+  };
+
+  // Fetch a test's details by UUID and open the dialog in edit mode.
+  // Hydrates the same shape the standalone /tests page uses, so the dialog
+  // can be reused as-is.
+  const openEditTest = async (uuid: string) => {
+    try {
+      setIsLoadingTest(true);
+      setEditingTestUuid(uuid);
+      setCreateDialogOpen(true);
+      setCreateError(null);
+      setNameConflictError(null);
+
+      const backendUrl = process.env.NEXT_PUBLIC_BACKEND_URL;
+      if (!backendUrl) {
+        throw new Error("BACKEND_URL environment variable is not set");
+      }
+
+      const response = await fetch(`${backendUrl}/tests/${uuid}`, {
+        method: "GET",
+        headers: {
+          accept: "application/json",
+          Authorization: `Bearer ${backendAccessToken}`,
+        },
+      });
+
+      if (response.status === 401) {
+        await signOut({ callbackUrl: "/login" });
+        return;
+      }
+
+      if (!response.ok) {
+        throw new Error("Failed to fetch test details");
+      }
+
+      const testData: TestDetail = await response.json();
+
+      setNewTestName(testData.name || "");
+      setInitialTab(
+        testData.type === "tool_call" ? "tool-invocation" : "next-reply",
+      );
+      if (testData.config) {
+        setInitialConfig(testData.config as TestConfig);
+      }
+      if (Array.isArray(testData.evaluators)) {
+        setInitialEvaluators(
+          testData.evaluators.map((e) => ({
+            evaluator_uuid: e.uuid,
+            name: e.name,
+            description: e.description ?? null,
+            slug: e.slug,
+            variables: Array.isArray(e.variables) ? e.variables : [],
+            variable_values: e.variable_values ?? null,
+          })),
+        );
+      } else {
+        setInitialEvaluators([]);
+      }
+    } catch (err) {
+      console.error("Error fetching test:", err);
+      setCreateError(
+        err instanceof Error ? err.message : "Failed to load test",
+      );
+    } finally {
+      setIsLoadingTest(false);
+    }
+  };
+
+  // Update an existing test via PUT /tests/{uuid}. The test's agent links
+  // are not touched here — this only edits the test itself.
+  const updateTest = async (
+    config: TestConfig,
+    evaluators: EvaluatorRefPayload[],
+  ) => {
+    setValidationAttempted(true);
+    if (!newTestName.trim() || !editingTestUuid) return;
+
+    try {
+      setIsCreating(true);
+      setCreateError(null);
+      setNameConflictError(null);
+      const backendUrl = process.env.NEXT_PUBLIC_BACKEND_URL;
+      if (!backendUrl) {
+        throw new Error("BACKEND_URL environment variable is not set");
+      }
+
+      // Mirror the standalone tests page: send `evaluators` for next-reply
+      // tests so the pivot set is replaced; omit it for tool-invocation tests
+      // so existing links are left untouched.
+      const body: {
+        name: string;
+        type: "response" | "tool_call";
+        config: TestConfig;
+        evaluators?: EvaluatorRefPayload[];
+      } = {
+        name: newTestName.trim(),
+        type: config.evaluation.type,
+        config: config,
+      };
+      if (config.evaluation.type === "response") {
+        body.evaluators = evaluators;
+      }
+
+      const response = await fetch(`${backendUrl}/tests/${editingTestUuid}`, {
+        method: "PUT",
+        headers: {
+          accept: "application/json",
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${backendAccessToken}`,
+        },
+        body: JSON.stringify(body),
+      });
+
+      if (response.status === 401) {
+        await signOut({ callbackUrl: "/login" });
+        return;
+      }
+
+      if (!response.ok) {
+        // PUT /tests/{uuid} returns 409 for name conflicts (single-test
+        // contract), not the 400 used by /tests/bulk.
+        const conflict = await readNameConflictMessage(response);
+        if (conflict) {
+          setNameConflictError(conflict);
+          setIsCreating(false);
+          return;
+        }
+        throw new Error("Failed to update test");
+      }
+
+      await fetchAgentTests();
+      setCreateDialogOpen(false);
+      resetTestDialog();
+    } catch (err) {
+      console.error("Error updating test:", err);
+      setCreateError(
+        err instanceof Error ? err.message : "Failed to update test",
+      );
+    } finally {
+      setIsCreating(false);
     }
   };
 
@@ -797,6 +1101,43 @@ export function TestsTabContent({
     }
   };
 
+  // Two new entry points sit alongside "Add test" (which attaches an existing
+  // test). "Create test" opens the in-place creation dialog; "Bulk upload"
+  // opens the CSV modal locked to this agent. Both use POST /tests/bulk with
+  // `agent_uuids: [agentUuid]` so new tests auto-attach to this agent.
+  const renderNewTestButtons = (
+    variant: "outline" | "primary" = "outline",
+  ) => {
+    const baseClass =
+      variant === "primary"
+        ? "h-9 md:h-10 px-4 md:px-5 rounded-md text-sm md:text-base font-medium bg-foreground text-background hover:opacity-90 transition-opacity cursor-pointer shadow-sm"
+        : "h-9 md:h-10 px-3 md:px-4 rounded-md text-sm md:text-base font-medium border border-border bg-background hover:bg-muted/50 transition-colors cursor-pointer";
+    return (
+      <>
+        <button
+          type="button"
+          onClick={() => {
+            setNewTestName("");
+            setValidationAttempted(false);
+            setCreateError(null);
+            setNameConflictError(null);
+            setCreateDialogOpen(true);
+          }}
+          className={baseClass}
+        >
+          Create test
+        </button>
+        <button
+          type="button"
+          onClick={() => setBulkUploadOpen(true)}
+          className={baseClass}
+        >
+          Bulk upload
+        </button>
+      </>
+    );
+  };
+
   const renderAddTestControl = (variant: "outline" | "primary" = "outline") => (
     <div className="relative" ref={dropdownRef}>
       <button
@@ -1023,6 +1364,58 @@ export function TestsTabContent({
           <div className="flex flex-wrap items-center gap-2 md:gap-3">
             {selectedTestUuids.size > 0 && (
               <>
+                {/* Run only the checked subset. Same connection-unverified
+                    gate and maxRowsPerEval limit as "Run all tests" — the
+                    backend cap applies regardless of how the subset was
+                    chosen. Selection is cleared on submit so the table
+                    visibly resets to a neutral state. */}
+                <div className="relative group/runselected">
+                  <button
+                    onClick={() => {
+                      if (isConnectionUnverified) return;
+                      if (selectedTestUuids.size > maxRowsPerEval) {
+                        showLimitToast(
+                          `You can only run up to ${maxRowsPerEval} tests at a time.`,
+                        );
+                        return;
+                      }
+                      const selected = agentTests.filter((t) =>
+                        selectedTestUuids.has(t.uuid),
+                      );
+                      if (selected.length === 0) return;
+                      setTestsToRun(selected);
+                      setRunAllLinked(false);
+                      setTestRunnerOpen(true);
+                      setSelectedTestUuids(new Set());
+                    }}
+                    disabled={isConnectionUnverified}
+                    className={`h-9 md:h-10 px-3 md:px-4 rounded-md text-sm md:text-base font-medium bg-foreground text-background transition-opacity flex items-center gap-2 ${
+                      isConnectionUnverified
+                        ? "opacity-50 cursor-not-allowed"
+                        : "hover:opacity-90 cursor-pointer"
+                    }`}
+                  >
+                    <svg
+                      className="w-4 h-4"
+                      fill="none"
+                      viewBox="0 0 24 24"
+                      stroke="currentColor"
+                      strokeWidth={2}
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        d="M5.25 5.653c0-.856.917-1.398 1.667-.986l11.54 6.348a1.125 1.125 0 010 1.971l-11.54 6.347a1.125 1.125 0 01-1.667-.985V5.653z"
+                      />
+                    </svg>
+                    Run selected ({selectedTestUuids.size})
+                  </button>
+                  {isConnectionUnverified && (
+                    <div className="absolute left-1/2 -translate-x-1/2 bottom-full mb-2 px-3 py-1.5 bg-foreground text-background text-xs rounded-lg shadow-lg opacity-0 group-hover/runselected:opacity-100 pointer-events-none transition-opacity whitespace-nowrap z-50">
+                      Verify agent connection first
+                    </div>
+                  )}
+                </div>
                 <button
                   onClick={() => openBulkDeleteDialog("remove")}
                   className="h-9 md:h-10 px-3 md:px-4 rounded-md text-sm md:text-base font-medium border border-red-500 text-red-500 hover:bg-red-500/10 transition-colors cursor-pointer"
@@ -1142,6 +1535,8 @@ export function TestsTabContent({
                 </div>
               )}
             </div>
+            {/* Create test / Bulk upload (new tests, auto-attached to this agent) */}
+            {renderNewTestButtons("outline")}
             {/* Run all tests */}
             <div className="relative group/runall">
               <button
@@ -1289,8 +1684,9 @@ export function TestsTabContent({
           <p className="text-sm md:text-base text-muted-foreground mb-3 md:mb-4 text-center max-w-md">
             This agent doesn&apos;t have any tests attached to it.
           </p>
-          <div className="flex items-center gap-2 md:gap-3">
+          <div className="flex flex-wrap items-center justify-center gap-2 md:gap-3">
             {renderAddTestControl("primary")}
+            {renderNewTestButtons("outline")}
           </div>
         </div>
       ) : agentTests.length === 0 ? (
@@ -1312,8 +1708,9 @@ export function TestsTabContent({
               <p className="text-sm md:text-base text-muted-foreground text-center max-w-md mb-0">
                 This agent doesn&apos;t have any tests linked right now
               </p>
-              <div className="flex justify-center mt-3 md:mt-4 w-full">
+              <div className="flex flex-wrap justify-center gap-2 md:gap-3 mt-3 md:mt-4 w-full">
                 {renderAddTestControl("primary")}
+                {renderNewTestButtons("outline")}
               </div>
             </div>
           </div>
@@ -1323,30 +1720,72 @@ export function TestsTabContent({
         <div className="flex-1 flex flex-col lg:flex-row gap-4 md:gap-6">
           {/* Left Panel - Tests Table */}
           <div className="flex-1 flex flex-col min-w-0">
-            {/* Search Input */}
-            <div className="relative mb-3 md:mb-4">
-              <div className="absolute inset-y-0 left-0 flex items-center pl-3 pointer-events-none">
-                <svg
-                  className="w-4 md:w-5 h-4 md:h-5 text-muted-foreground"
-                  fill="none"
-                  viewBox="0 0 24 24"
-                  stroke="currentColor"
-                  strokeWidth={2}
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    d="M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 5.196a7.5 7.5 0 0010.607 10.607z"
-                  />
-                </svg>
+            {/* Search Input + Type Filter */}
+            <div className="flex flex-col sm:flex-row sm:items-center gap-2 sm:gap-3 mb-3 md:mb-4">
+              <div className="relative flex-1 min-w-0">
+                <div className="absolute inset-y-0 left-0 flex items-center pl-3 pointer-events-none">
+                  <svg
+                    className="w-4 md:w-5 h-4 md:h-5 text-muted-foreground"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                    strokeWidth={2}
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      d="M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 5.196a7.5 7.5 0 0010.607 10.607z"
+                    />
+                  </svg>
+                </div>
+                <input
+                  type="text"
+                  value={testsSearchQuery}
+                  onChange={(e) => setTestsSearchQuery(e.target.value)}
+                  placeholder="Search tests"
+                  className="w-full h-9 md:h-10 pl-9 md:pl-10 pr-4 rounded-md text-sm md:text-base border border-border bg-background text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-accent focus:border-transparent"
+                />
               </div>
-              <input
-                type="text"
-                value={testsSearchQuery}
-                onChange={(e) => setTestsSearchQuery(e.target.value)}
-                placeholder="Search tests"
-                className="w-full h-9 md:h-10 pl-9 md:pl-10 pr-4 rounded-md text-sm md:text-base border border-border bg-background text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-accent focus:border-transparent"
-              />
+              {/* Type filter — segmented toggle. Matches the "Next Reply /
+                  Tool Call" pattern used in BulkUploadTestsModal. */}
+              <div className="flex rounded-lg border border-border overflow-hidden w-fit self-start sm:self-auto">
+                {(
+                  [
+                    { value: "all", label: "All" },
+                    { value: "response", label: "Next Reply" },
+                    { value: "tool_call", label: "Tool Call" },
+                  ] as const
+                ).map((opt) => (
+                  <button
+                    key={opt.value}
+                    type="button"
+                    onClick={() => {
+                      setTypeFilter(opt.value);
+                      // Drop any selection that no longer matches the new
+                      // filter so the bulk-action counts don't drift from
+                      // what's visible.
+                      setSelectedTestUuids((prev) => {
+                        if (prev.size === 0) return prev;
+                        const next = new Set<string>();
+                        for (const t of agentTests) {
+                          if (!prev.has(t.uuid)) continue;
+                          if (opt.value !== "all" && t.type !== opt.value)
+                            continue;
+                          next.add(t.uuid);
+                        }
+                        return next;
+                      });
+                    }}
+                    className={`h-9 md:h-10 px-3 text-sm font-medium transition-colors cursor-pointer ${
+                      typeFilter === opt.value
+                        ? "bg-foreground text-background"
+                        : "bg-background text-foreground hover:bg-muted/50"
+                    }`}
+                  >
+                    {opt.label}
+                  </button>
+                ))}
+              </div>
             </div>
 
             <p className="text-sm text-muted-foreground mb-3 md:mb-4">
@@ -1410,7 +1849,8 @@ export function TestsTabContent({
                   {filteredAgentTests.map((test) => (
                     <div
                       key={test.uuid}
-                      className="grid grid-cols-[40px_minmax(0,1fr)_120px_auto_auto] gap-4 px-4 py-2 border-b border-border last:border-b-0 hover:bg-muted/20 transition-colors"
+                      onClick={() => openEditTest(test.uuid)}
+                      className="grid grid-cols-[40px_minmax(0,1fr)_120px_auto_auto] gap-4 px-4 py-2 border-b border-border last:border-b-0 hover:bg-muted/20 transition-colors cursor-pointer items-center"
                     >
                       {/* Checkbox */}
                       <div className="flex items-center">
@@ -1490,7 +1930,8 @@ export function TestsTabContent({
                       {/* Run Button */}
                       <div className="flex items-center">
                         <button
-                          onClick={() => {
+                          onClick={(e) => {
+                            e.stopPropagation();
                             setTestsToRun([test]);
                             setRunAllLinked(false);
                             setTestRunnerOpen(true);
@@ -1517,7 +1958,10 @@ export function TestsTabContent({
                           remove-from-agent action to a permanent library delete. */}
                       <div className="flex items-center">
                         <button
-                          onClick={() => openDeleteDialog(test, "remove")}
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            openDeleteDialog(test, "remove");
+                          }}
                           className="w-8 h-8 flex items-center justify-center rounded-md text-muted-foreground hover:text-red-500 hover:bg-red-500/10 transition-colors cursor-pointer"
                           title="Delete test"
                         >
@@ -1544,7 +1988,8 @@ export function TestsTabContent({
                   {filteredAgentTests.map((test) => (
                     <div
                       key={test.uuid}
-                      className="border border-border rounded-xl p-3 bg-background"
+                      onClick={() => openEditTest(test.uuid)}
+                      className="border border-border rounded-xl p-3 bg-background hover:bg-muted/20 transition-colors cursor-pointer"
                     >
                       <div className="flex items-start justify-between gap-2">
                         <div className="flex items-start gap-2 flex-1 min-w-0">
@@ -1590,7 +2035,8 @@ export function TestsTabContent({
                         </div>
                         <div className="flex items-center gap-1 flex-shrink-0">
                           <button
-                            onClick={() => {
+                            onClick={(e) => {
+                              e.stopPropagation();
                               setTestsToRun([test]);
                               setRunAllLinked(false);
                               setTestRunnerOpen(true);
@@ -1613,7 +2059,10 @@ export function TestsTabContent({
                             </svg>
                           </button>
                           <button
-                            onClick={() => openDeleteDialog(test, "remove")}
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              openDeleteDialog(test, "remove");
+                            }}
                             className="w-8 h-8 flex items-center justify-center rounded-md text-muted-foreground hover:text-red-500 hover:bg-red-500/10 transition-colors cursor-pointer"
                             title="Delete test"
                           >
@@ -1696,6 +2145,46 @@ export function TestsTabContent({
             </label>
           ) : null
         }
+      />
+
+      {/* Create/edit test dialog. In create mode, submits via POST
+          /tests/bulk with agent_uuids: [agentUuid] so the new test
+          auto-attaches to this agent in one call. In edit mode (when
+          editingTestUuid is set), submits via PUT /tests/{uuid}. */}
+      {createDialogOpen && (
+        <AddTestDialog
+          isOpen={createDialogOpen}
+          onClose={() => {
+            setCreateDialogOpen(false);
+            resetTestDialog();
+          }}
+          isEditing={!!editingTestUuid}
+          isLoading={isLoadingTest}
+          isCreating={isCreating}
+          createError={createError}
+          nameError={nameConflictError}
+          testName={newTestName}
+          setTestName={(name) => {
+            setNewTestName(name);
+            if (nameConflictError) setNameConflictError(null);
+          }}
+          validationAttempted={validationAttempted}
+          onSubmit={editingTestUuid ? updateTest : createTestForAgent}
+          initialTab={initialTab}
+          initialConfig={initialConfig}
+          initialEvaluators={initialEvaluators}
+        />
+      )}
+
+      {/* Bulk-upload modal locked to this agent. The agent picker is
+          hidden and `agent_uuids: [agentUuid]` is sent with the upload. */}
+      <BulkUploadTestsModal
+        isOpen={bulkUploadOpen}
+        onClose={() => setBulkUploadOpen(false)}
+        onSuccess={() => {
+          fetchAgentTests();
+        }}
+        lockedAgentUuid={agentUuid}
       />
 
       {/* Test Runner Dialog */}

--- a/src/components/agent-tabs/TestsTabContent.tsx
+++ b/src/components/agent-tabs/TestsTabContent.tsx
@@ -1760,52 +1760,67 @@ export function TestsTabContent({
                 className="w-full h-9 md:h-10 pl-9 md:pl-10 pr-4 rounded-md text-sm md:text-base border border-border bg-background text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-accent focus:border-transparent"
               />
             </div>
-            {/* Type filter — segmented toggle. Sits on its own row below
-                the search bar. Matches the "Next Reply / Tool Call" pattern
-                used in BulkUploadTestsModal. */}
-            <div className="flex rounded-lg border border-border overflow-hidden w-fit mb-3 md:mb-4">
-              {(
-                [
-                  { value: "all", label: "All" },
-                  { value: "response", label: "Next Reply" },
-                  { value: "tool_call", label: "Tool Call" },
-                ] as const
-              ).map((opt, i, arr) => (
-                <button
-                  key={opt.value}
-                  type="button"
-                  onClick={() => {
-                    setTypeFilter(opt.value);
-                    // Drop any selection that no longer matches the new
-                    // filter so the bulk-action counts don't drift from
-                    // what's visible.
-                    setSelectedTestUuids((prev) => {
-                      if (prev.size === 0) return prev;
-                      const next = new Set<string>();
-                      for (const t of agentTests) {
-                        if (!prev.has(t.uuid)) continue;
-                        if (opt.value !== "all" && t.type !== opt.value)
-                          continue;
-                        next.add(t.uuid);
-                      }
-                      return next;
-                    });
-                  }}
-                  // Right-border on every segment except the last gives a
-                  // visible divider between options regardless of active
-                  // state (the parent's `overflow-hidden` clips the
-                  // trailing border against the rounded container edge).
-                  className={`h-9 md:h-10 px-3 text-sm font-medium transition-colors cursor-pointer ${
-                    i < arr.length - 1 ? "border-r border-border" : ""
-                  } ${
-                    typeFilter === opt.value
-                      ? "bg-foreground text-background"
-                      : "bg-background text-foreground hover:bg-muted/50"
-                  }`}
-                >
-                  {opt.label}
-                </button>
-              ))}
+            {/* Type filter — iOS-style segmented control. Visually
+                differentiated from the action buttons in the page header
+                (rectangular, h-9/h-10, foreground/border styling) by
+                using a muted pill track with smaller rounded chips, a
+                leading "Filter" label, and a softer height. Sits on its
+                own row below the search bar. */}
+            <div className="flex items-center gap-2 mb-3 md:mb-4">
+              <svg
+                className="w-3.5 h-3.5 text-muted-foreground"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+                strokeWidth={2}
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M3 4.5h18M6 12h12M10.5 19.5h3"
+                />
+              </svg>
+              <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                Type
+              </span>
+              <div className="flex items-center gap-0.5 rounded-full bg-muted/60 p-0.5">
+                {(
+                  [
+                    { value: "all", label: "All" },
+                    { value: "response", label: "Next Reply" },
+                    { value: "tool_call", label: "Tool Call" },
+                  ] as const
+                ).map((opt) => (
+                  <button
+                    key={opt.value}
+                    type="button"
+                    onClick={() => {
+                      setTypeFilter(opt.value);
+                      // Drop any selection that no longer matches the new
+                      // filter so the bulk-action counts don't drift from
+                      // what's visible.
+                      setSelectedTestUuids((prev) => {
+                        if (prev.size === 0) return prev;
+                        const next = new Set<string>();
+                        for (const t of agentTests) {
+                          if (!prev.has(t.uuid)) continue;
+                          if (opt.value !== "all" && t.type !== opt.value)
+                            continue;
+                          next.add(t.uuid);
+                        }
+                        return next;
+                      });
+                    }}
+                    className={`h-7 px-3 rounded-full text-xs font-medium transition-colors cursor-pointer ${
+                      typeFilter === opt.value
+                        ? "bg-background text-foreground shadow-sm"
+                        : "text-muted-foreground hover:text-foreground"
+                    }`}
+                  >
+                    {opt.label}
+                  </button>
+                ))}
+              </div>
             </div>
 
             <p className="text-sm text-muted-foreground mb-3 md:mb-4">

--- a/src/components/agent-tabs/TestsTabContent.tsx
+++ b/src/components/agent-tabs/TestsTabContent.tsx
@@ -726,9 +726,12 @@ export function TestsTabContent({
       }
 
       if (!response.ok) {
+        // Friendly fixed message instead of the backend's verbatim
+        // "Test names already exist: <name>" (plural reads awkwardly
+        // for a single-test create dialog).
         const conflict = await readBulkNameConflictMessage(response);
         if (conflict) {
-          setNameConflictError(conflict);
+          setNameConflictError("A test with this name already exists");
           setIsCreating(false);
           return;
         }
@@ -898,7 +901,7 @@ export function TestsTabContent({
         // contract), not the 400 used by /tests/bulk.
         const conflict = await readNameConflictMessage(response);
         if (conflict) {
-          setNameConflictError(conflict);
+          setNameConflictError("A test with this name already exists");
           setIsCreating(false);
           return;
         }

--- a/src/components/agent-tabs/TestsTabContent.tsx
+++ b/src/components/agent-tabs/TestsTabContent.tsx
@@ -173,12 +173,19 @@ export function TestsTabContent({
   // All available tests state
   const [allTests, setAllTests] = useState<TestData[]>([]);
   const [allTestsLoading, setAllTestsLoading] = useState(false);
-  // Tracks whether `/tests` has been fetched at least once during this
-  // session. Used by the empty state to decide whether the "Add test"
-  // (attach-existing) button is meaningful — if the user has no tests at
-  // all, the button is dropped entirely rather than offering an empty
-  // dropdown.
+  // Tracks the eager `/tests` library fetch used by the empty state.
+  // Two booleans, deliberately separate:
+  //   - `allTestsAttempted`: an attempt has completed (success OR failure).
+  //     Used by the retry guard so a failed fetch does not loop —
+  //     instead we wait for the user to open the attach-existing
+  //     dropdown, which is the natural retry trigger.
+  //   - `allTestsFetched`: an attempt SUCCEEDED. Used by the empty
+  //     state's copy + Add-test visibility so we only confidently hide
+  //     the button when we know the library is empty; on a failed
+  //     fetch we leave the button visible (clicking it will re-fetch
+  //     via the dropdown's own effect).
   const [allTestsFetched, setAllTestsFetched] = useState(false);
+  const [allTestsAttempted, setAllTestsAttempted] = useState(false);
 
   // UI state
   const [showTestDropdown, setShowTestDropdown] = useState(false);
@@ -378,6 +385,11 @@ export function TestsTabContent({
       console.error("Error fetching tests:", err);
     } finally {
       setAllTestsLoading(false);
+      // Mark the attempt complete regardless of outcome so the empty-
+      // state retry effect doesn't fire again as soon as
+      // `allTestsLoading` flips back to false. A failed fetch will be
+      // retried only when the user opens the attach-existing dropdown.
+      setAllTestsAttempted(true);
     }
   }, [backendAccessToken]);
 
@@ -389,13 +401,14 @@ export function TestsTabContent({
   }, [showTestDropdown, backendAccessToken, fetchAllTests]);
 
   // (2) Fetch when the agent's tests list is known to be empty, so the
-  // empty state can decide whether to show the Add-test button. Only
-  // fires once per session (gated on `allTestsFetched`).
+  // empty state can decide whether to show the Add-test button. Gated
+  // on `allTestsAttempted` so a failure doesn't trigger a tight retry
+  // loop — see comment on the state declarations above.
   useEffect(() => {
     if (
       !agentTestsLoading &&
       agentTests.length === 0 &&
-      !allTestsFetched &&
+      !allTestsAttempted &&
       !allTestsLoading &&
       backendAccessToken
     ) {
@@ -404,7 +417,7 @@ export function TestsTabContent({
   }, [
     agentTestsLoading,
     agentTests.length,
-    allTestsFetched,
+    allTestsAttempted,
     allTestsLoading,
     backendAccessToken,
     fetchAllTests,
@@ -1682,7 +1695,13 @@ export function TestsTabContent({
             {/* Only show the attach-existing button when the user actually
                 has tests to attach — otherwise the dropdown is empty and
                 the affordance is misleading. */}
-            {allTests.length > 0 && renderAddTestControl()}
+            {/* Hide Add-test only when we've confirmed the library is
+                empty. On a fetch failure (`allTestsAttempted && !allTestsFetched`)
+                leave it visible — clicking it re-fetches via the
+                dropdown's own effect. */}
+            {(allTests.length > 0 ||
+              (allTestsAttempted && !allTestsFetched)) &&
+              renderAddTestControl()}
             {renderNewTestButtons()}
           </div>
         </div>
@@ -1709,7 +1728,13 @@ export function TestsTabContent({
                   : " Add an existing test or create a new one."}
               </p>
               <div className="flex flex-wrap justify-center gap-2 md:gap-3 mt-3 md:mt-4 w-full">
-                {allTests.length > 0 && renderAddTestControl()}
+                {/* Hide Add-test only when we've confirmed the library is
+                empty. On a fetch failure (`allTestsAttempted && !allTestsFetched`)
+                leave it visible — clicking it re-fetches via the
+                dropdown's own effect. */}
+            {(allTests.length > 0 ||
+              (allTestsAttempted && !allTestsFetched)) &&
+              renderAddTestControl()}
                 {renderNewTestButtons()}
               </div>
             </div>

--- a/src/components/agent-tabs/TestsTabContent.tsx
+++ b/src/components/agent-tabs/TestsTabContent.tsx
@@ -1734,72 +1734,72 @@ export function TestsTabContent({
         <div className="flex-1 flex flex-col lg:flex-row gap-4 md:gap-6">
           {/* Left Panel - Tests Table */}
           <div className="flex-1 flex flex-col min-w-0">
-            {/* Search Input + Type Filter */}
-            <div className="flex flex-col sm:flex-row sm:items-center gap-2 sm:gap-3 mb-3 md:mb-4">
-              <div className="relative flex-1 min-w-0">
-                <div className="absolute inset-y-0 left-0 flex items-center pl-3 pointer-events-none">
-                  <svg
-                    className="w-4 md:w-5 h-4 md:h-5 text-muted-foreground"
-                    fill="none"
-                    viewBox="0 0 24 24"
-                    stroke="currentColor"
-                    strokeWidth={2}
-                  >
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      d="M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 5.196a7.5 7.5 0 0010.607 10.607z"
-                    />
-                  </svg>
-                </div>
-                <input
-                  type="text"
-                  value={testsSearchQuery}
-                  onChange={(e) => setTestsSearchQuery(e.target.value)}
-                  placeholder="Search tests"
-                  className="w-full h-9 md:h-10 pl-9 md:pl-10 pr-4 rounded-md text-sm md:text-base border border-border bg-background text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-accent focus:border-transparent"
-                />
+            {/* Search input — full width so long test names have room to
+                wrap; the type filter sits below it on its own row. */}
+            <div className="relative mb-2 md:mb-3">
+              <div className="absolute inset-y-0 left-0 flex items-center pl-3 pointer-events-none">
+                <svg
+                  className="w-4 md:w-5 h-4 md:h-5 text-muted-foreground"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                  strokeWidth={2}
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    d="M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 5.196a7.5 7.5 0 0010.607 10.607z"
+                  />
+                </svg>
               </div>
-              {/* Type filter — segmented toggle. Matches the "Next Reply /
-                  Tool Call" pattern used in BulkUploadTestsModal. */}
-              <div className="flex rounded-lg border border-border overflow-hidden w-fit self-start sm:self-auto">
-                {(
-                  [
-                    { value: "all", label: "All" },
-                    { value: "response", label: "Next Reply" },
-                    { value: "tool_call", label: "Tool Call" },
-                  ] as const
-                ).map((opt) => (
-                  <button
-                    key={opt.value}
-                    type="button"
-                    onClick={() => {
-                      setTypeFilter(opt.value);
-                      // Drop any selection that no longer matches the new
-                      // filter so the bulk-action counts don't drift from
-                      // what's visible.
-                      setSelectedTestUuids((prev) => {
-                        if (prev.size === 0) return prev;
-                        const next = new Set<string>();
-                        for (const t of agentTests) {
-                          if (!prev.has(t.uuid)) continue;
-                          if (opt.value !== "all" && t.type !== opt.value)
-                            continue;
-                          next.add(t.uuid);
-                        }
-                        return next;
-                      });
-                    }}
-                    className={`h-9 md:h-10 px-3 text-sm font-medium transition-colors cursor-pointer ${
-                      typeFilter === opt.value
-                        ? "bg-foreground text-background"
-                        : "bg-background text-foreground hover:bg-muted/50"
-                    }`}
-                  >
-                    {opt.label}
-                  </button>
-                ))}
-              </div>
+              <input
+                type="text"
+                value={testsSearchQuery}
+                onChange={(e) => setTestsSearchQuery(e.target.value)}
+                placeholder="Search tests"
+                className="w-full h-9 md:h-10 pl-9 md:pl-10 pr-4 rounded-md text-sm md:text-base border border-border bg-background text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-accent focus:border-transparent"
+              />
+            </div>
+            {/* Type filter — segmented toggle. Sits on its own row below
+                the search bar. Matches the "Next Reply / Tool Call" pattern
+                used in BulkUploadTestsModal. */}
+            <div className="flex rounded-lg border border-border overflow-hidden w-fit mb-3 md:mb-4">
+              {(
+                [
+                  { value: "all", label: "All" },
+                  { value: "response", label: "Next Reply" },
+                  { value: "tool_call", label: "Tool Call" },
+                ] as const
+              ).map((opt) => (
+                <button
+                  key={opt.value}
+                  type="button"
+                  onClick={() => {
+                    setTypeFilter(opt.value);
+                    // Drop any selection that no longer matches the new
+                    // filter so the bulk-action counts don't drift from
+                    // what's visible.
+                    setSelectedTestUuids((prev) => {
+                      if (prev.size === 0) return prev;
+                      const next = new Set<string>();
+                      for (const t of agentTests) {
+                        if (!prev.has(t.uuid)) continue;
+                        if (opt.value !== "all" && t.type !== opt.value)
+                          continue;
+                        next.add(t.uuid);
+                      }
+                      return next;
+                    });
+                  }}
+                  className={`h-9 md:h-10 px-3 text-sm font-medium transition-colors cursor-pointer ${
+                    typeFilter === opt.value
+                      ? "bg-foreground text-background"
+                      : "bg-background text-foreground hover:bg-muted/50"
+                  }`}
+                >
+                  {opt.label}
+                </button>
+              ))}
             </div>
 
             <p className="text-sm text-muted-foreground mb-3 md:mb-4">

--- a/src/components/agent-tabs/TestsTabContent.tsx
+++ b/src/components/agent-tabs/TestsTabContent.tsx
@@ -1456,7 +1456,7 @@ export function TestsTabContent({
                         d="M5.25 5.653c0-.856.917-1.398 1.667-.986l11.54 6.348a1.125 1.125 0 010 1.971l-11.54 6.347a1.125 1.125 0 01-1.667-.985V5.653z"
                       />
                     </svg>
-                    Run selected ({selectedTestUuids.size})
+                    Run ({selectedTestUuids.size})
                   </button>
                   {isConnectionUnverified && (
                     <div className="absolute left-1/2 -translate-x-1/2 bottom-full mb-2 px-3 py-1.5 bg-foreground text-background text-xs rounded-lg shadow-lg opacity-0 group-hover/runselected:opacity-100 pointer-events-none transition-opacity whitespace-nowrap z-50">
@@ -1469,14 +1469,14 @@ export function TestsTabContent({
                   className="h-9 md:h-10 px-3 md:px-4 rounded-md text-sm md:text-base font-medium border border-red-500 text-red-500 hover:bg-red-500/10 transition-colors cursor-pointer"
                   title="Remove selected tests from this agent only"
                 >
-                  Remove selected ({selectedTestUuids.size})
+                  Remove ({selectedTestUuids.size})
                 </button>
                 <button
                   onClick={() => openBulkDeleteDialog("permanent")}
                   className="h-9 md:h-10 px-3 md:px-4 rounded-md text-sm md:text-base font-medium bg-red-700 text-white hover:bg-red-800 transition-colors cursor-pointer"
                   title="Permanently delete selected tests from your test library"
                 >
-                  Delete selected ({selectedTestUuids.size})
+                  Delete ({selectedTestUuids.size})
                 </button>
               </>
             )}

--- a/src/components/agent-tabs/TestsTabContent.tsx
+++ b/src/components/agent-tabs/TestsTabContent.tsx
@@ -1410,76 +1410,12 @@ export function TestsTabContent({
       {agentTests.length > 0 && (
         <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-3 mb-4">
           <div className="flex flex-wrap items-center gap-2 md:gap-3">
-            {selectedTestUuids.size > 0 && (
-              <>
-                {/* Run only the checked subset. Same connection-unverified
-                    gate and maxRowsPerEval limit as "Run all tests" — the
-                    backend cap applies regardless of how the subset was
-                    chosen. Selection is cleared on submit so the table
-                    visibly resets to a neutral state. */}
-                <div className="relative group/runselected">
-                  <button
-                    onClick={() => {
-                      if (isConnectionUnverified) return;
-                      if (selectedTestUuids.size > maxRowsPerEval) {
-                        showLimitToast(
-                          `You can only run up to ${maxRowsPerEval} tests at a time.`,
-                        );
-                        return;
-                      }
-                      const selected = agentTests.filter((t) =>
-                        selectedTestUuids.has(t.uuid),
-                      );
-                      if (selected.length === 0) return;
-                      setTestsToRun(selected);
-                      setRunAllLinked(false);
-                      setTestRunnerOpen(true);
-                      setSelectedTestUuids(new Set());
-                    }}
-                    disabled={isConnectionUnverified}
-                    className={`h-9 md:h-10 px-3 md:px-4 rounded-md text-sm md:text-base font-medium bg-foreground text-background transition-opacity flex items-center gap-2 ${
-                      isConnectionUnverified
-                        ? "opacity-50 cursor-not-allowed"
-                        : "hover:opacity-90 cursor-pointer"
-                    }`}
-                  >
-                    <svg
-                      className="w-4 h-4"
-                      fill="none"
-                      viewBox="0 0 24 24"
-                      stroke="currentColor"
-                      strokeWidth={2}
-                    >
-                      <path
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        d="M5.25 5.653c0-.856.917-1.398 1.667-.986l11.54 6.348a1.125 1.125 0 010 1.971l-11.54 6.347a1.125 1.125 0 01-1.667-.985V5.653z"
-                      />
-                    </svg>
-                    Run ({selectedTestUuids.size})
-                  </button>
-                  {isConnectionUnverified && (
-                    <div className="absolute left-1/2 -translate-x-1/2 bottom-full mb-2 px-3 py-1.5 bg-foreground text-background text-xs rounded-lg shadow-lg opacity-0 group-hover/runselected:opacity-100 pointer-events-none transition-opacity whitespace-nowrap z-50">
-                      Verify agent connection first
-                    </div>
-                  )}
-                </div>
-                <button
-                  onClick={() => openBulkDeleteDialog("remove")}
-                  className="h-9 md:h-10 px-3 md:px-4 rounded-md text-sm md:text-base font-medium border border-red-500 text-red-500 hover:bg-red-500/10 transition-colors cursor-pointer"
-                  title="Remove selected tests from this agent only"
-                >
-                  Remove ({selectedTestUuids.size})
-                </button>
-                <button
-                  onClick={() => openBulkDeleteDialog("permanent")}
-                  className="h-9 md:h-10 px-3 md:px-4 rounded-md text-sm md:text-base font-medium bg-red-700 text-white hover:bg-red-800 transition-colors cursor-pointer"
-                  title="Permanently delete selected tests from your test library"
-                >
-                  Delete ({selectedTestUuids.size})
-                </button>
-              </>
-            )}
+            {/* Multi-select bulk-action toolbar lives right above the
+                table (further down in this component), modelled on the
+                same pattern used by the labelling task's items table.
+                The header here keeps just the Add / Create / Bulk /
+                Run-all / Compare actions, independent of selection
+                state. */}
             <div className="relative" ref={dropdownRef}>
               <button
                 onClick={() => setShowTestDropdown(!showTestDropdown)}
@@ -1869,6 +1805,92 @@ export function TestsTabContent({
             <p className="text-sm text-muted-foreground mb-3 md:mb-4">
               {agentTests.length} {agentTests.length === 1 ? "test" : "tests"}
             </p>
+
+            {/* Bulk-action toolbar — sits immediately above the table when
+                at least one row is selected. Modelled on the same pattern
+                as the human-alignment items table so the two surfaces
+                feel consistent: a muted strip with an "N selected"
+                count on the left and unprefixed action buttons on the
+                right (count is on the strip, not duplicated per button). */}
+            {selectedTestUuids.size > 0 && (
+              <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 sm:gap-3 rounded-md border border-border bg-muted/30 px-3 py-2 mb-3 md:mb-4">
+                <span className="text-sm">
+                  <span className="font-medium">
+                    {selectedTestUuids.size}
+                  </span>{" "}
+                  {selectedTestUuids.size === 1 ? "test" : "tests"} selected
+                </span>
+                <div className="flex flex-wrap items-center gap-2">
+                  <button
+                    onClick={() => setSelectedTestUuids(new Set())}
+                    className="h-8 px-3 rounded-md text-sm font-medium text-muted-foreground hover:text-foreground hover:bg-muted transition-colors cursor-pointer"
+                  >
+                    Clear
+                  </button>
+                  <button
+                    onClick={() => openBulkDeleteDialog("remove")}
+                    title="Detach from this agent only — the test stays in your library"
+                    className="h-8 px-3 rounded-md text-sm font-medium border border-red-500/30 bg-red-500/10 text-red-500 hover:bg-red-500/20 transition-colors cursor-pointer"
+                  >
+                    Remove
+                  </button>
+                  <button
+                    onClick={() => openBulkDeleteDialog("permanent")}
+                    title="Permanently delete from your test library"
+                    className="h-8 px-3 rounded-md text-sm font-medium bg-red-700 text-white hover:bg-red-800 transition-colors cursor-pointer"
+                  >
+                    Delete
+                  </button>
+                  <div className="relative group/runselected">
+                    <button
+                      onClick={() => {
+                        if (isConnectionUnverified) return;
+                        if (selectedTestUuids.size > maxRowsPerEval) {
+                          showLimitToast(
+                            `You can only run up to ${maxRowsPerEval} tests at a time.`,
+                          );
+                          return;
+                        }
+                        const selected = agentTests.filter((t) =>
+                          selectedTestUuids.has(t.uuid),
+                        );
+                        if (selected.length === 0) return;
+                        setTestsToRun(selected);
+                        setRunAllLinked(false);
+                        setTestRunnerOpen(true);
+                        setSelectedTestUuids(new Set());
+                      }}
+                      disabled={isConnectionUnverified}
+                      className={`h-8 px-3 rounded-md text-sm font-medium bg-foreground text-background transition-opacity flex items-center gap-1.5 ${
+                        isConnectionUnverified
+                          ? "opacity-50 cursor-not-allowed"
+                          : "hover:opacity-90 cursor-pointer"
+                      }`}
+                    >
+                      <svg
+                        className="w-3.5 h-3.5"
+                        fill="none"
+                        viewBox="0 0 24 24"
+                        stroke="currentColor"
+                        strokeWidth={2}
+                      >
+                        <path
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          d="M5.25 5.653c0-.856.917-1.398 1.667-.986l11.54 6.348a1.125 1.125 0 010 1.971l-11.54 6.347a1.125 1.125 0 01-1.667-.985V5.653z"
+                        />
+                      </svg>
+                      Run
+                    </button>
+                    {isConnectionUnverified && (
+                      <div className="absolute left-1/2 -translate-x-1/2 bottom-full mb-2 px-3 py-1.5 bg-foreground text-background text-xs rounded-lg shadow-lg opacity-0 group-hover/runselected:opacity-100 pointer-events-none transition-opacity whitespace-nowrap z-50">
+                        Verify agent connection first
+                      </div>
+                    )}
+                  </div>
+                </div>
+              </div>
+            )}
 
             {/* Tests Table */}
             {filteredAgentTests.length === 0 ? (

--- a/src/components/agent-tabs/TestsTabContent.tsx
+++ b/src/components/agent-tabs/TestsTabContent.tsx
@@ -1730,7 +1730,7 @@ export function TestsTabContent({
           <p className="text-sm md:text-base text-muted-foreground mb-3 md:mb-4 text-center max-w-md">
             This agent doesn&apos;t have any tests attached to it.
             {allTestsFetched && allTests.length === 0
-              ? " Create a new test or upload tests in bulk."
+              ? " Create a new test or upload tests from a CSV file to get started."
               : " Add an existing test or create a new one."}
           </p>
           <div className="flex flex-wrap items-center justify-center gap-2 md:gap-3">
@@ -1738,9 +1738,7 @@ export function TestsTabContent({
                 has tests to attach — otherwise the dropdown is empty and
                 the affordance is misleading. */}
             {allTests.length > 0 && renderAddTestControl("primary")}
-            {renderNewTestButtons(
-              allTests.length > 0 ? "outline" : "primary",
-            )}
+            {renderNewTestButtons(allTests.length > 0 ? "outline" : "primary")}
           </div>
         </div>
       ) : agentTests.length === 0 ? (
@@ -1760,7 +1758,10 @@ export function TestsTabContent({
                 No tests attached
               </h3>
               <p className="text-sm md:text-base text-muted-foreground text-center max-w-md mb-0">
-                This agent doesn&apos;t have any tests linked right now
+                This agent doesn&apos;t have any tests linked right now.
+                {allTestsFetched && allTests.length === 0
+                  ? " Create a new test or upload tests in bulk."
+                  : " Add an existing test or create a new one."}
               </p>
               <div className="flex flex-wrap justify-center gap-2 md:gap-3 mt-3 md:mt-4 w-full">
                 {allTests.length > 0 && renderAddTestControl("primary")}

--- a/src/components/agent-tabs/TestsTabContent.tsx
+++ b/src/components/agent-tabs/TestsTabContent.tsx
@@ -1770,7 +1770,7 @@ export function TestsTabContent({
                   { value: "response", label: "Next Reply" },
                   { value: "tool_call", label: "Tool Call" },
                 ] as const
-              ).map((opt) => (
+              ).map((opt, i, arr) => (
                 <button
                   key={opt.value}
                   type="button"
@@ -1791,7 +1791,13 @@ export function TestsTabContent({
                       return next;
                     });
                   }}
+                  // Right-border on every segment except the last gives a
+                  // visible divider between options regardless of active
+                  // state (the parent's `overflow-hidden` clips the
+                  // trailing border against the rounded container edge).
                   className={`h-9 md:h-10 px-3 text-sm font-medium transition-colors cursor-pointer ${
+                    i < arr.length - 1 ? "border-r border-border" : ""
+                  } ${
                     typeFilter === opt.value
                       ? "bg-foreground text-background"
                       : "bg-background text-foreground hover:bg-muted/50"

--- a/src/components/agent-tabs/TestsTabContent.tsx
+++ b/src/components/agent-tabs/TestsTabContent.tsx
@@ -1149,51 +1149,53 @@ export function TestsTabContent({
     }
   };
 
-  // Two new entry points sit alongside "Add test" (which attaches an existing
-  // test). "Create test" opens the in-place creation dialog; "Bulk upload"
-  // opens the CSV modal locked to this agent. Both use POST /tests/bulk with
-  // `agent_uuids: [agentUuid]` so new tests auto-attach to this agent.
-  const renderNewTestButtons = (variant: "outline" | "primary" = "outline") => {
-    const baseClass =
-      variant === "primary"
-        ? "h-9 md:h-10 px-4 md:px-5 rounded-md text-sm md:text-base font-medium bg-foreground text-background hover:opacity-90 transition-opacity cursor-pointer shadow-sm"
-        : "h-9 md:h-10 px-3 md:px-4 rounded-md text-sm md:text-base font-medium border border-border bg-background hover:bg-muted/50 transition-colors cursor-pointer";
-    return (
-      <>
-        <button
-          type="button"
-          onClick={() => {
-            setNewTestName("");
-            setValidationAttempted(false);
-            setCreateError(null);
-            setNameConflictError(null);
-            setCreateDialogOpen(true);
-          }}
-          className={baseClass}
-        >
-          Create test
-        </button>
-        <button
-          type="button"
-          onClick={() => setBulkUploadOpen(true)}
-          className={baseClass}
-        >
-          Bulk upload
-        </button>
-      </>
-    );
-  };
+  // The three test-creation entry points get their own fixed tint so they
+  // read as distinct actions in every layout: header bar and both empty
+  // states use the same colour mapping regardless of which other buttons
+  // are present. Hue palette is picked to avoid colliding with the
+  // Share/Public/Copy-link (purple/blue/amber) and Export (teal) actions.
+  //
+  //   Add test (attach existing) → indigo
+  //   Create test               → pink
+  //   Bulk upload               → orange
+  const ADD_TEST_BUTTON_CLASS =
+    "h-9 md:h-10 px-3 md:px-4 rounded-md text-sm md:text-base font-medium border cursor-pointer transition-colors bg-indigo-500/12 border-indigo-500/45 text-indigo-950 dark:text-indigo-100 hover:bg-indigo-500/22 dark:hover:bg-indigo-500/18";
+  const CREATE_TEST_BUTTON_CLASS =
+    "h-9 md:h-10 px-3 md:px-4 rounded-md text-sm md:text-base font-medium border cursor-pointer transition-colors bg-pink-500/12 border-pink-500/45 text-pink-950 dark:text-pink-100 hover:bg-pink-500/22 dark:hover:bg-pink-500/18";
+  const BULK_UPLOAD_BUTTON_CLASS =
+    "h-9 md:h-10 px-3 md:px-4 rounded-md text-sm md:text-base font-medium border cursor-pointer transition-colors bg-orange-500/12 border-orange-500/45 text-orange-950 dark:text-orange-100 hover:bg-orange-500/22 dark:hover:bg-orange-500/18";
 
-  const renderAddTestControl = (variant: "outline" | "primary" = "outline") => (
+  const renderNewTestButtons = () => (
+    <>
+      <button
+        type="button"
+        onClick={() => {
+          setNewTestName("");
+          setValidationAttempted(false);
+          setCreateError(null);
+          setNameConflictError(null);
+          setCreateDialogOpen(true);
+        }}
+        className={CREATE_TEST_BUTTON_CLASS}
+      >
+        Create test
+      </button>
+      <button
+        type="button"
+        onClick={() => setBulkUploadOpen(true)}
+        className={BULK_UPLOAD_BUTTON_CLASS}
+      >
+        Bulk upload
+      </button>
+    </>
+  );
+
+  const renderAddTestControl = () => (
     <div className="relative" ref={dropdownRef}>
       <button
         onClick={() => setShowTestDropdown(!showTestDropdown)}
         type="button"
-        className={
-          variant === "primary"
-            ? "h-9 md:h-10 px-4 md:px-5 rounded-md text-sm md:text-base font-medium bg-foreground text-background hover:opacity-90 transition-opacity cursor-pointer shadow-sm"
-            : "h-9 md:h-10 px-3 md:px-4 rounded-md text-sm md:text-base font-medium border border-border bg-background hover:bg-muted/50 transition-colors cursor-pointer"
-        }
+        className={ADD_TEST_BUTTON_CLASS}
       >
         Add test
       </button>
@@ -1481,7 +1483,7 @@ export function TestsTabContent({
             <div className="relative" ref={dropdownRef}>
               <button
                 onClick={() => setShowTestDropdown(!showTestDropdown)}
-                className="h-9 md:h-10 px-3 md:px-4 rounded-md text-sm md:text-base font-medium bg-foreground text-background hover:opacity-90 transition-opacity cursor-pointer"
+                className={ADD_TEST_BUTTON_CLASS}
               >
                 Add test
               </button>
@@ -1582,7 +1584,7 @@ export function TestsTabContent({
               )}
             </div>
             {/* Create test / Bulk upload (new tests, auto-attached to this agent) */}
-            {renderNewTestButtons("outline")}
+            {renderNewTestButtons()}
             {/* Run all tests */}
             <div className="relative group/runall">
               <button
@@ -1737,8 +1739,8 @@ export function TestsTabContent({
             {/* Only show the attach-existing button when the user actually
                 has tests to attach — otherwise the dropdown is empty and
                 the affordance is misleading. */}
-            {allTests.length > 0 && renderAddTestControl("primary")}
-            {renderNewTestButtons(allTests.length > 0 ? "outline" : "primary")}
+            {allTests.length > 0 && renderAddTestControl()}
+            {renderNewTestButtons()}
           </div>
         </div>
       ) : agentTests.length === 0 ? (
@@ -1764,10 +1766,8 @@ export function TestsTabContent({
                   : " Add an existing test or create a new one."}
               </p>
               <div className="flex flex-wrap justify-center gap-2 md:gap-3 mt-3 md:mt-4 w-full">
-                {allTests.length > 0 && renderAddTestControl("primary")}
-                {renderNewTestButtons(
-                  allTests.length > 0 ? "outline" : "primary",
-                )}
+                {allTests.length > 0 && renderAddTestControl()}
+                {renderNewTestButtons()}
               </div>
             </div>
           </div>

--- a/src/components/agent-tabs/TestsTabContent.tsx
+++ b/src/components/agent-tabs/TestsTabContent.tsx
@@ -701,8 +701,22 @@ export function TestsTabContent({
         throw new Error("Failed to create test");
       }
 
-      // Refresh the agent's test list so the new test appears immediately.
+      // Bulk endpoint creates the test atomically but links it best-effort.
+      // If linking to this agent failed, the test is in the user's library
+      // but won't show up in this agent's list — refresh anyway (it's still
+      // a no-op for the agent table) but surface the warning and keep the
+      // dialog open so the user knows they need to retry the attach.
+      const result = (await response.json().catch(() => null)) as
+        | { warnings?: string[] | null }
+        | null;
       await fetchAgentTests();
+      if (result?.warnings && result.warnings.length > 0) {
+        setCreateError(
+          `Test created but could not be attached to this agent: ${result.warnings.join("; ")}`,
+        );
+        setIsCreating(false);
+        return;
+      }
       setNewTestName("");
       setValidationAttempted(false);
       setCreateDialogOpen(false);

--- a/src/components/agent-tabs/TestsTabContent.tsx
+++ b/src/components/agent-tabs/TestsTabContent.tsx
@@ -173,6 +173,12 @@ export function TestsTabContent({
   // All available tests state
   const [allTests, setAllTests] = useState<TestData[]>([]);
   const [allTestsLoading, setAllTestsLoading] = useState(false);
+  // Tracks whether `/tests` has been fetched at least once during this
+  // session. Used by the empty state to decide whether the "Add test"
+  // (attach-existing) button is meaningful — if the user has no tests at
+  // all, the button is dropped entirely rather than offering an empty
+  // dropdown.
+  const [allTestsFetched, setAllTestsFetched] = useState(false);
 
   // UI state
   const [showTestDropdown, setShowTestDropdown] = useState(false);
@@ -181,9 +187,9 @@ export function TestsTabContent({
   // Filter the agent's tests by test type. "all" shows both kinds; "response"
   // is Next Reply, "tool_call" is Tool Call. The "select all" checkbox keys
   // off `filteredAgentTests`, so this filter also narrows what gets selected.
-  const [typeFilter, setTypeFilter] = useState<"all" | "response" | "tool_call">(
-    "all",
-  );
+  const [typeFilter, setTypeFilter] = useState<
+    "all" | "response" | "tool_call"
+  >("all");
   const dropdownRef = useRef<HTMLDivElement>(null);
 
   // Create-test dialog state (single test created in-place from the agent
@@ -335,46 +341,74 @@ export function TestsTabContent({
     }
   }, [agentUuid, backendAccessToken, fetchAgentTests]);
 
-  // Fetch all available tests when dropdown opens
+  // Fetch the user's full /tests library. Triggered from two places: when
+  // the attach-existing dropdown opens, and when the agent's tests list
+  // is empty (so the empty state can decide whether the Add-test button
+  // is meaningful).
+  const fetchAllTests = useCallback(async () => {
+    if (!backendAccessToken) return;
+    try {
+      setAllTestsLoading(true);
+      const backendUrl = process.env.NEXT_PUBLIC_BACKEND_URL;
+      if (!backendUrl) {
+        throw new Error("BACKEND_URL environment variable is not set");
+      }
+
+      const response = await fetch(`${backendUrl}/tests`, {
+        method: "GET",
+        headers: {
+          accept: "application/json",
+          Authorization: `Bearer ${backendAccessToken}`,
+        },
+      });
+
+      if (response.status === 401) {
+        await signOut({ callbackUrl: "/login" });
+        return;
+      }
+
+      if (!response.ok) {
+        throw new Error("Failed to fetch tests");
+      }
+
+      const data: TestData[] = await response.json();
+      setAllTests(data);
+      setAllTestsFetched(true);
+    } catch (err) {
+      console.error("Error fetching tests:", err);
+    } finally {
+      setAllTestsLoading(false);
+    }
+  }, [backendAccessToken]);
+
+  // (1) Fetch when the attach-existing dropdown opens.
   useEffect(() => {
     if (showTestDropdown && backendAccessToken) {
-      const fetchTests = async () => {
-        try {
-          setAllTestsLoading(true);
-          const backendUrl = process.env.NEXT_PUBLIC_BACKEND_URL;
-          if (!backendUrl) {
-            throw new Error("BACKEND_URL environment variable is not set");
-          }
-
-          const response = await fetch(`${backendUrl}/tests`, {
-            method: "GET",
-            headers: {
-              accept: "application/json",
-              Authorization: `Bearer ${backendAccessToken}`,
-            },
-          });
-
-          if (response.status === 401) {
-            await signOut({ callbackUrl: "/login" });
-            return;
-          }
-
-          if (!response.ok) {
-            throw new Error("Failed to fetch tests");
-          }
-
-          const data: TestData[] = await response.json();
-          setAllTests(data);
-        } catch (err) {
-          console.error("Error fetching tests:", err);
-        } finally {
-          setAllTestsLoading(false);
-        }
-      };
-
-      fetchTests();
+      fetchAllTests();
     }
-  }, [showTestDropdown, backendAccessToken]);
+  }, [showTestDropdown, backendAccessToken, fetchAllTests]);
+
+  // (2) Fetch when the agent's tests list is known to be empty, so the
+  // empty state can decide whether to show the Add-test button. Only
+  // fires once per session (gated on `allTestsFetched`).
+  useEffect(() => {
+    if (
+      !agentTestsLoading &&
+      agentTests.length === 0 &&
+      !allTestsFetched &&
+      !allTestsLoading &&
+      backendAccessToken
+    ) {
+      fetchAllTests();
+    }
+  }, [
+    agentTestsLoading,
+    agentTests.length,
+    allTestsFetched,
+    allTestsLoading,
+    backendAccessToken,
+    fetchAllTests,
+  ]);
 
   // Close dropdown when clicking outside
   useEffect(() => {
@@ -706,9 +740,9 @@ export function TestsTabContent({
       // but won't show up in this agent's list — refresh anyway (it's still
       // a no-op for the agent table) but surface the warning and keep the
       // dialog open so the user knows they need to retry the attach.
-      const result = (await response.json().catch(() => null)) as
-        | { warnings?: string[] | null }
-        | null;
+      const result = (await response.json().catch(() => null)) as {
+        warnings?: string[] | null;
+      } | null;
       await fetchAgentTests();
       if (result?.warnings && result.warnings.length > 0) {
         setCreateError(
@@ -1119,9 +1153,7 @@ export function TestsTabContent({
   // test). "Create test" opens the in-place creation dialog; "Bulk upload"
   // opens the CSV modal locked to this agent. Both use POST /tests/bulk with
   // `agent_uuids: [agentUuid]` so new tests auto-attach to this agent.
-  const renderNewTestButtons = (
-    variant: "outline" | "primary" = "outline",
-  ) => {
+  const renderNewTestButtons = (variant: "outline" | "primary" = "outline") => {
     const baseClass =
       variant === "primary"
         ? "h-9 md:h-10 px-4 md:px-5 rounded-md text-sm md:text-base font-medium bg-foreground text-background hover:opacity-90 transition-opacity cursor-pointer shadow-sm"
@@ -1697,10 +1729,18 @@ export function TestsTabContent({
           </h3>
           <p className="text-sm md:text-base text-muted-foreground mb-3 md:mb-4 text-center max-w-md">
             This agent doesn&apos;t have any tests attached to it.
+            {allTestsFetched && allTests.length === 0
+              ? " Create a new test or upload tests in bulk."
+              : " Add an existing test or create a new one."}
           </p>
           <div className="flex flex-wrap items-center justify-center gap-2 md:gap-3">
-            {renderAddTestControl("primary")}
-            {renderNewTestButtons("outline")}
+            {/* Only show the attach-existing button when the user actually
+                has tests to attach — otherwise the dropdown is empty and
+                the affordance is misleading. */}
+            {allTests.length > 0 && renderAddTestControl("primary")}
+            {renderNewTestButtons(
+              allTests.length > 0 ? "outline" : "primary",
+            )}
           </div>
         </div>
       ) : agentTests.length === 0 ? (
@@ -1723,8 +1763,10 @@ export function TestsTabContent({
                 This agent doesn&apos;t have any tests linked right now
               </p>
               <div className="flex flex-wrap justify-center gap-2 md:gap-3 mt-3 md:mt-4 w-full">
-                {renderAddTestControl("primary")}
-                {renderNewTestButtons("outline")}
+                {allTests.length > 0 && renderAddTestControl("primary")}
+                {renderNewTestButtons(
+                  allTests.length > 0 ? "outline" : "primary",
+                )}
               </div>
             </div>
           </div>

--- a/src/components/eval-details/BenchmarkOutputsPanel.tsx
+++ b/src/components/eval-details/BenchmarkOutputsPanel.tsx
@@ -226,6 +226,7 @@ export function BenchmarkOutputsPanel({
             <EvaluationCriteriaPanel
               evaluation={selectedTestResult.test_case?.evaluation}
               testCaseEvaluators={selectedTestResult.test_case?.evaluators}
+              passed={selectedTestResult.passed}
               judgeResults={selectedTestResult.judge_results}
               reasoning={selectedTestResult.reasoning}
               scaleByEvaluatorUuid={scaleByEvaluatorUuid}

--- a/src/components/eval-details/TestRunOutputsPanel.tsx
+++ b/src/components/eval-details/TestRunOutputsPanel.tsx
@@ -166,6 +166,13 @@ export function TestRunOutputsPanel({
             <EvaluationCriteriaPanel
               evaluation={selectedResult.testCase?.evaluation}
               testCaseEvaluators={selectedResult.testCase?.evaluators}
+              passed={
+                selectedResult.status === "passed"
+                  ? true
+                  : selectedResult.status === "failed"
+                    ? false
+                    : null
+              }
               judgeResults={selectedResult.judgeResults}
               reasoning={selectedResult.reasoning}
               scaleByEvaluatorUuid={scaleByEvaluatorUuid}

--- a/src/components/test-results/shared.tsx
+++ b/src/components/test-results/shared.tsx
@@ -792,6 +792,7 @@ function EvaluatorPanelCard({
 export function EvaluationCriteriaPanel({
   evaluation,
   testType,
+  passed,
   judgeResults,
   reasoning,
   testCaseEvaluators,
@@ -801,6 +802,10 @@ export function EvaluationCriteriaPanel({
 }: {
   evaluation?: TestCaseEvaluation;
   testType?: string;
+  /** Top-level test verdict. Used to colour the tool-call evaluator card
+   * (green=pass, red=fail). Null/undefined leaves the card neutral, which
+   * is the right default while a run is still in progress. */
+  passed?: boolean | null;
   /** Per-evaluator verdicts from `result.judge_results`. Response tests
    * only — null/absent for tool-call and legacy response runs. */
   judgeResults?: JudgeResult[] | null;
@@ -863,7 +868,14 @@ export function EvaluationCriteriaPanel({
         {isToolCall ? "Expected Tool Calls" : "Evaluators"}
       </h3>
 
-      {/* Tool-call test: expected tool calls + top-level reasoning verdict. */}
+      {/* Tool-call test: expected tool calls + verdict-coloured reasoning
+          card. The deterministic tool-call match is binary, so we surface
+          it through the same `EvaluatorVerdictCard` (read mode) the
+          response-test per-evaluator cards use — name fixed to "Tool call
+          test", verdict driven by the top-level `passed` field, reasoning
+          attached as the collapsible explainer. While the run is still
+          pending (`passed` null/undefined), we fall back to the neutral
+          reasoning strip so the card doesn't show a misleading colour. */}
       {isToolCall && (
         <>
           {hasExpectedToolCalls ? (
@@ -880,11 +892,22 @@ export function EvaluationCriteriaPanel({
               No expected tool calls specified
             </p>
           )}
-          <CollapsibleReasoningStrip
-            text={reasoning}
-            mutedBody={false}
-            leadingLabel="Reasoning"
-          />
+          {typeof passed === "boolean" ? (
+            <EvaluatorVerdictCard
+              mode="read"
+              name="Tool call test"
+              outputType="binary"
+              enableLink={false}
+              match={passed}
+              reasoning={reasoning ?? null}
+            />
+          ) : (
+            <CollapsibleReasoningStrip
+              text={reasoning}
+              mutedBody={false}
+              leadingLabel="Reasoning"
+            />
+          )}
         </>
       )}
 

--- a/src/lib/parseBackendError.ts
+++ b/src/lib/parseBackendError.ts
@@ -48,6 +48,31 @@ export async function readNameConflictMessage(
 }
 
 /**
+ * Variant of `readNameConflictMessage` for `POST /tests/bulk`, which surfaces
+ * test-name conflicts as **400** (with a detail string mentioning "already
+ * exists" or "duplicate") rather than 409. Returns the detail string for the
+ * duplicate-name case; null otherwise — including null for unrelated 400s,
+ * so callers fall through to their general error path.
+ */
+export async function readBulkNameConflictMessage(
+  response: Response,
+): Promise<string | null> {
+  if (response.status !== 400) return null;
+  try {
+    const data = (await response.clone().json()) as { detail?: unknown };
+    if (
+      typeof data?.detail === "string" &&
+      /already exists|duplicate/i.test(data.detail)
+    ) {
+      return data.detail;
+    }
+  } catch {
+    // body wasn't JSON — fall through
+  }
+  return null;
+}
+
+/**
  * Same check as `readNameConflictMessage` but for an apiClient-thrown
  * Error (whose message follows "Request failed: <status> - <body>"). Returns
  * the detail string when the error is a 409 name-collision, null otherwise.

--- a/src/lib/parseBackendError.ts
+++ b/src/lib/parseBackendError.ts
@@ -49,10 +49,12 @@ export async function readNameConflictMessage(
 
 /**
  * Variant of `readNameConflictMessage` for `POST /tests/bulk`, which surfaces
- * test-name conflicts as **400** (with a detail string mentioning "already
- * exists" or "duplicate") rather than 409. Returns the detail string for the
- * duplicate-name case; null otherwise — including null for unrelated 400s,
- * so callers fall through to their general error path.
+ * test-name conflicts as **400** (e.g. `{detail: "Test names already exist:
+ * <name>"}`) rather than 409. Matches both the singular ("name already
+ * exists") and plural ("names already exist") forms the backend emits.
+ * Returns the detail string for the duplicate-name case; null otherwise —
+ * including null for unrelated 400s, so callers fall through to their
+ * general error path.
  */
 export async function readBulkNameConflictMessage(
   response: Response,
@@ -62,7 +64,7 @@ export async function readBulkNameConflictMessage(
     const data = (await response.clone().json()) as { detail?: unknown };
     if (
       typeof data?.detail === "string" &&
-      /already exists|duplicate/i.test(data.detail)
+      /already exists?|duplicate/i.test(data.detail)
     ) {
       return data.detail;
     }


### PR DESCRIPTION
Fixes #90 
Fixes #91
Fixes #81 

## Summary

Several improvements to the agent page's Tests tab plus STT/TTS evaluation export and a tool-call verdict polish.

### Agent page Tests tab
- **Create test + Bulk upload** entry points added next to the existing *Add test* (attach existing) dropdown. Both flow through `POST /tests/bulk` with `agent_uuids: [agentUuid]` so a new test is created and auto-attached to the agent in one atomic call. No backend change needed — `/tests/bulk` already accepts the `agent_uuids` field. The standalone `/tests` page's single-test creation also switched to the bulk endpoint so all create paths share one contract.
- **Open / view / edit** any test from the row — clicking a row hydrates `AddTestDialog` from `GET /tests/{uuid}` and submits `PUT /tests/{uuid}`. The Run, Delete, and select checkbox stop event propagation so they still work.
- **Run selected (N)** button alongside the existing *Remove selected* / *Delete selected*, with the same `maxRowsPerEval` cap and connection-unverified gating as *Run all tests*.
- **Type filter** (All / Next Reply / Tool Call) next to the search input. Composes with search; because the table, row count, and select-all checkbox all key off `filteredAgentTests`, switching filters narrows what's runnable / deletable too. Switching filters also prunes any now-mismatched uuids from the current selection so the bulk-action counts stay accurate.
- `BulkUploadTestsModal` gains an optional `lockedAgentUuid` prop that hides the agent picker and pins `agent_uuids` for the agent-page invocation.

### STT / TTS export
- **STT run page**: new *Export* button (next to Share / Retry) downloads a CSV — one row per `(provider, row)` with columns Provider, Row, Reference text, Predicted text, WER, plus one column per attached evaluator (binary normalised to `"true"`/`"false"`, rating emitted as raw numeric).
- **TTS run page**: new *Export* button downloads a zip via the new `ExportZipButton`. The zip contains `results.csv` (Provider, Row, Audio name, Text, evaluator scores using the same convention as STT) and an `audios/` folder. Each clip is named `<provider>_<row>.<ext>` (extension inferred from the `audio_path` URL) and the CSV's `Audio name` column points at exactly that file. Asset fetches run in parallel; one bad URL is recorded as `<path>.error.txt` inside the zip instead of killing the whole export.

### Tool-call verdict card
`EvaluationCriteriaPanel`'s tool-call branch now renders an `EvaluatorVerdictCard` (read mode, binary) named **"Tool call test"** coloured by the top-level `passed` field (green = pass, red = fail), with the reasoning attached as the collapsible explainer — matches the per-evaluator cards used for response tests. While the run is pending (`passed` null/undefined), falls back to the neutral reasoning strip so the card doesn't show a misleading colour before the verdict lands. `passed` is threaded from both `TestRunOutputsPanel` and `BenchmarkOutputsPanel`.

## Why

The Tests tab previously only allowed attaching tests that already existed in the user's library, running all linked tests, or running a single test from the row. Creating a test or doing a CSV upload meant detouring to `/tests` and then attaching back. Bundling create / bulk-upload / open / run-subset into the tab itself removes that round-trip. The STT/TTS exports give users a portable copy of evaluation results for sharing or offline analysis. The tool-call card colour change brings parity with response tests so pass/fail is visible at a glance.

## Test plan

- [ ] Open an agent's Tests tab and use *Create test* — verify the new test appears in the agent's list and on `/tests` after refresh.
- [ ] Use *Bulk upload* with a CSV — verify tests are created and linked to the agent (agent picker should be hidden).
- [ ] Click a test row — verify the dialog opens with the test's content pre-populated; edit and save; row reflects the update.
- [ ] Select a few tests, click *Run selected (N)* — verify only those tests run.
- [ ] Toggle the type filter; verify table, select-all, and bulk-action counts narrow accordingly.
- [ ] Confirm the existing single-test create on `/tests` still works (now via `/tests/bulk`); duplicate names still surface inline.
- [ ] Open an STT eval run and click *Export* — verify CSV columns and per-evaluator binary/rating values.
- [ ] Open a TTS eval run and click *Export* — verify the zip contains `results.csv` plus an `audios/` folder where filenames match the CSV `Audio name` column.
- [ ] Open a tool-call test result — verify the right-column card is green when passed, red when failed, labelled "Tool call test", with reasoning collapsible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)