### PR TITLE
Item detail modal: annotator filter, evaluator-card polish

### DIFF
--- a/src/components/EvaluatorVerdictCard.tsx
+++ b/src/components/EvaluatorVerdictCard.tsx
@@ -116,16 +116,23 @@ export function EvaluatorVerdictCard(props: EvaluatorVerdictCardProps) {
     typeof props.variableValues === "object" &&
     Object.keys(props.variableValues).length > 0;
 
-  // Read mode now exposes variables and reasoning behind separate
-  // toggles so each surface can be expanded independently. Write mode
-  // still shows everything inline so annotators can see variables and
-  // write reasoning in one pass — no toggle.
+  // Read mode shows at most one toggle. When reasoning is present the
+  // toggle is labelled "See reasoning" and expanding it also reveals any
+  // variables. When reasoning is absent but variables are present the
+  // toggle is labelled "See variables". Write mode shows everything
+  // inline so annotators can see variables and write reasoning in one
+  // pass — no toggle.
   const hasReasoning = props.mode === "read" && !!props.reasoning?.trim();
-  const showVariablesToggle = props.mode === "read" && hasVariables;
-  const showReasoningToggle = props.mode === "read" && hasReasoning;
+  const toggleKind: "reasoning" | "variables" | null =
+    props.mode === "read"
+      ? hasReasoning
+        ? "reasoning"
+        : hasVariables
+          ? "variables"
+          : null
+      : null;
 
-  const [variablesOpen, setVariablesOpen] = useState(false);
-  const [reasoningOpen, setReasoningOpen] = useState(false);
+  const [open, setOpen] = useState(false);
 
   const surface = evaluatorCardSurfaceClass(tone);
 
@@ -160,17 +167,11 @@ export function EvaluatorVerdictCard(props: EvaluatorVerdictCardProps) {
                 scaleMax={props.scaleMax}
               />
             )}
