### PR TITLE
Labelling UX polish + chat bubble fit + benchmark toggle auto-save

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,3 +82,8 @@ Use `useSidebarState()` from `src/lib/sidebar.ts` for the open/closed state — 
 - All interactive elements need `cursor-pointer`; disabled elements `cursor-not-allowed disabled:opacity-50`.
 - Mobile-first. Primary breakpoint is `md:` (768px). Tables convert to card layouts on mobile (`hidden md:block` for the table, `md:hidden` for the card version).
 - Page titles are set via `document.title` in a `useEffect` in the page component AND via `metadata` export in the route's `layout.tsx` — keep them in sync when renaming.
+
+## Workflow
+
+- **Auto-commit when done**: once all changes for the user's request are complete and verified, create a git commit without waiting for the user to ask. Use a clear, scoped commit message that explains the why. Do not push unless the user asks.
+- **Keep CLAUDE.md in sync with reality**: after making changes, check whether any high-level understanding of the app has shifted — new routes, new top-level concepts, renamed nav items, changed auth flow, new architectural patterns, new conventions, retired features, etc. If yes, update CLAUDE.md in the same commit so this file stays an accurate map of the codebase. Skip updates for low-level details (individual component tweaks, copy changes, bug fixes that don't change architecture).

--- a/src/app/human-alignment/tasks/[uuid]/page.tsx
+++ b/src/app/human-alignment/tasks/[uuid]/page.tsx
@@ -649,7 +649,23 @@ function ItemRowActions({
   );
 }
 
-function JobsList({ jobs }: { jobs: LabellingJob[] }) {
+function JobsList({
+  jobs,
+  selectedJobUuids,
+  onToggleJob,
+  onToggleSelectAll,
+  allSelected,
+  someSelected,
+  onRequestDelete,
+}: {
+  jobs: LabellingJob[];
+  selectedJobUuids: Set<string>;
+  onToggleJob: (jobUuid: string) => void;
+  onToggleSelectAll: () => void;
+  allSelected: boolean;
+  someSelected: boolean;
+  onRequestDelete: (jobUuid: string) => void;
+}) {
   const router = useRouter();
   const [copiedToken, setCopiedToken] = useState<string | null>(null);
 
@@ -670,7 +686,17 @@ function JobsList({ jobs }: { jobs: LabellingJob[] }) {
 
   return (
     <div className="border border-border rounded-xl overflow-hidden">
-      <div className="grid grid-cols-[180px_minmax(0,1fr)_120px_120px] gap-4 [&>*:nth-child(3)]:pl-6 px-4 py-2 border-b border-border bg-muted/30 items-center">
+      <div className="grid grid-cols-[40px_180px_minmax(0,1fr)_120px_120px_60px] gap-4 [&>*:nth-child(4)]:pl-6 px-4 py-2 border-b border-border bg-muted/30 items-center">
+        <input
+          type="checkbox"
+          checked={allSelected}
+          ref={(el) => {
+            if (el) el.indeterminate = someSelected;
+          }}
+          onChange={onToggleSelectAll}
+          aria-label="Select all jobs"
+          className="w-4 h-4 cursor-pointer accent-foreground"
+        />
         <div className="text-sm font-medium text-muted-foreground">
           Annotator
         </div>
@@ -679,11 +705,15 @@ function JobsList({ jobs }: { jobs: LabellingJob[] }) {
         <div className="text-sm font-medium text-muted-foreground">
           Progress
         </div>
+        <div className="text-sm font-medium text-muted-foreground text-center">
+          Actions
+        </div>
       </div>
       {jobs.map((job) => {
         const isImported = job.public_token.startsWith("import:");
         const copied = copiedToken === job.public_token;
         const url = buildAnnotateUrl(job.public_token);
+        const isSelected = selectedJobUuids.has(job.uuid);
         return (
           <div
             key={job.uuid}
@@ -691,10 +721,18 @@ function JobsList({ jobs }: { jobs: LabellingJob[] }) {
               if (!isImported)
                 router.push(`/human-alignment/jobs/${job.public_token}`);
             }}
-            className={`grid grid-cols-[180px_minmax(0,1fr)_120px_120px] gap-4 [&>*:nth-child(3)]:pl-6 px-4 py-3 border-b border-border last:border-b-0 items-center hover:bg-muted/20 transition-colors ${
-              isImported ? "" : "cursor-pointer"
-            }`}
+            className={`grid grid-cols-[40px_180px_minmax(0,1fr)_120px_120px_60px] gap-4 [&>*:nth-child(4)]:pl-6 px-4 py-3 border-b border-border last:border-b-0 items-center transition-colors ${
+              isSelected ? "bg-muted/30" : "hover:bg-muted/20"
+            } ${isImported ? "" : "cursor-pointer"}`}
           >
+            <input
+              type="checkbox"
+              checked={isSelected}
+              onChange={() => onToggleJob(job.uuid)}
+              onClick={(e) => e.stopPropagation()}
+              aria-label={`Select job ${job.annotator_name}`}
+              className="w-4 h-4 cursor-pointer accent-foreground"
+            />
             <div className="text-sm font-medium truncate">
               {job.annotator_name}
             </div>
@@ -763,6 +801,32 @@ function JobsList({ jobs }: { jobs: LabellingJob[] }) {
             </div>
             <div className="text-sm text-muted-foreground tabular-nums">
               {job.completed_item_count} / {job.item_count}
+            </div>
+            <div className="flex justify-center">
+              <button
+                type="button"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onRequestDelete(job.uuid);
+                }}
+                aria-label="Delete job"
+                title="Delete job"
+                className="w-8 h-8 flex items-center justify-center rounded-md text-muted-foreground hover:bg-red-500/10 hover:text-red-500 transition-colors cursor-pointer"
+              >
+                <svg
+                  className="w-4 h-4"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                  strokeWidth={1.8}
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    d="M14.74 9l-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 01-2.244 2.077H8.084a2.25 2.25 0 01-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 00-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 013.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 00-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 00-7.5 0"
+                  />
+                </svg>
+              </button>
             </div>
           </div>
         );
@@ -838,6 +902,14 @@ function LabellingTaskPageInner() {
   const [assignOpen, setAssignOpen] = useState(false);
   const [deleteSelectedOpen, setDeleteSelectedOpen] = useState(false);
   const [deletingSelected, setDeletingSelected] = useState(false);
+
+  const [selectedJobUuids, setSelectedJobUuids] = useState<Set<string>>(
+    new Set(),
+  );
+  const [deleteJobsOpen, setDeleteJobsOpen] = useState(false);
+  const [deletingJobs, setDeletingJobs] = useState(false);
+  const [deletingJobUuid, setDeletingJobUuid] = useState<string | null>(null);
+  const [deletingJobInFlight, setDeletingJobInFlight] = useState(false);
   const [editSttItemsOpen, setEditSttItemsOpen] = useState(false);
   const [editSttSingleItemUuid, setEditSttSingleItemUuid] = useState<
     string | null
@@ -1120,6 +1192,38 @@ function LabellingTaskPageInner() {
     });
   }, [items]);
 
+  const toggleJob = (jobUuid: string) => {
+    setSelectedJobUuids((prev) => {
+      const next = new Set(prev);
+      if (next.has(jobUuid)) next.delete(jobUuid);
+      else next.add(jobUuid);
+      return next;
+    });
+  };
+
+  const allJobsSelected =
+    jobs.length > 0 && selectedJobUuids.size === jobs.length;
+  const someJobsSelected = selectedJobUuids.size > 0 && !allJobsSelected;
+  const toggleSelectAllJobs = () => {
+    setSelectedJobUuids((prev) =>
+      prev.size === jobs.length
+        ? new Set()
+        : new Set(jobs.map((j) => j.uuid)),
+    );
+  };
+
+  useEffect(() => {
+    setSelectedJobUuids((prev) => {
+      if (prev.size === 0) return prev;
+      const ids = new Set(jobs.map((j) => j.uuid));
+      const next = new Set<string>();
+      prev.forEach((id) => {
+        if (ids.has(id)) next.add(id);
+      });
+      return next.size === prev.size ? prev : next;
+    });
+  }, [jobs]);
+
   const [startingRun, setStartingRun] = useState(false);
   // Run evaluators dialog state. itemUuids: null = all items in task,
   // []/non-empty = the specific items to run for.
@@ -1235,6 +1339,52 @@ function LabellingTaskPageInner() {
       setError(parseApiError(err, "Failed to delete item"));
     } finally {
       setDeletingOneInFlight(false);
+    }
+  };
+
+  const confirmDeleteOneJob = async () => {
+    if (!accessToken || !deletingJobUuid) return;
+    const jobUuid = deletingJobUuid;
+    setDeletingJobInFlight(true);
+    try {
+      await apiClient<{ message: string }>(
+        `/annotation-tasks/${uuid}/jobs/${jobUuid}`,
+        accessToken,
+        { method: "DELETE" },
+      );
+      setSelectedJobUuids((prev) => {
+        const next = new Set(prev);
+        next.delete(jobUuid);
+        return next;
+      });
+      setDeletingJobUuid(null);
+      await fetchTask();
+    } catch (err) {
+      toast.error(parseApiError(err, "Failed to delete labelling job"));
+    } finally {
+      setDeletingJobInFlight(false);
+    }
+  };
+
+  const handleDeleteSelectedJobs = async () => {
+    if (selectedJobUuids.size === 0 || !accessToken) return;
+    setDeletingJobs(true);
+    try {
+      await apiClient<{ deleted_count: number }>(
+        `/annotation-tasks/${uuid}/jobs`,
+        accessToken,
+        {
+          method: "DELETE",
+          body: { job_uuids: Array.from(selectedJobUuids) },
+        },
+      );
+      setDeleteJobsOpen(false);
+      setSelectedJobUuids(new Set());
+      await fetchTask();
+    } catch (err) {
+      toast.error(parseApiError(err, "Failed to delete labelling jobs"));
+    } finally {
+      setDeletingJobs(false);
     }
   };
 
@@ -2703,7 +2853,39 @@ function LabellingTaskPageInner() {
               description="Assigning items to annotators creates a job they need to complete"
             />
           ) : (
-            <JobsList jobs={jobs} />
+            <div className="space-y-3">
+              {selectedJobUuids.size > 0 && (
+                <div className="flex items-center justify-between gap-3 rounded-md border border-border bg-muted/30 px-3 py-2">
+                  <span className="text-sm">
+                    <span className="font-medium">{selectedJobUuids.size}</span>{" "}
+                    job{selectedJobUuids.size === 1 ? "" : "s"} selected
+                  </span>
+                  <div className="flex items-center gap-2">
+                    <button
+                      onClick={() => setSelectedJobUuids(new Set())}
+                      className="h-8 px-3 rounded-md text-sm font-medium text-muted-foreground hover:text-foreground hover:bg-muted transition-colors cursor-pointer"
+                    >
+                      Clear
+                    </button>
+                    <button
+                      onClick={() => setDeleteJobsOpen(true)}
+                      className="h-8 px-3 rounded-md text-sm font-medium border border-red-500/30 bg-red-500/10 text-red-500 hover:bg-red-500/20 transition-colors cursor-pointer"
+                    >
+                      Delete
+                    </button>
+                  </div>
+                </div>
+              )}
+              <JobsList
+                jobs={jobs}
+                selectedJobUuids={selectedJobUuids}
+                onToggleJob={toggleJob}
+                onToggleSelectAll={toggleSelectAllJobs}
+                allSelected={allJobsSelected}
+                someSelected={someJobsSelected}
+                onRequestDelete={(jobUuid) => setDeletingJobUuid(jobUuid)}
+              />
+            </div>
           ))}
 
         {activeTab === "runs" && (
@@ -3174,6 +3356,30 @@ function LabellingTaskPageInner() {
         message="Delete this item? Any annotations on it will also be lost. This cannot be undone."
         confirmText="Delete"
         isDeleting={deletingOneInFlight}
+      />
+
+      <DeleteConfirmationDialog
+        isOpen={deleteJobsOpen}
+        onClose={() => {
+          if (!deletingJobs) setDeleteJobsOpen(false);
+        }}
+        onConfirm={handleDeleteSelectedJobs}
+        title="Delete labelling jobs"
+        message={`Delete ${selectedJobUuids.size} labelling job${selectedJobUuids.size === 1 ? "" : "s"}? Any annotations recorded against ${selectedJobUuids.size === 1 ? "this job" : "these jobs"} will be lost. This cannot be undone.`}
+        confirmText="Delete"
+        isDeleting={deletingJobs}
+      />
+
+      <DeleteConfirmationDialog
+        isOpen={!!deletingJobUuid}
+        onClose={() => {
+          if (!deletingJobInFlight) setDeletingJobUuid(null);
+        }}
+        onConfirm={confirmDeleteOneJob}
+        title="Delete labelling job"
+        message="Delete this labelling job? Any annotations recorded against it will be lost. This cannot be undone."
+        confirmText="Delete"
+        isDeleting={deletingJobInFlight}
       />
 
       <DeleteConfirmationDialog

--- a/src/app/human-alignment/tasks/[uuid]/page.tsx
+++ b/src/app/human-alignment/tasks/[uuid]/page.tsx
@@ -957,16 +957,6 @@ function LabellingTaskPageInner() {
     fetchTask();
   }, [fetchTask]);
 
-  useEffect(() => {
-    if (autoTabSwitchedRef.current) return;
-    if (!task) return;
-    autoTabSwitchedRef.current = true;
-    if (isTab(initialTab)) return; // user pinned a tab via URL
-    if ((task.items?.length ?? 0) === 0) {
-      handleTabChange("items");
-    }
-  }, [task, initialTab, handleTabChange]);
-
   const fetchAgreement = useCallback(async () => {
     if (!accessToken || !uuid) return;
     setAgreementLoading(true);
@@ -1038,6 +1028,43 @@ function LabellingTaskPageInner() {
   useEffect(() => {
     if (activeTab === "overview" || activeTab === "items") fetchTaskSummary();
   }, [activeTab, fetchTaskSummary]);
+
+  useEffect(() => {
+    if (autoTabSwitchedRef.current) return;
+    if (!task) return;
+    if (isTab(initialTab)) {
+      autoTabSwitchedRef.current = true;
+      return; // user pinned a tab via URL
+    }
+    if ((task.items?.length ?? 0) === 0) {
+      autoTabSwitchedRef.current = true;
+      handleTabChange("items");
+      return;
+    }
+    // Items exist — peek at overview's data sources to decide if the
+    // overview would just be empty states. If both the agreement panel
+    // and the per-item summary table have nothing to show, jump straight
+    // to the items tab. Wait for both fetches to complete first.
+    if (!agreementFetchCompleted) return;
+    if (taskSummary === null) return;
+    const agreementEmpty =
+      !agreement ||
+      ((agreement.human_human?.pair_count ?? 0) === 0 &&
+        (agreement.evaluators ?? []).every((e) => (e.pair_count ?? 0) === 0));
+    const summaryEmpty =
+      (taskSummary.rows ?? []).filter(summaryRowHasAnyValue).length === 0;
+    autoTabSwitchedRef.current = true;
+    if (agreementEmpty && summaryEmpty) {
+      handleTabChange("items");
+    }
+  }, [
+    task,
+    initialTab,
+    handleTabChange,
+    agreement,
+    agreementFetchCompleted,
+    taskSummary,
+  ]);
 
   // Set of item uuids that have at least one summary row with a value
   // worth displaying. Used to disable the per-item "View results" button

--- a/src/components/AddTestDialog.tsx
+++ b/src/components/AddTestDialog.tsx
@@ -2300,7 +2300,7 @@ export function AddTestDialog({
                               }`}
                             >
                               {inlineDeleteBtn}
-                              <div className="w-1/2 flex flex-col">
+                              <div className="w-fit max-w-[50%] min-w-[180px] flex flex-col">
                                 <textarea
                                   value={message.content}
                                   placeholder={
@@ -2327,7 +2327,7 @@ export function AddTestDialog({
                                   ref={autoSizeOnMount}
                                   data-msg-id={message.id}
                                   rows={1}
-                                  className={`w-full px-4 py-2 rounded-xl text-sm text-foreground border focus:outline-none focus:ring-1 resize-none overflow-hidden placeholder:text-muted-foreground ${
+                                  className={`[field-sizing:content] min-w-[180px] max-w-full px-4 py-2 rounded-xl text-sm text-foreground border focus:outline-none focus:ring-1 resize-none overflow-hidden placeholder:text-muted-foreground ${
                                     isEmpty
                                       ? "border-red-500 focus:ring-red-500"
                                       : "focus:ring-accent " +

--- a/src/components/AgentDetail.tsx
+++ b/src/components/AgentDetail.tsx
@@ -691,6 +691,43 @@ export function AgentDetail({
     backendAccessToken,
   ]);
 
+  // Auto-save the benchmarking toggle every time it changes, regardless of
+  // verification state. Toggling `supports_benchmark` doesn't change the
+  // connection identity (URL + headers), so there's no risk of persisting a
+  // configuration the user hasn't re-verified. For initially-unverified
+  // agents the debounced auto-save below already covers this; this effect
+  // is what lets verified agents persist the toggle without going through
+  // the Save button or the re-verify popup.
+  const lastAutoSavedBenchmarkRef = useRef<boolean | null | undefined>(
+    undefined,
+  );
+  useEffect(() => {
+    if (!agent || agent.type !== "connection") return;
+    if (isLoading) return;
+    // Skip the initially-unverified path — it already auto-saves config
+    // changes (with debounce) and we don't want a double-save race.
+    if (initialConnectionVerified === false) {
+      lastAutoSavedBenchmarkRef.current = connectionConfig.supports_benchmark;
+      return;
+    }
+    const current = connectionConfig.supports_benchmark;
+    // Seed the ref on first run so the initial render doesn't trigger a
+    // save of the value we just loaded from the backend.
+    if (lastAutoSavedBenchmarkRef.current === undefined) {
+      lastAutoSavedBenchmarkRef.current = current;
+      return;
+    }
+    if (lastAutoSavedBenchmarkRef.current === current) return;
+    lastAutoSavedBenchmarkRef.current = current;
+    if (isSavingRef.current) return;
+    saveRef.current({ silent: true });
+  }, [
+    agent,
+    isLoading,
+    initialConnectionVerified,
+    connectionConfig.supports_benchmark,
+  ]);
+
   // Auto-save changes for initially-unverified connection agents.
   // Intentionally skipped when the agent was already verified at fetch time —
   // those changes only persist after the user re-verifies and confirms.

--- a/src/components/agent-tabs/AgentConnectionTabContent.tsx
+++ b/src/components/agent-tabs/AgentConnectionTabContent.tsx
@@ -273,7 +273,8 @@ export function AgentConnectionTabContent({
             <button
               type="button"
               onClick={handleBenchmarkToggle}
-              className={`relative inline-flex h-5 w-9 items-center rounded-full transition-colors cursor-pointer ${
+              disabled={isSaving}
+              className={`relative inline-flex h-5 w-9 items-center rounded-full transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed ${
                 supportsBenchmark ? "bg-foreground" : "bg-border"
               }`}
             >

--- a/src/components/eval-details/SimulationTranscriptDialog.tsx
+++ b/src/components/eval-details/SimulationTranscriptDialog.tsx
@@ -97,7 +97,7 @@ export function SimulationTranscriptDialog({ simulation, runType, onClose, onAud
                     )}
 
                     {entry.role === "user" && entry.content && (
-                      <div className="w-full md:w-1/2">
+                      <div className="max-w-full md:max-w-1/2 w-fit">
                         <div className="px-4 py-3 rounded-xl text-sm text-foreground bg-muted border border-border whitespace-pre-wrap">
                           {entry.content}
                         </div>
@@ -105,7 +105,7 @@ export function SimulationTranscriptDialog({ simulation, runType, onClose, onAud
                     )}
 
                     {entry.role === "assistant" && entry.content && !entry.tool_calls && (
-                      <div className="w-full md:w-1/2">
+                      <div className="max-w-full md:max-w-1/2 w-fit">
                         <div className="px-4 py-3 rounded-xl text-sm text-foreground bg-accent border border-border whitespace-pre-wrap">
                           {entry.content}
                         </div>

--- a/src/components/human-labelling/bulk-upload-shared.tsx
+++ b/src/components/human-labelling/bulk-upload-shared.tsx
@@ -571,7 +571,7 @@ export function turnContentString(t: TurnObject): string {
 
 export function roleLabel(role: string): string {
   if (role === "user") return "User";
-  if (role === "assistant") return "AI";
+  if (role === "assistant") return "Agent";
   if (role === "system") return "System";
   if (role === "tool") return "Tool";
   return role;

--- a/src/components/test-results/shared.tsx
+++ b/src/components/test-results/shared.tsx
@@ -549,7 +549,7 @@ export function TestDetailView({
               >
                 {/* User Message */}
                 {message.role === "user" && (
-                  <div className="w-[88%] md:w-3/4 flex flex-col">
+                  <div className="max-w-[88%] md:max-w-3/4 w-fit flex flex-col">
                     <div className="px-3 md:px-4 py-2.5 md:py-3 rounded-xl bg-muted border border-border">
                       <p className="text-sm text-foreground whitespace-pre-wrap">
                         {message.content}
@@ -576,7 +576,7 @@ export function TestDetailView({
                         </span>
                       )}
                     </div>
-                    <div className="w-[88%] md:w-3/4 flex flex-col">
+                    <div className="max-w-[88%] md:max-w-3/4 w-fit flex flex-col">
                       <div className="px-3 md:px-4 py-2.5 md:py-3 rounded-xl bg-background border border-border">
                         <p className="text-sm text-foreground whitespace-pre-wrap">
                           {message.content}
@@ -669,7 +669,7 @@ export function TestDetailView({
                   />
                 </div>
               )}
-              <div className="w-[88%] md:w-3/4">
+              <div className="max-w-[88%] md:max-w-3/4 w-fit">
                 <div className="px-3 md:px-4 py-2.5 md:py-3 rounded-xl bg-background border border-border">
                   <p className="text-sm text-foreground whitespace-pre-wrap">
                     {output.response}


### PR DESCRIPTION
Fixes #101 
Fixes #111 
Fixes #112 
Fixes #108 
Fixes #96 

## Summary

- **Bulk upload preview**: assistant role label now reads **Agent** instead of **AI** to match the product's voice-agent terminology. Adds a Workflow section to CLAUDE.md (auto-commit on completion; keep CLAUDE.md in sync when high-level understanding shifts).
- **Chat bubbles** in read-only conversation history (test/benchmark results, labelling job panes, simulation transcript dialog) now shrink to fit short messages while keeping the same max width. In the editable test-case / labelling-item chat editor, textareas start compact and grow with content via `field-sizing: content`.
- **Labelling jobs table** gets per-row and bulk delete with checkboxes, mirroring the items-table pattern on the same page. Wires the two new backend endpoints (`DELETE /annotation-tasks/{uuid}/jobs/{job_uuid}` and `DELETE /annotation-tasks/{uuid}/jobs`).
- **Labelling task landing**: if the Overview tab would render only empty states (no agreement pairs and no summary rows with values), auto-switch to the Items tab. `?tab=…` in the URL still takes precedence.
- **Connection agent**: toggling _Support benchmarking different models_ now auto-saves silently. No more clicking Save or going through the re-verify popup for this single-switch preference.

## Test plan

- [x] Open a bulk-upload preview dialog and confirm assistant turns are labelled **Agent**, not **AI**
- [x] View a test result / benchmark result / labelling job pane / simulation transcript with both short and long messages — short bubbles hug their content; long bubbles cap at the same max as before
- [x] In the test-case editor (and labelling-item editor), add a chat message — empty textarea is compact, widens as you type, stops at the max
- [x] On a labelling task with multiple jobs:
  - [x] Single-row trash deletes one job
  - [x] Select all → Delete removes them in bulk
  - [x] Selection survives a refetch (only stale ids are pruned)
- [x] Land on a labelling task with items but no labelling/eval activity → Items tab opens automatically
- [x] Land on the same task with `?tab=overview` → Overview is respected
- [x] On a verified connection agent, flip the benchmarking toggle → it persists without clicking Save and without the re-verify popup
- [x] On a not-yet-verified connection agent, flip the toggle → existing debounced auto-save still handles it (no double save)

🤖 Generated with [Claude Code](https://claude.com/claude-code)