### PR TITLE
Labelling: per-item description, per-turn timestamps, smart-quote-tolerant bulk upload

### DIFF
--- a/src/app/human-alignment/tasks/[uuid]/page.tsx
+++ b/src/app/human-alignment/tasks/[uuid]/page.tsx
@@ -844,6 +844,7 @@ function LabellingTaskPageInner() {
   >(null);
   const [editLlmItemUuid, setEditLlmItemUuid] = useState<string | null>(null);
   const [editLlmItemName, setEditLlmItemName] = useState("");
+  const [editLlmItemDescription, setEditLlmItemDescription] = useState("");
   const [savingLlmItem, setSavingLlmItem] = useState(false);
   const [editLlmError, setEditLlmError] = useState<string | null>(null);
 
@@ -1337,23 +1338,28 @@ function LabellingTaskPageInner() {
         const toolCalls = obj.tool_calls;
         const toolCallId =
           typeof obj.tool_call_id === "string" ? obj.tool_call_id : undefined;
+        const createdAt =
+          typeof obj.created_at === "string" ? obj.created_at : undefined;
+        const tsField = createdAt ? { created_at: createdAt } : {};
         if (role === "assistant") {
           if (Array.isArray(toolCalls) && toolCalls.length > 0) {
             out.push({
               role: "assistant",
               ...(content != null ? { content } : {}),
               tool_calls: toolCalls as HistoryItem["tool_calls"],
+              ...tsField,
             });
           } else if (content != null) {
-            out.push({ role: "assistant", content });
+            out.push({ role: "assistant", content, ...tsField });
           }
         } else if (role === "user" && content != null) {
-          out.push({ role: "user", content });
+          out.push({ role: "user", content, ...tsField });
         } else if (role === "tool" && content != null) {
           out.push({
             role: "tool",
             content,
             ...(toolCallId ? { tool_call_id: toolCallId } : {}),
+            ...tsField,
           });
         }
       }
@@ -1387,6 +1393,11 @@ function LabellingTaskPageInner() {
           ? (editingPayload.name as string)
           : `Item ${editingItem.id}`;
       setEditLlmItemName(n);
+      const d =
+        typeof editingPayload?.description === "string"
+          ? (editingPayload.description as string)
+          : "";
+      setEditLlmItemDescription(d);
       setEditLlmError(null);
     }
   }, [editingItem?.uuid, editingPayload]);