-            {showVariablesToggle && (
+            {toggleKind && (
               <ReasoningToggleButton
-                kind="variables"
-                open={variablesOpen}
-                onToggle={() => setVariablesOpen((o) => !o)}
-              />
-            )}
-            {showReasoningToggle && (
-              <ReasoningToggleButton
-                open={reasoningOpen}
-                onToggle={() => setReasoningOpen((o) => !o)}
+                kind={toggleKind}
+                open={open}
+                onToggle={() => setOpen((o) => !o)}
               />
             )}
           </div>
@@ -203,30 +204,23 @@ export function EvaluatorVerdictCard(props: EvaluatorVerdictCardProps) {
         </>
       )}
 
-      {props.mode === "read" && variablesOpen && hasVariables && (
+      {props.mode === "read" && open && toggleKind && (
         <div
           data-reasoning-body
           className="pt-2 border-t border-border/60 space-y-3"
         >
-          <VariableValuesBlock values={props.variableValues!} />
-        </div>
-      )}
-
-      {props.mode === "read" &&
-        reasoningOpen &&
-        showReasoningToggle &&
-        props.reasoning?.trim() && (
-          <div
-            data-reasoning-body
-            className="pt-2 border-t border-border/60 space-y-3"
-          >
+          {hasVariables && (
+            <VariableValuesBlock values={props.variableValues!} />
+          )}
+          {hasReasoning && props.reasoning?.trim() && (
             <ReasoningExpandedContent
               text={props.reasoning}
               showReasoningLabel
               mutedBody={false}
             />
-          </div>
-        )}
+          )}
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/EvaluatorVerdictCard.tsx
+++ b/src/components/EvaluatorVerdictCard.tsx
@@ -490,7 +490,6 @@ export function ReasoningToggleButton({
   );
 }
 
-
 /** Read-only reasoning body — shared with the tool-call collapsible
  * strip in shared.tsx so all reasoning content uses the same typography. */
 export function ReasoningExpandedContent({

--- a/src/components/EvaluatorVerdictCard.tsx
+++ b/src/components/EvaluatorVerdictCard.tsx
@@ -116,36 +116,21 @@ export function EvaluatorVerdictCard(props: EvaluatorVerdictCardProps) {
     typeof props.variableValues === "object" &&
     Object.keys(props.variableValues).length > 0;
 
-  // Read mode collapses both variables and reasoning behind one toggle
-  // (matches the LLM test output cards). Write mode shows everything
-  // inline so annotators can see variables and write reasoning in one
-  // pass — no toggle.
+  // Read mode now exposes variables and reasoning behind separate
+  // toggles so each surface can be expanded independently. Write mode
+  // still shows everything inline so annotators can see variables and
+  // write reasoning in one pass — no toggle.
   const hasReasoning = props.mode === "read" && !!props.reasoning?.trim();
-  const hasCollapsibleBody =
-    props.mode === "read" && (hasVariables || hasReasoning);
+  const showVariablesToggle = props.mode === "read" && hasVariables;
+  const showReasoningToggle = props.mode === "read" && hasReasoning;
 
-  const [open, setOpen] = useState(false);
-
-  const onSurfaceClick = (e: React.MouseEvent) => {
-    if (props.mode !== "read" || !hasCollapsibleBody) return;
-    const el = e.target as HTMLElement;
-    if (el.closest("button") || el.closest("a[href]")) return;
-    if (el.closest("[data-reasoning-body]")) return;
-    if (el.closest("[data-evaluator-verdict-chips]")) return;
-    setOpen((o) => !o);
-  };
+  const [variablesOpen, setVariablesOpen] = useState(false);
+  const [reasoningOpen, setReasoningOpen] = useState(false);
 
   const surface = evaluatorCardSurfaceClass(tone);
-  const isReadCollapsibleClickable =
-    props.mode === "read" && hasCollapsibleBody;
 
   return (
-    <div
-      onClick={isReadCollapsibleClickable ? onSurfaceClick : undefined}
-      className={`${surface} p-3 space-y-3${
-        isReadCollapsibleClickable ? " cursor-pointer" : ""
-      }`}
-    >
+    <div className={`${surface} p-3 space-y-3`}>
       {/* Header: name + verdict pill + toggle on one row; description
           on its own row below so it can use the full card width. */}
       <div className="space-y-1">
@@ -175,10 +160,17 @@ export function EvaluatorVerdictCard(props: EvaluatorVerdictCardProps) {
                 scaleMax={props.scaleMax}
               />
             )}
-            {hasCollapsibleBody && (
+            {showVariablesToggle && (
               <ReasoningToggleButton
-                open={open}
-                onToggle={() => setOpen((o) => !o)}
+                kind="variables"
+                open={variablesOpen}
+                onToggle={() => setVariablesOpen((o) => !o)}
+              />
+            )}
+            {showReasoningToggle && (
+              <ReasoningToggleButton
+                open={reasoningOpen}
+                onToggle={() => setReasoningOpen((o) => !o)}
               />
             )}
           </div>
@@ -211,23 +203,30 @@ export function EvaluatorVerdictCard(props: EvaluatorVerdictCardProps) {
         </>
       )}
 
-      {props.mode === "read" && open && hasCollapsibleBody && (
+      {props.mode === "read" && variablesOpen && hasVariables && (
         <div
           data-reasoning-body
           className="pt-2 border-t border-border/60 space-y-3"
         >
-          {hasVariables && (
-            <VariableValuesBlock values={props.variableValues!} />
-          )}
-          {props.reasoning?.trim() && (
+          <VariableValuesBlock values={props.variableValues!} />
+        </div>
+      )}
+
+      {props.mode === "read" &&
+        reasoningOpen &&
+        showReasoningToggle &&
+        props.reasoning?.trim() && (
+          <div
+            data-reasoning-body
+            className="pt-2 border-t border-border/60 space-y-3"
+          >
             <ReasoningExpandedContent
               text={props.reasoning}
               showReasoningLabel
               mutedBody={false}
             />
-          )}
-        </div>
-      )}
+          </div>
+        )}
     </div>
   );
 }
@@ -456,11 +455,27 @@ function WriteReasoning({
 export function ReasoningToggleButton({
   open,
   onToggle,
+  kind = "reasoning",
 }: {
   open: boolean;
   onToggle: () => void;
+  kind?: "reasoning" | "variables";
 }) {
-  const label = open ? "Hide reasoning" : "See reasoning";
+  const labels =
+    kind === "variables"
+      ? { open: "Hide variables", closed: "See variables" }
+      : { open: "Hide reasoning", closed: "See reasoning" };
+  const label = open ? labels.open : labels.closed;
+  // Variables toggle uses a violet palette so it reads as a distinct
+  // surface from the reasoning toggle when both appear on the same card.
+  const toneClass =
+    kind === "variables"
+      ? open
+        ? "border-violet-500/50 bg-violet-500/16 text-violet-950 dark:border-violet-500/45 dark:bg-violet-500/18 dark:text-violet-100 hover:bg-violet-500/26 dark:hover:bg-violet-500/28"
+        : "border-indigo-500/50 bg-indigo-500/14 text-indigo-950 dark:border-indigo-500/45 dark:bg-indigo-500/16 dark:text-indigo-100 hover:bg-indigo-500/24 dark:hover:bg-indigo-500/22"
+      : open
+        ? "border-fuchsia-500/50 bg-fuchsia-500/16 text-fuchsia-950 dark:border-fuchsia-500/45 dark:bg-fuchsia-500/18 dark:text-fuchsia-100 hover:bg-fuchsia-500/26 dark:hover:bg-fuchsia-500/28"
+        : "border-cyan-500/50 bg-cyan-500/14 text-cyan-950 dark:border-cyan-500/45 dark:bg-cyan-500/16 dark:text-cyan-100 hover:bg-cyan-500/24 dark:hover:bg-cyan-500/22";
   return (
     <button
       type="button"
@@ -469,11 +484,7 @@ export function ReasoningToggleButton({
         onToggle();
       }}
       aria-expanded={open}
-      className={`inline-flex items-center gap-1.5 max-w-[min(100%,14rem)] rounded-md border px-2 py-1 text-[11px] font-medium transition-colors cursor-pointer shrink-0 ${
-        open
-          ? "border-fuchsia-500/50 bg-fuchsia-500/16 text-fuchsia-950 dark:border-fuchsia-500/45 dark:bg-fuchsia-500/18 dark:text-fuchsia-100 hover:bg-fuchsia-500/26 dark:hover:bg-fuchsia-500/28"
-          : "border-cyan-500/50 bg-cyan-500/14 text-cyan-950 dark:border-cyan-500/45 dark:bg-cyan-500/16 dark:text-cyan-100 hover:bg-cyan-500/24 dark:hover:bg-cyan-500/22"
-      }`}
+      className={`inline-flex items-center gap-1.5 max-w-[min(100%,14rem)] rounded-md border px-2 py-1 text-[11px] font-medium transition-colors cursor-pointer shrink-0 ${toneClass}`}
     >
       <span className="truncate">{label}</span>
       <ChevronDownIcon
@@ -484,6 +495,7 @@ export function ReasoningToggleButton({
     </button>
   );
 }
+
 
 /** Read-only reasoning body — shared with the tool-call collapsible
  * strip in shared.tsx so all reasoning content uses the same typography. */

--- a/src/components/human-labelling/EvaluatorRunDetailView.tsx
+++ b/src/components/human-labelling/EvaluatorRunDetailView.tsx
@@ -8,7 +8,7 @@
  * data-agnostic — caller fetches the job & task and passes them in.
  */
 
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useMemo, useState } from "react";
 import Link from "next/link";
 import { EvaluatorVerdictCard } from "@/components/EvaluatorVerdictCard";
 import {
@@ -1016,12 +1016,13 @@ function GroupedEvaluatorCard({
       ? `a:${annotations[0].annotator_id}`
       : `v:${versions[0]?.ev.evaluator_version_id ?? ""}`;
 
-  const [selection, setSelection] = useState<string>(defaultSelection);
+  const [storedSelection, setSelection] = useState<string>(defaultSelection);
 
   // When the available versions or annotations change (e.g. the parent
-  // toggles "Live versions only" and the previously-selected version
-  // disappears from the list), the stored selection token can dangle and
-  // the card renders blank. Reconcile by snapping back to the default.
+  // toggles "Live versions only" or filters annotators, removing the
+  // previously-selected pill), the stored token can dangle and the card
+  // renders blank. Resolve to the default at render time instead — no
+  // effect needed.
   const availableTokens = useMemo(() => {
     const tokens = new Set<string>();
     for (const x of versions) {
@@ -1031,10 +1032,10 @@ function GroupedEvaluatorCard({
     return tokens;
   }, [versions, annotations]);
 
-  useEffect(() => {
-    if (availableTokens.size === 0) return;
-    if (!availableTokens.has(selection)) setSelection(defaultSelection);
-  }, [availableTokens, selection, defaultSelection]);
+  const selection =
+    availableTokens.size === 0 || availableTokens.has(storedSelection)
+      ? storedSelection
+      : defaultSelection;
 
   const selectedVersion = selection.startsWith("v:")
     ? versions.find(

--- a/src/components/human-labelling/EvaluatorRunDetailView.tsx
+++ b/src/components/human-labelling/EvaluatorRunDetailView.tsx
@@ -1075,8 +1075,19 @@ function GroupedEvaluatorCard({
     outputType,
   );
 
+  // If no evaluator version produced a value (e.g. the parent suppressed
+  // evaluator results via the annotator filter) and there is exactly one
+  // annotation, a solitary annotator pill offers nothing to switch to —
+  // hide the pills row entirely.
+  const hasAnyVersionPill = versions.some((x) => x.hasValue);
+  const showAnnotatorPills = hasAnyVersionPill || annotations.length > 1;
+  const pillCount =
+    versions.filter((x) => x.hasValue).length +
+    (showAnnotatorPills ? annotations.length : 0);
+
   return (
     <div className="space-y-2">
+      {pillCount > 0 && (
       <div className="flex flex-wrap items-center gap-1.5">
         {versions.map((x) => {
           if (!x.hasValue) return null;
@@ -1091,7 +1102,7 @@ function GroupedEvaluatorCard({
             />
           );
         })}
-        {annotations.map((a) => {
+        {showAnnotatorPills && annotations.map((a) => {
           const token = `a:${a.annotator_id}`;
           return (
             <SourcePill
@@ -1103,6 +1114,7 @@ function GroupedEvaluatorCard({
           );
         })}
       </div>
+      )}
       <EvaluatorVerdictCard
         mode="read"
         name={evaluatorName}

--- a/src/components/human-labelling/EvaluatorRunDetailView.tsx
+++ b/src/components/human-labelling/EvaluatorRunDetailView.tsx
@@ -8,7 +8,7 @@
  * data-agnostic — caller fetches the job & task and passes them in.
  */
 
-import React, { useMemo, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import { EvaluatorVerdictCard } from "@/components/EvaluatorVerdictCard";
 import {
@@ -1017,6 +1017,24 @@ function GroupedEvaluatorCard({
       : `v:${versions[0]?.ev.evaluator_version_id ?? ""}`;
 
   const [selection, setSelection] = useState<string>(defaultSelection);
+
+  // When the available versions or annotations change (e.g. the parent
+  // toggles "Live versions only" and the previously-selected version
+  // disappears from the list), the stored selection token can dangle and
+  // the card renders blank. Reconcile by snapping back to the default.
+  const availableTokens = useMemo(() => {
+    const tokens = new Set<string>();
+    for (const x of versions) {
+      if (x.hasValue) tokens.add(`v:${x.ev.evaluator_version_id ?? ""}`);
+    }
+    for (const a of annotations) tokens.add(`a:${a.annotator_id}`);
+    return tokens;
+  }, [versions, annotations]);
+
+  useEffect(() => {
+    if (availableTokens.size === 0) return;
+    if (!availableTokens.has(selection)) setSelection(defaultSelection);
+  }, [availableTokens, selection, defaultSelection]);
 
   const selectedVersion = selection.startsWith("v:")
     ? versions.find(

--- a/src/components/human-labelling/EvaluatorRunDetailView.tsx
+++ b/src/components/human-labelling/EvaluatorRunDetailView.tsx
@@ -614,6 +614,7 @@ export function EvaluatorResultsPane({
   alwaysShowSourcePills = false,
   showVersionInSourcePill = false,
   groupVersionsByEvaluator = false,
+  annotatorFilterActive = false,
 }: {
   evaluators: {
     evaluator_id: string;
@@ -638,6 +639,9 @@ export function EvaluatorResultsPane({
   showVersionInSourcePill?: boolean;
   /** Render all versions of the same evaluator side-by-side in one row. */
   groupVersionsByEvaluator?: boolean;
+  /** Parent has narrowed annotations to a subset — lets grouped cards
+   *  hide a solitary annotator pill when only one annotation remains. */
+  annotatorFilterActive?: boolean;
 }) {
   const [selectionByEvaluator, setSelectionByEvaluator] = useState<
     Record<string, string>
@@ -930,6 +934,7 @@ export function EvaluatorResultsPane({
             evaluatorVariablesByEvaluatorId={evaluatorVariablesByEvaluatorId}
             jobStatus={jobStatus}
             linkEvaluators={linkEvaluators}
+            annotatorFilterActive={annotatorFilterActive}
           />
         ))}
       </div>
@@ -960,6 +965,7 @@ function GroupedEvaluatorCard({
   evaluatorVariablesByEvaluatorId,
   jobStatus,
   linkEvaluators,
+  annotatorFilterActive = false,
 }: {
   evaluators: {
     evaluator_id: string;
@@ -973,6 +979,10 @@ function GroupedEvaluatorCard({
   evaluatorVariablesByEvaluatorId: Record<string, Record<string, string>>;
   jobStatus: EvaluatorRunJob["status"];
   linkEvaluators: boolean;
+  /** When true, callers have filtered annotations to a subset; the card
+   * may then hide a solitary annotator pill since the user has already
+   * committed to that annotator at the parent level. */
+  annotatorFilterActive?: boolean;
 }) {
   const evaluatorId = evaluators[0]?.evaluator_id ?? "";
 
@@ -1075,14 +1085,15 @@ function GroupedEvaluatorCard({
     outputType,
   );
 
-  // If no evaluator version produced a value (e.g. the parent suppressed
-  // evaluator results via the annotator filter) and there is exactly one
-  // annotation, a solitary annotator pill offers nothing to switch to —
-  // hide the pills row entirely.
+  // Hide a solitary annotator pill only when the parent has narrowed
+  // annotations via a filter — there's nothing to switch between and
+  // the user already knows who they picked. Outside of that case the
+  // pill still surfaces the annotator's name.
   const hasAnyVersionPill = versions.some((x) => x.hasValue);
-  const showAnnotatorPills = hasAnyVersionPill || annotations.length > 1;
+  const showAnnotatorPills =
+    !(annotatorFilterActive && annotations.length === 1);
   const pillCount =
-    versions.filter((x) => x.hasValue).length +
+    (hasAnyVersionPill ? versions.filter((x) => x.hasValue).length : 0) +
     (showAnnotatorPills ? annotations.length : 0);
 
   return (
@@ -1158,6 +1169,7 @@ export function ItemDetailPane({
   alwaysShowSourcePills = false,
   showVersionInSourcePill = false,
   groupVersionsByEvaluator = false,
+  annotatorFilterActive = false,
 }: {
   item: Item;
   taskType: LabellingTaskFull["type"];
@@ -1178,6 +1190,7 @@ export function ItemDetailPane({
   alwaysShowSourcePills?: boolean;
   showVersionInSourcePill?: boolean;
   groupVersionsByEvaluator?: boolean;
+  annotatorFilterActive?: boolean;
 }) {
   const itemPayload =
     item.payload && typeof item.payload === "object"
@@ -1209,6 +1222,7 @@ export function ItemDetailPane({
           alwaysShowSourcePills={alwaysShowSourcePills}
           showVersionInSourcePill={showVersionInSourcePill}
           groupVersionsByEvaluator={groupVersionsByEvaluator}
+          annotatorFilterActive={annotatorFilterActive}
         />
       </div>
     </div>

--- a/src/components/human-labelling/ItemDetailDialog.tsx
+++ b/src/components/human-labelling/ItemDetailDialog.tsx
@@ -402,7 +402,7 @@ export function ItemDetailDialog({
                 type="button"
                 onClick={() => setLiveOnly((v) => !v)}
                 aria-pressed={liveOnly}
-                className={`h-8 px-3 inline-flex items-center gap-1.5 rounded-md text-xs font-medium border transition-colors cursor-pointer ${
+                className={`h-11 px-4 inline-flex items-center gap-1.5 rounded-xl text-sm font-medium border transition-colors cursor-pointer ${
                   liveOnly
                     ? "bg-foreground text-background border-foreground"
                     : "bg-transparent text-muted-foreground border-border hover:border-muted-foreground hover:text-foreground"

--- a/src/components/human-labelling/ItemDetailDialog.tsx
+++ b/src/components/human-labelling/ItemDetailDialog.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { apiClient } from "@/lib/api";
 import { Tooltip } from "@/components/Tooltip";
+import { MultiSelectPicker, type PickerItem } from "@/components/MultiSelectPicker";
 import { type Item } from "@/components/human-labelling/AnnotationJobView";
 import {
   ItemDetailPane,
@@ -80,6 +81,11 @@ export function ItemDetailDialog({
   // Restricts the per-evaluator version pills to each evaluator's live
   // version. Default on (matches the previous overview filter default).
   const [liveOnly, setLiveOnly] = useState(true);
+  // Annotator filter: when non-empty, the per-evaluator pills + selection
+  // restrict to these annotators. Empty array = show all annotators.
+  const [selectedAnnotators, setSelectedAnnotators] = useState<PickerItem[]>(
+    [],
+  );
 
   const taskUuid = task?.uuid;
   const itemUuid = item?.uuid;
@@ -109,7 +115,10 @@ export function ItemDetailDialog({
 
   // Reset toggle when modal closes so it opens fresh next time.
   useEffect(() => {
-    if (!isOpen) setLiveOnly(true);
+    if (!isOpen) {
+      setLiveOnly(true);
+      setSelectedAnnotators([]);
+    }
   }, [isOpen]);
 
   // Drop stale summary when the modal switches to a different item so we
@@ -132,6 +141,37 @@ export function ItemDetailDialog({
     () => (item ? extractEvaluatorVariables(item.payload) : {}),
     [item],
   );
+
+  // Annotators who actually labelled this item across any evaluator/version.
+  // We only surface the filter when this list is non-empty.
+  const availableAnnotators = useMemo<PickerItem[]>(() => {
+    if (!summary) return [];
+    const seen = new Set<string>();
+    for (const row of summary.rows) {
+      for (const [annUuid, ann] of Object.entries(row.annotations ?? {})) {
+        if (ann && ann.value !== null && ann.value !== undefined) {
+          seen.add(annUuid);
+        }
+      }
+    }
+    return (summary.annotators ?? [])
+      .filter((a) => seen.has(a.uuid))
+      .map((a) => ({ uuid: a.uuid, name: a.name }));
+  }, [summary]);
+
+  // Drop selections that no longer correspond to an annotator with data
+  // (e.g. after the modal re-fetches with different filters) at render
+  // time so we don't have to round-trip through setState.
+  const effectiveSelectedAnnotators = useMemo<PickerItem[]>(() => {
+    if (selectedAnnotators.length === 0) return [];
+    const valid = new Set(availableAnnotators.map((a) => a.uuid));
+    return selectedAnnotators.filter((a) => valid.has(a.uuid));
+  }, [availableAnnotators, selectedAnnotators]);
+
+  const annotatorFilter = useMemo<Set<string> | null>(() => {
+    if (effectiveSelectedAnnotators.length === 0) return null;
+    return new Set(effectiveSelectedAnnotators.map((a) => a.uuid));
+  }, [effectiveSelectedAnnotators]);
 
   const hasAnyLabel = useMemo(() => {
     if (!summary) return false;
@@ -224,6 +264,7 @@ export function ItemDetailDialog({
       const human_annotations: HumanAnnotation[] = [];
       for (const [annUuid, ann] of Object.entries(row.annotations ?? {})) {
         if (!ann || ann.value === null || ann.value === undefined) continue;
+        if (annotatorFilter && !annotatorFilter.has(annUuid)) continue;
         human_annotations.push({
           annotation_id: `${row.evaluator_id}:${row.evaluator_version_id ?? ""}:${annUuid}`,
           annotator_id: annUuid,
@@ -257,7 +298,7 @@ export function ItemDetailDialog({
       versionLabels,
       humanAgreementForItem,
     };
-  }, [summary, task, item]);
+  }, [summary, task, item, annotatorFilter]);
 
   if (!isOpen) return null;
 
@@ -316,6 +357,17 @@ export function ItemDetailDialog({
                   d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
                 />
               </svg>
+            )}
+            {availableAnnotators.length > 0 && (
+              <div className="w-56">
+                <MultiSelectPicker
+                  items={availableAnnotators}
+                  selectedItems={effectiveSelectedAnnotators}
+                  onSelectionChange={setSelectedAnnotators}
+                  placeholder="All annotators"
+                  searchPlaceholder="Search annotators"
+                />
+              </div>
             )}
             <Tooltip
               position="bottom"

--- a/src/components/human-labelling/ItemDetailDialog.tsx
+++ b/src/components/human-labelling/ItemDetailDialog.tsx
@@ -28,16 +28,21 @@ type SummaryRow = {
   evaluator_version_number?: number | null;
   evaluator_value: boolean | number | null;
   evaluator_reasoning?: string | null;
-  // Total runs for this (item, evaluator) across every version. Unaffected
-  // by the `live_only` query param, so we can trust it even when the
-  // visible rows only cover the live version.
-  evaluator_run_count?: number;
   human_agreement: number | null;
   evaluator_agreement: number | null;
   annotations: Record<string, SummaryAnnotation | null>;
 };
+type SummaryEvaluator = {
+  evaluator_id: string;
+  name?: string;
+  output_type?: "binary" | "rating";
+  // Total runs for this evaluator across every version, restricted to the
+  // items in scope. Unaffected by `live_only`.
+  run_count?: number;
+};
 type TaskSummaryResponse = {
   annotators: SummaryAnnotator[];
+  evaluators?: SummaryEvaluator[];
   rows: SummaryRow[];
 };
 
@@ -174,11 +179,11 @@ export function ItemDetailDialog({
 
   // Hide the live-versions toggle when no evaluator has ever been run
   // against this item — across every version, not just the live one.
-  // Backend's `evaluator_run_count` is unaffected by the `live_only`
+  // Backend's per-evaluator `run_count` is unaffected by the `live_only`
   // query param, so this works even while the toggle is on.
   const hasAnyEvaluatorRun = useMemo(() => {
     if (!summary) return false;
-    return summary.rows.some((r) => (r.evaluator_run_count ?? 0) > 0);
+    return (summary.evaluators ?? []).some((e) => (e.run_count ?? 0) > 0);
   }, [summary]);
 
   const annotatorFilter = useMemo<Set<string> | null>(() => {

--- a/src/components/human-labelling/ItemDetailDialog.tsx
+++ b/src/components/human-labelling/ItemDetailDialog.tsx
@@ -493,6 +493,7 @@ export function ItemDetailDialog({
               alwaysShowSourcePills
               showVersionInSourcePill
               groupVersionsByEvaluator
+              annotatorFilterActive={annotatorFilter !== null}
             />
           )}
         </div>

--- a/src/components/human-labelling/ItemDetailDialog.tsx
+++ b/src/components/human-labelling/ItemDetailDialog.tsx
@@ -334,24 +334,6 @@ export function ItemDetailDialog({
             <h2 className="text-base md:text-lg font-semibold text-foreground truncate">
               {itemTitle(item)}
             </h2>
-            {!loading && !error && summary && !hasAnyLabel && (
-              <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-md text-xs font-medium border border-amber-500/40 bg-amber-500/10 text-amber-700 dark:text-amber-400">
-                <svg
-                  className="w-3.5 h-3.5"
-                  fill="none"
-                  viewBox="0 0 24 24"
-                  stroke="currentColor"
-                  strokeWidth={2}
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126zM12 15.75h.007v.008H12v-.008z"
-                  />
-                </svg>
-                No labels yet
-              </span>
-            )}
           </div>
           <div className="flex items-center gap-2 shrink-0">
             {loading && summary && (
@@ -375,6 +357,24 @@ export function ItemDetailDialog({
                   d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
                 />
               </svg>
+            )}
+            {!loading && !error && summary && !hasAnyLabel && (
+              <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-md text-xs font-medium border border-amber-500/40 bg-amber-500/10 text-amber-700 dark:text-amber-400">
+                <svg
+                  className="w-3.5 h-3.5"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                  strokeWidth={2}
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126zM12 15.75h.007v.008H12v-.008z"
+                  />
+                </svg>
+                No labels yet
+              </span>
             )}
             {availableAnnotators.length > 0 && (
               <div className="w-56">

--- a/src/components/human-labelling/ItemDetailDialog.tsx
+++ b/src/components/human-labelling/ItemDetailDialog.tsx
@@ -168,8 +168,12 @@ export function ItemDetailDialog({
     return selectedAnnotators.filter((a) => valid.has(a.uuid));
   }, [availableAnnotators, selectedAnnotators]);
 
-  // Only show the live-versions toggle when at least one evaluator has
-  // produced a result on this item — otherwise there's nothing to filter.
+  // Drives toggle visibility together with the toggle's own state — see
+  // the render site for the full condition. We hide the toggle only when
+  // it is OFF and there are no results, because when it is ON the loaded
+  // summary reflects only live-version data and may be empty even though
+  // the item has results on non-live versions; hiding it in that case
+  // would strand the user with no way to flip it off.
   const hasAnyEvaluatorResult = useMemo(() => {
     if (!summary) return false;
     return summary.rows.some((r) => r.evaluator_value !== null);
@@ -387,7 +391,7 @@ export function ItemDetailDialog({
                 />
               </div>
             )}
-            {hasAnyEvaluatorResult && (
+            {(liveOnly || hasAnyEvaluatorResult) && (
             <Tooltip
               position="bottom"
               content="Show results for only the live versions of each evaluator. Toggle to see the results for all versions."

--- a/src/components/human-labelling/ItemDetailDialog.tsx
+++ b/src/components/human-labelling/ItemDetailDialog.tsx
@@ -212,6 +212,26 @@ export function ItemDetailDialog({
     const haEvaluators: HumanAgreementItem["evaluators"] = [];
 
     for (const row of summary.rows) {
+      const human_annotations: HumanAnnotation[] = [];
+      for (const [annUuid, ann] of Object.entries(row.annotations ?? {})) {
+        if (!ann || ann.value === null || ann.value === undefined) continue;
+        if (annotatorFilter && !annotatorFilter.has(annUuid)) continue;
+        human_annotations.push({
+          annotation_id: `${row.evaluator_id}:${row.evaluator_version_id ?? ""}:${annUuid}`,
+          annotator_id: annUuid,
+          annotator_name: annotatorNameById.get(annUuid) ?? null,
+          job_id: "",
+          value: { value: ann.value, reasoning: ann.reasoning ?? null },
+          reasoning: ann.reasoning ?? null,
+          updated_at: "",
+        });
+      }
+
+      // When the annotator filter is active, suppress evaluator-produced
+      // values entirely (no version pill, no verdict card content) and
+      // drop rows that have no matching annotations.
+      if (annotatorFilter && human_annotations.length === 0) continue;
+
       const evKey = `${row.evaluator_id}-${row.evaluator_version_id ?? ""}`;
       if (!seenEvKey.has(evKey)) {
         seenEvKey.add(evKey);
@@ -238,6 +258,12 @@ export function ItemDetailDialog({
       const scaleMax =
         typeof taskEv?.scale_max === "number" ? taskEv.scale_max : null;
 
+      const suppressEvaluator = annotatorFilter !== null;
+      const effectiveValue = suppressEvaluator ? null : row.evaluator_value;
+      const effectiveReasoning = suppressEvaluator
+        ? null
+        : row.evaluator_reasoning;
+
       runs.push({
         uuid: `${row.item_id}:${row.evaluator_id}:${row.evaluator_version_id ?? ""}`,
         job_id: "",
@@ -245,13 +271,13 @@ export function ItemDetailDialog({
         evaluator_id: row.evaluator_id,
         evaluator_version_id: row.evaluator_version_id ?? "",
         value:
-          row.evaluator_value === null && !row.evaluator_reasoning
+          effectiveValue === null && !effectiveReasoning
             ? null
             : {
-                value: row.evaluator_value,
-                reasoning: row.evaluator_reasoning ?? null,
+                value: effectiveValue,
+                reasoning: effectiveReasoning ?? null,
               },
-        status: row.evaluator_value !== null ? "completed" : "pending",
+        status: effectiveValue !== null ? "completed" : "pending",
         created_at: "",
         completed_at: null,
         evaluator_version: {
@@ -267,21 +293,6 @@ export function ItemDetailDialog({
           output_type: row.output_type,
         },
       });
-
-      const human_annotations: HumanAnnotation[] = [];
-      for (const [annUuid, ann] of Object.entries(row.annotations ?? {})) {
-        if (!ann || ann.value === null || ann.value === undefined) continue;
-        if (annotatorFilter && !annotatorFilter.has(annUuid)) continue;
-        human_annotations.push({
-          annotation_id: `${row.evaluator_id}:${row.evaluator_version_id ?? ""}:${annUuid}`,
-          annotator_id: annUuid,
-          annotator_name: annotatorNameById.get(annUuid) ?? null,
-          job_id: "",
-          value: { value: ann.value, reasoning: ann.reasoning ?? null },
-          reasoning: ann.reasoning ?? null,
-          updated_at: "",
-        });
-      }
       haEvaluators.push({
         evaluator_id: row.evaluator_id,
         agreement: row.evaluator_agreement,

--- a/src/components/human-labelling/ItemDetailDialog.tsx
+++ b/src/components/human-labelling/ItemDetailDialog.tsx
@@ -168,6 +168,13 @@ export function ItemDetailDialog({
     return selectedAnnotators.filter((a) => valid.has(a.uuid));
   }, [availableAnnotators, selectedAnnotators]);
 
+  // Only show the live-versions toggle when at least one evaluator has
+  // produced a result on this item — otherwise there's nothing to filter.
+  const hasAnyEvaluatorResult = useMemo(() => {
+    if (!summary) return false;
+    return summary.rows.some((r) => r.evaluator_value !== null);
+  }, [summary]);
+
   const annotatorFilter = useMemo<Set<string> | null>(() => {
     if (effectiveSelectedAnnotators.length === 0) return null;
     return new Set(effectiveSelectedAnnotators.map((a) => a.uuid));
@@ -369,6 +376,7 @@ export function ItemDetailDialog({
                 />
               </div>
             )}
+            {hasAnyEvaluatorResult && (
             <Tooltip
               position="bottom"
               content="Show results for only the live versions of each evaluator. Toggle to see the results for all versions."
@@ -406,6 +414,7 @@ export function ItemDetailDialog({
                 Live versions only
               </button>
             </Tooltip>
+            )}
           <button
             onClick={onClose}
             aria-label="Close"

--- a/src/components/human-labelling/ItemDetailDialog.tsx
+++ b/src/components/human-labelling/ItemDetailDialog.tsx
@@ -28,6 +28,10 @@ type SummaryRow = {
   evaluator_version_number?: number | null;
   evaluator_value: boolean | number | null;
   evaluator_reasoning?: string | null;
+  // Total runs for this (item, evaluator) across every version. Unaffected
+  // by the `live_only` query param, so we can trust it even when the
+  // visible rows only cover the live version.
+  evaluator_run_count?: number;
   human_agreement: number | null;
   evaluator_agreement: number | null;
   annotations: Record<string, SummaryAnnotation | null>;
@@ -168,15 +172,13 @@ export function ItemDetailDialog({
     return selectedAnnotators.filter((a) => valid.has(a.uuid));
   }, [availableAnnotators, selectedAnnotators]);
 
-  // Drives toggle visibility together with the toggle's own state — see
-  // the render site for the full condition. We hide the toggle only when
-  // it is OFF and there are no results, because when it is ON the loaded
-  // summary reflects only live-version data and may be empty even though
-  // the item has results on non-live versions; hiding it in that case
-  // would strand the user with no way to flip it off.
-  const hasAnyEvaluatorResult = useMemo(() => {
+  // Hide the live-versions toggle when no evaluator has ever been run
+  // against this item — across every version, not just the live one.
+  // Backend's `evaluator_run_count` is unaffected by the `live_only`
+  // query param, so this works even while the toggle is on.
+  const hasAnyEvaluatorRun = useMemo(() => {
     if (!summary) return false;
-    return summary.rows.some((r) => r.evaluator_value !== null);
+    return summary.rows.some((r) => (r.evaluator_run_count ?? 0) > 0);
   }, [summary]);
 
   const annotatorFilter = useMemo<Set<string> | null>(() => {
@@ -391,7 +393,7 @@ export function ItemDetailDialog({
                 />
               </div>
             )}
-            {(liveOnly || hasAnyEvaluatorResult) && (
+            {hasAnyEvaluatorRun && (
             <Tooltip
               position="bottom"
               content="Show results for only the live versions of each evaluator. Toggle to see the results for all versions."


### PR DESCRIPTION
Fix #132 

## Summary
- Fix stale-selection bug in the labelling-task item modal: toggling "Live versions only" no longer leaves the verdict card blank when the previously-selected version drops out of the list (resolves selection at render time instead of via effect).
- Add a multi-select annotator filter beside "Live versions only" (reuses `MultiSelectPicker`). Hidden when the item has no human labels. When active, evaluator-produced values are suppressed and cards with no matching annotations are dropped.
- Hide "Live versions only" when the item has no evaluator results at all.
- Drop the lone annotator pill when an evaluator card has no version pills and exactly one annotation (typical when the filter narrows to a single annotator).
- Move the "No labels yet" pill from beside the title to the right-side header cluster.
- EvaluatorVerdictCard: single toggle per card — "See reasoning" when reasoning exists (also reveals variables), "See variables" when only variables exist.

## Test plan
- [ ] Open an item with multiple evaluator versions, toggle "Live versions only" — card stays populated, no blank state.
- [ ] Item with annotations from multiple annotators: filter dropdown appears, selecting one or more restricts every card's pills + verdict to those annotators, evaluator values hidden.
- [ ] Item with no annotators in any row: dropdown is hidden.
- [ ] Item with no evaluator results: "Live versions only" toggle is hidden.
- [ ] Single-annotator filter selection: the solitary annotator pill is hidden, verdict card still shows the annotation.
- [ ] Evaluator card with reasoning only → "See reasoning" toggle; with variables only → "See variables"; with both → "See reasoning" reveals both; with neither → no toggle.
- [ ] "No labels yet" pill renders in the right header cluster when applicable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)