### PR TITLE
Item detail nav, bulk-select dialogs, job-link shortcuts, annotator rename

### DIFF
--- a/src/app/human-alignment/annotators/[uuid]/page.tsx
+++ b/src/app/human-alignment/annotators/[uuid]/page.tsx
@@ -176,6 +176,47 @@ function AnnotatorDetailPageInner() {
     fetchDetail();
   }, [fetchDetail]);
 
+  const [isEditingName, setIsEditingName] = useState(false);
+  const [editingName, setEditingName] = useState("");
+  const [savingName, setSavingName] = useState(false);
+  const [editError, setEditError] = useState<string | null>(null);
+
+  const startEditName = () => {
+    if (!annotator) return;
+    setEditingName(annotator.name);
+    setEditError(null);
+    setIsEditingName(true);
+  };
+  const cancelEditName = () => {
+    setIsEditingName(false);
+    setEditError(null);
+  };
+  const saveEditName = async () => {
+    if (!annotator || !accessToken || savingName) return;
+    const name = editingName.trim();
+    if (!name || name === annotator.name) {
+      setIsEditingName(false);
+      return;
+    }
+    setSavingName(true);
+    setEditError(null);
+    try {
+      await apiClient<{ message: string }>(
+        `/annotators/${annotator.uuid}`,
+        accessToken,
+        { method: "PUT", body: { name } },
+      );
+      setDetail((prev) =>
+        prev ? { ...prev, annotator: { ...prev.annotator, name } } : prev,
+      );
+      setIsEditingName(false);
+    } catch (err) {
+      setEditError(parseApiError(err, "Failed to rename annotator"));
+    } finally {
+      setSavingName(false);
+    }
+  };
+
   const formatPercent = (value: number | null | undefined): string => {
     if (value == null) return "—";
     return `${Math.round(value * 100)}%`;
@@ -221,7 +262,67 @@ function AnnotatorDetailPageInner() {
 
         {/* Header */}
         <div>
-          <h1 className="text-2xl font-semibold">{annotator?.name ?? "—"}</h1>
+          {isEditingName && annotator ? (
+            <div className="flex items-center gap-2 flex-wrap">
+              <input
+                type="text"
+                value={editingName}
+                onChange={(e) => setEditingName(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") saveEditName();
+                  else if (e.key === "Escape") cancelEditName();
+                }}
+                disabled={savingName}
+                autoFocus
+                className="text-2xl font-semibold bg-background border border-border rounded-md px-2 py-1 outline-none focus:border-foreground disabled:opacity-50"
+              />
+              <button
+                onClick={saveEditName}
+                disabled={savingName || !editingName.trim()}
+                className="h-9 px-3 rounded-md text-sm font-medium bg-foreground text-background hover:opacity-90 transition-opacity cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                {savingName ? "Saving..." : "Save"}
+              </button>
+              <button
+                onClick={cancelEditName}
+                disabled={savingName}
+                className="h-9 px-3 rounded-md text-sm font-medium border border-border bg-background hover:bg-muted/50 transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                Cancel
+              </button>
+              {editError && (
+                <span className="text-sm text-red-500">{editError}</span>
+              )}
+            </div>
+          ) : (
+            <div className="flex items-center gap-2 group">
+              <h1 className="text-2xl font-semibold">
+                {annotator?.name ?? "—"}
+              </h1>
+              {annotator && (
+                <button
+                  onClick={startEditName}
+                  aria-label="Rename annotator"
+                  title="Rename"
+                  className="w-8 h-8 flex items-center justify-center rounded-md text-muted-foreground hover:text-foreground hover:bg-muted transition-colors cursor-pointer"
+                >
+                  <svg
+                    className="w-4 h-4"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                    strokeWidth={1.8}
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      d="M16.862 4.487l1.687-1.688a1.875 1.875 0 112.652 2.652L10.582 16.07a4.5 4.5 0 01-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 011.13-1.897L16.863 4.487zm0 0L19.5 7.125"
+                    />
+                  </svg>
+                </button>
+              )}
+            </div>
+          )}
         </div>
 
         {/* Tabs */}

--- a/src/app/human-alignment/page.tsx
+++ b/src/app/human-alignment/page.tsx
@@ -172,6 +172,15 @@ function HumanLabellingPageInner() {
   );
   const [isDeleting, setIsDeleting] = useState(false);
 
+  const [editingAnnotatorUuid, setEditingAnnotatorUuid] = useState<
+    string | null
+  >(null);
+  const [editingAnnotatorName, setEditingAnnotatorName] = useState("");
+  const [savingAnnotatorEdit, setSavingAnnotatorEdit] = useState(false);
+  const [annotatorEditError, setAnnotatorEditError] = useState<string | null>(
+    null,
+  );
+
   const [taskToDelete, setTaskToDelete] = useState<LabellingTask | null>(null);
   const [isDeletingTask, setIsDeletingTask] = useState(false);
 
@@ -340,6 +349,48 @@ function HumanLabellingPageInner() {
       setAddError(parseApiError(err, "Failed to add annotator"));
     } finally {
       setIsAdding(false);
+    }
+  };
+
+  const startEditAnnotator = (a: Annotator) => {
+    setEditingAnnotatorUuid(a.uuid);
+    setEditingAnnotatorName(a.name);
+    setAnnotatorEditError(null);
+  };
+  const cancelEditAnnotator = () => {
+    setEditingAnnotatorUuid(null);
+    setAnnotatorEditError(null);
+  };
+  const saveEditAnnotator = async () => {
+    if (!editingAnnotatorUuid || !accessToken || savingAnnotatorEdit) return;
+    const name = editingAnnotatorName.trim();
+    const current = annotators.find((a) => a.uuid === editingAnnotatorUuid);
+    if (!name || !current || name === current.name) {
+      setEditingAnnotatorUuid(null);
+      return;
+    }
+    setSavingAnnotatorEdit(true);
+    setAnnotatorEditError(null);
+    try {
+      await apiClient<{ message: string }>(
+        `/annotators/${editingAnnotatorUuid}`,
+        accessToken,
+        { method: "PUT", body: { name } },
+      );
+      setAnnotators((prev) =>
+        prev
+          .map((a) =>
+            a.uuid === editingAnnotatorUuid ? { ...a, name } : a,
+          )
+          .sort((a, b) => a.name.localeCompare(b.name)),
+      );
+      setEditingAnnotatorUuid(null);
+    } catch (err) {
+      setAnnotatorEditError(
+        parseApiError(err, "Failed to rename annotator"),
+      );
+    } finally {
+      setSavingAnnotatorEdit(false);
     }
   };
 
@@ -702,6 +753,9 @@ function HumanLabellingPageInner() {
             </form>
 
             {addError && <p className="text-sm text-red-500">{addError}</p>}
+            {annotatorEditError && (
+              <p className="text-sm text-red-500">{annotatorEditError}</p>
+            )}
 
             {/* Annotator list */}
             {annotatorsLoading || !annotatorsFetchCompleted ? (
@@ -755,7 +809,7 @@ function HumanLabellingPageInner() {
               <>
                 {/* Desktop table */}
                 <div className="hidden md:block border border-border rounded-xl overflow-hidden">
-                  <div className="grid grid-cols-[minmax(0,1fr)_120px_180px_40px] gap-4 px-4 py-2 border-b border-border bg-muted/30">
+                  <div className="grid grid-cols-[minmax(0,1fr)_120px_180px_88px] gap-4 px-4 py-2 border-b border-border bg-muted/30">
                     <div className="text-sm font-medium text-muted-foreground">
                       Name
                     </div>
@@ -769,19 +823,48 @@ function HumanLabellingPageInner() {
                   </div>
                   {annotators.map((annotator) => {
                     const agreement = annotator.current_agreement;
+                    const isEditing = editingAnnotatorUuid === annotator.uuid;
                     return (
                       <div
                         key={annotator.uuid}
-                        onClick={() =>
+                        onClick={() => {
+                          if (isEditing) return;
                           router.push(
                             `/human-alignment/annotators/${annotator.uuid}`,
-                          )
-                        }
-                        className="grid grid-cols-[minmax(0,1fr)_120px_180px_40px] gap-4 px-4 py-3 border-b border-border last:border-b-0 hover:bg-muted/20 transition-colors cursor-pointer items-center"
+                          );
+                        }}
+                        className={`grid grid-cols-[minmax(0,1fr)_120px_180px_88px] gap-4 px-4 py-3 border-b border-border last:border-b-0 transition-colors items-center ${
+                          isEditing
+                            ? "bg-muted/20"
+                            : "hover:bg-muted/20 cursor-pointer"
+                        }`}
                       >
-                        <p className="text-sm font-medium text-foreground truncate">
-                          {annotator.name}
-                        </p>
+                        {isEditing ? (
+                          <div
+                            onClick={(e) => e.stopPropagation()}
+                            className="flex items-center gap-2 min-w-0"
+                          >
+                            <input
+                              type="text"
+                              value={editingAnnotatorName}
+                              onChange={(e) =>
+                                setEditingAnnotatorName(e.target.value)
+                              }
+                              onKeyDown={(e) => {
+                                if (e.key === "Enter") saveEditAnnotator();
+                                else if (e.key === "Escape")
+                                  cancelEditAnnotator();
+                              }}
+                              disabled={savingAnnotatorEdit}
+                              autoFocus
+                              className="flex-1 min-w-0 text-sm font-medium bg-background border border-border rounded-md px-2 py-1 outline-none focus:border-foreground disabled:opacity-50"
+                            />
+                          </div>
+                        ) : (
+                          <p className="text-sm font-medium text-foreground truncate">
+                            {annotator.name}
+                          </p>
+                        )}
                         <p className="text-sm text-muted-foreground tabular-nums">
                           {annotator.jobs_count ?? 0}
                         </p>
@@ -792,29 +875,109 @@ function HumanLabellingPageInner() {
                             ? `${Math.round(agreement * 100)}%`
                             : "—"}
                         </p>
-                        <button
-                          onClick={(e) => {
-                            e.stopPropagation();
-                            setAnnotatorToDelete(annotator);
-                          }}
-                          aria-label={`Remove ${annotator.name}`}
-                          title="Remove annotator"
-                          className="w-8 h-8 flex items-center justify-center rounded-md text-muted-foreground hover:text-red-500 hover:bg-red-500/10 transition-colors cursor-pointer"
+                        <div
+                          className="flex items-center justify-end gap-1"
+                          onClick={(e) => e.stopPropagation()}
                         >
-                          <svg
-                            className="w-4 h-4"
-                            fill="none"
-                            viewBox="0 0 24 24"
-                            stroke="currentColor"
-                            strokeWidth={1.8}
-                          >
-                            <path
-                              strokeLinecap="round"
-                              strokeLinejoin="round"
-                              d="M14.74 9l-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 01-2.244 2.077H8.084a2.25 2.25 0 01-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 00-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 013.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 00-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 00-7.5 0"
-                            />
-                          </svg>
-                        </button>
+                          {isEditing ? (
+                            <>
+                              <button
+                                onClick={saveEditAnnotator}
+                                disabled={
+                                  savingAnnotatorEdit ||
+                                  !editingAnnotatorName.trim()
+                                }
+                                aria-label="Save name"
+                                title="Save"
+                                className="w-8 h-8 flex items-center justify-center rounded-md text-emerald-600 hover:text-emerald-700 hover:bg-emerald-500/10 transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+                              >
+                                <svg
+                                  className="w-4 h-4"
+                                  fill="none"
+                                  viewBox="0 0 24 24"
+                                  stroke="currentColor"
+                                  strokeWidth={2}
+                                >
+                                  <path
+                                    strokeLinecap="round"
+                                    strokeLinejoin="round"
+                                    d="M4.5 12.75l6 6 9-13.5"
+                                  />
+                                </svg>
+                              </button>
+                              <button
+                                onClick={cancelEditAnnotator}
+                                disabled={savingAnnotatorEdit}
+                                aria-label="Cancel rename"
+                                title="Cancel"
+                                className="w-8 h-8 flex items-center justify-center rounded-md text-muted-foreground hover:text-foreground hover:bg-muted transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+                              >
+                                <svg
+                                  className="w-4 h-4"
+                                  fill="none"
+                                  viewBox="0 0 24 24"
+                                  stroke="currentColor"
+                                  strokeWidth={2}
+                                >
+                                  <path
+                                    strokeLinecap="round"
+                                    strokeLinejoin="round"
+                                    d="M6 18L18 6M6 6l12 12"
+                                  />
+                                </svg>
+                              </button>
+                            </>
+                          ) : (
+                            <>
+                              <button
+                                onClick={(e) => {
+                                  e.stopPropagation();
+                                  startEditAnnotator(annotator);
+                                }}
+                                aria-label={`Rename ${annotator.name}`}
+                                title="Rename annotator"
+                                className="w-8 h-8 flex items-center justify-center rounded-md text-muted-foreground hover:text-foreground hover:bg-muted transition-colors cursor-pointer"
+                              >
+                                <svg
+                                  className="w-4 h-4"
+                                  fill="none"
+                                  viewBox="0 0 24 24"
+                                  stroke="currentColor"
+                                  strokeWidth={1.8}
+                                >
+                                  <path
+                                    strokeLinecap="round"
+                                    strokeLinejoin="round"
+                                    d="M16.862 4.487l1.687-1.688a1.875 1.875 0 112.652 2.652L10.582 16.07a4.5 4.5 0 01-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 011.13-1.897L16.863 4.487zm0 0L19.5 7.125"
+                                  />
+                                </svg>
+                              </button>
+                              <button
+                                onClick={(e) => {
+                                  e.stopPropagation();
+                                  setAnnotatorToDelete(annotator);
+                                }}
+                                aria-label={`Remove ${annotator.name}`}
+                                title="Remove annotator"
+                                className="w-8 h-8 flex items-center justify-center rounded-md text-muted-foreground hover:text-red-500 hover:bg-red-500/10 transition-colors cursor-pointer"
+                              >
+                                <svg
+                                  className="w-4 h-4"
+                                  fill="none"
+                                  viewBox="0 0 24 24"
+                                  stroke="currentColor"
+                                  strokeWidth={1.8}
+                                >
+                                  <path
+                                    strokeLinecap="round"
+                                    strokeLinejoin="round"
+                                    d="M14.74 9l-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 01-2.244 2.077H8.084a2.25 2.25 0 01-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 00-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 013.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 00-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 00-7.5 0"
+                                  />
+                                </svg>
+                              </button>
+                            </>
+                          )}
+                        </div>
                       </div>
                     );
                   })}
@@ -824,20 +987,45 @@ function HumanLabellingPageInner() {
                 <div className="md:hidden space-y-2">
                   {annotators.map((annotator) => {
                     const agreement = annotator.current_agreement;
+                    const isEditing = editingAnnotatorUuid === annotator.uuid;
                     return (
                       <div
                         key={annotator.uuid}
-                        onClick={() =>
+                        onClick={() => {
+                          if (isEditing) return;
                           router.push(
                             `/human-alignment/annotators/${annotator.uuid}`,
-                          )
-                        }
-                        className="border border-border rounded-xl p-4 hover:bg-muted/20 transition-colors cursor-pointer flex items-start gap-3"
+                          );
+                        }}
+                        className={`border border-border rounded-xl p-4 transition-colors flex items-start gap-3 ${
+                          isEditing
+                            ? "bg-muted/20"
+                            : "hover:bg-muted/20 cursor-pointer"
+                        }`}
                       >
                         <div className="flex-1 min-w-0">
-                          <p className="text-sm font-medium text-foreground truncate mb-1">
-                            {annotator.name}
-                          </p>
+                          {isEditing ? (
+                            <input
+                              type="text"
+                              value={editingAnnotatorName}
+                              onChange={(e) =>
+                                setEditingAnnotatorName(e.target.value)
+                              }
+                              onClick={(e) => e.stopPropagation()}
+                              onKeyDown={(e) => {
+                                if (e.key === "Enter") saveEditAnnotator();
+                                else if (e.key === "Escape")
+                                  cancelEditAnnotator();
+                              }}
+                              disabled={savingAnnotatorEdit}
+                              autoFocus
+                              className="w-full text-sm font-medium bg-background border border-border rounded-md px-2 py-1 mb-1 outline-none focus:border-foreground disabled:opacity-50"
+                            />
+                          ) : (
+                            <p className="text-sm font-medium text-foreground truncate mb-1">
+                              {annotator.name}
+                            </p>
+                          )}
                           <p className="text-xs text-muted-foreground">
                             {annotator.jobs_count ?? 0} job
                             {(annotator.jobs_count ?? 0) === 1 ? "" : "s"}
@@ -851,6 +1039,79 @@ function HumanLabellingPageInner() {
                             </span>
                           </p>
                         </div>
+                        {isEditing ? (
+                          <div
+                            className="flex items-center gap-1 flex-shrink-0"
+                            onClick={(e) => e.stopPropagation()}
+                          >
+                            <button
+                              onClick={saveEditAnnotator}
+                              disabled={
+                                savingAnnotatorEdit ||
+                                !editingAnnotatorName.trim()
+                              }
+                              aria-label="Save name"
+                              className="w-8 h-8 flex items-center justify-center rounded-md text-emerald-600 hover:bg-emerald-500/10 transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+                            >
+                              <svg
+                                className="w-4 h-4"
+                                fill="none"
+                                viewBox="0 0 24 24"
+                                stroke="currentColor"
+                                strokeWidth={2}
+                              >
+                                <path
+                                  strokeLinecap="round"
+                                  strokeLinejoin="round"
+                                  d="M4.5 12.75l6 6 9-13.5"
+                                />
+                              </svg>
+                            </button>
+                            <button
+                              onClick={cancelEditAnnotator}
+                              disabled={savingAnnotatorEdit}
+                              aria-label="Cancel rename"
+                              className="w-8 h-8 flex items-center justify-center rounded-md text-muted-foreground hover:text-foreground hover:bg-muted transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+                            >
+                              <svg
+                                className="w-4 h-4"
+                                fill="none"
+                                viewBox="0 0 24 24"
+                                stroke="currentColor"
+                                strokeWidth={2}
+                              >
+                                <path
+                                  strokeLinecap="round"
+                                  strokeLinejoin="round"
+                                  d="M6 18L18 6M6 6l12 12"
+                                />
+                              </svg>
+                            </button>
+                          </div>
+                        ) : (
+                          <div className="flex items-center gap-1 flex-shrink-0">
+                            <button
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                startEditAnnotator(annotator);
+                              }}
+                              aria-label={`Rename ${annotator.name}`}
+                              className="w-8 h-8 flex items-center justify-center rounded-md text-muted-foreground hover:text-foreground hover:bg-muted transition-colors cursor-pointer"
+                            >
+                              <svg
+                                className="w-4 h-4"
+                                fill="none"
+                                viewBox="0 0 24 24"
+                                stroke="currentColor"
+                                strokeWidth={1.8}
+                              >
+                                <path
+                                  strokeLinecap="round"
+                                  strokeLinejoin="round"
+                                  d="M16.862 4.487l1.687-1.688a1.875 1.875 0 112.652 2.652L10.582 16.07a4.5 4.5 0 01-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 011.13-1.897L16.863 4.487zm0 0L19.5 7.125"
+                                />
+                              </svg>
+                            </button>
                         <button
                           onClick={(e) => {
                             e.stopPropagation();
@@ -873,6 +1134,8 @@ function HumanLabellingPageInner() {
                             />
                           </svg>
                         </button>
+                          </div>
+                        )}
                       </div>
                     );
                   })}

--- a/src/app/human-alignment/tasks/[uuid]/page.tsx
+++ b/src/app/human-alignment/tasks/[uuid]/page.tsx
@@ -2873,6 +2873,33 @@ function LabellingTaskPageInner() {
           };
         })()}
         accessToken={accessToken}
+        hasPrev={(() => {
+          if (!itemDetailUuid) return false;
+          const idx = items.findIndex((i) => i.uuid === itemDetailUuid);
+          return idx > 0;
+        })()}
+        hasNext={(() => {
+          if (!itemDetailUuid) return false;
+          const idx = items.findIndex((i) => i.uuid === itemDetailUuid);
+          return idx >= 0 && idx < items.length - 1;
+        })()}
+        onPrev={() => {
+          if (!itemDetailUuid) return;
+          const idx = items.findIndex((i) => i.uuid === itemDetailUuid);
+          if (idx > 0) setItemDetailUuid(items[idx - 1].uuid);
+        }}
+        onNext={() => {
+          if (!itemDetailUuid) return;
+          const idx = items.findIndex((i) => i.uuid === itemDetailUuid);
+          if (idx >= 0 && idx < items.length - 1)
+            setItemDetailUuid(items[idx + 1].uuid);
+        }}
+        position={(() => {
+          if (!itemDetailUuid) return undefined;
+          const idx = items.findIndex((i) => i.uuid === itemDetailUuid);
+          if (idx < 0) return undefined;
+          return { index: idx, total: items.length };
+        })()}
       />
     </AppLayout>
   );

--- a/src/components/human-labelling/AssignAnnotatorsDialog.tsx
+++ b/src/components/human-labelling/AssignAnnotatorsDialog.tsx
@@ -86,6 +86,16 @@ export function AssignAnnotatorsDialog({
     });
   };
 
+  const allPicked = annotators.length > 0 && picked.size === annotators.length;
+  const somePicked = picked.size > 0 && !allPicked;
+  const toggleSelectAll = () => {
+    if (allPicked) {
+      setPicked(new Set());
+    } else {
+      setPicked(new Set(annotators.map((a) => a.uuid)));
+    }
+  };
+
   const handleConfirm = async () => {
     if (picked.size === 0 || submitting) return;
     setSubmitting(true);
@@ -194,22 +204,41 @@ export function AssignAnnotatorsDialog({
               }
             />
           ) : (
-            annotators.map((a) => (
-              <label
-                key={a.uuid}
-                className="flex items-center gap-3 px-3 py-2 rounded-md border border-border hover:bg-muted/30 transition-colors cursor-pointer"
-              >
-                <input
-                  type="checkbox"
-                  checked={picked.has(a.uuid)}
-                  onChange={() => toggle(a.uuid)}
-                  className="w-4 h-4 cursor-pointer accent-foreground"
-                />
-                <div className="flex-1 min-w-0">
-                  <div className="text-sm font-medium truncate">{a.name}</div>
-                </div>
-              </label>
-            ))
+            <>
+              {annotators.length > 1 && (
+                <label className="flex items-center gap-3 px-3 py-2 cursor-pointer select-none">
+                  <input
+                    type="checkbox"
+                    checked={allPicked}
+                    ref={(el) => {
+                      if (el) el.indeterminate = somePicked;
+                    }}
+                    onChange={toggleSelectAll}
+                    aria-label={allPicked ? "Unselect all annotators" : "Select all annotators"}
+                    className="w-4 h-4 cursor-pointer accent-foreground"
+                  />
+                  <span className="text-xs font-medium text-muted-foreground">
+                    {allPicked ? "Unselect all" : "Select all"}
+                  </span>
+                </label>
+              )}
+              {annotators.map((a) => (
+                <label
+                  key={a.uuid}
+                  className="flex items-center gap-3 px-3 py-2 rounded-md border border-border hover:bg-muted/30 transition-colors cursor-pointer"
+                >
+                  <input
+                    type="checkbox"
+                    checked={picked.has(a.uuid)}
+                    onChange={() => toggle(a.uuid)}
+                    className="w-4 h-4 cursor-pointer accent-foreground"
+                  />
+                  <div className="flex-1 min-w-0">
+                    <div className="text-sm font-medium truncate">{a.name}</div>
+                  </div>
+                </label>
+              ))}
+            </>
           )}
           {submitError && <p className="text-sm text-red-500">{submitError}</p>}
         </div>

--- a/src/components/human-labelling/ItemDetailDialog.tsx
+++ b/src/components/human-labelling/ItemDetailDialog.tsx
@@ -376,7 +376,7 @@ export function ItemDetailDialog({
           <div className="min-w-0 flex items-center gap-2 flex-wrap">
             {(onPrev || onNext) && (
               <div className="flex items-center gap-1 mr-1">
-                <Tooltip position="bottom" content="Previous item (←)">
+                <Tooltip position="bottom" content="Previous item">
                   <button
                     type="button"
                     onClick={onPrev}
@@ -399,7 +399,7 @@ export function ItemDetailDialog({
                     </svg>
                   </button>
                 </Tooltip>
-                <Tooltip position="bottom" content="Next item (→)">
+                <Tooltip position="bottom" content="Next item">
                   <button
                     type="button"
                     onClick={onNext}

--- a/src/components/human-labelling/ItemDetailDialog.tsx
+++ b/src/components/human-labelling/ItemDetailDialog.tsx
@@ -372,10 +372,15 @@ export function ItemDetailDialog({
         onClick={(e) => e.stopPropagation()}
         className="bg-background rounded-none md:rounded-xl w-full max-w-[92rem] h-full md:h-[92vh] flex flex-col shadow-2xl overflow-hidden"
       >
-        <div className="flex items-center justify-between gap-3 px-4 md:px-6 py-3 md:py-4 border-b border-border">
+        <div className="relative flex items-center justify-between gap-3 px-4 md:px-6 py-3 md:py-4 border-b border-border">
           <div className="min-w-0 flex items-center gap-2 flex-wrap">
-            {(onPrev || onNext) && (
-              <div className="flex items-center gap-1 mr-1">
+            <h2 className="text-base md:text-lg font-semibold text-foreground truncate">
+              {itemTitle(item)}
+            </h2>
+          </div>
+          {(onPrev || onNext) && (
+            <div className="hidden md:flex absolute left-1/2 -translate-x-1/2 items-center gap-2 pointer-events-none">
+              <div className="pointer-events-auto">
                 <Tooltip position="bottom" content="Previous item">
                   <button
                     type="button"
@@ -399,6 +404,15 @@ export function ItemDetailDialog({
                     </svg>
                   </button>
                 </Tooltip>
+              </div>
+              {position && position.total > 0 ? (
+                <span className="text-xs text-muted-foreground tabular-nums min-w-[4rem] text-center">
+                  {position.index + 1} of {position.total}
+                </span>
+              ) : (
+                <span className="min-w-[4rem]" />
+              )}
+              <div className="pointer-events-auto">
                 <Tooltip position="bottom" content="Next item">
                   <button
                     type="button"
@@ -423,16 +437,8 @@ export function ItemDetailDialog({
                   </button>
                 </Tooltip>
               </div>
-            )}
-            <h2 className="text-base md:text-lg font-semibold text-foreground truncate">
-              {itemTitle(item)}
-            </h2>
-            {position && position.total > 0 && (
-              <span className="text-xs text-muted-foreground shrink-0">
-                {position.index + 1} of {position.total}
-              </span>
-            )}
-          </div>
+            </div>
+          )}
           <div className="flex items-center gap-2 shrink-0">
             {loading && summary && (
               <svg

--- a/src/components/human-labelling/ItemDetailDialog.tsx
+++ b/src/components/human-labelling/ItemDetailDialog.tsx
@@ -77,12 +77,22 @@ export function ItemDetailDialog({
   task,
   item,
   accessToken,
+  onPrev,
+  onNext,
+  hasPrev = false,
+  hasNext = false,
+  position,
 }: {
   isOpen: boolean;
   onClose: () => void;
   task: ItemDetailDialogTask | null;
   item: Item | null;
   accessToken: string | null;
+  onPrev?: () => void;
+  onNext?: () => void;
+  hasPrev?: boolean;
+  hasNext?: boolean;
+  position?: { index: number; total: number };
 }) {
   const [summary, setSummary] = useState<TaskSummaryResponse | null>(null);
   const [loading, setLoading] = useState(false);
@@ -136,15 +146,37 @@ export function ItemDetailDialog({
     setSummary(null);
   }, [taskUuid, itemUuid]);
 
-  // Close on Escape.
+  // Close on Escape; navigate with arrow keys.
   useEffect(() => {
     if (!isOpen) return;
     const handler = (e: KeyboardEvent) => {
-      if (e.key === "Escape") onClose();
+      if (e.key === "Escape") {
+        onClose();
+        return;
+      }
+      const target = e.target as HTMLElement | null;
+      if (target) {
+        const tag = target.tagName;
+        if (
+          tag === "INPUT" ||
+          tag === "TEXTAREA" ||
+          tag === "SELECT" ||
+          target.isContentEditable
+        ) {
+          return;
+        }
+      }
+      if (e.key === "ArrowLeft" && hasPrev && onPrev) {
+        e.preventDefault();
+        onPrev();
+      } else if (e.key === "ArrowRight" && hasNext && onNext) {
+        e.preventDefault();
+        onNext();
+      }
     };
     window.addEventListener("keydown", handler);
     return () => window.removeEventListener("keydown", handler);
-  }, [isOpen, onClose]);
+  }, [isOpen, onClose, hasPrev, hasNext, onPrev, onNext]);
 
   const evaluatorVariables = useMemo(
     () => (item ? extractEvaluatorVariables(item.payload) : {}),
@@ -342,9 +374,64 @@ export function ItemDetailDialog({
       >
         <div className="flex items-center justify-between gap-3 px-4 md:px-6 py-3 md:py-4 border-b border-border">
           <div className="min-w-0 flex items-center gap-2 flex-wrap">
+            {(onPrev || onNext) && (
+              <div className="flex items-center gap-1 mr-1">
+                <Tooltip position="bottom" content="Previous item (←)">
+                  <button
+                    type="button"
+                    onClick={onPrev}
+                    disabled={!hasPrev}
+                    aria-label="Previous item"
+                    className="flex items-center justify-center w-8 h-8 rounded-md border border-border hover:bg-muted transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+                  >
+                    <svg
+                      className="w-4 h-4"
+                      fill="none"
+                      viewBox="0 0 24 24"
+                      stroke="currentColor"
+                      strokeWidth={2}
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        d="M15 19l-7-7 7-7"
+                      />
+                    </svg>
+                  </button>
+                </Tooltip>
+                <Tooltip position="bottom" content="Next item (→)">
+                  <button
+                    type="button"
+                    onClick={onNext}
+                    disabled={!hasNext}
+                    aria-label="Next item"
+                    className="flex items-center justify-center w-8 h-8 rounded-md border border-border hover:bg-muted transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+                  >
+                    <svg
+                      className="w-4 h-4"
+                      fill="none"
+                      viewBox="0 0 24 24"
+                      stroke="currentColor"
+                      strokeWidth={2}
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        d="M9 5l7 7-7 7"
+                      />
+                    </svg>
+                  </button>
+                </Tooltip>
+              </div>
+            )}
             <h2 className="text-base md:text-lg font-semibold text-foreground truncate">
               {itemTitle(item)}
             </h2>
+            {position && position.total > 0 && (
+              <span className="text-xs text-muted-foreground shrink-0">
+                {position.index + 1} of {position.total}
+              </span>
+            )}
           </div>
           <div className="flex items-center gap-2 shrink-0">
             {loading && summary && (

--- a/src/components/human-labelling/JobsCreatedDialog.tsx
+++ b/src/components/human-labelling/JobsCreatedDialog.tsx
@@ -90,7 +90,7 @@ export function JobsCreatedDialog({
             <div className="grid grid-cols-[minmax(0,1fr)_minmax(0,3fr)_auto] gap-4 px-4 py-2.5 bg-muted/30 text-xs font-medium text-muted-foreground uppercase tracking-wide">
               <div>Annotator</div>
               <div>Link</div>
-              <div className="w-16" />
+              <div className="w-[7.5rem]" />
             </div>
             {jobs.map((job, idx) => {
               const url = buildJobUrl(job.public_token);
@@ -108,16 +108,40 @@ export function JobsCreatedDialog({
                   <div className="text-xs font-mono text-muted-foreground break-all">
                     {url}
                   </div>
-                  <button
-                    onClick={() => handleCopy(job.public_token)}
-                    className={`h-8 px-3 rounded-md text-xs font-medium border transition-colors cursor-pointer w-16 ${
-                      copied
-                        ? "border-emerald-500/40 bg-emerald-500/10 text-emerald-500"
-                        : "border-border bg-background hover:bg-muted/50"
-                    }`}
-                  >
-                    {copied ? "Copied" : "Copy"}
-                  </button>
+                  <div className="flex items-center gap-2">
+                    <button
+                      onClick={() => handleCopy(job.public_token)}
+                      className={`h-8 px-3 rounded-md text-xs font-medium border transition-colors cursor-pointer w-16 ${
+                        copied
+                          ? "border-emerald-500/40 bg-emerald-500/10 text-emerald-500"
+                          : "border-border bg-background hover:bg-muted/50"
+                      }`}
+                    >
+                      {copied ? "Copied" : "Copy"}
+                    </button>
+                    <a
+                      href={url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      aria-label={`Open ${job.annotator_name}'s job in a new tab`}
+                      title="Open in new tab"
+                      className="h-8 w-8 flex items-center justify-center rounded-md border border-border bg-background hover:bg-muted/50 transition-colors cursor-pointer"
+                    >
+                      <svg
+                        className="w-3.5 h-3.5"
+                        fill="none"
+                        viewBox="0 0 24 24"
+                        stroke="currentColor"
+                        strokeWidth={2}
+                      >
+                        <path
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          d="M13.5 6H5.25A2.25 2.25 0 003 8.25v10.5A2.25 2.25 0 005.25 21h10.5A2.25 2.25 0 0018 18.75V10.5m-10.5 6L21 3m0 0h-5.25M21 3v5.25"
+                        />
+                      </svg>
+                    </a>
+                  </div>
                 </div>
               );
             })}

--- a/src/components/human-labelling/JobsCreatedDialog.tsx
+++ b/src/components/human-labelling/JobsCreatedDialog.tsx
@@ -114,7 +114,7 @@ export function JobsCreatedDialog({
                       className={`h-8 px-3 rounded-md text-xs font-medium border transition-colors cursor-pointer w-16 ${
                         copied
                           ? "border-emerald-500/40 bg-emerald-500/10 text-emerald-500"
-                          : "border-border bg-background hover:bg-muted/50"
+                          : "border-indigo-500/30 bg-indigo-500/10 text-indigo-600 dark:text-indigo-300 hover:bg-indigo-500/20"
                       }`}
                     >
                       {copied ? "Copied" : "Copy"}
@@ -125,7 +125,7 @@ export function JobsCreatedDialog({
                       rel="noopener noreferrer"
                       aria-label={`Open ${job.annotator_name}'s job in a new tab`}
                       title="Open in new tab"
-                      className="h-8 w-8 flex items-center justify-center rounded-md border border-border bg-background hover:bg-muted/50 transition-colors cursor-pointer"
+                      className="h-8 w-8 flex items-center justify-center rounded-md border border-amber-500/30 bg-amber-500/10 text-amber-600 dark:text-amber-300 hover:bg-amber-500/20 transition-colors cursor-pointer"
                     >
                       <svg
                         className="w-3.5 h-3.5"

--- a/src/components/human-labelling/RunEvaluatorsDialog.tsx
+++ b/src/components/human-labelling/RunEvaluatorsDialog.tsx
@@ -174,6 +174,16 @@ export function RunEvaluatorsDialog({
     setPicked((prev) => ({ ...prev, [id]: !prev[id] }));
   };
 
+  const allPicked =
+    evaluators.length > 0 && evaluators.every((e) => picked[e.uuid]);
+  const somePicked = pickedCount > 0 && !allPicked;
+  const toggleSelectAll = () => {
+    const next: Record<string, boolean> = {};
+    const target = !allPicked;
+    for (const e of evaluators) next[e.uuid] = target;
+    setPicked(next);
+  };
+
   const handleConfirm = async () => {
     if (pickedCount === 0 || submitting) return;
     const selections: RunEvaluatorsSelection[] = [];
@@ -261,7 +271,25 @@ export function RunEvaluatorsDialog({
               No evaluators are linked to this task.
             </p>
           ) : (
-            evaluators.map((ev) => {
+            <>
+              {evaluators.length > 1 && (
+                <label className="flex items-center gap-3 px-3 py-2 cursor-pointer select-none">
+                  <input
+                    type="checkbox"
+                    checked={allPicked}
+                    ref={(el) => {
+                      if (el) el.indeterminate = somePicked;
+                    }}
+                    onChange={toggleSelectAll}
+                    aria-label={allPicked ? "Unselect all evaluators" : "Select all evaluators"}
+                    className="w-4 h-4 cursor-pointer accent-foreground"
+                  />
+                  <span className="text-xs font-medium text-muted-foreground">
+                    {allPicked ? "Unselect all" : "Select all"}
+                  </span>
+                </label>
+              )}
+              {evaluators.map((ev) => {
               const evInfo = info[ev.uuid];
               const versions = evInfo?.versions ?? [];
               const liveVersionId = evInfo?.liveVersionId ?? null;
@@ -362,7 +390,8 @@ export function RunEvaluatorsDialog({
                   )}
                 </div>
               );
-            })
+            })}
+            </>
           )}
           {submitError && <p className="text-sm text-red-500">{submitError}</p>}
         </div>


### PR DESCRIPTION
## Summary
- **Item detail modal**: prev/next buttons (←/→ shortcuts) centered with an "M of N" indicator so reviewers can step through every item without closing the modal.
- **Run evaluators / Assign annotators dialogs**: "Select all" / "Unselect all" checkbox (with indeterminate state) above lists of 2+ rows.
- **Jobs created dialog**: open-in-new-tab button next to Copy for each job, with distinct colors (indigo Copy, amber Open) so they're not visually identical.
- **Annotators**: inline rename via pencil button on both the all-annotators list (desktop + mobile) and the individual annotator page header. Backed by `PUT /annotators/{uuid}`.

## Test plan
- [ ] Open an item from a task → step through items with the on-screen buttons and ←/→ keys; verify boundaries disable correctly and the "M of N" counter is accurate.
- [ ] Click "Evaluate selected" → toggle "Select all", verify indeterminate state when one row is unchecked.
- [ ] Click "Label selected" → same check on the annotator list.
- [ ] After creating labelling jobs, verify the Copy and Open-in-new-tab buttons look distinct and the new-tab button opens the right URL.
- [ ] Rename an annotator from the list (desktop and mobile) and from the detail page; verify name updates everywhere and persists after refresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)