@@ -1594,6 +1605,7 @@ function LabellingTaskPageInner() {
     useState(false);
   const [bulkUploadLlmOpen, setBulkUploadLlmOpen] = useState(false);
   const [newItemName, setNewItemName] = useState("");
+  const [newItemDescription, setNewItemDescription] = useState("");
   const [creatingItem, setCreatingItem] = useState(false);
   const [createItemError, setCreateItemError] = useState<string | null>(null);
   const [validationAttempted, setValidationAttempted] = useState(false);
@@ -1740,6 +1752,7 @@ function LabellingTaskPageInner() {
                 onClick={() => {
                   if (taskType === "llm" || taskType === "simulation") {
                     setNewItemName("");
+                    setNewItemDescription("");
                     setCreateItemError(null);
                     setValidationAttempted(false);
                     setAddItemOpen(true);
@@ -2531,7 +2544,7 @@ function LabellingTaskPageInner() {
                 </div>
               ) : (
                 <div className="border border-border rounded-xl overflow-hidden">
-                  <div className="grid grid-cols-[40px_minmax(0,1fr)_440px] gap-4 px-4 py-2 border-b border-border bg-muted/30 items-center">
+                  <div className="grid grid-cols-[40px_minmax(0,1fr)_minmax(0,1.2fr)_440px] gap-4 px-4 py-2 border-b border-border bg-muted/30 items-center">
                     <input
                       type="checkbox"
                       checked={allSelected}
@@ -2545,6 +2558,9 @@ function LabellingTaskPageInner() {
                     <div className="text-sm font-medium text-muted-foreground">
                       Name
                     </div>
+                    <div className="text-sm font-medium text-muted-foreground">
+                      Description
+                    </div>
                     <div className="text-sm font-medium text-muted-foreground text-center">
                       Actions
                     </div>
@@ -2552,11 +2568,20 @@ function LabellingTaskPageInner() {
                   {items.map((item) => {
                     const isSelected = selectedItemIds.has(item.uuid);
                     const isResultsOpen = expandedResultsItemId === item.uuid;
+                    const itemPayloadObj =
+                      item.payload && typeof item.payload === "object"
+                        ? (item.payload as Record<string, unknown>)
+                        : null;
+                    const itemDescription =
+                      itemPayloadObj &&
+                      typeof itemPayloadObj.description === "string"
+                        ? (itemPayloadObj.description as string)
+                        : "";
                     return (
                       <Fragment key={item.uuid}>
                         <div
                           onClick={() => setEditLlmItemUuid(item.uuid)}
-                          className={`grid grid-cols-[40px_minmax(0,1fr)_440px] gap-4 px-4 py-3 border-b border-border last:border-b-0 transition-colors items-center cursor-pointer ${
+                          className={`grid grid-cols-[40px_minmax(0,1fr)_minmax(0,1.2fr)_440px] gap-4 px-4 py-3 border-b border-border last:border-b-0 transition-colors items-center cursor-pointer ${
                             isSelected ? "bg-muted/30" : "hover:bg-muted/20"
                           }`}
                         >
@@ -2570,6 +2595,14 @@ function LabellingTaskPageInner() {
                           />
                           <p className="text-sm text-foreground line-clamp-1">
                             {previewItemPayload(item.payload, taskType)}
+                          </p>
+                          <p
+                            className="text-sm text-muted-foreground line-clamp-2"
+                            title={itemDescription || undefined}
+                          >
+                            {itemDescription || (
+                              <span className="text-muted-foreground/60">—</span>
+                            )}
                           </p>
                           <ItemRowActions
                             itemUuid={item.uuid}
@@ -2721,6 +2754,8 @@ function LabellingTaskPageInner() {
           createError={createItemError}
           testName={newItemName}
           setTestName={setNewItemName}
+          itemDescription={newItemDescription}
+          setItemDescription={setNewItemDescription}
           validationAttempted={validationAttempted}
           mode="labelItem"
           allowAgentLastMessage={taskType === "simulation"}
@@ -2767,10 +2802,16 @@ function LabellingTaskPageInner() {
               }
             }
 
+            const trimmedDescription = newItemDescription.trim();
+            const descriptionField = trimmedDescription
+              ? { description: trimmedDescription }
+              : {};
+
             let payload: Record<string, unknown>;
             if (taskType === "simulation") {
               payload = {
                 name: newItemName.trim(),
+                ...descriptionField,
                 transcript: history,
                 evaluator_variables,
               };
@@ -2794,6 +2835,7 @@ function LabellingTaskPageInner() {
               }
               payload = {
                 name: newItemName.trim(),
+                ...descriptionField,
                 chat_history,
                 agent_response,
                 evaluator_variables,
@@ -2832,6 +2874,8 @@ function LabellingTaskPageInner() {
           createError={editLlmError}
           testName={editLlmItemName}
           setTestName={setEditLlmItemName}
+          itemDescription={editLlmItemDescription}
+          setItemDescription={setEditLlmItemDescription}
           validationAttempted={false}
           mode="labelItem"
           allowAgentLastMessage={taskType === "simulation"}
@@ -2869,10 +2913,14 @@ function LabellingTaskPageInner() {
                 };
               }
             }
+            const trimmedDescription = editLlmItemDescription.trim();
+            const descriptionField = { description: trimmedDescription };
+
             let payload: Record<string, unknown>;
             if (taskType === "simulation") {
               payload = {
                 name: editLlmItemName.trim(),
+                ...descriptionField,
                 transcript: history,
                 evaluator_variables,
               };
@@ -2893,6 +2941,7 @@ function LabellingTaskPageInner() {
               }
               payload = {
                 name: editLlmItemName.trim(),
+                ...descriptionField,
                 chat_history,
                 agent_response,
                 evaluator_variables,

--- a/src/components/AddTestDialog.tsx
+++ b/src/components/AddTestDialog.tsx
@@ -6,6 +6,7 @@ import { useAccessToken } from "@/hooks";
 import { ToolPicker, AvailableTool } from "@/components/ToolPicker";
 import { INBUILT_TOOLS } from "@/constants/inbuilt-tools";
 import { useHideFloatingButton } from "@/components/AppLayout";
+import { formatTurnTimestamp } from "@/components/test-results/shared";
 
 type SelectedToolConfig = {
   id: string;
@@ -33,6 +34,10 @@ export type TestConfig = {
       type: "function";
     }>;
     tool_call_id?: string;
+    /** Optional per-turn timestamp. Round-tripped opaquely through the
+     * dialog so bulk-uploaded labelling items don't lose timestamps when
+     * edited. The dialog never asks the user to set this. */
+    created_at?: string;
   }>;
   evaluation: {
     type: "tool_call" | "response";
@@ -101,6 +106,12 @@ type AddTestDialogProps = {
   nameError?: string | null;
   testName: string;
   setTestName: (name: string) => void;
+  /**
+   * Optional free-form description for a labelling item. Shown only when
+   * `mode === "labelItem"` (LLM / simulation item creation & edit).
+   */
+  itemDescription?: string;
+  setItemDescription?: (description: string) => void;
   validationAttempted: boolean;
   onSubmit: (config: TestConfig, evaluators: EvaluatorRefPayload[]) => void;
   initialTab?: "next-reply" | "tool-invocation";
@@ -139,6 +150,8 @@ export function AddTestDialog({
   nameError,
   testName,
   setTestName,
+  itemDescription,
+  setItemDescription,
   validationAttempted,
   onSubmit,
   initialTab,
@@ -189,6 +202,7 @@ export function AddTestDialog({
           toolParams?: Array<{ name: string; value: string; group?: string }>;
           isWebhook?: boolean;
           linkedToolCallId?: string;
+          createdAt?: string;
         }> = [];
 
         // Helper to format value - stringify objects/arrays for display
@@ -209,6 +223,10 @@ export function AddTestDialog({
         const toolCallIds: string[] = [];
 
         initialConfig.history.forEach((historyItem, index) => {
+          const createdAt =
+            typeof historyItem.created_at === "string"
+              ? historyItem.created_at
+              : undefined;
           if (historyItem.role === "assistant") {
             if (historyItem.tool_calls && historyItem.tool_calls.length > 0) {
               // This is a tool call message
@@ -274,6 +292,7 @@ export function AddTestDialog({
                 toolName: toolCall.function.name,
                 toolParams,
                 isWebhook,
+                ...(createdAt ? { createdAt } : {}),
               });
             } else {
               // Regular assistant message
@@ -281,6 +300,7 @@ export function AddTestDialog({
                 id: `msg-${index}`,
                 role: "agent",
                 content: historyItem.content || "",
+                ...(createdAt ? { createdAt } : {}),
               });
             }
           } else if (historyItem.role === "user") {
@@ -288,6 +308,7 @@ export function AddTestDialog({
               id: `msg-${index}`,
               role: "user",
               content: historyItem.content || "",
+              ...(createdAt ? { createdAt } : {}),
             });
           } else if (historyItem.role === "tool" && historyItem.content) {
             // Tool response message - link to the tool call
@@ -307,6 +328,7 @@ export function AddTestDialog({
               content: historyItem.content,
               linkedToolCallId,
               toolName: linkedToolCall?.toolName || "",
+              ...(createdAt ? { createdAt } : {}),
             });
           }
         });
@@ -405,6 +427,7 @@ export function AddTestDialog({
       toolParams?: Array<{ name: string; value: string; group?: string }>;
       isWebhook?: boolean;
       linkedToolCallId?: string; // For tool_response to link back to tool_call
+      createdAt?: string;
     }>
   >(() => {
     const u = (id: string) => ({
@@ -1033,15 +1056,18 @@ export function AddTestDialog({
 
     // Convert chat messages to the API format
     for (const message of chatMessages) {
+      const ts = message.createdAt ? { created_at: message.createdAt } : {};
       if (message.role === "agent") {
         history.push({
           role: "assistant",
           content: message.content,
+          ...ts,
         });
       } else if (message.role === "user") {
         history.push({
           role: "user",
           content: message.content,
+          ...ts,
         });
       } else if (message.role === "tool_call") {
         // Generate a unique ID for this tool call
@@ -1080,6 +1106,7 @@ export function AddTestDialog({
               type: "function",
             },
           ],
+          ...ts,
         });
 
         // For webhook tools, find the linked tool_response message and add it to history
@@ -1094,6 +1121,9 @@ export function AddTestDialog({
               role: "tool",
               content: linkedResponse.content,
               tool_call_id: toolCallId,
+              ...(linkedResponse.createdAt
+                ? { created_at: linkedResponse.createdAt }
+                : {}),
             });
           }
         }
@@ -1424,6 +1454,22 @@ export function AddTestDialog({
                     )
                   )}
                 </div>
+
+                {/* Description (labelling items only) */}
+                {isLabelItem && setItemDescription && (
+                  <div>
+                    <label className="block text-base font-medium text-foreground mb-2">
+                      Description
+                    </label>
+                    <textarea
+                      value={itemDescription ?? ""}
+                      onChange={(e) => setItemDescription(e.target.value)}
+                      placeholder="Optional — what is this item about? Shown to annotators alongside the evaluators."
+                      rows={3}
+                      className="w-full px-4 py-2.5 rounded-lg text-base bg-background text-foreground placeholder:text-muted-foreground border border-border focus:outline-none focus:ring-2 focus:ring-accent resize-y"
+                    />
+                  </div>
+                )}
 
                 {/* Evaluators (next-reply tab only) */}
                 <div className="relative">
@@ -2190,6 +2236,7 @@ export function AddTestDialog({
                     index === lastNonToolResponseIndex;
                   const showInlineDelete =
                     message.role !== "tool_response" && !isLastNonToolResponse;
+                  const turnTimestamp = formatTurnTimestamp(message.createdAt);
                   return (
                     <div
                       key={message.id}
@@ -2204,7 +2251,7 @@ export function AddTestDialog({
                       {/* Message Header - show for agent messages and tool calls */}
                       {(message.role === "agent" ||
                         message.role === "tool_call") && (
-                        <div className="flex items-center gap-2">
+                        <div className="flex items-center gap-2 flex-wrap">
                           <span className="text-sm font-medium text-foreground">
                             {message.role === "tool_call"
                               ? "Agent Tool Call"
@@ -2253,7 +2300,7 @@ export function AddTestDialog({
                               }`}
                             >
                               {inlineDeleteBtn}
-                              <div className="w-1/2">
+                              <div className="w-1/2 flex flex-col">
                                 <textarea
                                   value={message.content}
                                   placeholder={
@@ -2294,6 +2341,17 @@ export function AddTestDialog({
                                     Message cannot be empty
                                   </p>
                                 )}
+                                {turnTimestamp && (
+                                  <span
+                                    className={`text-[11px] text-muted-foreground tabular-nums mt-1 ${
+                                      message.role === "user"
+                                        ? "self-start"
+                                        : "self-end"
+                                    }`}
+                                  >
+                                    {turnTimestamp}
+                                  </span>
+                                )}
                               </div>
                             </div>
                           );
@@ -2329,7 +2387,7 @@ export function AddTestDialog({
                               </svg>
                             </button>
                           )}
-                          <div className="w-1/2">
+                          <div className="w-1/2 flex flex-col">
                             <div className="bg-muted border border-border rounded-2xl p-4">
                               <div className="flex items-center gap-2 mb-2">
                                 <svg
@@ -2521,6 +2579,11 @@ export function AddTestDialog({
                                   </div>
                                 )}
                             </div>
+                            {turnTimestamp && (
+                              <span className="self-end text-[11px] text-muted-foreground tabular-nums mt-1">
+                                {turnTimestamp}
+                              </span>
+                            )}
                           </div>
                         </div>
                       )}

--- a/src/components/BulkUploadTestsModal.tsx
+++ b/src/components/BulkUploadTestsModal.tsx
@@ -18,6 +18,7 @@ import {
 import type { EvaluatorRefPayload } from "@/components/AddTestDialog";
 import type { AvailableTool } from "@/components/ToolPicker";
 import { INBUILT_TOOLS } from "@/constants/inbuilt-tools";
+import { sanitizeJsonString, parseJsonLenient } from "@/lib/jsonSanitize";
 
 // Inline link styling for the in-modal helper text. Tuned to read as a link
 // inside small muted body copy without shouting — `text-foreground` plus a
@@ -670,8 +671,17 @@ export function BulkUploadTestsModal({
             return;
           }
 
+          // Sanitise smart-quotes etc. up front so the value we hand back
+          // to handleSubmit (and any downstream JSON.parse) already has
+          // ASCII-only quote characters. The original cell text may have
+          // been pasted out of Word / Google Sheets which silently swaps
+          // straight quotes for curly ones; bail out only if the cleanup
+          // still doesn't yield valid JSON.
+          row.conversation_history = sanitizeJsonString(
+            row.conversation_history,
+          );
           try {
-            const history = JSON.parse(row.conversation_history);
+            const history = parseJsonLenient(row.conversation_history);
             if (!Array.isArray(history)) {
               errors.push(
                 `Row ${rowNum}: conversation_history must be a JSON array`,
@@ -731,9 +741,10 @@ export function BulkUploadTestsModal({
               errors.push(`Row ${rowNum}: missing tool_calls`);
               return;
             }
+            row.tool_calls = sanitizeJsonString(row.tool_calls);
             let toolCalls: Array<{ tool?: unknown }>;
             try {
-              const parsed = JSON.parse(row.tool_calls);
+              const parsed = parseJsonLenient(row.tool_calls);
               if (!Array.isArray(parsed)) {
                 errors.push(`Row ${rowNum}: tool_calls must be a JSON array`);
                 return;
@@ -834,7 +845,7 @@ export function BulkUploadTestsModal({
       }
 
       const tests = parsedTests.map((test) => {
-        const conversation_history = JSON.parse(test.conversation_history);
+        const conversation_history = parseJsonLenient(test.conversation_history);
 
         if (isResponseType) {
           // Send the resolved EvaluatorRefPayload[] (same shape as the
@@ -848,7 +859,7 @@ export function BulkUploadTestsModal({
             evaluators: test.evaluators ?? [],
           };
         } else {
-          const tool_calls = JSON.parse(test.tool_calls!);
+          const tool_calls = parseJsonLenient(test.tool_calls!);
           return {
             name: test.name,
             conversation_history,

--- a/src/components/BulkUploadTestsModal.tsx
+++ b/src/components/BulkUploadTestsModal.tsx
@@ -18,7 +18,7 @@ import {
 import type { EvaluatorRefPayload } from "@/components/AddTestDialog";
 import type { AvailableTool } from "@/components/ToolPicker";
 import { INBUILT_TOOLS } from "@/constants/inbuilt-tools";
-import { sanitizeJsonString, parseJsonLenient } from "@/lib/jsonSanitize";
+import { parseJsonLenient } from "@/lib/jsonSanitize";
 
 // Inline link styling for the in-modal helper text. Tuned to read as a link
 // inside small muted body copy without shouting — `text-foreground` plus a
@@ -671,15 +671,12 @@ export function BulkUploadTestsModal({
             return;
           }
 
-          // Sanitise smart-quotes etc. up front so the value we hand back
-          // to handleSubmit (and any downstream JSON.parse) already has
-          // ASCII-only quote characters. The original cell text may have
-          // been pasted out of Word / Google Sheets which silently swaps
-          // straight quotes for curly ones; bail out only if the cleanup
-          // still doesn't yield valid JSON.
-          row.conversation_history = sanitizeJsonString(
-            row.conversation_history,
-          );
+          // `parseJsonLenient` first attempts a vanilla JSON.parse and only
+          // falls back to smart-quote sanitisation if that fails — so
+          // legitimate curly quotes inside conversation content (e.g. a
+          // user message containing `She said "hello"`) are preserved
+          // whenever the file already parses cleanly. Eagerly rewriting
+          // the row up front would corrupt that case.
           try {
             const history = parseJsonLenient(row.conversation_history);
             if (!Array.isArray(history)) {
@@ -741,7 +738,6 @@ export function BulkUploadTestsModal({
               errors.push(`Row ${rowNum}: missing tool_calls`);
               return;
             }
-            row.tool_calls = sanitizeJsonString(row.tool_calls);
             let toolCalls: Array<{ tool?: unknown }>;
             try {
               const parsed = parseJsonLenient(row.tool_calls);

--- a/src/components/human-labelling/AnnotationJobView.tsx
+++ b/src/components/human-labelling/AnnotationJobView.tsx
@@ -803,19 +803,31 @@ function EvaluatorsPane({
   setField: (key: FieldKey, partial: Partial<FieldValue>) => void;
   readOnly: boolean;
 }) {
-  if (evaluators.length === 0) {
-    return (
-      <div className="border border-border rounded-xl p-4 text-sm text-muted-foreground">
-        No evaluators are attached to this task.
-      </div>
-    );
-  }
-
   // Per-item, per-evaluator variable values live on
   // `payload.evaluator_variables[<evaluator_uuid>]`. Surface them on
   // each card so annotators (and admins reviewing) can see the criteria
   // / variable values they're judging against.
   const itemPayload = (item.payload ?? {}) as Record<string, unknown>;
+  const itemDescription =
+    typeof itemPayload.description === "string"
+      ? (itemPayload.description as string).trim()
+      : "";
+  const descriptionBlock = itemDescription ? (
+    <p className="text-sm text-foreground whitespace-pre-wrap break-words">
+      {itemDescription}
+    </p>
+  ) : null;
+
+  if (evaluators.length === 0) {
+    return (
+      <div className="space-y-3">
+        {descriptionBlock}
+        <div className="border border-border rounded-xl p-4 text-sm text-muted-foreground">
+          No evaluators are attached to this task.
+        </div>
+      </div>
+    );
+  }
   const itemEvaluatorVariables = (() => {
     const raw = itemPayload.evaluator_variables;
     if (!raw || typeof raw !== "object" || Array.isArray(raw)) return {};
@@ -836,6 +848,7 @@ function EvaluatorsPane({
 
   return (
     <div className="space-y-3 pb-4 md:pb-6">
+      {descriptionBlock}
       {evaluators.map((ev) => {
         const k = fieldKey(item.uuid, ev.uuid);
         const f = fields[k];

--- a/src/components/human-labelling/BulkUploadLlmItemsDialog.tsx
+++ b/src/components/human-labelling/BulkUploadLlmItemsDialog.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 import Papa from "papaparse";
 import { apiClient } from "@/lib/api";
+import { parseJsonLenient } from "@/lib/jsonSanitize";
 import {
   AnnotationOptIn,
   BulkUploadDialogShell,
@@ -49,6 +50,7 @@ type EvaluatorRef = {
 
 type ParsedItem = {
   name: string;
+  description: string;
   chat_history: TurnObject[];
   agent_response: string;
   evaluators: EvaluatorRef[];
@@ -56,6 +58,7 @@ type ParsedItem = {
 };
 
 const NAME_HEADERS = ["name", "title"];
+const DESCRIPTION_HEADERS = ["description", "desc", "notes"];
 const CONVERSATION_HEADERS = [
   "conversation_history",
   "conversation",
@@ -106,15 +109,16 @@ function buildSampleCsv(
   const rows = [
     {
       name: "Greeting reply",
+      description: "Return policy explanation, friendly tone expected.",
       conversation: [{ role: "user", content: "What is your return policy?" }],
       response: "You can return any item within 30 days for a full refund.",
       sampleVariableValue:
         "The agent should clearly explain the return policy in a helpful and friendly tone.",
-      sampleReasoning:
-        "The agent answered the policy clearly and politely.",
+      sampleReasoning: "The agent answered the policy clearly and politely.",
     },
     {
       name: "Refund flow",
+      description: "",
       conversation: [{ role: "user", content: "I was charged twice" }],
       response:
         "I'm sorry to hear that. Can you confirm the order ID so I can investigate?",
@@ -126,6 +130,7 @@ function buildSampleCsv(
 
   const headerCells = [
     "name",
+    "description",
     "conversation_history",
     "agent_response",
     ...variableColumns.map((c) =>
@@ -141,6 +146,7 @@ function buildSampleCsv(
   const lines = rows.map((r) =>
     [
       csvEscape(r.name),
+      csvEscape(r.description),
       csvEscape(JSON.stringify(r.conversation)),
       csvEscape(r.response),
       ...variableColumns.map(() => csvEscape(r.sampleVariableValue)),
@@ -192,9 +198,7 @@ export function BulkUploadLlmItemsDialog({
   const annotatorsState = useAnnotators(isOpen, accessToken);
   const { annotatedCheck, annotatedCheckLoading } = useAnnotatedItemsCheck({
     enabled:
-      uploadAnnotations &&
-      !!selectedAnnotatorId &&
-      parsedItems.length > 0,
+      uploadAnnotations && !!selectedAnnotatorId && parsedItems.length > 0,
     taskUuid,
     accessToken,
     annotatorId: selectedAnnotatorId,
@@ -271,6 +275,7 @@ export function BulkUploadLlmItemsDialog({
       complete: (results) => {
         const headers = results.meta.fields ?? [];
         const nameKey = findHeaderKey(headers, NAME_HEADERS);
+        const descriptionKey = findHeaderKey(headers, DESCRIPTION_HEADERS);
         const conversationKey = findHeaderKey(headers, CONVERSATION_HEADERS);
         const responseKey = findHeaderKey(headers, RESPONSE_HEADERS);
 
@@ -347,6 +352,9 @@ export function BulkUploadLlmItemsDialog({
         for (let i = 0; i < results.data.length; i++) {
           const row = results.data[i];
           const name = (row[nameKey] ?? "").trim();
+          const description = descriptionKey
+            ? (row[descriptionKey] ?? "").trim()
+            : "";
           const conversationRaw = (row[conversationKey] ?? "").trim();
           const responseRaw = (row[responseKey] ?? "").trim();
 
@@ -373,7 +381,7 @@ export function BulkUploadLlmItemsDialog({
 
           let conversation: unknown;
           try {
-            conversation = JSON.parse(conversationRaw);
+            conversation = parseJsonLenient(conversationRaw);
           } catch {
             setParseError(
               `Row ${i + 1}: "conversation_history" must be valid JSON. Wrap the JSON in double quotes and escape inner double quotes by doubling them.`,
@@ -431,7 +439,10 @@ export function BulkUploadLlmItemsDialog({
           const annotations: ParsedAnnotation[] = [];
           if (uploadAnnotations) {
             for (const meta of annotationEvaluatorsMeta) {
-              if (meta.output_type !== "binary" && meta.output_type !== "rating")
+              if (
+                meta.output_type !== "binary" &&
+                meta.output_type !== "rating"
+              )
                 continue;
               const valueHeader = evaluatorValueColumn(meta.name);
               const reasoningHeader = evaluatorReasoningColumn(meta.name);
@@ -459,6 +470,7 @@ export function BulkUploadLlmItemsDialog({
 
           items.push({
             name,
+            description,
             chat_history: turns,
             agent_response: responseRaw,
             evaluators: refs,
@@ -492,10 +504,7 @@ export function BulkUploadLlmItemsDialog({
     setUploadError(null);
     try {
       const itemsBody = parsedItems.map((p) => {
-        const evaluator_variables: Record<
-          string,
-          Record<string, string>
-        > = {};
+        const evaluator_variables: Record<string, Record<string, string>> = {};
         for (const ref of p.evaluators) {
           if (ref.variable_values) {
             evaluator_variables[ref.evaluator_uuid] = {
@@ -509,6 +518,7 @@ export function BulkUploadLlmItemsDialog({
         return {
           payload: {
             name: p.name,
+            ...(p.description ? { description: p.description } : {}),
             chat_history: p.chat_history,
             agent_response: p.agent_response,
             evaluator_variables,
@@ -543,9 +553,9 @@ export function BulkUploadLlmItemsDialog({
       {
         name: "conversation_history",
         description:
-          'A JSON array of chat messages that represents the conversation that has happened so far, before the agent response being judged. Each message is an object with a "role" and "content" field.\n\nrole — either "user" or "assistant"\ncontent — the message said by that role',
+          'A JSON array of chat messages that represents the conversation that has happened so far, before the agent response being judged. Each message is an object with a "role" and "content" field.\n\nrole — either "user" or "assistant"\ncontent — the message said by that role\ncreated_at — (optional) ISO-8601 timestamp for when this turn happened',
         example: `[
-  {"role": "user", "content": "What is your return policy?"},
+  {"role": "user", "content": "What is your return policy?", "created_at": "2026-05-18T09:14:02Z"},
   {"role": "assistant", "content": "You can return any item within 30 days."}
 ]`,
       },
@@ -586,9 +596,16 @@ export function BulkUploadLlmItemsDialog({
       }
     }
 
+    columns.push({
+      name: "description",
+      description:
+        "(optional) A description of this item. Shown to annotators alongside the evaluators while they label.",
+    });
+
     return {
       title: "Bulk upload — LLM labelling items",
-      intro: "Upload a CSV with the following columns. Each row creates one LLM annotation item.",
+      intro:
+        "Upload a CSV with the following columns. Each row creates one LLM annotation item.",
       columns,
     };
   };
@@ -618,18 +635,23 @@ export function BulkUploadLlmItemsDialog({
           },
         ])
       : [];
+  // Surface a Description column in the preview only when at least one
+  // uploaded row carries a non-empty description — keeps the preview tight
+  // for the common case where descriptions aren't used.
+  const showDescriptionColumn = parsedItems.some(
+    (p) => p.description.trim().length > 0,
+  );
   // Capped column widths so preview cells stay readable without stretching
   // to fill the dialog; extra columns scroll horizontally.
   const gridStyle = {
     gridTemplateColumns: [
       "minmax(96px, 132px)",
+      ...(showDescriptionColumn ? ["minmax(120px, 200px)"] : []),
       "minmax(120px, 200px)",
       "minmax(120px, 200px)",
       ...variableColumns.map(() => "minmax(120px, 200px)"),
       ...annotationColumns.map((c) =>
-        c.kind === "value"
-          ? "minmax(64px, 88px)"
-          : "minmax(100px, 176px)",
+        c.kind === "value" ? "minmax(64px, 88px)" : "minmax(100px, 176px)",
       ),
     ].join(" "),
   };
@@ -640,108 +662,119 @@ export function BulkUploadLlmItemsDialog({
       annotatedCheckLoading={annotatedCheckLoading}
       annotatedCheck={annotatedCheck}
     >
+      <div
+        className="grid gap-2 px-3 py-2 border-b border-border bg-muted sticky top-0 z-10"
+        style={gridStyle}
+      >
+        <div className="text-xs font-medium text-muted-foreground">Name</div>
+        {showDescriptionColumn && (
+          <div className="text-xs font-medium text-muted-foreground">
+            Description
+          </div>
+        )}
+        <div className="text-xs font-medium text-muted-foreground">
+          Chat history
+        </div>
+        <div className="text-xs font-medium text-muted-foreground">
+          AI reply
+        </div>
+        {variableColumns.map((c) => (
           <div
-            className="grid gap-2 px-3 py-2 border-b border-border bg-muted sticky top-0 z-10"
-            style={gridStyle}
+            key={`h-${c.evaluatorUuid}-${c.varName}`}
+            className="text-xs font-medium text-muted-foreground font-mono truncate"
+            title={c.header}
           >
-            <div className="text-xs font-medium text-muted-foreground">
-              Name
-            </div>
-            <div className="text-xs font-medium text-muted-foreground">
-              Chat history
-            </div>
-            <div className="text-xs font-medium text-muted-foreground">
-              AI reply
-            </div>
-            {variableColumns.map((c) => (
-              <div
-                key={`h-${c.evaluatorUuid}-${c.varName}`}
-                className="text-xs font-medium text-muted-foreground font-mono truncate"
-                title={c.header}
-              >
-                {c.header}
-              </div>
-            ))}
-            {annotationColumns.map((c) => (
-              <div
-                key={`ah-${c.evaluatorUuid}-${c.kind}`}
-                className="text-xs font-medium text-muted-foreground font-mono truncate"
-                title={c.header}
-              >
-                {c.header}
-              </div>
-            ))}
+            {c.header}
           </div>
-          <div className="divide-y divide-border">
-            {parsedItems.slice(0, 50).map((p, idx) => {
-              const valuesByKey = new Map<string, string>();
-              for (const ref of p.evaluators) {
-                if (!ref.variable_values) continue;
-                for (const [varName, value] of Object.entries(
-                  ref.variable_values,
-                )) {
-                  valuesByKey.set(`${ref.evaluator_uuid}/${varName}`, value);
-                }
-              }
-              return (
+        ))}
+        {annotationColumns.map((c) => (
+          <div
+            key={`ah-${c.evaluatorUuid}-${c.kind}`}
+            className="text-xs font-medium text-muted-foreground font-mono truncate"
+            title={c.header}
+          >
+            {c.header}
+          </div>
+        ))}
+      </div>
+      <div className="divide-y divide-border">
+        {parsedItems.slice(0, 50).map((p, idx) => {
+          const valuesByKey = new Map<string, string>();
+          for (const ref of p.evaluators) {
+            if (!ref.variable_values) continue;
+            for (const [varName, value] of Object.entries(
+              ref.variable_values,
+            )) {
+              valuesByKey.set(`${ref.evaluator_uuid}/${varName}`, value);
+            }
+          }
+          return (
+            <div
+              key={idx}
+              className={`grid gap-2 px-3 py-2 text-xs items-start ${bulkUploadAnnotatedRowBgClass(idx, annotatedCheck)}`}
+              style={gridStyle}
+            >
+              <div className="truncate text-foreground" title={p.name}>
+                {p.name}
+              </div>
+              {showDescriptionColumn && (
                 <div
-                  key={idx}
-                  className={`grid gap-2 px-3 py-2 text-xs items-start ${bulkUploadAnnotatedRowBgClass(idx, annotatedCheck)}`}
-                  style={gridStyle}
+                  className="min-w-0 max-h-24 overflow-y-auto pr-1 leading-snug text-foreground break-words whitespace-pre-wrap"
+                  title={p.description || undefined}
                 >
-                  <div className="truncate text-foreground" title={p.name}>
-                    {p.name}
-                  </div>
-                  <div className="min-w-0">
-                    <ChatHistoryPreview turns={p.chat_history} />
-                  </div>
-                  <div className="min-w-0">
-                    <AgentReplyPreview agentResponse={p.agent_response} />
-                  </div>
-                  {variableColumns.map((c) => {
-                    const value =
-                      valuesByKey.get(`${c.evaluatorUuid}/${c.varName}`) ?? "";
-                    return (
-                      <div
-                        key={`${idx}-${c.evaluatorUuid}-${c.varName}`}
-                        className="min-w-0 max-h-24 overflow-y-auto pr-1 leading-snug text-foreground break-words whitespace-pre-wrap"
-                      >
-                        {value}
-                      </div>
-                    );
-                  })}
-                  {annotationColumns.map((c) => {
-                    const ann = p.annotations.find(
-                      (a) => a.evaluator_uuid === c.evaluatorUuid,
-                    );
-                    const display =
-                      c.kind === "value"
-                        ? ann
-                          ? typeof ann.value === "boolean"
-                            ? ann.value
-                              ? "true"
-                              : "false"
-                            : String(ann.value)
-                          : ""
-                        : (ann?.reasoning ?? "");
-                    return (
-                      <div
-                        key={`${idx}-a-${c.evaluatorUuid}-${c.kind}`}
-                        className="min-w-0 max-h-24 overflow-y-auto pr-1 leading-snug text-foreground break-words whitespace-pre-wrap"
-                      >
-                        {display}
-                      </div>
-                    );
-                  })}
+                  {p.description}
                 </div>
-              );
-            })}
-            {parsedItems.length > 50 && (
-              <div className="px-4 py-2 text-xs text-muted-foreground">
-                + {parsedItems.length - 50} more rows
+              )}
+              <div className="min-w-0">
+                <ChatHistoryPreview turns={p.chat_history} />
               </div>
-            )}
+              <div className="min-w-0">
+                <AgentReplyPreview agentResponse={p.agent_response} />
+              </div>
+              {variableColumns.map((c) => {
+                const value =
+                  valuesByKey.get(`${c.evaluatorUuid}/${c.varName}`) ?? "";
+                return (
+                  <div
+                    key={`${idx}-${c.evaluatorUuid}-${c.varName}`}
+                    className="min-w-0 max-h-24 overflow-y-auto pr-1 leading-snug text-foreground break-words whitespace-pre-wrap"
+                  >
+                    {value}
+                  </div>
+                );
+              })}
+              {annotationColumns.map((c) => {
+                const ann = p.annotations.find(
+                  (a) => a.evaluator_uuid === c.evaluatorUuid,
+                );
+                const display =
+                  c.kind === "value"
+                    ? ann
+                      ? typeof ann.value === "boolean"
+                        ? ann.value
+                          ? "true"
+                          : "false"
+                        : String(ann.value)
+                      : ""
+                    : (ann?.reasoning ?? "");
+                return (
+                  <div
+                    key={`${idx}-a-${c.evaluatorUuid}-${c.kind}`}
+                    className="min-w-0 max-h-24 overflow-y-auto pr-1 leading-snug text-foreground break-words whitespace-pre-wrap"
+                  >
+                    {display}
+                  </div>
+                );
+              })}
+            </div>
+          );
+        })}
+        {parsedItems.length > 50 && (
+          <div className="px-4 py-2 text-xs text-muted-foreground">
+            + {parsedItems.length - 50} more rows
           </div>
+        )}
+      </div>
     </BulkUploadItemsPreviewShell>
   );
 
@@ -762,17 +795,15 @@ export function BulkUploadLlmItemsDialog({
         {duplicateNames.length > 0 && (
           <div className="rounded-md border border-red-500/30 bg-red-500/10 p-3 text-xs text-red-600 dark:text-red-400">
             Two or more linked evaluators share the same name (
-            {duplicateNames.map((n) => `"${n}"`).join(", ")}). Their
-            variable and annotation columns would collide in the CSV —
-            rename one on the evaluators page before uploading.
+            {duplicateNames.map((n) => `"${n}"`).join(", ")}). Their variable
+            and annotation columns would collide in the CSV — rename one on the
+            evaluators page before uploading.
           </div>
         )}
         {uploadAnnotations && evaluatorsMissingOutputType.length > 0 && (
           <div className="rounded-md border border-red-500/30 bg-red-500/10 p-3 text-xs text-red-600 dark:text-red-400">
             Annotation upload isn&apos;t available — evaluator(s){" "}
-            {evaluatorsMissingOutputType
-              .map((e) => `"${e.name}"`)
-              .join(", ")}{" "}
+            {evaluatorsMissingOutputType.map((e) => `"${e.name}"`).join(", ")}{" "}
             have no binary/rating output configured.
           </div>
         )}

--- a/src/components/human-labelling/BulkUploadSimulationItemsDialog.tsx
+++ b/src/components/human-labelling/BulkUploadSimulationItemsDialog.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 import Papa from "papaparse";
 import { apiClient } from "@/lib/api";
+import { parseJsonLenient } from "@/lib/jsonSanitize";
 import {
   AnnotationOptIn,
   BulkUploadDialogShell,
@@ -35,6 +36,7 @@ const TRANSCRIPT_HEADERS = [
   "conversation_history",
 ];
 const NAME_HEADERS = ["name", "title", "simulation_name"];
+const DESCRIPTION_HEADERS = ["description", "desc", "notes"];
 
 function csvEscape(s: string): string {
   return `"${s.replace(/"/g, '""')}"`;
@@ -42,11 +44,14 @@ function csvEscape(s: string): string {
 
 const SAMPLE_SIMULATION_BASE_ROWS: Array<{
   name: string;
+  description: string;
   transcript: string;
   reasoning: string;
 }> = [
   {
     name: "Card lost - happy path",
+    description:
+      "Lost card flow — agent should verify identity before blocking.",
     transcript: JSON.stringify([
       { role: "assistant", content: "Hi, how can I help?" },
       { role: "user", content: "I lost my card" },
@@ -60,6 +65,7 @@ const SAMPLE_SIMULATION_BASE_ROWS: Array<{
   },
   {
     name: "Refund flow",
+    description: "",
     transcript: JSON.stringify([
       { role: "user", content: "I was charged twice" },
       {
@@ -78,6 +84,7 @@ function buildSampleSimulationCsv(
 ): string {
   const headerCells = [
     "name",
+    "description",
     "transcript",
     ...(includeAnnotations
       ? evaluators.flatMap((e) => [
@@ -89,6 +96,7 @@ function buildSampleSimulationCsv(
   const lines = SAMPLE_SIMULATION_BASE_ROWS.map((r) =>
     [
       csvEscape(r.name),
+      csvEscape(r.description),
       csvEscape(r.transcript),
       ...(includeAnnotations
         ? evaluators.flatMap((e) => [
@@ -103,6 +111,7 @@ function buildSampleSimulationCsv(
 
 type ParsedItem = {
   name: string;
+  description: string;
   transcript: TurnObject[];
   annotations: ParsedAnnotation[];
 };
@@ -171,9 +180,7 @@ export function BulkUploadSimulationItemsDialog({
   const annotatorsState = useAnnotators(isOpen, accessToken);
   const { annotatedCheck, annotatedCheckLoading } = useAnnotatedItemsCheck({
     enabled:
-      uploadAnnotations &&
-      !!selectedAnnotatorId &&
-      parsedItems.length > 0,
+      uploadAnnotations && !!selectedAnnotatorId && parsedItems.length > 0,
     taskUuid,
     accessToken,
     annotatorId: selectedAnnotatorId,
@@ -235,6 +242,7 @@ export function BulkUploadSimulationItemsDialog({
         const headers = results.meta.fields ?? [];
         const transcriptKey = findHeaderKey(headers, TRANSCRIPT_HEADERS);
         const nameKey = findHeaderKey(headers, NAME_HEADERS);
+        const descriptionKey = findHeaderKey(headers, DESCRIPTION_HEADERS);
         if (!nameKey || !transcriptKey) {
           setParseError(
             `CSV must include "name" and "transcript" columns. Found: ${headers.join(", ") || "(none)"}`,
@@ -269,6 +277,9 @@ export function BulkUploadSimulationItemsDialog({
           const row = results.data[i];
           const raw = (row[transcriptKey] ?? "").trim();
           const name = (row[nameKey] ?? "").trim();
+          const description = descriptionKey
+            ? (row[descriptionKey] ?? "").trim()
+            : "";
           if (!raw && !name) continue;
           if (!name) {
             setParseError(`Row ${i + 1}: "name" is required.`);
@@ -280,7 +291,7 @@ export function BulkUploadSimulationItemsDialog({
           }
           let parsed: unknown;
           try {
-            parsed = JSON.parse(raw);
+            parsed = parseJsonLenient(raw);
           } catch {
             setParseError(
               `Row ${i + 1}: "transcript" must be valid JSON. Wrap the JSON in double quotes and escape inner double quotes by doubling them.`,
@@ -311,7 +322,10 @@ export function BulkUploadSimulationItemsDialog({
           const annotations: ParsedAnnotation[] = [];
           if (uploadAnnotations) {
             for (const meta of annotationEvaluatorsMeta) {
-              if (meta.output_type !== "binary" && meta.output_type !== "rating")
+              if (
+                meta.output_type !== "binary" &&
+                meta.output_type !== "rating"
+              )
                 continue;
               const valueHeader = evaluatorValueColumn(meta.name);
               const reasoningHeader = evaluatorReasoningColumn(meta.name);
@@ -338,6 +352,7 @@ export function BulkUploadSimulationItemsDialog({
           }
           items.push({
             name,
+            description,
             transcript: parsed as TurnObject[],
             annotations,
           });
@@ -372,7 +387,11 @@ export function BulkUploadSimulationItemsDialog({
           ? buildItemAnnotationsPayload(p.annotations)
           : undefined;
         return {
-          payload: { name: p.name, transcript: p.transcript },
+          payload: {
+            name: p.name,
+            ...(p.description ? { description: p.description } : {}),
+            transcript: p.transcript,
+          },
           ...(annotationsObj ? { annotations: annotationsObj } : {}),
         };
       });
@@ -403,9 +422,9 @@ export function BulkUploadSimulationItemsDialog({
       {
         name: "transcript",
         description:
-          'A JSON array of chat messages representing the full conversation. Each message is an object with a "role" and "content" field.\n\nrole — either "user" or "assistant"\ncontent — the message said by that role',
+          'A JSON array of chat messages representing the full conversation. Each message is an object with a "role" and "content" field.\n\nrole — either "user" or "assistant"\ncontent — the message said by that role\ncreated_at — (optional) ISO-8601 timestamp for when this turn happened',
         example: `[
-  {"role": "assistant", "content": "Hi, how can I help?"},
+  {"role": "assistant", "content": "Hi, how can I help?", "created_at": "2026-05-18T09:14:02Z"},
   {"role": "user", "content": "I lost my card"}
 ]`,
       },
@@ -432,6 +451,12 @@ export function BulkUploadSimulationItemsDialog({
       }
     }
 
+    columns.push({
+      name: "description",
+      description:
+        "(optional) A description of this item. Shown to annotators alongside the evaluators while they label.",
+    });
+
     return {
       title: "Bulk upload — Simulation labelling items",
       intro:
@@ -455,15 +480,19 @@ export function BulkUploadSimulationItemsDialog({
           },
         ])
       : [];
+  // Surface a Description column in the preview only when at least one
+  // uploaded row carries a non-empty description.
+  const showDescriptionColumn = parsedItems.some(
+    (p) => p.description.trim().length > 0,
+  );
   const simGridStyle = {
     gridTemplateColumns: [
       "minmax(100px, 152px)",
+      ...(showDescriptionColumn ? ["minmax(120px, 200px)"] : []),
       "minmax(140px, 220px)",
       "48px",
       ...annotationColumns.map((c) =>
-        c.kind === "value"
-          ? "minmax(64px, 88px)"
-          : "minmax(100px, 176px)",
+        c.kind === "value" ? "minmax(64px, 88px)" : "minmax(100px, 176px)",
       ),
     ].join(" "),
   };
@@ -474,76 +503,87 @@ export function BulkUploadSimulationItemsDialog({
       annotatedCheckLoading={annotatedCheckLoading}
       annotatedCheck={annotatedCheck}
     >
+      <div
+        className="grid gap-2 px-3 py-2 border-b border-border bg-muted sticky top-0 z-10"
+        style={simGridStyle}
+      >
+        <div className="text-xs font-medium text-muted-foreground">Name</div>
+        {showDescriptionColumn && (
+          <div className="text-xs font-medium text-muted-foreground">
+            Description
+          </div>
+        )}
+        <div className="text-xs font-medium text-muted-foreground">
+          Transcript
+        </div>
+        <div className="text-xs font-medium text-muted-foreground text-right">
+          Turns
+        </div>
+        {annotationColumns.map((c) => (
           <div
-            className="grid gap-2 px-3 py-2 border-b border-border bg-muted sticky top-0 z-10"
+            key={`ah-${c.evaluatorUuid}-${c.kind}`}
+            className="text-xs font-medium text-muted-foreground font-mono truncate"
+            title={c.header}
+          >
+            {c.header}
+          </div>
+        ))}
+      </div>
+      <div className="divide-y divide-border">
+        {parsedItems.slice(0, 50).map((p, idx) => (
+          <div
+            key={idx}
+            className={`grid gap-2 px-3 py-2 text-xs items-start ${bulkUploadAnnotatedRowBgClass(idx, annotatedCheck)}`}
             style={simGridStyle}
           >
-            <div className="text-xs font-medium text-muted-foreground">
-              Name
+            <div className="truncate text-foreground" title={p.name}>
+              {p.name}
             </div>
-            <div className="text-xs font-medium text-muted-foreground">
-              Transcript
-            </div>
-            <div className="text-xs font-medium text-muted-foreground text-right">
-              Turns
-            </div>
-            {annotationColumns.map((c) => (
+            {showDescriptionColumn && (
               <div
-                key={`ah-${c.evaluatorUuid}-${c.kind}`}
-                className="text-xs font-medium text-muted-foreground font-mono truncate"
-                title={c.header}
+                className="min-w-0 max-h-24 overflow-y-auto pr-1 leading-snug text-foreground break-words whitespace-pre-wrap"
+                title={p.description || undefined}
               >
-                {c.header}
-              </div>
-            ))}
-          </div>
-          <div className="divide-y divide-border">
-            {parsedItems.slice(0, 50).map((p, idx) => (
-              <div
-                key={idx}
-                className={`grid gap-2 px-3 py-2 text-xs items-start ${bulkUploadAnnotatedRowBgClass(idx, annotatedCheck)}`}
-                style={simGridStyle}
-              >
-                <div className="truncate text-foreground" title={p.name}>
-                  {p.name}
-                </div>
-                <div className="min-w-0">
-                  <TranscriptPreview turns={p.transcript} />
-                </div>
-                <div className="text-right tabular-nums text-muted-foreground">
-                  {p.transcript.length}
-                </div>
-                {annotationColumns.map((c) => {
-                  const ann = p.annotations.find(
-                    (a) => a.evaluator_uuid === c.evaluatorUuid,
-                  );
-                  const display =
-                    c.kind === "value"
-                      ? ann
-                        ? typeof ann.value === "boolean"
-                          ? ann.value
-                            ? "true"
-                            : "false"
-                          : String(ann.value)
-                        : ""
-                      : (ann?.reasoning ?? "");
-                  return (
-                    <div
-                      key={`${idx}-a-${c.evaluatorUuid}-${c.kind}`}
-                      className="min-w-0 max-h-24 overflow-y-auto pr-1 leading-snug text-foreground break-words whitespace-pre-wrap"
-                    >
-                      {display}
-                    </div>
-                  );
-                })}
-              </div>
-            ))}
-            {parsedItems.length > 50 && (
-              <div className="px-4 py-2 text-xs text-muted-foreground">
-                + {parsedItems.length - 50} more rows
+                {p.description}
               </div>
             )}
+            <div className="min-w-0">
+              <TranscriptPreview turns={p.transcript} />
+            </div>
+            <div className="text-right tabular-nums text-muted-foreground">
+              {p.transcript.length}
+            </div>
+            {annotationColumns.map((c) => {
+              const ann = p.annotations.find(
+                (a) => a.evaluator_uuid === c.evaluatorUuid,
+              );
+              const display =
+                c.kind === "value"
+                  ? ann
+                    ? typeof ann.value === "boolean"
+                      ? ann.value
+                        ? "true"
+                        : "false"
+                      : String(ann.value)
+                    : ""
+                  : (ann?.reasoning ?? "");
+              return (
+                <div
+                  key={`${idx}-a-${c.evaluatorUuid}-${c.kind}`}
+                  className="min-w-0 max-h-24 overflow-y-auto pr-1 leading-snug text-foreground break-words whitespace-pre-wrap"
+                >
+                  {display}
+                </div>
+              );
+            })}
           </div>
+        ))}
+        {parsedItems.length > 50 && (
+          <div className="px-4 py-2 text-xs text-muted-foreground">
+            + {parsedItems.length - 50} more rows
+          </div>
+        )}
+      </div>
     </BulkUploadItemsPreviewShell>
   );
 
@@ -562,16 +602,14 @@ export function BulkUploadSimulationItemsDialog({
         {uploadAnnotations && duplicateNames.length > 0 && (
           <div className="rounded-md border border-red-500/30 bg-red-500/10 p-3 text-xs text-red-600 dark:text-red-400">
             Two or more linked evaluators share the same name (
-            {duplicateNames.map((n) => `"${n}"`).join(", ")}). Rename one
-            on the evaluators page before uploading annotations.
+            {duplicateNames.map((n) => `"${n}"`).join(", ")}). Rename one on the
+            evaluators page before uploading annotations.
           </div>
         )}
         {uploadAnnotations && evaluatorsMissingOutputType.length > 0 && (
           <div className="rounded-md border border-red-500/30 bg-red-500/10 p-3 text-xs text-red-600 dark:text-red-400">
             Annotation upload isn&apos;t available — evaluator(s){" "}
-            {evaluatorsMissingOutputType
-              .map((e) => `"${e.name}"`)
-              .join(", ")}{" "}
+            {evaluatorsMissingOutputType.map((e) => `"${e.name}"`).join(", ")}{" "}
             have no binary/rating output configured.
           </div>
         )}

--- a/src/components/human-labelling/item-panes/LlmItemPane.tsx
+++ b/src/components/human-labelling/item-panes/LlmItemPane.tsx
@@ -48,25 +48,30 @@ function normaliseHistoryItem(raw: unknown): TestCaseHistory | null {
   const toolCalls = obj.tool_calls;
   const toolCallId =
     typeof obj.tool_call_id === "string" ? obj.tool_call_id : undefined;
+  const createdAt =
+    typeof obj.created_at === "string" ? obj.created_at : undefined;
+  const tsField = createdAt ? { created_at: createdAt } : {};
   if (role === "assistant") {
     if (Array.isArray(toolCalls) && toolCalls.length > 0) {
       return {
         role: "assistant",
         ...(content != null ? { content } : {}),
         tool_calls: toolCalls as TestCaseHistory["tool_calls"],
+        ...tsField,
       };
     }
-    if (content != null) return { role: "assistant", content };
+    if (content != null) return { role: "assistant", content, ...tsField };
     return null;
   }
   if (role === "user" && content != null) {
-    return { role: "user", content };
+    return { role: "user", content, ...tsField };
   }
   if (role === "tool" && content != null) {
     return {
       role: "tool",
       content,
       ...(toolCallId ? { tool_call_id: toolCallId } : {}),
+      ...tsField,
     };
   }
   return null;

--- a/src/components/human-labelling/item-panes/SimulationItemPane.tsx
+++ b/src/components/human-labelling/item-panes/SimulationItemPane.tsx
@@ -38,25 +38,30 @@ function normaliseHistoryItem(raw: unknown): TestCaseHistory | null {
   const toolCalls = obj.tool_calls;
   const toolCallId =
     typeof obj.tool_call_id === "string" ? obj.tool_call_id : undefined;
+  const createdAt =
+    typeof obj.created_at === "string" ? obj.created_at : undefined;
+  const tsField = createdAt ? { created_at: createdAt } : {};
   if (role === "assistant") {
     if (Array.isArray(toolCalls) && toolCalls.length > 0) {
       return {
         role: "assistant",
         ...(content != null ? { content } : {}),
         tool_calls: toolCalls as TestCaseHistory["tool_calls"],
+        ...tsField,
       };
     }
-    if (content != null) return { role: "assistant", content };
+    if (content != null) return { role: "assistant", content, ...tsField };
     return null;
   }
   if (role === "user" && content != null) {
-    return { role: "user", content };
+    return { role: "user", content, ...tsField };
   }
   if (role === "tool" && content != null) {
     return {
       role: "tool",
       content,
       ...(toolCallId ? { tool_call_id: toolCallId } : {}),
+      ...tsField,
     };
   }
   return null;

--- a/src/components/test-results/shared.tsx
+++ b/src/components/test-results/shared.tsx
@@ -72,6 +72,10 @@ export type TestCaseHistory = {
     type: string;
   }>;
   tool_call_id?: string;
+  /** Optional per-turn timestamp. Set by labelling items that bulk-upload a
+   * conversation with `created_at` on each turn; rendered next to the role
+   * label so annotators see when each message happened. */
+  created_at?: string;
 };
 
 export type TestCaseEvaluation = {
@@ -444,6 +448,20 @@ export function JudgeResultsList({
   );
 }
 
+// Format an optional per-turn timestamp for display. Accepts ISO-8601 or
+// epoch milliseconds; falls back to the raw string when parsing fails so
+// bulk-uploaded freeform timestamps still show up. Returns `null` for empty
+// or missing input so callers can skip rendering entirely.
+export function formatTurnTimestamp(raw: unknown): string | null {
+  if (raw == null) return null;
+  const s = typeof raw === "string" ? raw.trim() : String(raw);
+  if (!s) return null;
+  const asNumber = /^\d+$/.test(s) ? Number(s) : NaN;
+  const d = Number.isFinite(asNumber) ? new Date(asNumber) : new Date(s);
+  if (Number.isNaN(d.getTime())) return s;
+  return d.toLocaleString();
+}
+
 // Shared Test Detail View Component
 export function TestDetailView({
   history,
@@ -517,6 +535,7 @@ export function TestDetailView({
           <div className="space-y-4">
             {history.map((message, index) => {
               const isEvalTarget = index === evalTargetIndex;
+              const timestamp = formatTurnTimestamp(message.created_at);
               return (
               <div
                 key={index}
@@ -530,19 +549,24 @@ export function TestDetailView({
               >
                 {/* User Message */}
                 {message.role === "user" && (
-                  <div className="w-[88%] md:w-3/4">
+                  <div className="w-[88%] md:w-3/4 flex flex-col">
                     <div className="px-3 md:px-4 py-2.5 md:py-3 rounded-xl bg-muted border border-border">
                       <p className="text-sm text-foreground whitespace-pre-wrap">
                         {message.content}
                       </p>
                     </div>
+                    {timestamp && (
+                      <span className="self-start text-[11px] text-muted-foreground tabular-nums mt-1">
+                        {timestamp}
+                      </span>
+                    )}
                   </div>
                 )}
 
                 {/* Agent Message (text response) */}
                 {message.role === "assistant" && !message.tool_calls && (
                   <>
-                    <div className="flex items-center gap-2">
+                    <div className="flex items-center gap-2 flex-wrap">
                       <span className="text-sm font-medium text-foreground">
                         Agent
                       </span>
@@ -552,12 +576,17 @@ export function TestDetailView({
                         </span>
                       )}
                     </div>
-                    <div className="w-[88%] md:w-3/4">
+                    <div className="w-[88%] md:w-3/4 flex flex-col">
                       <div className="px-3 md:px-4 py-2.5 md:py-3 rounded-xl bg-background border border-border">
                         <p className="text-sm text-foreground whitespace-pre-wrap">
                           {message.content}
                         </p>
                       </div>
+                      {timestamp && (
+                        <span className="self-end text-[11px] text-muted-foreground tabular-nums mt-1">
+                          {timestamp}
+                        </span>
+                      )}
                     </div>
                   </>
                 )}
@@ -567,7 +596,7 @@ export function TestDetailView({
                   message.tool_calls &&
                   message.tool_calls.length > 0 && (
                     <>
-                      <div className="flex items-center gap-2">
+                      <div className="flex items-center gap-2 flex-wrap">
                         <span className="text-sm font-medium text-foreground">
                           Agent Tool Call
                         </span>
@@ -577,7 +606,7 @@ export function TestDetailView({
                           </span>
                         )}
                       </div>
-                      <div className="w-[88%] md:w-3/4">
+                      <div className="w-[88%] md:w-3/4 flex flex-col">
                         {message.tool_calls.map((toolCall, tcIndex) => {
                           const { toolName, args } =
                             normalizeToolCall(toolCall);
@@ -589,6 +618,11 @@ export function TestDetailView({
                             />
                           );
                         })}
+                        {timestamp && (
+                          <span className="self-end text-[11px] text-muted-foreground tabular-nums mt-1">
+                            {timestamp}
+                          </span>
+                        )}
                       </div>
                     </>
                   )}

--- a/src/lib/jsonSanitize.ts
+++ b/src/lib/jsonSanitize.ts
@@ -1,0 +1,31 @@
+// Bulk-upload CSVs frequently come out of Word / Google Sheets / Notes,
+// which silently rewrite straight ASCII quotes to "smart" curly quotes
+// (U+201C, U+201D, U+2018, U+2019). JSON.parse rejects those, so before
+// we surface a parsing error to the user we try replacing common Unicode
+// quote look-alikes with their ASCII equivalents and re-parse. Only if
+// the sanitised string still doesn't parse do we let the error bubble up.
+
+const QUOTE_REPLACEMENTS: Array<[RegExp, string]> = [
+  [/[“”„‟″‶]/g, '"'],
+  [/[‘’‚‛′‵]/g, "'"],
+];
+
+export function sanitizeJsonString(raw: string): string {
+  let out = raw;
+  for (const [re, replacement] of QUOTE_REPLACEMENTS) {
+    out = out.replace(re, replacement);
+  }
+  return out;
+}
+
+/** Parse JSON, retrying once with smart-quote → ASCII-quote sanitisation
+ * before propagating the parse error. */
+export function parseJsonLenient(raw: string): unknown {
+  try {
+    return JSON.parse(raw);
+  } catch (firstError) {
+    const sanitized = sanitizeJsonString(raw);
+    if (sanitized === raw) throw firstError;
+    return JSON.parse(sanitized);
+  }
+}


### PR DESCRIPTION
Fix https://github.com/ARTPARK-SAHAI-ORG/calibrate-frontend/issues/85

## Summary

- LLM / simulation labelling items gain an optional **description** (per-item).
  - Add Test/Item dialog now has a description textarea (label-item mode only).
  - Items table shows a Description column for LLM / simulation tasks.
  - Annotator job view renders the description as plain text above the evaluator cards.
  - Bulk upload accepts a `description` CSV column (aliases: `desc`, `notes`), surfaces a Description column in the preview when at least one row supplies one, and documents the column in the CSV format guidelines. Sample CSV includes the field.
- Conversation turns may now carry an optional **`created_at`** timestamp.
  - Flows through `LlmItemPane` / `SimulationItemPane`, `TestDetailView`, and the Add Test/Item dialog editor (round-tripped opaquely on edit).
  - Rendered as a small label below each bubble, aligned away from the inline delete buttons — left for user turns, right for assistant / tool-call turns.
  - Bulk upload guidelines mention `created_at` as an optional per-turn field; sample CSV intentionally omits it.
- Bulk-upload CSVs are now **smart-quote tolerant**.
  - New `src/lib/jsonSanitize.ts` exports `sanitizeJsonString` / `parseJsonLenient` — swaps `“ ” ‘ ’` etc. for ASCII quotes and retries `JSON.parse` before propagating an error.
  - Wired into `BulkUploadTestsModal` (conversation_history + tool_calls), `BulkUploadLlmItemsDialog` (conversation_history), `BulkUploadSimulationItemsDialog` (transcript).

## Why

Annotators kept asking for context about each item beyond the name; descriptions provide that without overloading the name field. Per-turn timestamps make replayed conversations easier to reason about. Smart-quote tolerance unblocks the common case of CSVs pasted out of Word / Google Sheets, where straight quotes silently become curly quotes and break JSON parsing.

## Notes for reviewers

- `description` is stored inside `item.payload`, matching how `name`, `chat_history`, `transcript`, etc. are persisted — no new task-level fields touched.
- `created_at` is a pass-through field: the dialog doesn't expose UI to edit it, but parse/serialize preserve it so editing other fields doesn't strip bulk-uploaded timestamps.
- Description column in the items table only renders for LLM / simulation tasks; STT is unchanged.

## Test plan
- [ ] Create an LLM / simulation labelling item with and without description; confirm it shows in the items table and in the annotator job view.
- [ ] Edit a previously-bulk-uploaded item with `created_at` timestamps and confirm the timestamps survive the round-trip.
- [ ] Bulk upload an LLM CSV with a `description` column populated on some rows; confirm the preview shows a Description column.
- [ ] Bulk upload a CSV whose `conversation_history` / `transcript` JSON contains curly quotes (e.g. “key”); confirm it parses successfully.
- [ ] Verify TestDetailView in test/benchmark contexts is visually unchanged (no `created_at` → no timestamp rendered).

🤖 Generated with [Claude Code](https://claude.com/claude-code)