### PR TITLE
Workspaces: sidebar switcher, create flow, members management

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,7 +56,7 @@ There is currently no test suite checked in — `jest.config.js` is configured b
 - `src/components/OrganizationBootstrapper.tsx` — mounted in the root layout. Installs the interceptor and, on first authenticated load, fetches `/organizations` and stashes a default uuid (preferring the personal workspace).
 - `src/hooks/useOrganizations.ts` — `useOrganizations` (list + create + rename), `useActiveOrgUuid` (subscribes to the event), `useOrgMembers` (list + invite + remove).
 - `src/components/WorkspaceSwitcher.tsx` — sidebar dropdown rendered above the nav in both expanded and collapsed sidebar modes. Switching workspaces triggers `window.location.reload()` so all in-flight resource fetches re-run under the new context.
-- `/workspace-settings` — rename the active workspace, and (for non-personal workspaces) manage members. The "Remove" button is disabled for `role === "owner"`; pending invitees (`has_logged_in === false`) render with a "Pending" badge.
+- `/workspace-settings` — rename the active workspace and manage members (shown for all workspaces, including personal). The "Remove" button is disabled for `role === "owner"`; pending invitees (`has_logged_in === false`) render with a "Pending" badge.
 
 **Page skeleton**: every authenticated page is:
 ```tsx

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,7 +56,7 @@ There is currently no test suite checked in — `jest.config.js` is configured b
 - `src/components/OrganizationBootstrapper.tsx` — mounted in the root layout. Installs the interceptor and, on first authenticated load, fetches `/organizations` and stashes a default uuid (preferring the personal workspace).
 - `src/hooks/useOrganizations.ts` — `useOrganizations` (list + create + rename), `useActiveOrgUuid` (subscribes to the event), `useOrgMembers` (list + invite + remove).
 - `src/components/WorkspaceSwitcher.tsx` — sidebar dropdown rendered above the nav in both expanded and collapsed sidebar modes. Switching workspaces triggers `window.location.reload()` so all in-flight resource fetches re-run under the new context.
-- `/workspace-settings` — rename the active workspace and manage members (shown for all workspaces, including personal). Each row shows the member's role (`owner` or `admin`) as a pill; the "Remove" button is disabled for `role === "owner"`.
+- `/workspace-settings` — rename the active workspace and manage members (shown for all workspaces, including personal). Each row shows the member's role (`owner` or `admin`) as a pill; the "Remove" button is hidden entirely for `role === "owner"`.
 
 **Page skeleton**: every authenticated page is:
 ```tsx

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,7 +37,7 @@ There is currently no test suite checked in — `jest.config.js` is configured b
 
 **Routing structure** (`src/app/`):
 - Public: `/` (landing), `/login`, `/signup`, `/public/...` (shareable result pages)
-- Authenticated app pages: `/agents`, `/tools`, `/evaluators`, `/stt`, `/tests`, `/tts`, `/personas`, `/scenarios`, `/simulations`, `/datasets/[id]`
+- Authenticated app pages: `/agents`, `/tools`, `/evaluators`, `/stt`, `/tests`, `/tts`, `/personas`, `/scenarios`, `/simulations`, `/datasets/[id]`, `/workspace-settings`
 - API routes: `/api/auth` (NextAuth handler), `/api/debug-env`
 - The sidebar in `src/components/AppLayout.tsx` drives navigation: each `NavItem.id` maps to the route `/${id}`. Renaming a nav item's `id` changes the route.
 
@@ -45,9 +45,18 @@ There is currently no test suite checked in — `jest.config.js` is configured b
 
 **Access token hook**: Use `useAuth()` / `useAccessToken()` from `src/hooks/useAccessToken.ts` in new code — it unifies NextAuth session and localStorage JWT. Do NOT use `useSession()` directly (it only covers Google OAuth, not email/password).
 
-**Sign-out must clear all three**: `localStorage` (`access_token`, `user`), the `access_token` cookie, and `signOut()`.
+**Sign-out must clear all four**: `localStorage` (`access_token`, `user`, `activeOrgUuid`), the `access_token` cookie, and `signOut()`.
 
-**API client**: `src/lib/api.ts` wraps fetch with default headers (Bearer token) and auto-signs-out on 401. Prefer it over raw fetch when adding new backend calls.
+**API client**: `src/lib/api.ts` wraps fetch with default headers (Bearer token, `X-Org-UUID`) and auto-signs-out on 401. Prefer it over raw fetch when adding new backend calls.
+
+**Workspaces / orgs**: The backend is multi-tenant — every request resolves an active workspace from the `X-Org-UUID` header (falling back to the user's personal workspace if absent). Frontend plumbing:
+- `src/lib/orgs.ts` — types (`Organization`, `OrganizationMember`), localStorage helpers (`getActiveOrgUuid`, `setActiveOrgUuid`), and the `calibrate:active-org-changed` event.
+- `src/lib/api.ts` — `getDefaultHeaders()` reads the active uuid and attaches `X-Org-UUID`.
+- `src/lib/fetchInterceptor.ts` — monkey-patches `window.fetch` so legacy raw-fetch call sites also get the header.
+- `src/components/OrganizationBootstrapper.tsx` — mounted in the root layout. Installs the interceptor and, on first authenticated load, fetches `/organizations` and stashes a default uuid (preferring the personal workspace).
+- `src/hooks/useOrganizations.ts` — `useOrganizations` (list + create + rename), `useActiveOrgUuid` (subscribes to the event), `useOrgMembers` (list + invite + remove).
+- `src/components/WorkspaceSwitcher.tsx` — sidebar dropdown rendered above the nav in both expanded and collapsed sidebar modes. Switching workspaces triggers `window.location.reload()` so all in-flight resource fetches re-run under the new context.
+- `/workspace-settings` — rename the active workspace, and (for non-personal workspaces) manage members. The "Remove" button is disabled for `role === "owner"`; pending invitees (`has_logged_in === false`) render with a "Pending" badge.
 
 **Page skeleton**: every authenticated page is:
 ```tsx

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,7 +56,7 @@ There is currently no test suite checked in — `jest.config.js` is configured b
 - `src/components/OrganizationBootstrapper.tsx` — mounted in the root layout. Installs the interceptor and, on first authenticated load, fetches `/organizations` and stashes a default uuid (preferring the personal workspace).
 - `src/hooks/useOrganizations.ts` — `useOrganizations` (list + create + rename), `useActiveOrgUuid` (subscribes to the event), `useOrgMembers` (list + invite + remove).
 - `src/components/WorkspaceSwitcher.tsx` — sidebar dropdown rendered above the nav in both expanded and collapsed sidebar modes. Switching workspaces triggers `window.location.reload()` so all in-flight resource fetches re-run under the new context.
-- `/workspace-settings` — rename the active workspace and manage members (shown for all workspaces, including personal). Each row shows the member's role (`owner` or `admin`) as a pill; the "Remove" button is hidden entirely for `role === "owner"`.
+- `/workspace-settings` — rename the active workspace and manage members (shown for all workspaces, including personal). Each row shows the member's role (`owner` or `admin`) as a pill; the "Remove" button is hidden entirely for `role === "owner"`. On the current user's own row the button reads "Leave" and the confirm dialog uses leave-flavoured copy; after a successful self-leave, `clearActiveOrgUuid()` runs and the user is routed to `/agents` so the bootstrapper picks a fresh workspace.
 
 **Page skeleton**: every authenticated page is:
 ```tsx

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,7 +56,7 @@ There is currently no test suite checked in — `jest.config.js` is configured b
 - `src/components/OrganizationBootstrapper.tsx` — mounted in the root layout. Installs the interceptor and, on first authenticated load, fetches `/organizations` and stashes a default uuid (preferring the personal workspace).
 - `src/hooks/useOrganizations.ts` — `useOrganizations` (list + create + rename), `useActiveOrgUuid` (subscribes to the event), `useOrgMembers` (list + invite + remove).
 - `src/components/WorkspaceSwitcher.tsx` — sidebar dropdown rendered above the nav in both expanded and collapsed sidebar modes. Switching workspaces triggers `window.location.reload()` so all in-flight resource fetches re-run under the new context.
-- `/workspace-settings` — rename the active workspace and manage members (shown for all workspaces, including personal). The "Remove" button is disabled for `role === "owner"`; pending invitees (`has_logged_in === false`) render with a "Pending" badge.
+- `/workspace-settings` — rename the active workspace and manage members (shown for all workspaces, including personal). Each row shows the member's role (`owner` or `admin`) as a pill; the "Remove" button is disabled for `role === "owner"`.
 
 **Page skeleton**: every authenticated page is:
 ```tsx

--- a/src/app/human-alignment/jobs/[token]/page.tsx
+++ b/src/app/human-alignment/jobs/[token]/page.tsx
@@ -122,16 +122,16 @@ export default function AdminAnnotateJobPage() {
                 <button
                   type="button"
                   onClick={handleCopyJobLink}
-                  className={`inline-flex items-center gap-1.5 h-8 px-3 rounded-md text-xs md:text-sm font-medium border transition-colors cursor-pointer ${
+                  className={`flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-[13px] font-medium border transition-colors cursor-pointer ${
                     copied
-                      ? "border-green-200 bg-green-100 text-green-700 dark:border-green-500/40 dark:bg-green-500/20 dark:text-green-400"
-                      : "border-border bg-background text-foreground hover:bg-muted/50"
+                      ? "bg-emerald-500/15 border-emerald-500/45 text-emerald-900 dark:text-emerald-200 hover:bg-emerald-500/25 dark:hover:bg-emerald-500/20"
+                      : "bg-indigo-500/14 border-indigo-500/45 text-indigo-900 dark:text-indigo-200 hover:bg-indigo-500/26 dark:hover:bg-indigo-500/20"
                   }`}
                   aria-label={copied ? "Copied job link" : "Copy job link"}
                 >
                   {copied ? (
                     <svg
-                      className="w-4 h-4"
+                      className="w-3.5 h-3.5"
                       fill="none"
                       viewBox="0 0 24 24"
                       stroke="currentColor"
@@ -145,11 +145,11 @@ export default function AdminAnnotateJobPage() {
                     </svg>
                   ) : (
                     <svg
-                      className="w-4 h-4"
+                      className="w-3.5 h-3.5"
                       fill="none"
                       viewBox="0 0 24 24"
                       stroke="currentColor"
-                      strokeWidth={1.75}
+                      strokeWidth={1.8}
                     >
                       <path
                         strokeLinecap="round"

--- a/src/app/human-alignment/jobs/[token]/page.tsx
+++ b/src/app/human-alignment/jobs/[token]/page.tsx
@@ -122,13 +122,17 @@ export default function AdminAnnotateJobPage() {
                 <button
                   type="button"
                   onClick={handleCopyJobLink}
-                  className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-[13px] font-medium border border-border bg-muted/40 text-foreground hover:bg-muted transition-colors cursor-pointer"
-                  aria-label={copied ? "Copied job link" : "Copy job link"}
+                  className={`flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-[13px] font-medium border transition-colors cursor-pointer ${
+                    copied
+                      ? "bg-emerald-500/15 border-emerald-500/45 text-emerald-900 dark:text-emerald-200 hover:bg-emerald-500/25 dark:hover:bg-emerald-500/20"
+                      : "bg-amber-500/16 border-amber-500/50 text-amber-950 dark:text-amber-100 hover:bg-amber-500/28 dark:hover:bg-amber-500/22"
+                  }`}
+                  title="Copy job link"
                 >
                   {copied ? (
                     <>
                       <svg
-                        className="w-3.5 h-3.5 text-emerald-500"
+                        className="w-3.5 h-3.5 text-emerald-600 dark:text-emerald-300"
                         fill="none"
                         viewBox="0 0 24 24"
                         stroke="currentColor"
@@ -140,7 +144,7 @@ export default function AdminAnnotateJobPage() {
                           d="M4.5 12.75l6 6 9-13.5"
                         />
                       </svg>
-                      <span className="text-emerald-500">Copied</span>
+                      <span>Copied</span>
                     </>
                   ) : (
                     <>
@@ -154,7 +158,7 @@ export default function AdminAnnotateJobPage() {
                         <path
                           strokeLinecap="round"
                           strokeLinejoin="round"
-                          d="M15.666 3.888A2.25 2.25 0 0013.5 2.25h-3c-1.03 0-1.9.693-2.166 1.638m7.332 0c.055.194.084.4.084.612v0a.75.75 0 01-.75.75H9a.75.75 0 01-.75-.75v0c0-.212.03-.418.084-.612m7.332 0c.646.049 1.288.11 1.927.184 1.1.128 1.907 1.077 1.907 2.185V19.5a2.25 2.25 0 01-2.25 2.25H6.75A2.25 2.25 0 014.5 19.5V6.257c0-1.108.806-2.057 1.907-2.185a48.208 48.208 0 011.927-.184"
+                          d="M13.19 8.688a4.5 4.5 0 011.242 7.244l-4.5 4.5a4.5 4.5 0 01-6.364-6.364l1.757-1.757m13.35-.622l1.757-1.757a4.5 4.5 0 00-6.364-6.364l-4.5 4.5a4.5 4.5 0 001.242 7.244"
                         />
                       </svg>
                       Copy job link

--- a/src/app/human-alignment/jobs/[token]/page.tsx
+++ b/src/app/human-alignment/jobs/[token]/page.tsx
@@ -122,43 +122,44 @@ export default function AdminAnnotateJobPage() {
                 <button
                   type="button"
                   onClick={handleCopyJobLink}
-                  className={`flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-[13px] font-medium border transition-colors cursor-pointer ${
-                    copied
-                      ? "bg-emerald-500/15 border-emerald-500/45 text-emerald-900 dark:text-emerald-200 hover:bg-emerald-500/25 dark:hover:bg-emerald-500/20"
-                      : "bg-indigo-500/14 border-indigo-500/45 text-indigo-900 dark:text-indigo-200 hover:bg-indigo-500/26 dark:hover:bg-indigo-500/20"
-                  }`}
+                  className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-[13px] font-medium border border-border bg-muted/40 text-foreground hover:bg-muted transition-colors cursor-pointer"
                   aria-label={copied ? "Copied job link" : "Copy job link"}
                 >
                   {copied ? (
-                    <svg
-                      className="w-3.5 h-3.5"
-                      fill="none"
-                      viewBox="0 0 24 24"
-                      stroke="currentColor"
-                      strokeWidth={2.5}
-                    >
-                      <path
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        d="M5 13l4 4L19 7"
-                      />
-                    </svg>
+                    <>
+                      <svg
+                        className="w-3.5 h-3.5 text-emerald-500"
+                        fill="none"
+                        viewBox="0 0 24 24"
+                        stroke="currentColor"
+                        strokeWidth={2}
+                      >
+                        <path
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          d="M4.5 12.75l6 6 9-13.5"
+                        />
+                      </svg>
+                      <span className="text-emerald-500">Copied</span>
+                    </>
                   ) : (
-                    <svg
-                      className="w-3.5 h-3.5"
-                      fill="none"
-                      viewBox="0 0 24 24"
-                      stroke="currentColor"
-                      strokeWidth={1.8}
-                    >
-                      <path
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        d="M15.75 17.25v3.375c0 .621-.504 1.125-1.125 1.125h-9.75a1.125 1.125 0 01-1.125-1.125V7.875c0-.621.504-1.125 1.125-1.125H6.75a9.06 9.06 0 011.5.124m7.5 10.376h3.375c.621 0 1.125-.504 1.125-1.125V11.25c0-4.46-3.243-8.161-7.5-8.876a9.06 9.06 0 00-1.5-.124H9.375c-.621 0-1.125.504-1.125 1.125v3.5m7.5 10.375H9.375a1.125 1.125 0 01-1.125-1.125v-9.25m12 6.625v-1.875a3.375 3.375 0 00-3.375-3.375h-1.5a1.125 1.125 0 01-1.125-1.125v-1.5a3.375 3.375 0 00-3.375-3.375H9.75"
-                      />
-                    </svg>
+                    <>
+                      <svg
+                        className="w-3.5 h-3.5"
+                        fill="none"
+                        viewBox="0 0 24 24"
+                        stroke="currentColor"
+                        strokeWidth={2}
+                      >
+                        <path
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          d="M15.666 3.888A2.25 2.25 0 0013.5 2.25h-3c-1.03 0-1.9.693-2.166 1.638m7.332 0c.055.194.084.4.084.612v0a.75.75 0 01-.75.75H9a.75.75 0 01-.75-.75v0c0-.212.03-.418.084-.612m7.332 0c.646.049 1.288.11 1.927.184 1.1.128 1.907 1.077 1.907 2.185V19.5a2.25 2.25 0 01-2.25 2.25H6.75A2.25 2.25 0 014.5 19.5V6.257c0-1.108.806-2.057 1.907-2.185a48.208 48.208 0 011.927-.184"
+                        />
+                      </svg>
+                      Copy job link
+                    </>
                   )}
-                  {copied ? "Copied" : "Copy job link"}
                 </button>
                 {meta.jobStatus === "completed" && accessToken && (
                   <ShareButton

--- a/src/app/human-alignment/jobs/[token]/page.tsx
+++ b/src/app/human-alignment/jobs/[token]/page.tsx
@@ -34,6 +34,28 @@ export default function AdminAnnotateJobPage() {
 
   const handleLoaded = useCallback((m: AnnotationJobMeta) => setMeta(m), []);
 
+  // Copy the annotator-facing URL (/annotate-job/{token}) to the clipboard.
+  // Mirrors the per-job copy button used in the tasks detail jobs table.
+  const [copied, setCopied] = useState(false);
+  useEffect(() => {
+    if (!copied) return;
+    const t = setTimeout(() => setCopied(false), 1500);
+    return () => clearTimeout(t);
+  }, [copied]);
+  const handleCopyJobLink = async () => {
+    if (!token) return;
+    const url =
+      typeof window === "undefined"
+        ? `/annotate-job/${token}`
+        : `${window.location.origin}/annotate-job/${token}`;
+    try {
+      await navigator.clipboard.writeText(url);
+      setCopied(true);
+    } catch {
+      // ignore — clipboard can fail in insecure contexts; user can still copy manually.
+    }
+  };
+
   const customHeader = (
     <button
       onClick={() => router.back()}
@@ -96,15 +118,58 @@ export default function AdminAnnotateJobPage() {
               >
                 {jobStatusLabel(meta.jobStatus)}
               </span>
-              {meta.jobStatus === "completed" && accessToken && (
-                <ShareButton
-                  entityType="annotation-job"
-                  entityId={`${meta.task.uuid}:${meta.job.uuid}`}
-                  accessToken={accessToken}
-                  initialIsPublic={meta.job.is_public}
-                  initialShareToken={meta.job.view_token}
-                />
-              )}
+              <div className="flex items-center gap-2">
+                <button
+                  type="button"
+                  onClick={handleCopyJobLink}
+                  className={`inline-flex items-center gap-1.5 h-8 px-3 rounded-md text-xs md:text-sm font-medium border transition-colors cursor-pointer ${
+                    copied
+                      ? "border-green-200 bg-green-100 text-green-700 dark:border-green-500/40 dark:bg-green-500/20 dark:text-green-400"
+                      : "border-border bg-background text-foreground hover:bg-muted/50"
+                  }`}
+                  aria-label={copied ? "Copied job link" : "Copy job link"}
+                >
+                  {copied ? (
+                    <svg
+                      className="w-4 h-4"
+                      fill="none"
+                      viewBox="0 0 24 24"
+                      stroke="currentColor"
+                      strokeWidth={2.5}
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        d="M5 13l4 4L19 7"
+                      />
+                    </svg>
+                  ) : (
+                    <svg
+                      className="w-4 h-4"
+                      fill="none"
+                      viewBox="0 0 24 24"
+                      stroke="currentColor"
+                      strokeWidth={1.75}
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        d="M15.75 17.25v3.375c0 .621-.504 1.125-1.125 1.125h-9.75a1.125 1.125 0 01-1.125-1.125V7.875c0-.621.504-1.125 1.125-1.125H6.75a9.06 9.06 0 011.5.124m7.5 10.376h3.375c.621 0 1.125-.504 1.125-1.125V11.25c0-4.46-3.243-8.161-7.5-8.876a9.06 9.06 0 00-1.5-.124H9.375c-.621 0-1.125.504-1.125 1.125v3.5m7.5 10.375H9.375a1.125 1.125 0 01-1.125-1.125v-9.25m12 6.625v-1.875a3.375 3.375 0 00-3.375-3.375h-1.5a1.125 1.125 0 01-1.125-1.125v-1.5a3.375 3.375 0 00-3.375-3.375H9.75"
+                      />
+                    </svg>
+                  )}
+                  {copied ? "Copied" : "Copy job link"}
+                </button>
+                {meta.jobStatus === "completed" && accessToken && (
+                  <ShareButton
+                    entityType="annotation-job"
+                    entityId={`${meta.task.uuid}:${meta.job.uuid}`}
+                    accessToken={accessToken}
+                    initialIsPublic={meta.job.is_public}
+                    initialShareToken={meta.job.view_token}
+                  />
+                )}
+              </div>
             </div>
             <div className="flex flex-wrap gap-3">
               <FieldRow label="Labelling task">

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import { Geist, Geist_Mono, Inter, DM_Sans } from "next/font/google";
 import "./globals.css";
 import { SessionProvider } from "@/components/providers/SessionProvider";
 import { FloatingButtonProvider } from "@/components/providers/FloatingButtonProvider";
+import { OrganizationBootstrapper } from "@/components/OrganizationBootstrapper";
 import { Analytics } from "@vercel/analytics/next";
 import { GoogleAnalytics } from "@next/third-parties/google";
 import { Toaster } from "sonner";
@@ -47,6 +48,7 @@ export default function RootLayout({
         className={`${geistSans.variable} ${geistMono.variable} ${inter.variable} ${dmSans.variable} antialiased`}
       >
         <SessionProvider>
+          <OrganizationBootstrapper />
           <FloatingButtonProvider>{children}</FloatingButtonProvider>
         </SessionProvider>
         <Toaster richColors position="top-right" closeButton />

--- a/src/app/workspace-settings/layout.tsx
+++ b/src/app/workspace-settings/layout.tsx
@@ -1,0 +1,13 @@
+import { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Workspace settings | Calibrate",
+};
+
+export default function WorkspaceSettingsLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return children;
+}

--- a/src/app/workspace-settings/page.tsx
+++ b/src/app/workspace-settings/page.tsx
@@ -1,0 +1,320 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
+import {
+  useAccessToken,
+  useActiveOrgUuid,
+  useOrganizations,
+  useOrgMembers,
+} from "@/hooks";
+import { AppLayout } from "@/components/AppLayout";
+import { DeleteConfirmationDialog } from "@/components/DeleteConfirmationDialog";
+import { useSidebarState } from "@/lib/sidebar";
+import type { OrganizationMember } from "@/lib/orgs";
+
+export default function WorkspaceSettingsPage() {
+  const router = useRouter();
+  const accessToken = useAccessToken();
+  const [sidebarOpen, setSidebarOpen] = useSidebarState();
+
+  useEffect(() => {
+    document.title = "Workspace settings | Calibrate";
+  }, []);
+
+  const {
+    organizations,
+    isLoading: orgsLoading,
+    renameOrganization,
+  } = useOrganizations(accessToken);
+  const [activeUuid] = useActiveOrgUuid();
+
+  const activeOrg = useMemo(
+    () => organizations.find((o) => o.uuid === activeUuid) ?? null,
+    [organizations, activeUuid],
+  );
+
+  // --- Rename state ---
+  const [nameInput, setNameInput] = useState("");
+  const [isRenaming, setIsRenaming] = useState(false);
+  const [renameError, setRenameError] = useState<string | null>(null);
+  const [renameSuccess, setRenameSuccess] = useState(false);
+
+  useEffect(() => {
+    setNameInput(activeOrg?.name ?? "");
+    setRenameError(null);
+    setRenameSuccess(false);
+  }, [activeOrg?.uuid, activeOrg?.name]);
+
+  const isDirty = !!activeOrg && nameInput.trim() !== activeOrg.name;
+
+  const handleRename = async () => {
+    if (!activeOrg) return;
+    const trimmed = nameInput.trim();
+    if (!trimmed || trimmed === activeOrg.name) return;
+    setIsRenaming(true);
+    setRenameError(null);
+    setRenameSuccess(false);
+    try {
+      await renameOrganization(activeOrg.uuid, trimmed);
+      setRenameSuccess(true);
+    } catch (err) {
+      setRenameError(
+        err instanceof Error ? err.message : "Failed to rename workspace",
+      );
+    } finally {
+      setIsRenaming(false);
+    }
+  };
+
+  return (
+    <AppLayout
+      activeItem=""
+      onItemChange={(id) => router.push(`/${id}`)}
+      sidebarOpen={sidebarOpen}
+      onSidebarToggle={() => setSidebarOpen(!sidebarOpen)}
+      customHeader={
+        <h1 className="text-base md:text-lg font-semibold text-foreground">
+          Workspace settings
+        </h1>
+      }
+    >
+      <div className="max-w-3xl mx-auto py-6 md:py-8 space-y-8">
+        {orgsLoading && !activeOrg ? (
+          <p className="text-sm text-muted-foreground">Loading…</p>
+        ) : !activeOrg ? (
+          <p className="text-sm text-muted-foreground">
+            No active workspace selected.
+          </p>
+        ) : (
+          <>
+            <section className="space-y-3">
+              <div>
+                <h2 className="text-base md:text-lg font-semibold text-foreground">
+                  General
+                </h2>
+                <p className="text-sm text-muted-foreground">
+                  {activeOrg.is_personal
+                    ? "This is your personal workspace."
+                    : "Edit the name of this workspace."}
+                </p>
+              </div>
+
+              <label className="block text-sm font-medium text-foreground">
+                Name
+              </label>
+              <div className="flex flex-col sm:flex-row gap-2 sm:items-center">
+                <input
+                  type="text"
+                  value={nameInput}
+                  onChange={(e) => {
+                    setNameInput(e.target.value);
+                    setRenameSuccess(false);
+                    setRenameError(null);
+                  }}
+                  disabled={isRenaming}
+                  className="flex-1 h-10 px-3 rounded-md border border-border bg-background text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-foreground/10 disabled:opacity-50"
+                />
+                <button
+                  type="button"
+                  onClick={handleRename}
+                  disabled={!isDirty || isRenaming || !nameInput.trim()}
+                  className="h-10 px-4 rounded-md text-sm font-medium bg-foreground text-background hover:opacity-90 transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+                >
+                  {isRenaming ? "Saving..." : "Save"}
+                </button>
+              </div>
+              {renameError && (
+                <p className="text-sm text-red-600 dark:text-red-400">
+                  {renameError}
+                </p>
+              )}
+              {renameSuccess && !renameError && (
+                <p className="text-sm text-muted-foreground">Saved.</p>
+              )}
+            </section>
+
+            {!activeOrg.is_personal && (
+              <MembersSection orgUuid={activeOrg.uuid} />
+            )}
+          </>
+        )}
+      </div>
+    </AppLayout>
+  );
+}
+
+// ----- Members section (only shown for non-personal workspaces) -----
+
+function MembersSection({ orgUuid }: { orgUuid: string }) {
+  const accessToken = useAccessToken();
+  const {
+    members,
+    isLoading,
+    error: loadError,
+    refetch,
+    addMember,
+    removeMember,
+  } = useOrgMembers(accessToken, orgUuid);
+
+  const [inviteEmail, setInviteEmail] = useState("");
+  const [isAdding, setIsAdding] = useState(false);
+  const [addError, setAddError] = useState<string | null>(null);
+
+  const [memberToRemove, setMemberToRemove] =
+    useState<OrganizationMember | null>(null);
+  const [isRemoving, setIsRemoving] = useState(false);
+
+  const handleAdd = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const email = inviteEmail.trim();
+    if (!email || isAdding) return;
+    setIsAdding(true);
+    setAddError(null);
+    try {
+      await addMember(email);
+      setInviteEmail("");
+    } catch (err) {
+      setAddError(
+        err instanceof Error ? err.message : "Failed to add member",
+      );
+    } finally {
+      setIsAdding(false);
+    }
+  };
+
+  const handleRemove = async () => {
+    if (!memberToRemove) return;
+    setIsRemoving(true);
+    const ok = await removeMember(memberToRemove.user_id);
+    setIsRemoving(false);
+    if (ok) {
+      setMemberToRemove(null);
+    } else {
+      // Bring fresh data from server in case state is out of sync.
+      refetch();
+    }
+  };
+
+  return (
+    <section className="space-y-4">
+      <div>
+        <h2 className="text-base md:text-lg font-semibold text-foreground">
+          Members
+        </h2>
+        <p className="text-sm text-muted-foreground">
+          Invite teammates by email. New invites can access the workspace
+          immediately; their name will show as &quot;pending&quot; until they
+          finish signing up.
+        </p>
+      </div>
+
+      <form onSubmit={handleAdd} className="flex flex-col sm:flex-row gap-2">
+        <input
+          type="email"
+          value={inviteEmail}
+          onChange={(e) => {
+            setInviteEmail(e.target.value);
+            setAddError(null);
+          }}
+          placeholder="teammate@example.com"
+          disabled={isAdding}
+          className="flex-1 h-10 px-3 rounded-md border border-border bg-background text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-foreground/10 disabled:opacity-50"
+        />
+        <button
+          type="submit"
+          disabled={!inviteEmail.trim() || isAdding}
+          className="h-10 px-4 rounded-md text-sm font-medium bg-foreground text-background hover:opacity-90 transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          {isAdding ? "Adding..." : "Add member"}
+        </button>
+      </form>
+      {addError && (
+        <p className="text-sm text-red-600 dark:text-red-400">{addError}</p>
+      )}
+
+      <div className="border border-border rounded-lg overflow-hidden">
+        {isLoading && members.length === 0 ? (
+          <p className="px-4 py-6 text-sm text-muted-foreground">Loading…</p>
+        ) : loadError ? (
+          <p className="px-4 py-6 text-sm text-red-600 dark:text-red-400">
+            {loadError}
+          </p>
+        ) : members.length === 0 ? (
+          <p className="px-4 py-6 text-sm text-muted-foreground">
+            No members yet.
+          </p>
+        ) : (
+          <ul className="divide-y divide-border">
+            {members.map((member) => {
+              const displayName =
+                `${member.first_name} ${member.last_name}`.trim() ||
+                member.email;
+              const isOwner = member.role === "owner";
+              return (
+                <li
+                  key={member.user_id}
+                  className="flex items-center gap-3 px-4 py-3"
+                >
+                  <div className="w-9 h-9 rounded-full bg-purple-600 text-white text-sm font-medium flex items-center justify-center flex-shrink-0">
+                    {(displayName.trim()[0] || "?").toUpperCase()}
+                  </div>
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-center gap-2 flex-wrap">
+                      <p className="text-sm font-medium text-foreground truncate">
+                        {displayName}
+                      </p>
+                      {!member.has_logged_in && (
+                        <span className="text-[10px] uppercase tracking-wider px-1.5 py-0.5 rounded bg-muted text-muted-foreground border border-border">
+                          Pending
+                        </span>
+                      )}
+                      <span className="text-[10px] uppercase tracking-wider px-1.5 py-0.5 rounded bg-muted text-muted-foreground border border-border">
+                        {member.role}
+                      </span>
+                    </div>
+                    <p className="text-xs text-muted-foreground truncate">
+                      {member.email}
+                    </p>
+                  </div>
+                  <button
+                    type="button"
+                    onClick={() => setMemberToRemove(member)}
+                    disabled={isOwner}
+                    title={
+                      isOwner
+                        ? "The workspace owner cannot be removed."
+                        : "Remove from workspace"
+                    }
+                    className="h-9 px-3 rounded-md text-xs font-medium border border-border bg-background hover:bg-muted/50 transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+                  >
+                    Remove
+                  </button>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </div>
+
+      <DeleteConfirmationDialog
+        isOpen={!!memberToRemove}
+        onClose={() => {
+          if (!isRemoving) setMemberToRemove(null);
+        }}
+        onConfirm={handleRemove}
+        title="Remove member"
+        message={
+          memberToRemove
+            ? `Remove ${
+                `${memberToRemove.first_name} ${memberToRemove.last_name}`.trim() ||
+                memberToRemove.email
+              } from this workspace? They will lose access immediately.`
+            : ""
+        }
+        confirmText="Remove"
+        isDeleting={isRemoving}
+      />
+    </section>
+  );
+}

--- a/src/app/workspace-settings/page.tsx
+++ b/src/app/workspace-settings/page.tsx
@@ -9,6 +9,7 @@ import {
   useOrgMembers,
 } from "@/hooks";
 import { useSession } from "next-auth/react";
+import { toast } from "sonner";
 import { AppLayout } from "@/components/AppLayout";
 import { DeleteConfirmationDialog } from "@/components/DeleteConfirmationDialog";
 import { useSidebarState } from "@/lib/sidebar";
@@ -48,15 +49,13 @@ export default function WorkspaceSettingsPage() {
   const [nameInput, setNameInput] = useState("");
   const [isRenaming, setIsRenaming] = useState(false);
   const [renameError, setRenameError] = useState<string | null>(null);
-  const [renameSuccess, setRenameSuccess] = useState(false);
 
-  // Only reset the form when the active workspace itself changes (uuid).
-  // Don't include `activeOrg.name` in the dep list — that would fire right
-  // after a successful rename and immediately wipe the "Saved." indicator.
+  // Sync the input with the currently active workspace. Keyed on uuid only —
+  // we deliberately don't refresh from `activeOrg.name` so a successful
+  // rename doesn't briefly snap the input back.
   useEffect(() => {
     setNameInput(activeOrg?.name ?? "");
     setRenameError(null);
-    setRenameSuccess(false);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [activeOrg?.uuid]);
 
@@ -68,10 +67,9 @@ export default function WorkspaceSettingsPage() {
     if (!trimmed || trimmed === activeOrg.name) return;
     setIsRenaming(true);
     setRenameError(null);
-    setRenameSuccess(false);
     try {
       await renameOrganization(activeOrg.uuid, trimmed);
-      setRenameSuccess(true);
+      toast.success("Workspace name updated");
     } catch (err) {
       setRenameError(parseBackendErrorMessage(err, "Failed to rename workspace"));
     } finally {
@@ -111,7 +109,6 @@ export default function WorkspaceSettingsPage() {
                     value={nameInput}
                     onChange={(e) => {
                       setNameInput(e.target.value);
-                      setRenameSuccess(false);
                       setRenameError(null);
                     }}
                     disabled={isRenaming}
@@ -132,11 +129,6 @@ export default function WorkspaceSettingsPage() {
                 </div>
                 {renameError && (
                   <p className="mt-1 text-[13px] text-red-500">{renameError}</p>
-                )}
-                {renameSuccess && !renameError && (
-                  <p className="mt-1 text-[13px] text-muted-foreground">
-                    Saved.
-                  </p>
                 )}
               </div>
             </section>

--- a/src/app/workspace-settings/page.tsx
+++ b/src/app/workspace-settings/page.tsx
@@ -50,11 +50,15 @@ export default function WorkspaceSettingsPage() {
   const [renameError, setRenameError] = useState<string | null>(null);
   const [renameSuccess, setRenameSuccess] = useState(false);
 
+  // Only reset the form when the active workspace itself changes (uuid).
+  // Don't include `activeOrg.name` in the dep list — that would fire right
+  // after a successful rename and immediately wipe the "Saved." indicator.
   useEffect(() => {
     setNameInput(activeOrg?.name ?? "");
     setRenameError(null);
     setRenameSuccess(false);
-  }, [activeOrg?.uuid, activeOrg?.name]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [activeOrg?.uuid]);
 
   const isDirty = !!activeOrg && nameInput.trim() !== activeOrg.name;
 

--- a/src/app/workspace-settings/page.tsx
+++ b/src/app/workspace-settings/page.tsx
@@ -135,8 +135,6 @@ export default function WorkspaceSettingsPage() {
   );
 }
 
-// ----- Members section (only shown for non-personal workspaces) -----
-
 function MembersSection({ orgUuid }: { orgUuid: string }) {
   const accessToken = useAccessToken();
   const {
@@ -166,9 +164,7 @@ function MembersSection({ orgUuid }: { orgUuid: string }) {
       await addMember(email);
       setInviteEmail("");
     } catch (err) {
-      setAddError(
-        err instanceof Error ? err.message : "Failed to add member",
-      );
+      setAddError(err instanceof Error ? err.message : "Failed to add member");
     } finally {
       setIsAdding(false);
     }
@@ -194,9 +190,7 @@ function MembersSection({ orgUuid }: { orgUuid: string }) {
           Members
         </h2>
         <p className="text-sm text-muted-foreground">
-          Invite teammates by email. New invites can access the workspace
-          immediately; their name will show as &quot;pending&quot; until they
-          finish signing up.
+          Invite team members by email
         </p>
       </div>
 

--- a/src/app/workspace-settings/page.tsx
+++ b/src/app/workspace-settings/page.tsx
@@ -259,19 +259,16 @@ function MembersSection({ orgUuid }: { orgUuid: string }) {
                       {member.email}
                     </p>
                   </div>
-                  <button
-                    type="button"
-                    onClick={() => setMemberToRemove(member)}
-                    disabled={isOwner}
-                    title={
-                      isOwner
-                        ? "The workspace owner cannot be removed."
-                        : "Remove from workspace"
-                    }
-                    className="h-9 px-3 rounded-md text-xs font-medium border border-border bg-background hover:bg-muted/50 transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
-                  >
-                    Remove
-                  </button>
+                  {!isOwner && (
+                    <button
+                      type="button"
+                      onClick={() => setMemberToRemove(member)}
+                      title="Remove from workspace"
+                      className="h-9 px-3 rounded-md text-xs font-medium border border-border bg-background hover:bg-muted/50 transition-colors cursor-pointer"
+                    >
+                      Remove
+                    </button>
+                  )}
                 </li>
               );
             })}

--- a/src/app/workspace-settings/page.tsx
+++ b/src/app/workspace-settings/page.tsx
@@ -7,6 +7,7 @@ import {
   useActiveOrgUuid,
   useOrganizations,
   useOrgMembers,
+  seedOrgsCache,
 } from "@/hooks";
 import { useSession } from "next-auth/react";
 import { toast } from "sonner";
@@ -217,28 +218,34 @@ function MembersSection({
     if (!memberToRemove) return;
     const wasSelf = memberToRemove.user_id === currentUserId;
     setIsRemoving(true);
-    const ok = await removeMember(memberToRemove.user_id);
-    setIsRemoving(false);
-    if (!ok) {
+    try {
+      await removeMember(memberToRemove.user_id);
+    } catch (err) {
+      setIsRemoving(false);
       // Bring fresh data from server in case state is out of sync.
       refetch();
+      toast.error(
+        parseBackendErrorMessage(
+          err,
+          wasSelf ? "Failed to leave workspace" : "Failed to remove member",
+        ),
+      );
       return;
     }
+    setIsRemoving(false);
     setMemberToRemove(null);
     if (wasSelf) {
-      // User just left the workspace they were viewing. We need to:
-      //   1. Pick a new active workspace from the workspaces they still
-      //      belong to (the bootstrapper only runs once at app load, so it
-      //      won't auto-recover here).
-      //   2. Tell every mounted useOrganizations to refetch so the sidebar
-      //      switcher drops the just-left workspace.
-      //   3. Navigate to /agents under the new context.
+      // User just left the workspace they were viewing. Fetch a fresh
+      // /organizations list, pick a new active workspace, seed the module
+      // cache so the next mount on /agents doesn't briefly show the
+      // just-left workspace, then navigate.
       if (accessToken) {
         try {
           const orgs = await apiGet<Organization[]>(
             "/organizations",
             accessToken,
           );
+          seedOrgsCache(orgs, accessToken);
           const chosen = pickDefaultOrg(orgs);
           if (chosen) {
             setActiveOrgUuid(chosen.uuid);

--- a/src/app/workspace-settings/page.tsx
+++ b/src/app/workspace-settings/page.tsx
@@ -89,16 +89,9 @@ export default function WorkspaceSettingsPage() {
         ) : (
           <>
             <section className="space-y-3">
-              <div>
-                <h2 className="text-base md:text-lg font-semibold text-foreground">
-                  General
-                </h2>
-                <p className="text-sm text-muted-foreground">
-                  {activeOrg.is_personal
-                    ? "This is your personal workspace."
-                    : "Edit the name of this workspace."}
-                </p>
-              </div>
+              <p className="text-sm text-muted-foreground">
+                Edit the name of this workspace.
+              </p>
 
               <label className="block text-sm font-medium text-foreground">
                 Name
@@ -134,9 +127,7 @@ export default function WorkspaceSettingsPage() {
               )}
             </section>
 
-            {!activeOrg.is_personal && (
-              <MembersSection orgUuid={activeOrg.uuid} />
-            )}
+            <MembersSection orgUuid={activeOrg.uuid} />
           </>
         )}
       </div>

--- a/src/app/workspace-settings/page.tsx
+++ b/src/app/workspace-settings/page.tsx
@@ -89,10 +89,6 @@ export default function WorkspaceSettingsPage() {
         ) : (
           <>
             <section className="space-y-3">
-              <p className="text-sm text-muted-foreground">
-                Edit the name of this workspace.
-              </p>
-
               <label className="block text-sm font-medium text-foreground">
                 Name
               </label>

--- a/src/app/workspace-settings/page.tsx
+++ b/src/app/workspace-settings/page.tsx
@@ -245,11 +245,6 @@ function MembersSection({ orgUuid }: { orgUuid: string }) {
                       <p className="text-sm font-medium text-foreground truncate">
                         {displayName}
                       </p>
-                      {!member.has_logged_in && (
-                        <span className="text-[10px] uppercase tracking-wider px-1.5 py-0.5 rounded bg-muted text-muted-foreground border border-border">
-                          Pending
-                        </span>
-                      )}
                       <span className="text-[10px] uppercase tracking-wider px-1.5 py-0.5 rounded bg-muted text-muted-foreground border border-border">
                         {member.role}
                       </span>

--- a/src/app/workspace-settings/page.tsx
+++ b/src/app/workspace-settings/page.tsx
@@ -100,33 +100,41 @@ export default function WorkspaceSettingsPage() {
               <label className="block text-sm font-medium text-foreground">
                 Name
               </label>
-              <div className="flex flex-col sm:flex-row gap-2 sm:items-center">
-                <input
-                  type="text"
-                  value={nameInput}
-                  onChange={(e) => {
-                    setNameInput(e.target.value);
-                    setRenameSuccess(false);
-                    setRenameError(null);
-                  }}
-                  disabled={isRenaming}
-                  className="flex-1 h-10 px-3 rounded-md border border-border bg-background text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-foreground/10 disabled:opacity-50"
-                />
-                <button
-                  type="button"
-                  onClick={handleRename}
-                  disabled={!isDirty || isRenaming || !nameInput.trim()}
-                  className="h-10 px-4 rounded-md text-sm font-medium bg-foreground text-background hover:opacity-90 transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
-                >
-                  {isRenaming ? "Saving..." : "Save"}
-                </button>
+              <div>
+                <div className="flex flex-col sm:flex-row gap-2 sm:items-center">
+                  <input
+                    type="text"
+                    value={nameInput}
+                    onChange={(e) => {
+                      setNameInput(e.target.value);
+                      setRenameSuccess(false);
+                      setRenameError(null);
+                    }}
+                    disabled={isRenaming}
+                    className={`flex-1 h-10 px-3 rounded-md border bg-background text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 disabled:opacity-50 ${
+                      renameError
+                        ? "border-red-500/60 focus:ring-red-500/20"
+                        : "border-border focus:ring-foreground/10"
+                    }`}
+                  />
+                  <button
+                    type="button"
+                    onClick={handleRename}
+                    disabled={!isDirty || isRenaming || !nameInput.trim()}
+                    className="h-10 px-4 rounded-md text-sm font-medium bg-foreground text-background hover:opacity-90 transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+                  >
+                    {isRenaming ? "Saving..." : "Save"}
+                  </button>
+                </div>
+                {renameError && (
+                  <p className="mt-1 text-[13px] text-red-500">{renameError}</p>
+                )}
+                {renameSuccess && !renameError && (
+                  <p className="mt-1 text-[13px] text-muted-foreground">
+                    Saved.
+                  </p>
+                )}
               </div>
-              {renameError && (
-                <p className="mt-1 text-[13px] text-red-500">{renameError}</p>
-              )}
-              {renameSuccess && !renameError && (
-                <p className="mt-1 text-[13px] text-muted-foreground">Saved.</p>
-              )}
             </section>
 
             <MembersSection orgUuid={activeOrg.uuid} orgName={activeOrg.name} />
@@ -263,29 +271,35 @@ function MembersSection({
         </p>
       </div>
 
-      <form onSubmit={handleAdd} className="flex flex-col sm:flex-row gap-2">
-        <input
-          type="email"
-          value={inviteEmail}
-          onChange={(e) => {
-            setInviteEmail(e.target.value);
-            setAddError(null);
-          }}
-          placeholder="teammate@example.com"
-          disabled={isAdding}
-          className="flex-1 h-10 px-3 rounded-md border border-border bg-background text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-foreground/10 disabled:opacity-50"
-        />
-        <button
-          type="submit"
-          disabled={!inviteEmail.trim() || isAdding}
-          className="h-10 px-4 rounded-md text-sm font-medium bg-foreground text-background hover:opacity-90 transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
-        >
-          {isAdding ? "Adding..." : "Add member"}
-        </button>
-      </form>
-      {addError && (
-        <p className="mt-1 text-[13px] text-red-500">{addError}</p>
-      )}
+      <div>
+        <form onSubmit={handleAdd} className="flex flex-col sm:flex-row gap-2">
+          <input
+            type="email"
+            value={inviteEmail}
+            onChange={(e) => {
+              setInviteEmail(e.target.value);
+              setAddError(null);
+            }}
+            placeholder="teammate@example.com"
+            disabled={isAdding}
+            className={`flex-1 h-10 px-3 rounded-md border bg-background text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 disabled:opacity-50 ${
+              addError
+                ? "border-red-500/60 focus:ring-red-500/20"
+                : "border-border focus:ring-foreground/10"
+            }`}
+          />
+          <button
+            type="submit"
+            disabled={!inviteEmail.trim() || isAdding}
+            className="h-10 px-4 rounded-md text-sm font-medium bg-foreground text-background hover:opacity-90 transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {isAdding ? "Adding..." : "Add member"}
+          </button>
+        </form>
+        {addError && (
+          <p className="mt-1 text-[13px] text-red-500">{addError}</p>
+        )}
+      </div>
 
       <div className="border border-border rounded-lg overflow-hidden">
         {isLoading && members.length === 0 ? (

--- a/src/app/workspace-settings/page.tsx
+++ b/src/app/workspace-settings/page.tsx
@@ -8,10 +8,11 @@ import {
   useOrganizations,
   useOrgMembers,
 } from "@/hooks";
+import { useSession } from "next-auth/react";
 import { AppLayout } from "@/components/AppLayout";
 import { DeleteConfirmationDialog } from "@/components/DeleteConfirmationDialog";
 import { useSidebarState } from "@/lib/sidebar";
-import type { OrganizationMember } from "@/lib/orgs";
+import { clearActiveOrgUuid, type OrganizationMember } from "@/lib/orgs";
 
 export default function WorkspaceSettingsPage() {
   const router = useRouter();
@@ -123,7 +124,10 @@ export default function WorkspaceSettingsPage() {
               )}
             </section>
 
-            <MembersSection orgUuid={activeOrg.uuid} />
+            <MembersSection
+              orgUuid={activeOrg.uuid}
+              orgName={activeOrg.name}
+            />
           </>
         )}
       </div>
@@ -131,8 +135,42 @@ export default function WorkspaceSettingsPage() {
   );
 }
 
-function MembersSection({ orgUuid }: { orgUuid: string }) {
+/**
+ * Resolve the current user's uuid from either NextAuth (Google sign-in,
+ * exposed as `session.backendUser`) or localStorage (email/password login,
+ * stored under "user").
+ */
+function useCurrentUserId(): string | null {
+  const { data: session } = useSession();
+  const [localUuid, setLocalUuid] = useState<string | null>(null);
+
+  useEffect(() => {
+    const raw = localStorage.getItem("user");
+    if (!raw) return;
+    try {
+      const parsed = JSON.parse(raw) as { uuid?: string };
+      if (typeof parsed.uuid === "string") setLocalUuid(parsed.uuid);
+    } catch {
+      // ignore
+    }
+  }, []);
+
+  const sessionUuid =
+    (session as { backendUser?: { uuid?: string } } | null)?.backendUser
+      ?.uuid ?? null;
+  return sessionUuid || localUuid;
+}
+
+function MembersSection({
+  orgUuid,
+  orgName,
+}: {
+  orgUuid: string;
+  orgName: string;
+}) {
+  const router = useRouter();
   const accessToken = useAccessToken();
+  const currentUserId = useCurrentUserId();
   const {
     members,
     isLoading,
@@ -149,6 +187,9 @@ function MembersSection({ orgUuid }: { orgUuid: string }) {
   const [memberToRemove, setMemberToRemove] =
     useState<OrganizationMember | null>(null);
   const [isRemoving, setIsRemoving] = useState(false);
+
+  const isSelfRemoval =
+    !!memberToRemove && memberToRemove.user_id === currentUserId;
 
   const handleAdd = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -168,14 +209,22 @@ function MembersSection({ orgUuid }: { orgUuid: string }) {
 
   const handleRemove = async () => {
     if (!memberToRemove) return;
+    const wasSelf = memberToRemove.user_id === currentUserId;
     setIsRemoving(true);
     const ok = await removeMember(memberToRemove.user_id);
     setIsRemoving(false);
-    if (ok) {
-      setMemberToRemove(null);
-    } else {
+    if (!ok) {
       // Bring fresh data from server in case state is out of sync.
       refetch();
+      return;
+    }
+    setMemberToRemove(null);
+    if (wasSelf) {
+      // The user just left the workspace they were viewing — they no longer
+      // have access here. Drop the active uuid so the bootstrapper picks a
+      // new default (typically the personal workspace) and send them home.
+      clearActiveOrgUuid();
+      router.replace("/agents");
     }
   };
 
@@ -259,16 +308,23 @@ function MembersSection({ orgUuid }: { orgUuid: string }) {
                       {member.email}
                     </p>
                   </div>
-                  {!isOwner && (
-                    <button
-                      type="button"
-                      onClick={() => setMemberToRemove(member)}
-                      title="Remove from workspace"
-                      className="h-9 px-3 rounded-md text-xs font-medium border border-border bg-background hover:bg-muted/50 transition-colors cursor-pointer"
-                    >
-                      Remove
-                    </button>
-                  )}
+                  {!isOwner && (() => {
+                    const isSelf = member.user_id === currentUserId;
+                    return (
+                      <button
+                        type="button"
+                        onClick={() => setMemberToRemove(member)}
+                        title={
+                          isSelf
+                            ? "Leave this workspace"
+                            : "Remove from workspace"
+                        }
+                        className="h-9 px-3 rounded-md text-xs font-medium border border-border bg-background hover:bg-muted/50 transition-colors cursor-pointer"
+                      >
+                        {isSelf ? "Leave" : "Remove"}
+                      </button>
+                    );
+                  })()}
                 </li>
               );
             })}
@@ -282,16 +338,18 @@ function MembersSection({ orgUuid }: { orgUuid: string }) {
           if (!isRemoving) setMemberToRemove(null);
         }}
         onConfirm={handleRemove}
-        title="Remove member"
+        title={isSelfRemoval ? "Leave workspace" : "Remove member"}
         message={
           memberToRemove
-            ? `Remove ${
-                `${memberToRemove.first_name} ${memberToRemove.last_name}`.trim() ||
-                memberToRemove.email
-              } from this workspace? They will lose access immediately.`
+            ? isSelfRemoval
+              ? `Are you sure you want to leave ${orgName}? You'll lose access to its agents, tests, and simulations immediately.`
+              : `Remove ${
+                  `${memberToRemove.first_name} ${memberToRemove.last_name}`.trim() ||
+                  memberToRemove.email
+                } from this workspace? They will lose access immediately.`
             : ""
         }
-        confirmText="Remove"
+        confirmText={isSelfRemoval ? "Leave" : "Remove"}
         isDeleting={isRemoving}
       />
     </section>

--- a/src/app/workspace-settings/page.tsx
+++ b/src/app/workspace-settings/page.tsx
@@ -13,6 +13,7 @@ import { AppLayout } from "@/components/AppLayout";
 import { DeleteConfirmationDialog } from "@/components/DeleteConfirmationDialog";
 import { useSidebarState } from "@/lib/sidebar";
 import { apiGet } from "@/lib/api";
+import { parseBackendErrorMessage } from "@/lib/parseBackendError";
 import {
   clearActiveOrgUuid,
   notifyOrganizationsChanged,
@@ -68,9 +69,7 @@ export default function WorkspaceSettingsPage() {
       await renameOrganization(activeOrg.uuid, trimmed);
       setRenameSuccess(true);
     } catch (err) {
-      setRenameError(
-        err instanceof Error ? err.message : "Failed to rename workspace",
-      );
+      setRenameError(parseBackendErrorMessage(err, "Failed to rename workspace"));
     } finally {
       setIsRenaming(false);
     }
@@ -123,12 +122,10 @@ export default function WorkspaceSettingsPage() {
                 </button>
               </div>
               {renameError && (
-                <p className="text-sm text-red-600 dark:text-red-400">
-                  {renameError}
-                </p>
+                <p className="mt-1 text-[13px] text-red-500">{renameError}</p>
               )}
               {renameSuccess && !renameError && (
-                <p className="text-sm text-muted-foreground">Saved.</p>
+                <p className="mt-1 text-[13px] text-muted-foreground">Saved.</p>
               )}
             </section>
 
@@ -206,7 +203,7 @@ function MembersSection({
       await addMember(email);
       setInviteEmail("");
     } catch (err) {
-      setAddError(err instanceof Error ? err.message : "Failed to add member");
+      setAddError(parseBackendErrorMessage(err, "Failed to add member"));
     } finally {
       setIsAdding(false);
     }
@@ -287,16 +284,14 @@ function MembersSection({
         </button>
       </form>
       {addError && (
-        <p className="text-sm text-red-600 dark:text-red-400">{addError}</p>
+        <p className="mt-1 text-[13px] text-red-500">{addError}</p>
       )}
 
       <div className="border border-border rounded-lg overflow-hidden">
         {isLoading && members.length === 0 ? (
           <p className="px-4 py-6 text-sm text-muted-foreground">Loading…</p>
         ) : loadError ? (
-          <p className="px-4 py-6 text-sm text-red-600 dark:text-red-400">
-            {loadError}
-          </p>
+          <p className="px-4 py-6 text-[13px] text-red-500">{loadError}</p>
         ) : members.length === 0 ? (
           <p className="px-4 py-6 text-sm text-muted-foreground">
             No members yet.

--- a/src/app/workspace-settings/page.tsx
+++ b/src/app/workspace-settings/page.tsx
@@ -124,10 +124,7 @@ export default function WorkspaceSettingsPage() {
               )}
             </section>
 
-            <MembersSection
-              orgUuid={activeOrg.uuid}
-              orgName={activeOrg.name}
-            />
+            <MembersSection orgUuid={activeOrg.uuid} orgName={activeOrg.name} />
           </>
         )}
       </div>
@@ -308,23 +305,24 @@ function MembersSection({
                       {member.email}
                     </p>
                   </div>
-                  {!isOwner && (() => {
-                    const isSelf = member.user_id === currentUserId;
-                    return (
-                      <button
-                        type="button"
-                        onClick={() => setMemberToRemove(member)}
-                        title={
-                          isSelf
-                            ? "Leave this workspace"
-                            : "Remove from workspace"
-                        }
-                        className="h-9 px-3 rounded-md text-xs font-medium border border-border bg-background hover:bg-muted/50 transition-colors cursor-pointer"
-                      >
-                        {isSelf ? "Leave" : "Remove"}
-                      </button>
-                    );
-                  })()}
+                  {!isOwner &&
+                    (() => {
+                      const isSelf = member.user_id === currentUserId;
+                      return (
+                        <button
+                          type="button"
+                          onClick={() => setMemberToRemove(member)}
+                          title={
+                            isSelf
+                              ? "Leave this workspace"
+                              : "Remove from workspace"
+                          }
+                          className="h-9 px-3 rounded-md text-xs font-medium text-red-500 bg-red-500/10 hover:bg-red-500/20 transition-colors cursor-pointer"
+                        >
+                          {isSelf ? "Leave" : "Remove"}
+                        </button>
+                      );
+                    })()}
                 </li>
               );
             })}
@@ -342,7 +340,7 @@ function MembersSection({
         message={
           memberToRemove
             ? isSelfRemoval
-              ? `Are you sure you want to leave ${orgName}? You'll lose access to its agents, tests, and simulations immediately.`
+              ? `Are you sure you want to leave ${orgName}? You will lose all access immediately.`
               : `Remove ${
                   `${memberToRemove.first_name} ${memberToRemove.last_name}`.trim() ||
                   memberToRemove.email

--- a/src/app/workspace-settings/page.tsx
+++ b/src/app/workspace-settings/page.tsx
@@ -245,7 +245,13 @@ function MembersSection({ orgUuid }: { orgUuid: string }) {
                       <p className="text-sm font-medium text-foreground truncate">
                         {displayName}
                       </p>
-                      <span className="text-[10px] uppercase tracking-wider px-1.5 py-0.5 rounded bg-muted text-muted-foreground border border-border">
+                      <span
+                        className={`text-[10px] uppercase tracking-wider px-1.5 py-0.5 rounded ${
+                          member.role === "owner"
+                            ? "bg-amber-500/10 text-amber-700 dark:text-amber-400 border border-amber-500/30"
+                            : "bg-blue-500/10 text-blue-700 dark:text-blue-400 border border-blue-500/30"
+                        }`}
+                      >
                         {member.role}
                       </span>
                     </div>

--- a/src/app/workspace-settings/page.tsx
+++ b/src/app/workspace-settings/page.tsx
@@ -12,7 +12,15 @@ import { useSession } from "next-auth/react";
 import { AppLayout } from "@/components/AppLayout";
 import { DeleteConfirmationDialog } from "@/components/DeleteConfirmationDialog";
 import { useSidebarState } from "@/lib/sidebar";
-import { clearActiveOrgUuid, type OrganizationMember } from "@/lib/orgs";
+import { apiGet } from "@/lib/api";
+import {
+  clearActiveOrgUuid,
+  notifyOrganizationsChanged,
+  pickDefaultOrg,
+  setActiveOrgUuid,
+  type Organization,
+  type OrganizationMember,
+} from "@/lib/orgs";
 
 export default function WorkspaceSettingsPage() {
   const router = useRouter();
@@ -217,10 +225,32 @@ function MembersSection({
     }
     setMemberToRemove(null);
     if (wasSelf) {
-      // The user just left the workspace they were viewing — they no longer
-      // have access here. Drop the active uuid so the bootstrapper picks a
-      // new default (typically the personal workspace) and send them home.
-      clearActiveOrgUuid();
+      // User just left the workspace they were viewing. We need to:
+      //   1. Pick a new active workspace from the workspaces they still
+      //      belong to (the bootstrapper only runs once at app load, so it
+      //      won't auto-recover here).
+      //   2. Tell every mounted useOrganizations to refetch so the sidebar
+      //      switcher drops the just-left workspace.
+      //   3. Navigate to /agents under the new context.
+      if (accessToken) {
+        try {
+          const orgs = await apiGet<Organization[]>(
+            "/organizations",
+            accessToken,
+          );
+          const chosen = pickDefaultOrg(orgs);
+          if (chosen) {
+            setActiveOrgUuid(chosen.uuid);
+          } else {
+            clearActiveOrgUuid();
+          }
+        } catch {
+          clearActiveOrgUuid();
+        }
+      } else {
+        clearActiveOrgUuid();
+      }
+      notifyOrganizationsChanged();
       router.replace("/agents");
     }
   };

--- a/src/components/AgentDetail.tsx
+++ b/src/components/AgentDetail.tsx
@@ -576,7 +576,7 @@ export function AgentDetail({
           agent.type === "connection"
             ? {
                 ...connectionConfig,
-                agent_url: connectionUrl,
+                agent_url: connectionUrl.trim(),
                 agent_headers: Object.fromEntries(
                   connectionHeaders
                     .filter((h) => h.key.trim())

--- a/src/components/AppLayout.tsx
+++ b/src/components/AppLayout.tsx
@@ -8,6 +8,7 @@ import {
   useHideFloatingButton,
   useFloatingButtonHideCount,
 } from "@/components/providers/FloatingButtonProvider";
+import { WorkspaceSwitcher } from "@/components/WorkspaceSwitcher";
 
 // Re-export the hook so existing imports continue to work
 export { useHideFloatingButton } from "@/components/providers/FloatingButtonProvider";
@@ -482,6 +483,9 @@ export function AppLayout({
           </div>
         </div>
 
+        {/* Workspace switcher - Expanded */}
+        {sidebarOpen && <WorkspaceSwitcher collapsed={false} />}
+
         {/* Navigation - Expanded */}
         {sidebarOpen && (
           <>
@@ -552,6 +556,9 @@ export function AppLayout({
             </nav>
           </>
         )}
+
+        {/* Workspace switcher - Collapsed */}
+        {!sidebarOpen && <WorkspaceSwitcher collapsed={true} />}
 
         {/* Navigation - Collapsed (icons only with tooltips) */}
         {!sidebarOpen && (
@@ -712,6 +719,7 @@ export function AppLayout({
                         // Clear localStorage
                         localStorage.removeItem("access_token");
                         localStorage.removeItem("user");
+                        localStorage.removeItem("activeOrgUuid");
                         // Clear cookie
                         document.cookie =
                           "access_token=; path=/; max-age=0; SameSite=Lax";

--- a/src/components/AppLayout.tsx
+++ b/src/components/AppLayout.tsx
@@ -9,6 +9,7 @@ import {
   useFloatingButtonHideCount,
 } from "@/components/providers/FloatingButtonProvider";
 import { WorkspaceSwitcher } from "@/components/WorkspaceSwitcher";
+import { clearOrgsCache } from "@/hooks";
 
 // Re-export the hook so existing imports continue to work
 export { useHideFloatingButton } from "@/components/providers/FloatingButtonProvider";
@@ -720,6 +721,8 @@ export function AppLayout({
                         localStorage.removeItem("access_token");
                         localStorage.removeItem("user");
                         localStorage.removeItem("activeOrgUuid");
+                        // Clear in-memory caches scoped to this user.
+                        clearOrgsCache();
                         // Clear cookie
                         document.cookie =
                           "access_token=; path=/; max-age=0; SameSite=Lax";

--- a/src/components/CreateWorkspaceDialog.tsx
+++ b/src/components/CreateWorkspaceDialog.tsx
@@ -1,0 +1,125 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useHideFloatingButton } from "@/components/AppLayout";
+
+type CreateWorkspaceDialogProps = {
+  isOpen: boolean;
+  onClose: () => void;
+  onCreate: (name: string) => Promise<void>;
+};
+
+export function CreateWorkspaceDialog({
+  isOpen,
+  onClose,
+  onCreate,
+}: CreateWorkspaceDialogProps) {
+  useHideFloatingButton(isOpen);
+
+  const [name, setName] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!isOpen) {
+      setName("");
+      setError(null);
+      setIsSubmitting(false);
+    }
+  }, [isOpen]);
+
+  if (!isOpen) return null;
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const trimmed = name.trim();
+    if (!trimmed || isSubmitting) return;
+    setIsSubmitting(true);
+    setError(null);
+    try {
+      await onCreate(trimmed);
+      onClose();
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : "Failed to create workspace",
+      );
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm p-4">
+      <form
+        onSubmit={handleSubmit}
+        className="bg-background rounded-xl w-full max-w-md p-5 md:p-6 shadow-2xl"
+      >
+        <h2 className="text-base md:text-lg font-semibold text-foreground mb-2">
+          Create workspace
+        </h2>
+        <p className="text-sm text-muted-foreground mb-4">
+          Workspaces let you collaborate with teammates on a shared set of
+          agents, tests, and simulations.
+        </p>
+
+        <label className="block text-sm font-medium text-foreground mb-1.5">
+          Name
+        </label>
+        <input
+          type="text"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="e.g. Acme Health"
+          autoFocus
+          disabled={isSubmitting}
+          className="w-full h-10 px-3 rounded-md border border-border bg-background text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-foreground/10 disabled:opacity-50"
+        />
+
+        {error && (
+          <p className="mt-3 text-sm text-red-600 dark:text-red-400">{error}</p>
+        )}
+
+        <div className="mt-5 flex items-center justify-end gap-2 md:gap-3">
+          <button
+            type="button"
+            onClick={onClose}
+            disabled={isSubmitting}
+            className="h-9 md:h-10 px-4 rounded-md text-xs md:text-sm font-medium border border-border bg-background hover:bg-muted/50 transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            disabled={isSubmitting || !name.trim()}
+            className="h-9 md:h-10 px-4 rounded-md text-xs md:text-sm font-medium bg-foreground text-background hover:opacity-90 transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2"
+          >
+            {isSubmitting && (
+              <svg
+                className="w-4 h-4 animate-spin"
+                fill="none"
+                viewBox="0 0 24 24"
+              >
+                <circle
+                  className="opacity-25"
+                  cx="12"
+                  cy="12"
+                  r="10"
+                  stroke="currentColor"
+                  strokeWidth="4"
+                />
+                <path
+                  className="opacity-75"
+                  fill="currentColor"
+                  d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+                />
+              </svg>
+            )}
+            {isSubmitting ? "Creating..." : "Create workspace"}
+          </button>
+        </div>
+      </form>
+
+      <div className="absolute inset-0 -z-10" onClick={onClose} />
+    </div>
+  );
+}

--- a/src/components/CreateWorkspaceDialog.tsx
+++ b/src/components/CreateWorkspaceDialog.tsx
@@ -58,8 +58,8 @@ export function CreateWorkspaceDialog({
           Create workspace
         </h2>
         <p className="text-sm text-muted-foreground mb-4">
-          Workspaces let you collaborate with teammates on a shared set of
-          agents, tests, and simulations.
+          Workspaces help you easily collaborate. Create a new workspace and add
+          team members to it.
         </p>
 
         <label className="block text-sm font-medium text-foreground mb-1.5">

--- a/src/components/OrganizationBootstrapper.tsx
+++ b/src/components/OrganizationBootstrapper.tsx
@@ -2,9 +2,8 @@
 
 import { useEffect, useRef } from "react";
 import { useAuth } from "@/hooks";
-import { apiGet } from "@/lib/api";
+import { fetchOrganizationsDedup } from "@/hooks/useOrganizations";
 import {
-  type Organization,
   getActiveOrgUuid,
   pickDefaultOrg,
   setActiveOrgUuid,
@@ -37,21 +36,20 @@ export function OrganizationBootstrapper() {
     hasFetchedRef.current = true;
 
     (async () => {
-      try {
-        const orgs = await apiGet<Organization[]>(
-          "/organizations",
-          accessToken,
-        );
-        const chosen = pickDefaultOrg(orgs);
-        if (chosen) {
-          setActiveOrgUuid(chosen.uuid);
-        }
-      } catch (err) {
-        // Non-fatal: the backend falls back to the personal workspace when
-        // the header is missing, so the user keeps working — they just
-        // can't switch workspaces until this succeeds on a later request.
-        console.error("Failed to bootstrap active workspace:", err);
+      // Routed through the shared dedup so a concurrent useOrganizations
+      // mount (e.g. the sidebar switcher) doesn't make a second request
+      // for the same data. fetchOrganizationsDedup also seeds the module
+      // cache on success.
+      const orgs = await fetchOrganizationsDedup(accessToken);
+      if (orgs === null) {
+        // Non-fatal: backend falls back to personal workspace without the
+        // header. The next user action will trigger a retry.
         hasFetchedRef.current = false;
+        return;
+      }
+      const chosen = pickDefaultOrg(orgs);
+      if (chosen) {
+        setActiveOrgUuid(chosen.uuid);
       }
     })();
   }, [accessToken, isAuthenticated]);

--- a/src/components/OrganizationBootstrapper.tsx
+++ b/src/components/OrganizationBootstrapper.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { useAuth } from "@/hooks";
+import { apiGet } from "@/lib/api";
+import {
+  type Organization,
+  getActiveOrgUuid,
+  pickDefaultOrg,
+  setActiveOrgUuid,
+} from "@/lib/orgs";
+import { installOrgFetchInterceptor } from "@/lib/fetchInterceptor";
+
+/**
+ * Bootstraps workspace state on the client:
+ *
+ *  1. Installs the global fetch interceptor that attaches `X-Org-UUID`.
+ *  2. When the user has a token but no active workspace stashed locally,
+ *     fetches /organizations and picks one (preferring the personal one).
+ *
+ * Until step 2 completes the backend falls back to the user's personal
+ * workspace, so this is safe to run lazily.
+ */
+export function OrganizationBootstrapper() {
+  const { accessToken, isAuthenticated } = useAuth();
+  const hasFetchedRef = useRef(false);
+
+  // Install the global fetch interceptor once, as early as possible.
+  useEffect(() => {
+    installOrgFetchInterceptor();
+  }, []);
+
+  useEffect(() => {
+    if (!isAuthenticated || !accessToken) return;
+    if (getActiveOrgUuid()) return;
+    if (hasFetchedRef.current) return;
+    hasFetchedRef.current = true;
+
+    (async () => {
+      try {
+        const orgs = await apiGet<Organization[]>(
+          "/organizations",
+          accessToken,
+        );
+        const chosen = pickDefaultOrg(orgs);
+        if (chosen) {
+          setActiveOrgUuid(chosen.uuid);
+        }
+      } catch (err) {
+        // Non-fatal: the backend falls back to the personal workspace when
+        // the header is missing, so the user keeps working — they just
+        // can't switch workspaces until this succeeds on a later request.
+        console.error("Failed to bootstrap active workspace:", err);
+        hasFetchedRef.current = false;
+      }
+    })();
+  }, [accessToken, isAuthenticated]);
+
+  return null;
+}

--- a/src/components/WorkspaceSwitcher.tsx
+++ b/src/components/WorkspaceSwitcher.tsx
@@ -43,7 +43,7 @@ function WorkspaceAvatar({
 
 export function WorkspaceSwitcher({ collapsed }: WorkspaceSwitcherProps) {
   const accessToken = useAccessToken();
-  const { organizations, isLoading, refetch, createOrganization } =
+  const { organizations, isLoading, createOrganization } =
     useOrganizations(accessToken);
   const [activeUuid, setActiveUuid] = useActiveOrgUuid();
 
@@ -108,10 +108,11 @@ export function WorkspaceSwitcher({ collapsed }: WorkspaceSwitcherProps) {
   };
 
   const handleCreate = async (name: string) => {
+    // createOrganization already pushes the new entry into local state and
+    // updates the module cache; no need to refetch /organizations again.
     const created = await createOrganization(name);
     if (created) {
       setActiveUuid(created.uuid);
-      await refetch();
       navigateAfterSwitch();
     }
   };

--- a/src/components/WorkspaceSwitcher.tsx
+++ b/src/components/WorkspaceSwitcher.tsx
@@ -8,7 +8,7 @@ import {
   useOrganizations,
 } from "@/hooks";
 import { CreateWorkspaceDialog } from "@/components/CreateWorkspaceDialog";
-import type { Organization } from "@/lib/orgs";
+import { pickDefaultOrg, type Organization } from "@/lib/orgs";
 
 type WorkspaceSwitcherProps = {
   collapsed: boolean;
@@ -71,6 +71,20 @@ export function WorkspaceSwitcher({ collapsed }: WorkspaceSwitcherProps) {
     organizations.find((o) => o.is_personal) ??
     organizations[0] ??
     null;
+
+  // Reconcile the stored active uuid against the fetched workspaces. If the
+  // user got removed from the active workspace (or it was deleted) while the
+  // app was open, the stored uuid no longer matches anything in the list.
+  // Without this, the sidebar silently shows the personal workspace as the
+  // label while API calls still carry the stale uuid as X-Org-UUID.
+  useEffect(() => {
+    if (organizations.length === 0) return;
+    if (activeUuid && organizations.some((o) => o.uuid === activeUuid)) return;
+    const fallback = pickDefaultOrg(organizations);
+    if (fallback && fallback.uuid !== activeUuid) {
+      setActiveUuid(fallback.uuid);
+    }
+  }, [organizations, activeUuid, setActiveUuid]);
 
   const navigateAfterSwitch = () => {
     // Stay on workspace settings if that's where the user is — switching

--- a/src/components/WorkspaceSwitcher.tsx
+++ b/src/components/WorkspaceSwitcher.tsx
@@ -72,14 +72,22 @@ export function WorkspaceSwitcher({ collapsed }: WorkspaceSwitcherProps) {
     organizations[0] ??
     null;
 
+  const navigateAfterSwitch = () => {
+    // Stay on workspace settings if that's where the user is — switching
+    // workspaces from there should just reload settings for the new one.
+    // Everywhere else, land on /agents (a known-good page for any workspace).
+    if (window.location.pathname === "/workspace-settings") {
+      window.location.reload();
+    } else {
+      window.location.assign("/agents");
+    }
+  };
+
   const handleSelect = (uuid: string) => {
     if (uuid !== activeUuid) {
       setActiveUuid(uuid);
       setOpen(false);
-      // Send the user to the agents home so they land on a known-good page
-      // for the new workspace. Full navigation (not router.push) ensures
-      // every in-flight data fetch re-runs under the new context.
-      window.location.assign("/agents");
+      navigateAfterSwitch();
       return;
     }
     setOpen(false);
@@ -90,7 +98,7 @@ export function WorkspaceSwitcher({ collapsed }: WorkspaceSwitcherProps) {
     if (created) {
       setActiveUuid(created.uuid);
       await refetch();
-      window.location.assign("/agents");
+      navigateAfterSwitch();
     }
   };
 

--- a/src/components/WorkspaceSwitcher.tsx
+++ b/src/components/WorkspaceSwitcher.tsx
@@ -76,9 +76,10 @@ export function WorkspaceSwitcher({ collapsed }: WorkspaceSwitcherProps) {
     if (uuid !== activeUuid) {
       setActiveUuid(uuid);
       setOpen(false);
-      // Reload to refetch all data under the new workspace context. The
-      // header is read from localStorage so subsequent requests pick it up.
-      window.location.reload();
+      // Send the user to the agents home so they land on a known-good page
+      // for the new workspace. Full navigation (not router.push) ensures
+      // every in-flight data fetch re-runs under the new context.
+      window.location.assign("/agents");
       return;
     }
     setOpen(false);
@@ -88,10 +89,8 @@ export function WorkspaceSwitcher({ collapsed }: WorkspaceSwitcherProps) {
     const created = await createOrganization(name);
     if (created) {
       setActiveUuid(created.uuid);
-      // Refresh the list so the new workspace appears next time the
-      // dropdown opens, then reload so the page reflects the new context.
       await refetch();
-      window.location.reload();
+      window.location.assign("/agents");
     }
   };
 

--- a/src/components/WorkspaceSwitcher.tsx
+++ b/src/components/WorkspaceSwitcher.tsx
@@ -250,11 +250,6 @@ function DropdownPanel({
                     <span className="flex-1 min-w-0 truncate text-left">
                       {org.name}
                     </span>
-                    {org.is_personal && (
-                      <span className="text-[10px] uppercase tracking-wider text-muted-foreground">
-                        Personal
-                      </span>
-                    )}
                     {isActive && (
                       <svg
                         className="w-4 h-4 text-foreground flex-shrink-0"

--- a/src/components/WorkspaceSwitcher.tsx
+++ b/src/components/WorkspaceSwitcher.tsx
@@ -180,7 +180,7 @@ export function WorkspaceSwitcher({ collapsed }: WorkspaceSwitcherProps) {
         </button>
 
         {open && (
-          <div className="absolute left-3 right-3 top-full z-50 mt-1">
+          <div className="absolute left-3 top-full z-50 mt-1">
             <DropdownPanel
               organizations={organizations}
               isLoading={isLoading}
@@ -227,7 +227,7 @@ function DropdownPanel({
   return (
     <div
       role="menu"
-      className="w-64 bg-background border border-border rounded-xl shadow-lg overflow-hidden"
+      className="w-max min-w-[240px] max-w-sm bg-background border border-border rounded-xl shadow-lg overflow-hidden"
     >
       <div className="p-2 max-h-64 overflow-y-auto">
         <p className="px-2 py-1 text-xs font-medium uppercase tracking-wider text-muted-foreground">
@@ -255,7 +255,7 @@ function DropdownPanel({
                     }`}
                   >
                     <WorkspaceAvatar org={org} size="sm" />
-                    <span className="flex-1 min-w-0 truncate text-left">
+                    <span className="flex-1 whitespace-nowrap text-left">
                       {org.name}
                     </span>
                     {isActive && (

--- a/src/components/WorkspaceSwitcher.tsx
+++ b/src/components/WorkspaceSwitcher.tsx
@@ -1,0 +1,333 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useRef, useState } from "react";
+import {
+  useAccessToken,
+  useActiveOrgUuid,
+  useOrganizations,
+} from "@/hooks";
+import { CreateWorkspaceDialog } from "@/components/CreateWorkspaceDialog";
+import type { Organization } from "@/lib/orgs";
+
+type WorkspaceSwitcherProps = {
+  collapsed: boolean;
+};
+
+function workspaceInitial(name: string): string {
+  const trimmed = name.trim();
+  return trimmed ? trimmed[0].toUpperCase() : "W";
+}
+
+function WorkspaceAvatar({
+  org,
+  size = "md",
+}: {
+  org: Organization | null;
+  size?: "sm" | "md";
+}) {
+  const sizeClasses =
+    size === "sm" ? "w-6 h-6 text-xs" : "w-7 h-7 text-xs";
+  const colorClass = org?.is_personal
+    ? "bg-muted text-foreground border border-border"
+    : "bg-purple-600 text-white";
+  return (
+    <span
+      className={`${sizeClasses} ${colorClass} rounded-md flex items-center justify-center font-semibold flex-shrink-0`}
+      aria-hidden
+    >
+      {org ? workspaceInitial(org.name) : "·"}
+    </span>
+  );
+}
+
+export function WorkspaceSwitcher({ collapsed }: WorkspaceSwitcherProps) {
+  const accessToken = useAccessToken();
+  const { organizations, isLoading, refetch, createOrganization } =
+    useOrganizations(accessToken);
+  const [activeUuid, setActiveUuid] = useActiveOrgUuid();
+
+  const [open, setOpen] = useState(false);
+  const [createOpen, setCreateOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  // Close on outside click
+  useEffect(() => {
+    if (!open) return;
+    const onClick = (e: MouseEvent) => {
+      if (
+        containerRef.current &&
+        !containerRef.current.contains(e.target as Node)
+      ) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", onClick);
+    return () => document.removeEventListener("mousedown", onClick);
+  }, [open]);
+
+  const activeOrg =
+    organizations.find((o) => o.uuid === activeUuid) ??
+    organizations.find((o) => o.is_personal) ??
+    organizations[0] ??
+    null;
+
+  const handleSelect = (uuid: string) => {
+    if (uuid !== activeUuid) {
+      setActiveUuid(uuid);
+      setOpen(false);
+      // Reload to refetch all data under the new workspace context. The
+      // header is read from localStorage so subsequent requests pick it up.
+      window.location.reload();
+      return;
+    }
+    setOpen(false);
+  };
+
+  const handleCreate = async (name: string) => {
+    const created = await createOrganization(name);
+    if (created) {
+      setActiveUuid(created.uuid);
+      // Refresh the list so the new workspace appears next time the
+      // dropdown opens, then reload so the page reflects the new context.
+      await refetch();
+      window.location.reload();
+    }
+  };
+
+  // Collapsed mode: render a small button-only avatar with a tooltip.
+  if (collapsed) {
+    return (
+      <>
+        <div className="px-2 pt-3 pb-2 flex justify-center" ref={containerRef}>
+          <div className="relative group/tip">
+            <button
+              type="button"
+              onClick={() => setOpen((v) => !v)}
+              aria-label="Workspace switcher"
+              className="w-10 h-10 flex items-center justify-center rounded-md hover:bg-accent/50 transition-colors cursor-pointer"
+            >
+              <WorkspaceAvatar org={activeOrg} />
+            </button>
+            {!open && (
+              <div className="fixed ml-[3.5rem] -mt-9 px-2 py-1.5 rounded-md text-xs font-medium bg-popover text-popover-foreground border border-border shadow-md whitespace-nowrap opacity-0 pointer-events-none group-hover/tip:opacity-100 transition-opacity z-[9999]">
+                {activeOrg?.name ?? "Workspace"}
+              </div>
+            )}
+
+            {open && (
+              <div className="absolute left-12 top-0 z-50">
+                <DropdownPanel
+                  organizations={organizations}
+                  isLoading={isLoading}
+                  activeUuid={activeUuid}
+                  activeOrg={activeOrg}
+                  onSelect={handleSelect}
+                  onCreateClick={() => {
+                    setOpen(false);
+                    setCreateOpen(true);
+                  }}
+                  onSettingsClick={() => setOpen(false)}
+                />
+              </div>
+            )}
+          </div>
+        </div>
+        <CreateWorkspaceDialog
+          isOpen={createOpen}
+          onClose={() => setCreateOpen(false)}
+          onCreate={handleCreate}
+        />
+      </>
+    );
+  }
+
+  // Expanded mode: full-width switcher button.
+  return (
+    <>
+      <div className="px-3 pt-3 pb-2 relative" ref={containerRef}>
+        <button
+          type="button"
+          onClick={() => setOpen((v) => !v)}
+          aria-haspopup="menu"
+          aria-expanded={open}
+          className="w-full flex items-center gap-2 px-2 py-2 rounded-md border border-border bg-background hover:bg-accent/40 transition-colors cursor-pointer text-left"
+        >
+          <WorkspaceAvatar org={activeOrg} />
+          <span className="flex-1 min-w-0 text-sm font-medium text-foreground truncate">
+            {activeOrg?.name ?? (isLoading ? "Loading…" : "Workspace")}
+          </span>
+          <svg
+            className="w-4 h-4 text-muted-foreground flex-shrink-0"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            strokeWidth={2}
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              d="M8 9l4-4 4 4m0 6l-4 4-4-4"
+            />
+          </svg>
+        </button>
+
+        {open && (
+          <div className="absolute left-3 right-3 top-full z-50 mt-1">
+            <DropdownPanel
+              organizations={organizations}
+              isLoading={isLoading}
+              activeUuid={activeUuid}
+              activeOrg={activeOrg}
+              onSelect={handleSelect}
+              onCreateClick={() => {
+                setOpen(false);
+                setCreateOpen(true);
+              }}
+              onSettingsClick={() => setOpen(false)}
+            />
+          </div>
+        )}
+      </div>
+      <CreateWorkspaceDialog
+        isOpen={createOpen}
+        onClose={() => setCreateOpen(false)}
+        onCreate={handleCreate}
+      />
+    </>
+  );
+}
+
+type DropdownPanelProps = {
+  organizations: Organization[];
+  isLoading: boolean;
+  activeUuid: string | null;
+  activeOrg: Organization | null;
+  onSelect: (uuid: string) => void;
+  onCreateClick: () => void;
+  onSettingsClick: () => void;
+};
+
+function DropdownPanel({
+  organizations,
+  isLoading,
+  activeUuid,
+  activeOrg,
+  onSelect,
+  onCreateClick,
+  onSettingsClick,
+}: DropdownPanelProps) {
+  return (
+    <div
+      role="menu"
+      className="w-64 bg-background border border-border rounded-xl shadow-lg overflow-hidden"
+    >
+      <div className="p-2 max-h-64 overflow-y-auto">
+        <p className="px-2 py-1 text-xs font-medium uppercase tracking-wider text-muted-foreground">
+          Workspaces
+        </p>
+        {isLoading && organizations.length === 0 ? (
+          <p className="px-2 py-2 text-sm text-muted-foreground">Loading…</p>
+        ) : organizations.length === 0 ? (
+          <p className="px-2 py-2 text-sm text-muted-foreground">
+            No workspaces yet.
+          </p>
+        ) : (
+          <ul className="space-y-0.5">
+            {organizations.map((org) => {
+              const isActive = org.uuid === activeUuid;
+              return (
+                <li key={org.uuid}>
+                  <button
+                    type="button"
+                    onClick={() => onSelect(org.uuid)}
+                    className={`w-full flex items-center gap-2 px-2 py-1.5 rounded-md text-sm transition-colors cursor-pointer ${
+                      isActive
+                        ? "bg-accent text-accent-foreground"
+                        : "text-foreground hover:bg-accent/50"
+                    }`}
+                  >
+                    <WorkspaceAvatar org={org} size="sm" />
+                    <span className="flex-1 min-w-0 truncate text-left">
+                      {org.name}
+                    </span>
+                    {org.is_personal && (
+                      <span className="text-[10px] uppercase tracking-wider text-muted-foreground">
+                        Personal
+                      </span>
+                    )}
+                    {isActive && (
+                      <svg
+                        className="w-4 h-4 text-foreground flex-shrink-0"
+                        fill="none"
+                        viewBox="0 0 24 24"
+                        stroke="currentColor"
+                        strokeWidth={2}
+                      >
+                        <path
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          d="M5 13l4 4L19 7"
+                        />
+                      </svg>
+                    )}
+                  </button>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </div>
+
+      <div className="border-t border-border p-2 space-y-0.5">
+        {activeOrg && (
+          <Link
+            href="/workspace-settings"
+            onClick={onSettingsClick}
+            className="w-full flex items-center gap-2 px-2 py-1.5 rounded-md text-sm text-foreground hover:bg-accent/50 transition-colors cursor-pointer"
+          >
+            <svg
+              className="w-4 h-4 text-muted-foreground"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              strokeWidth={1.5}
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M10.343 3.94c.09-.542.56-.94 1.11-.94h1.093c.55 0 1.02.398 1.11.94l.149.894c.07.424.384.764.78.93.398.164.855.142 1.205-.108l.737-.527a1.125 1.125 0 011.45.12l.773.774c.39.389.44 1.002.12 1.45l-.527.737c-.25.35-.272.806-.107 1.204.165.397.505.71.93.78l.893.15c.543.09.94.56.94 1.109v1.094c0 .55-.397 1.02-.94 1.11l-.893.149c-.425.07-.765.383-.93.78-.165.398-.143.854.107 1.204l.527.738c.32.447.269 1.06-.12 1.45l-.774.773a1.125 1.125 0 01-1.449.12l-.738-.527c-.35-.25-.806-.272-1.203-.107-.397.165-.71.505-.781.929l-.149.894c-.09.542-.56.94-1.11.94h-1.094c-.55 0-1.019-.398-1.11-.94l-.148-.894c-.071-.424-.384-.764-.781-.93-.398-.164-.854-.142-1.204.108l-.738.527c-.447.32-1.06.269-1.45-.12l-.773-.774a1.125 1.125 0 01-.12-1.45l.527-.737c.25-.35.272-.806.108-1.204-.166-.397-.506-.71-.93-.78l-.894-.15c-.542-.09-.94-.56-.94-1.109v-1.094c0-.55.398-1.02.94-1.11l.894-.149c.424-.07.764-.383.93-.78.165-.398.143-.854-.108-1.204l-.526-.738a1.125 1.125 0 01.12-1.45l.773-.773a1.125 1.125 0 011.45-.12l.737.527c.35.25.807.272 1.204.107.397-.165.71-.505.78-.929l.15-.894z"
+              />
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
+              />
+            </svg>
+            Workspace settings
+          </Link>
+        )}
+        <button
+          type="button"
+          onClick={onCreateClick}
+          className="w-full flex items-center gap-2 px-2 py-1.5 rounded-md text-sm text-foreground hover:bg-accent/50 transition-colors cursor-pointer"
+        >
+          <svg
+            className="w-4 h-4 text-muted-foreground"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            strokeWidth={2}
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              d="M12 4v16m8-8H4"
+            />
+          </svg>
+          Create workspace
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/WorkspaceSwitcher.tsx
+++ b/src/components/WorkspaceSwitcher.tsx
@@ -8,7 +8,11 @@ import {
   useOrganizations,
 } from "@/hooks";
 import { CreateWorkspaceDialog } from "@/components/CreateWorkspaceDialog";
-import { pickDefaultOrg, type Organization } from "@/lib/orgs";
+import {
+  getActiveOrgUuid,
+  pickDefaultOrg,
+  type Organization,
+} from "@/lib/orgs";
 
 type WorkspaceSwitcherProps = {
   collapsed: boolean;
@@ -77,11 +81,19 @@ export function WorkspaceSwitcher({ collapsed }: WorkspaceSwitcherProps) {
   // app was open, the stored uuid no longer matches anything in the list.
   // Without this, the sidebar silently shows the personal workspace as the
   // label while API calls still carry the stale uuid as X-Org-UUID.
+  //
+  // Read from localStorage directly rather than the React `activeUuid` state:
+  // useActiveOrgUuid initialises to null and only reads localStorage in an
+  // effect, so on every mount there's a window where the React state is null
+  // even though localStorage holds the real choice. Trusting the state here
+  // would overwrite the user's selection with the personal-fallback on every
+  // navigation.
   useEffect(() => {
     if (organizations.length === 0) return;
-    if (activeUuid && organizations.some((o) => o.uuid === activeUuid)) return;
+    const persisted = getActiveOrgUuid();
+    if (persisted && organizations.some((o) => o.uuid === persisted)) return;
     const fallback = pickDefaultOrg(organizations);
-    if (fallback && fallback.uuid !== activeUuid) {
+    if (fallback && fallback.uuid !== persisted) {
       setActiveUuid(fallback.uuid);
     }
   }, [organizations, activeUuid, setActiveUuid]);

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -10,4 +10,5 @@ export {
   useActiveOrgUuid,
   useOrgMembers,
   clearOrgsCache,
+  seedOrgsCache,
 } from "./useOrganizations";

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -5,3 +5,8 @@ export { useDatasetManagement } from "./useDatasetManagement";
 export { useVerifyConnection } from "./useVerifyConnection";
 export type { VerifyConnectionResult } from "./useVerifyConnection";
 export { useMaxRowsPerEval } from "./useMaxRowsPerEval";
+export {
+  useOrganizations,
+  useActiveOrgUuid,
+  useOrgMembers,
+} from "./useOrganizations";

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -9,4 +9,5 @@ export {
   useOrganizations,
   useActiveOrgUuid,
   useOrgMembers,
+  clearOrgsCache,
 } from "./useOrganizations";

--- a/src/hooks/useOrganizations.ts
+++ b/src/hooks/useOrganizations.ts
@@ -25,25 +25,47 @@ type UseOrganizationsReturn = {
 };
 
 /**
+ * Module-level cache keyed by access token. Every route in the app
+ * remounts AppLayout (and the workspace switcher), so without a cache the
+ * sidebar shows a loading flash on every navigation. The cache seeds the
+ * initial state on subsequent mounts; we still refetch in the background
+ * to stay fresh, but the UI no longer flickers.
+ */
+let cachedOrgs: Organization[] | null = null;
+let cachedForToken: string | null = null;
+
+/**
  * List + create + rename workspaces for the current user.
  */
 export function useOrganizations(
   accessToken: string | null | undefined,
 ): UseOrganizationsReturn {
-  const [organizations, setOrganizations] = useState<Organization[]>([]);
-  const [isLoading, setIsLoading] = useState(true);
+  const hasCache =
+    !!accessToken && accessToken === cachedForToken && cachedOrgs !== null;
+  const [organizations, setOrganizations] = useState<Organization[]>(
+    hasCache ? (cachedOrgs as Organization[]) : [],
+  );
+  // Only show the loading state on the very first fetch for this token.
+  // Cached hydration skips it; background refetches don't toggle it either.
+  const [isLoading, setIsLoading] = useState(!hasCache);
   const [error, setError] = useState<string | null>(null);
 
   const refetch = useCallback(async (): Promise<Organization[] | null> => {
     if (!accessToken) {
       setOrganizations([]);
       setIsLoading(false);
+      cachedOrgs = null;
+      cachedForToken = null;
       return null;
     }
+    const hadCache =
+      accessToken === cachedForToken && cachedOrgs !== null;
     try {
-      setIsLoading(true);
+      if (!hadCache) setIsLoading(true);
       setError(null);
       const data = await apiGet<Organization[]>("/organizations", accessToken);
+      cachedOrgs = data;
+      cachedForToken = accessToken;
       setOrganizations(data);
       return data;
     } catch (err) {
@@ -80,7 +102,12 @@ export function useOrganizations(
           accessToken,
           { name },
         );
-        setOrganizations((prev) => [...prev, created]);
+        setOrganizations((prev) => {
+          const next = [...prev, created];
+          cachedOrgs = next;
+          cachedForToken = accessToken;
+          return next;
+        });
         notifyOrganizationsChanged();
         return created;
       } catch (err) {
@@ -100,9 +127,12 @@ export function useOrganizations(
           accessToken,
           { method: "PATCH", body: { name } },
         );
-        setOrganizations((prev) =>
-          prev.map((o) => (o.uuid === uuid ? updated : o)),
-        );
+        setOrganizations((prev) => {
+          const next = prev.map((o) => (o.uuid === uuid ? updated : o));
+          cachedOrgs = next;
+          cachedForToken = accessToken;
+          return next;
+        });
         notifyOrganizationsChanged();
         return updated;
       } catch (err) {

--- a/src/hooks/useOrganizations.ts
+++ b/src/hooks/useOrganizations.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { apiClient, apiDelete, apiGet, apiPost } from "@/lib/api";
 import {
   ACTIVE_ORG_CHANGED_EVENT,
@@ -59,6 +59,41 @@ export function seedOrgsCache(orgs: Organization[], accessToken: string): void {
 }
 
 /**
+ * Shared in-flight fetch promise. When the bootstrapper and the workspace
+ * switcher mount in the same tick, they both want /organizations — without
+ * this, two requests go out in parallel. With it, the second caller awaits
+ * the first caller's promise.
+ */
+let inFlightFetch: Promise<Organization[] | null> | null = null;
+let inFlightToken: string | null = null;
+
+/**
+ * Fetch /organizations through the module-level cache + in-flight dedup.
+ * Returns null on error (logged).
+ */
+export async function fetchOrganizationsDedup(
+  accessToken: string,
+): Promise<Organization[] | null> {
+  if (inFlightFetch && inFlightToken === accessToken) return inFlightFetch;
+  inFlightToken = accessToken;
+  inFlightFetch = (async () => {
+    try {
+      const data = await apiGet<Organization[]>("/organizations", accessToken);
+      cachedOrgs = data;
+      cachedForToken = accessToken;
+      return data;
+    } catch (err) {
+      console.error("Error fetching organizations:", err);
+      return null;
+    } finally {
+      inFlightFetch = null;
+      inFlightToken = null;
+    }
+  })();
+  return inFlightFetch;
+}
+
+/**
  * List + create + rename workspaces for the current user.
  */
 export function useOrganizations(
@@ -73,6 +108,12 @@ export function useOrganizations(
   // Cached hydration skips it; background refetches don't toggle it either.
   const [isLoading, setIsLoading] = useState(!hasCache);
   const [error, setError] = useState<string | null>(null);
+  // Stable per-instance source tag so the mutator can skip the refetch
+  // its own notifyOrganizationsChanged() triggers.
+  const instanceRef = useRef<symbol>(undefined as unknown as symbol);
+  if (instanceRef.current === undefined) {
+    instanceRef.current = Symbol("useOrganizations");
+  }
 
   const refetch = useCallback(async (): Promise<Organization[] | null> => {
     if (!accessToken) {
@@ -83,34 +124,35 @@ export function useOrganizations(
       setIsLoading(false);
       return null;
     }
-    const hadCache =
-      accessToken === cachedForToken && cachedOrgs !== null;
-    try {
-      if (!hadCache) setIsLoading(true);
-      setError(null);
-      const data = await apiGet<Organization[]>("/organizations", accessToken);
-      cachedOrgs = data;
-      cachedForToken = accessToken;
-      setOrganizations(data);
-      return data;
-    } catch (err) {
-      console.error("Error fetching organizations:", err);
-      setError(err instanceof Error ? err.message : "Failed to load workspaces");
-      return null;
-    } finally {
+    setError(null);
+    const data = await fetchOrganizationsDedup(accessToken);
+    if (data === null) {
+      setError("Failed to load workspaces");
       setIsLoading(false);
+      return null;
     }
+    setOrganizations(data);
+    setIsLoading(false);
+    return data;
   }, [accessToken]);
 
+  // Fetch on mount only when we don't already have a fresh cached list for
+  // this token. The bootstrapper fetches once at app start and seeds the
+  // cache; subsequent mounts of useOrganizations (sidebar switcher,
+  // workspace settings) hydrate from cache and skip the duplicate fetch.
   useEffect(() => {
+    if (!accessToken) return;
+    if (accessToken === cachedForToken && cachedOrgs !== null) return;
     refetch();
-  }, [refetch]);
+  }, [refetch, accessToken]);
 
-  // Keep multiple mounted `useOrganizations` instances in sync: when one
-  // mutates a workspace, others refetch so the sidebar switcher reflects
-  // changes made on the settings page (and vice versa).
+  // Cross-instance sync after mutations. The instance that dispatched the
+  // event already applied the change locally + updated the cache, so we
+  // skip refetch when the event came from us.
   useEffect(() => {
-    const handler = () => {
+    const handler = (e: Event) => {
+      const detail = (e as CustomEvent<{ source?: symbol }>).detail;
+      if (detail?.source === instanceRef.current) return;
       refetch();
     };
     window.addEventListener(ORGANIZATIONS_CHANGED_EVENT, handler);
@@ -133,7 +175,7 @@ export function useOrganizations(
           cachedForToken = accessToken;
           return next;
         });
-        notifyOrganizationsChanged();
+        notifyOrganizationsChanged(instanceRef.current);
         return created;
       } catch (err) {
         console.error("Error creating organization:", err);
@@ -158,7 +200,7 @@ export function useOrganizations(
           cachedForToken = accessToken;
           return next;
         });
-        notifyOrganizationsChanged();
+        notifyOrganizationsChanged(instanceRef.current);
         return updated;
       } catch (err) {
         console.error("Error renaming organization:", err);

--- a/src/hooks/useOrganizations.ts
+++ b/src/hooks/useOrganizations.ts
@@ -49,6 +49,16 @@ export function clearOrgsCache(): void {
 }
 
 /**
+ * Replace the cache with a freshly-fetched list. Useful for paths that
+ * already have the latest data in hand (e.g. self-leave) and want the
+ * next remount to hydrate without showing stale entries.
+ */
+export function seedOrgsCache(orgs: Organization[], accessToken: string): void {
+  cachedOrgs = orgs;
+  cachedForToken = accessToken;
+}
+
+/**
  * List + create + rename workspaces for the current user.
  */
 export function useOrganizations(
@@ -197,7 +207,7 @@ type UseOrgMembersReturn = {
   error: string | null;
   refetch: () => Promise<void>;
   addMember: (email: string) => Promise<OrganizationMember | null>;
-  removeMember: (userId: string) => Promise<boolean>;
+  removeMember: (userId: string) => Promise<void>;
 };
 
 /**
@@ -252,19 +262,15 @@ export function useOrgMembers(
   );
 
   const removeMember = useCallback(
-    async (userId: string): Promise<boolean> => {
-      if (!accessToken || !orgUuid) return false;
-      try {
-        await apiDelete(
-          `/organizations/${orgUuid}/members/${userId}`,
-          accessToken,
-        );
-        setMembers((prev) => prev.filter((m) => m.user_id !== userId));
-        return true;
-      } catch (err) {
-        console.error("Error removing member:", err);
-        return false;
+    async (userId: string): Promise<void> => {
+      if (!accessToken || !orgUuid) {
+        throw new Error("Not signed in");
       }
+      await apiDelete(
+        `/organizations/${orgUuid}/members/${userId}`,
+        accessToken,
+      );
+      setMembers((prev) => prev.filter((m) => m.user_id !== userId));
     },
     [accessToken, orgUuid],
   );

--- a/src/hooks/useOrganizations.ts
+++ b/src/hooks/useOrganizations.ts
@@ -30,9 +30,23 @@ type UseOrganizationsReturn = {
  * sidebar shows a loading flash on every navigation. The cache seeds the
  * initial state on subsequent mounts; we still refetch in the background
  * to stay fresh, but the UI no longer flickers.
+ *
+ * Cache lifetime is tied to actual sign-out, not to the access token
+ * momentarily reading null while the auth hook hydrates from localStorage.
+ * Only `clearOrgsCache()` (called from real sign-out paths) wipes it.
  */
 let cachedOrgs: Organization[] | null = null;
 let cachedForToken: string | null = null;
+
+/**
+ * Drop the in-memory workspace list cache. Call this from real sign-out
+ * paths (the user clicking Logout, or the 401-triggered auto-sign-out) —
+ * not from places where the access token is just transiently null.
+ */
+export function clearOrgsCache(): void {
+  cachedOrgs = null;
+  cachedForToken = null;
+}
 
 /**
  * List + create + rename workspaces for the current user.
@@ -52,10 +66,11 @@ export function useOrganizations(
 
   const refetch = useCallback(async (): Promise<Organization[] | null> => {
     if (!accessToken) {
-      setOrganizations([]);
+      // The auth hook briefly returns null while it hydrates from
+      // localStorage (email/password users) — don't drop the cache here,
+      // we'd just have to refetch it a few ms later. Real sign-out paths
+      // call clearOrgsCache() explicitly.
       setIsLoading(false);
-      cachedOrgs = null;
-      cachedForToken = null;
       return null;
     }
     const hadCache =

--- a/src/hooks/useOrganizations.ts
+++ b/src/hooks/useOrganizations.ts
@@ -4,9 +4,11 @@ import { useCallback, useEffect, useState } from "react";
 import { apiClient, apiDelete, apiGet, apiPost } from "@/lib/api";
 import {
   ACTIVE_ORG_CHANGED_EVENT,
+  ORGANIZATIONS_CHANGED_EVENT,
   type Organization,
   type OrganizationMember,
   getActiveOrgUuid,
+  notifyOrganizationsChanged,
   setActiveOrgUuid as persistActiveOrgUuid,
 } from "@/lib/orgs";
 
@@ -57,6 +59,18 @@ export function useOrganizations(
     refetch();
   }, [refetch]);
 
+  // Keep multiple mounted `useOrganizations` instances in sync: when one
+  // mutates a workspace, others refetch so the sidebar switcher reflects
+  // changes made on the settings page (and vice versa).
+  useEffect(() => {
+    const handler = () => {
+      refetch();
+    };
+    window.addEventListener(ORGANIZATIONS_CHANGED_EVENT, handler);
+    return () =>
+      window.removeEventListener(ORGANIZATIONS_CHANGED_EVENT, handler);
+  }, [refetch]);
+
   const createOrganization = useCallback(
     async (name: string): Promise<Organization | null> => {
       if (!accessToken) return null;
@@ -67,6 +81,7 @@ export function useOrganizations(
           { name },
         );
         setOrganizations((prev) => [...prev, created]);
+        notifyOrganizationsChanged();
         return created;
       } catch (err) {
         console.error("Error creating organization:", err);
@@ -88,6 +103,7 @@ export function useOrganizations(
         setOrganizations((prev) =>
           prev.map((o) => (o.uuid === uuid ? updated : o)),
         );
+        notifyOrganizationsChanged();
         return updated;
       } catch (err) {
         console.error("Error renaming organization:", err);

--- a/src/hooks/useOrganizations.ts
+++ b/src/hooks/useOrganizations.ts
@@ -1,0 +1,212 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { apiClient, apiDelete, apiGet, apiPost } from "@/lib/api";
+import {
+  ACTIVE_ORG_CHANGED_EVENT,
+  type Organization,
+  type OrganizationMember,
+  getActiveOrgUuid,
+  setActiveOrgUuid as persistActiveOrgUuid,
+} from "@/lib/orgs";
+
+type UseOrganizationsReturn = {
+  organizations: Organization[];
+  isLoading: boolean;
+  error: string | null;
+  refetch: () => Promise<Organization[] | null>;
+  createOrganization: (name: string) => Promise<Organization | null>;
+  renameOrganization: (
+    uuid: string,
+    name: string,
+  ) => Promise<Organization | null>;
+};
+
+/**
+ * List + create + rename workspaces for the current user.
+ */
+export function useOrganizations(
+  accessToken: string | null | undefined,
+): UseOrganizationsReturn {
+  const [organizations, setOrganizations] = useState<Organization[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const refetch = useCallback(async (): Promise<Organization[] | null> => {
+    if (!accessToken) {
+      setOrganizations([]);
+      setIsLoading(false);
+      return null;
+    }
+    try {
+      setIsLoading(true);
+      setError(null);
+      const data = await apiGet<Organization[]>("/organizations", accessToken);
+      setOrganizations(data);
+      return data;
+    } catch (err) {
+      console.error("Error fetching organizations:", err);
+      setError(err instanceof Error ? err.message : "Failed to load workspaces");
+      return null;
+    } finally {
+      setIsLoading(false);
+    }
+  }, [accessToken]);
+
+  useEffect(() => {
+    refetch();
+  }, [refetch]);
+
+  const createOrganization = useCallback(
+    async (name: string): Promise<Organization | null> => {
+      if (!accessToken) return null;
+      try {
+        const created = await apiPost<Organization>(
+          "/organizations",
+          accessToken,
+          { name },
+        );
+        setOrganizations((prev) => [...prev, created]);
+        return created;
+      } catch (err) {
+        console.error("Error creating organization:", err);
+        throw err;
+      }
+    },
+    [accessToken],
+  );
+
+  const renameOrganization = useCallback(
+    async (uuid: string, name: string): Promise<Organization | null> => {
+      if (!accessToken) return null;
+      try {
+        const updated = await apiClient<Organization>(
+          `/organizations/${uuid}`,
+          accessToken,
+          { method: "PATCH", body: { name } },
+        );
+        setOrganizations((prev) =>
+          prev.map((o) => (o.uuid === uuid ? updated : o)),
+        );
+        return updated;
+      } catch (err) {
+        console.error("Error renaming organization:", err);
+        throw err;
+      }
+    },
+    [accessToken],
+  );
+
+  return {
+    organizations,
+    isLoading,
+    error,
+    refetch,
+    createOrganization,
+    renameOrganization,
+  };
+}
+
+/**
+ * Reactive accessor for the active workspace uuid. Subscribes to the custom
+ * "active-org-changed" event so components re-render when the user switches.
+ */
+export function useActiveOrgUuid(): [
+  string | null,
+  (uuid: string) => void,
+] {
+  const [uuid, setUuid] = useState<string | null>(null);
+
+  useEffect(() => {
+    setUuid(getActiveOrgUuid());
+    const handler = (e: Event) => {
+      const detail = (e as CustomEvent<{ uuid: string | null }>).detail;
+      setUuid(detail?.uuid ?? getActiveOrgUuid());
+    };
+    window.addEventListener(ACTIVE_ORG_CHANGED_EVENT, handler);
+    return () => window.removeEventListener(ACTIVE_ORG_CHANGED_EVENT, handler);
+  }, []);
+
+  return [uuid, persistActiveOrgUuid];
+}
+
+type UseOrgMembersReturn = {
+  members: OrganizationMember[];
+  isLoading: boolean;
+  error: string | null;
+  refetch: () => Promise<void>;
+  addMember: (email: string) => Promise<OrganizationMember | null>;
+  removeMember: (userId: string) => Promise<boolean>;
+};
+
+/**
+ * List + invite + remove members of a single workspace.
+ */
+export function useOrgMembers(
+  accessToken: string | null | undefined,
+  orgUuid: string | null,
+): UseOrgMembersReturn {
+  const [members, setMembers] = useState<OrganizationMember[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const refetch = useCallback(async () => {
+    if (!accessToken || !orgUuid) {
+      setMembers([]);
+      setIsLoading(false);
+      return;
+    }
+    try {
+      setIsLoading(true);
+      setError(null);
+      const data = await apiGet<OrganizationMember[]>(
+        `/organizations/${orgUuid}/members`,
+        accessToken,
+      );
+      setMembers(data);
+    } catch (err) {
+      console.error("Error fetching members:", err);
+      setError(err instanceof Error ? err.message : "Failed to load members");
+    } finally {
+      setIsLoading(false);
+    }
+  }, [accessToken, orgUuid]);
+
+  useEffect(() => {
+    refetch();
+  }, [refetch]);
+
+  const addMember = useCallback(
+    async (email: string): Promise<OrganizationMember | null> => {
+      if (!accessToken || !orgUuid) return null;
+      const created = await apiPost<OrganizationMember>(
+        `/organizations/${orgUuid}/members`,
+        accessToken,
+        { email },
+      );
+      setMembers((prev) => [...prev, created]);
+      return created;
+    },
+    [accessToken, orgUuid],
+  );
+
+  const removeMember = useCallback(
+    async (userId: string): Promise<boolean> => {
+      if (!accessToken || !orgUuid) return false;
+      try {
+        await apiDelete(
+          `/organizations/${orgUuid}/members/${userId}`,
+          accessToken,
+        );
+        setMembers((prev) => prev.filter((m) => m.user_id !== userId));
+        return true;
+      } catch (err) {
+        console.error("Error removing member:", err);
+        return false;
+      }
+    },
+    [accessToken, orgUuid],
+  );
+
+  return { members, isLoading, error, refetch, addMember, removeMember };
+}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,5 +1,6 @@
 import { signOut } from "next-auth/react";
 import { getActiveOrgUuid } from "@/lib/orgs";
+import { clearOrgsCache } from "@/hooks/useOrganizations";
 
 type RequestOptions = {
   method?: "GET" | "POST" | "PUT" | "DELETE" | "PATCH";
@@ -89,6 +90,8 @@ export async function apiClient<T>(
     localStorage.removeItem("access_token");
     localStorage.removeItem("user");
     localStorage.removeItem("activeOrgUuid");
+    // Clear in-memory caches that are scoped to the signed-in user.
+    clearOrgsCache();
     // Clear cookie
     document.cookie = "access_token=; path=/; max-age=0; SameSite=Lax";
     // Sign out via NextAuth

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,4 +1,5 @@
 import { signOut } from "next-auth/react";
+import { getActiveOrgUuid } from "@/lib/orgs";
 
 type RequestOptions = {
   method?: "GET" | "POST" | "PUT" | "DELETE" | "PATCH";
@@ -24,11 +25,19 @@ export function getDefaultHeaders(accessToken?: string): Record<string, string> 
   const headers: Record<string, string> = {
     accept: "application/json",
   };
-  
+
   if (accessToken) {
     headers.Authorization = `Bearer ${accessToken}`;
   }
-  
+
+  // Active workspace is resolved by the backend from this header. When absent
+  // the backend falls back to the user's personal workspace, so this is safe
+  // to omit (e.g. during initial boot before /organizations resolves).
+  const activeOrgUuid = getActiveOrgUuid();
+  if (activeOrgUuid) {
+    headers["X-Org-UUID"] = activeOrgUuid;
+  }
+
   return headers;
 }
 
@@ -71,6 +80,7 @@ export async function apiClient<T>(
     // Clear localStorage
     localStorage.removeItem("access_token");
     localStorage.removeItem("user");
+    localStorage.removeItem("activeOrgUuid");
     // Clear cookie
     document.cookie = "access_token=; path=/; max-age=0; SameSite=Lax";
     // Sign out via NextAuth

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -64,6 +64,14 @@ export async function apiClient<T>(
     ...customHeaders,
   };
 
+  // /organizations is the workspace-management surface (list, create,
+  // rename, members) and operates above any single workspace. Sending the
+  // active workspace header would either be ignored or — worse — cause a
+  // 403/404 after the user leaves the active workspace.
+  if (endpoint.startsWith("/organizations")) {
+    delete headers["X-Org-UUID"];
+  }
+
   // Add Content-Type for requests with body
   if (body && !headers["Content-Type"]) {
     headers["Content-Type"] = "application/json";

--- a/src/lib/fetchInterceptor.ts
+++ b/src/lib/fetchInterceptor.ts
@@ -39,6 +39,13 @@ export function installOrgFetchInterceptor(): void {
       return originalFetch(input, init);
     }
 
+    // The /organizations management surface (list/create/rename + members)
+    // operates above any single workspace — don't scope it with X-Org-UUID.
+    const path = url.slice(backendUrl.length);
+    if (path.startsWith("/organizations")) {
+      return originalFetch(input, init);
+    }
+
     const activeOrgUuid = getActiveOrgUuid();
     if (!activeOrgUuid) {
       return originalFetch(input, init);

--- a/src/lib/fetchInterceptor.ts
+++ b/src/lib/fetchInterceptor.ts
@@ -1,0 +1,59 @@
+/**
+ * Client-side fetch interceptor that attaches the `X-Org-UUID` header to
+ * every request targeting the backend.
+ *
+ * Several legacy pages call `fetch` directly (rather than going through
+ * `src/lib/api.ts`). Rather than touching each call site, we wrap
+ * `window.fetch` once on the client and add the header for requests whose
+ * URL starts with `NEXT_PUBLIC_BACKEND_URL`. The backend resolves the active
+ * workspace from this header.
+ */
+
+import { getActiveOrgUuid } from "@/lib/orgs";
+
+let installed = false;
+
+export function installOrgFetchInterceptor(): void {
+  if (typeof window === "undefined") return;
+  if (installed) return;
+
+  const backendUrl = process.env.NEXT_PUBLIC_BACKEND_URL;
+  if (!backendUrl) return;
+
+  const originalFetch = window.fetch.bind(window);
+
+  window.fetch = async (
+    input: RequestInfo | URL,
+    init?: RequestInit,
+  ): Promise<Response> => {
+    let url: string;
+    if (typeof input === "string") {
+      url = input;
+    } else if (input instanceof URL) {
+      url = input.toString();
+    } else {
+      url = input.url;
+    }
+
+    if (!url.startsWith(backendUrl)) {
+      return originalFetch(input, init);
+    }
+
+    const activeOrgUuid = getActiveOrgUuid();
+    if (!activeOrgUuid) {
+      return originalFetch(input, init);
+    }
+
+    // Merge X-Org-UUID into existing headers without clobbering anything else.
+    // The header may already have been set by `getDefaultHeaders` — that's
+    // fine; we only set it when absent.
+    const headers = new Headers(init?.headers);
+    if (!headers.has("X-Org-UUID")) {
+      headers.set("X-Org-UUID", activeOrgUuid);
+    }
+
+    return originalFetch(input, { ...init, headers });
+  };
+
+  installed = true;
+}

--- a/src/lib/orgs.ts
+++ b/src/lib/orgs.ts
@@ -10,6 +10,18 @@
 
 export const ACTIVE_ORG_UUID_KEY = "activeOrgUuid";
 export const ACTIVE_ORG_CHANGED_EVENT = "calibrate:active-org-changed";
+/**
+ * Fired when the user's set of workspaces (or one workspace's fields, e.g.
+ * its name) changes locally. Any mounted `useOrganizations` instance
+ * refetches when it sees this so the sidebar switcher stays in sync with
+ * actions taken on the settings page, and vice versa.
+ */
+export const ORGANIZATIONS_CHANGED_EVENT = "calibrate:organizations-changed";
+
+export function notifyOrganizationsChanged(): void {
+  if (typeof window === "undefined") return;
+  window.dispatchEvent(new CustomEvent(ORGANIZATIONS_CHANGED_EVENT));
+}
 
 export type OrganizationRole = "owner" | "admin";
 

--- a/src/lib/orgs.ts
+++ b/src/lib/orgs.ts
@@ -18,9 +18,17 @@ export const ACTIVE_ORG_CHANGED_EVENT = "calibrate:active-org-changed";
  */
 export const ORGANIZATIONS_CHANGED_EVENT = "calibrate:organizations-changed";
 
-export function notifyOrganizationsChanged(): void {
+/**
+ * Notify every mounted useOrganizations hook that the workspace list has
+ * changed. Pass the originating hook instance's source token to let the
+ * dispatcher's own listener skip the refetch (the mutator already applied
+ * the change locally and updated the module cache).
+ */
+export function notifyOrganizationsChanged(source?: symbol): void {
   if (typeof window === "undefined") return;
-  window.dispatchEvent(new CustomEvent(ORGANIZATIONS_CHANGED_EVENT));
+  window.dispatchEvent(
+    new CustomEvent(ORGANIZATIONS_CHANGED_EVENT, { detail: { source } }),
+  );
 }
 
 export type OrganizationRole = "owner" | "admin";

--- a/src/lib/orgs.ts
+++ b/src/lib/orgs.ts
@@ -1,0 +1,76 @@
+/**
+ * Workspace / organization state.
+ *
+ * The frontend stores the active workspace uuid in localStorage and sends it
+ * back to the backend on every request as the `X-Org-UUID` header (attached
+ * automatically in `src/lib/api.ts`). The backend falls back to the user's
+ * personal workspace when the header is missing or unknown, so the worst case
+ * during boot is "user briefly sees personal workspace data".
+ */
+
+export const ACTIVE_ORG_UUID_KEY = "activeOrgUuid";
+export const ACTIVE_ORG_CHANGED_EVENT = "calibrate:active-org-changed";
+
+export type OrganizationRole = "owner" | "admin";
+
+export type Organization = {
+  uuid: string;
+  name: string;
+  is_personal: boolean;
+  created_by_user_id: string;
+  member_role: OrganizationRole;
+  created_at: string;
+  updated_at: string;
+};
+
+export type OrganizationMember = {
+  user_id: string;
+  email: string;
+  first_name: string;
+  last_name: string;
+  role: OrganizationRole;
+  has_logged_in: boolean;
+  created_at: string;
+};
+
+export function getActiveOrgUuid(): string | null {
+  if (typeof window === "undefined") return null;
+  try {
+    return window.localStorage.getItem(ACTIVE_ORG_UUID_KEY);
+  } catch {
+    return null;
+  }
+}
+
+export function setActiveOrgUuid(uuid: string): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(ACTIVE_ORG_UUID_KEY, uuid);
+    window.dispatchEvent(
+      new CustomEvent(ACTIVE_ORG_CHANGED_EVENT, { detail: { uuid } }),
+    );
+  } catch {
+    // ignore
+  }
+}
+
+export function clearActiveOrgUuid(): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.removeItem(ACTIVE_ORG_UUID_KEY);
+    window.dispatchEvent(
+      new CustomEvent(ACTIVE_ORG_CHANGED_EVENT, { detail: { uuid: null } }),
+    );
+  } catch {
+    // ignore
+  }
+}
+
+/**
+ * Pick the org whose uuid should become active when no choice has been made
+ * yet. Prefer the personal workspace; fall back to the first entry.
+ */
+export function pickDefaultOrg(orgs: Organization[]): Organization | null {
+  if (orgs.length === 0) return null;
+  return orgs.find((o) => o.is_personal) ?? orgs[0];
+}

--- a/src/lib/orgs.ts
+++ b/src/lib/orgs.ts
@@ -29,7 +29,6 @@ export type OrganizationMember = {
   first_name: string;
   last_name: string;
   role: OrganizationRole;
-  has_logged_in: boolean;
   created_at: string;
 };
 


### PR DESCRIPTION
Fixes #79 

## Summary

Wires the frontend up to the new multi-tenant backend (every request now carries `X-Org-UUID`) and adds the supporting UI to switch, create, rename, and manage workspaces.

- **Plumbing.** New `src/lib/orgs.ts` (types, localStorage helpers, change events), `src/lib/fetchInterceptor.ts` (patches `window.fetch` so legacy raw-fetch call sites also send `X-Org-UUID`), and `src/components/OrganizationBootstrapper.tsx` (mounted in the root layout — installs the interceptor and stashes a default workspace on first authenticated load).
- **Sidebar switcher.** Added in both expanded and collapsed sidebar modes; dropdown grows to fit the longest workspace name. Switching workspaces routes to `/agents` (or reloads in place when on `/workspace-settings`). The cross-mount `useOrganizations` hook is module-cached so navigating between Agents/Tools/etc. no longer flashes a loading state, and mutations live-sync across mounted hook instances via a custom event.
- **Workspace settings (`/workspace-settings`).** Rename the active workspace + manage members (list / invite by email / remove). Member rows show role-coloured pills (amber = owner, blue = admin); owner rows render no Remove button; the current user's own row reads "Leave" with leave-flavoured dialog copy. After a self-leave we refetch `/organizations`, pick a new active workspace, then route home.
- **Polish.** Errors run through the existing `parseBackendErrorMessage` so users see just `detail` text; inputs turn red on error and the error text sits 4px below the input using the canonical app style.

Sign-out now also clears `activeOrgUuid`.

## Test plan

- [ ] Boot the app fresh (no `activeOrgUuid` in localStorage) → `OrganizationBootstrapper` picks the personal workspace and stashes its uuid; all subsequent requests include `X-Org-UUID`.
- [ ] Open the sidebar switcher (expanded + collapsed) → dropdown lists every workspace, active row has the check mark, dropdown widens to fit the longest name.
- [ ] Switch workspaces from anywhere → lands on `/agents` under the new context. From `/workspace-settings` → stays on `/workspace-settings`.
- [ ] Create workspace → new entry appears in the switcher immediately (no reload), routes to `/agents`.
- [ ] `/workspace-settings`: rename → sidebar switcher updates without reload (live-sync).
- [ ] `/workspace-settings`: invite an email already in the workspace → red border on input, parsed error text ("user is already a member of this organization") sits 4px below.
- [ ] `/workspace-settings`: remove another member → confirm dialog uses "Remove member" copy; member disappears from list.
- [ ] `/workspace-settings`: click "Leave" on your own row → confirm dialog uses "Leave workspace" copy; after confirm you're on `/agents` and the sidebar switcher shows a new active workspace (the personal one if you still have one).
- [ ] Navigate Agents → Tools → Evaluators → Tests → workspace switcher doesn't flicker / refetch list.
- [ ] Sign out → `activeOrgUuid` is removed from localStorage along with `access_token` and `user`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)