### PR TITLE
Custom binary/rating labels, item-detail polish, labelling actions

### DIFF
--- a/src/app/evaluators/[uuid]/page.tsx
+++ b/src/app/evaluators/[uuid]/page.tsx
@@ -946,7 +946,7 @@ function EvaluatorDetailPageInner() {
       {newVersionOpen && evaluator && (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm p-4">
           <div
-            className="bg-background border border-border rounded-xl w-full max-w-5xl shadow-2xl flex flex-col max-h-[90vh]"
+            className="bg-background border border-border rounded-xl w-full max-w-[96rem] shadow-2xl flex flex-col max-h-[90vh]"
           >
             {/* Header */}
             <div className="flex items-center justify-between px-5 md:px-6 py-4 border-b border-border">
@@ -978,7 +978,7 @@ function EvaluatorDetailPageInner() {
 
             {/* Body */}
             <div className="flex-1 overflow-y-auto px-5 md:px-6 py-4 md:py-5 space-y-4 md:space-y-5">
-              <div className="grid grid-cols-1 lg:grid-cols-[minmax(0,1.15fr)_minmax(320px,0.85fr)] gap-4 md:gap-6">
+              <div className="grid grid-cols-1 lg:grid-cols-[minmax(0,1.1fr)_minmax(280px,0.9fr)_minmax(300px,0.9fr)] gap-4 md:gap-6">
                 {/* Left column — Prompt */}
                 <div>
                   <label className="block text-xs md:text-sm font-medium mb-2">
@@ -1000,6 +1000,26 @@ function EvaluatorDetailPageInner() {
                         : "border-border"
                     }`}
                   />
+                </div>
+
+                {/* Middle column — Labels (rating scale / binary labels) */}
+                <div className="space-y-4 md:space-y-5">
+                  {evaluator.output_type === "rating" && (
+                    <RatingScaleEditor
+                      rows={newVersionScale}
+                      onChange={setNewVersionScale}
+                      validationAttempted={newVersionValidated}
+                      description="At least two rows. Description is optional rubric text sent to the judge."
+                      descriptionPlaceholder="Description (optional) - criteria for this level, shown to the judge"
+                    />
+                  )}
+
+                  {evaluator.output_type === "binary" && (
+                    <BinaryScaleEditor
+                      rows={newVersionBinaryScale}
+                      onChange={setNewVersionBinaryScale}
+                    />
+                  )}
                 </div>
 
                 {/* Right column — Version settings */}
@@ -1077,23 +1097,6 @@ function EvaluatorDetailPageInner() {
                       </svg>
                     </button>
                   </div>
-
-                  {evaluator.output_type === "rating" && (
-                    <RatingScaleEditor
-                      rows={newVersionScale}
-                      onChange={setNewVersionScale}
-                      validationAttempted={newVersionValidated}
-                      description="At least two rows. Description is optional rubric text sent to the judge."
-                      descriptionPlaceholder="Description (optional) - criteria for this level, shown to the judge"
-                    />
-                  )}
-
-                  {evaluator.output_type === "binary" && (
-                    <BinaryScaleEditor
-                      rows={newVersionBinaryScale}
-                      onChange={setNewVersionBinaryScale}
-                    />
-                  )}
 
                   {(() => {
                     const existingVariables =

--- a/src/app/evaluators/[uuid]/page.tsx
+++ b/src/app/evaluators/[uuid]/page.tsx
@@ -24,6 +24,11 @@ import {
 import { LLMSelectorModal } from "@/components/agent-tabs/LLMSelectorModal";
 import type { LLMModel } from "@/components/agent-tabs/constants/providers";
 import { RatingScaleEditor } from "@/components/evaluators/RatingScaleEditor";
+import {
+  BinaryScaleEditor,
+  defaultBinaryScale,
+  type BinaryScaleRow,
+} from "@/components/evaluators/BinaryScaleEditor";
 import { VersionCard } from "@/components/evaluators/VersionCard";
 import { extractVariableNames } from "@/lib/evaluatorVariables";
 import { SingleSelectPicker } from "@/components/SingleSelectPicker";
@@ -191,6 +196,9 @@ function EvaluatorDetailPageInner() {
   const [newVersionScale, setNewVersionScale] = useState<
     { value: number | string; name: string; description: string }[]
   >([]);
+  const [newVersionBinaryScale, setNewVersionBinaryScale] = useState<
+    BinaryScaleRow[]
+  >(defaultBinaryScale());
   const [newVersionLlmModalOpen, setNewVersionLlmModalOpen] = useState(false);
   const [newVersionSaving, setNewVersionSaving] = useState(false);
   const [newVersionError, setNewVersionError] = useState<string | null>(null);
@@ -403,6 +411,23 @@ function EvaluatorDetailPageInner() {
     } else {
       setNewVersionScale([]);
     }
+    if (evaluator.output_type === "binary") {
+      const scale = live?.output_config?.scale ?? [];
+      const trueEntry = scale.find((e) => e.value === true);
+      const falseEntry = scale.find((e) => e.value === false);
+      setNewVersionBinaryScale([
+        {
+          value: true,
+          name: trueEntry?.name ?? "",
+          description: trueEntry?.description ?? "",
+        },
+        {
+          value: false,
+          name: falseEntry?.name ?? "",
+          description: falseEntry?.description ?? "",
+        },
+      ]);
+    }
     setNewVersionError(null);
     setNewVersionValidated(false);
     setNewVersionChangelog("");
@@ -464,6 +489,21 @@ function EvaluatorDetailPageInner() {
               : {}),
           })),
         };
+      } else if (evaluator.output_type === "binary") {
+        const hasAnyOverride = newVersionBinaryScale.some(
+          (r) => r.name.trim().length > 0 || r.description.trim().length > 0,
+        );
+        if (hasAnyOverride) {
+          body.output_config = {
+            scale: newVersionBinaryScale.map((r) => ({
+              value: r.value,
+              name: r.name.trim() || (r.value ? "Correct" : "Wrong"),
+              ...(r.description.trim()
+                ? { description: r.description.trim() }
+                : {}),
+            })),
+          };
+        }
       }
       // Variable name set is pinned to the live version (we don't allow add /
       // rename / remove on a new version — see the amber callout in the UI).
@@ -1045,6 +1085,13 @@ function EvaluatorDetailPageInner() {
                       validationAttempted={newVersionValidated}
                       description="At least two rows. Description is optional rubric text sent to the judge."
                       descriptionPlaceholder="Description (optional) - criteria for this level, shown to the judge"
+                    />
+                  )}
+
+                  {evaluator.output_type === "binary" && (
+                    <BinaryScaleEditor
+                      rows={newVersionBinaryScale}
+                      onChange={setNewVersionBinaryScale}
                     />
                   )}
 

--- a/src/app/evaluators/[uuid]/page.tsx
+++ b/src/app/evaluators/[uuid]/page.tsx
@@ -29,6 +29,8 @@ import {
   defaultBinaryScale,
   type BinaryScaleRow,
 } from "@/components/evaluators/BinaryScaleEditor";
+import { defaultBinaryLabel } from "@/lib/binaryLabels";
+import { liveVersionOf } from "@/lib/evaluatorVersions";
 import { VersionCard } from "@/components/evaluators/VersionCard";
 import { extractVariableNames } from "@/lib/evaluatorVariables";
 import { SingleSelectPicker } from "@/components/SingleSelectPicker";
@@ -99,7 +101,10 @@ type EvaluatorDetail = {
   owner_user_id: string | null;
   slug: string | null;
   live_version_id: string | null;
-  live_version: EvaluatorVersion | null;
+  // Index into `versions[]` for the live version. Replaces the
+  // previously flattened `live_version` blob to keep the response
+  // smaller / DRY.
+  live_version_index: number | null;
   versions?: EvaluatorVersion[];
   evaluator_type?: EvaluatorType;
 };
@@ -270,9 +275,10 @@ function EvaluatorDetailPageInner() {
     if (!evaluator) return [] as EvaluatorVersion[];
     const all = evaluator.versions?.length
       ? [...evaluator.versions]
-      : evaluator.live_version
-        ? [evaluator.live_version]
-        : [];
+      : (() => {
+          const live = liveVersionOf(evaluator);
+          return live ? [live] : [];
+        })();
     const sorted = all.sort((a, b) => b.version_number - a.version_number);
     // Default evaluators always show only the most recent version of the prompt.
     if (!evaluator.owner_user_id) {
@@ -388,7 +394,7 @@ function EvaluatorDetailPageInner() {
 
   const openNewVersionDialog = () => {
     if (!evaluator) return;
-    const live = evaluator.live_version;
+    const live = liveVersionOf(evaluator);
     setNewVersionJudgeModel(
       live?.judge_model
         ? { id: live.judge_model, name: live.judge_model }
@@ -449,7 +455,7 @@ function EvaluatorDetailPageInner() {
       evaluator.output_type === "binary" ||
       (newVersionScale.length >= 2 &&
         newVersionScale.every((r) => r.name.trim().length > 0));
-    const existingVariables = evaluator.live_version?.variables ?? [];
+    const existingVariables = liveVersionOf(evaluator)?.variables ?? [];
     const variableDescriptionsValid =
       evaluator.evaluator_type !== "llm" ||
       existingVariables.every(
@@ -497,7 +503,7 @@ function EvaluatorDetailPageInner() {
           body.output_config = {
             scale: newVersionBinaryScale.map((r) => ({
               value: r.value,
-              name: r.name.trim() || (r.value ? "Correct" : "Wrong"),
+              name: r.name.trim() || defaultBinaryLabel(r.value),
               ...(r.description.trim()
                 ? { description: r.description.trim() }
                 : {}),
@@ -511,7 +517,7 @@ function EvaluatorDetailPageInner() {
       // descriptions and preserve `default`. Only LLM evaluators can carry
       // variables; for other types we omit the field entirely.
       if (evaluator.evaluator_type === "llm") {
-        const existing = evaluator.live_version?.variables ?? [];
+        const existing = liveVersionOf(evaluator)?.variables ?? [];
         if (existing.length > 0) {
           body.variables = existing.map((v) => {
             const description = (
@@ -1100,7 +1106,7 @@ function EvaluatorDetailPageInner() {
 
                   {(() => {
                     const existingVariables =
-                      evaluator.live_version?.variables ?? [];
+                      liveVersionOf(evaluator)?.variables ?? [];
                     const detected = extractVariableNames(
                       newVersionSystemPrompt,
                     );

--- a/src/app/evaluators/[uuid]/page.tsx
+++ b/src/app/evaluators/[uuid]/page.tsx
@@ -29,7 +29,10 @@ import {
   defaultBinaryScale,
   type BinaryScaleRow,
 } from "@/components/evaluators/BinaryScaleEditor";
-import { defaultBinaryLabel } from "@/lib/binaryLabels";
+import {
+  coerceBinaryValue,
+  defaultBinaryLabel,
+} from "@/lib/binaryLabels";
 import { liveVersionOf } from "@/lib/evaluatorVersions";
 import { VersionCard } from "@/components/evaluators/VersionCard";
 import { extractVariableNames } from "@/lib/evaluatorVariables";
@@ -418,9 +421,14 @@ function EvaluatorDetailPageInner() {
       setNewVersionScale([]);
     }
     if (evaluator.output_type === "binary") {
+      // Coerce so legacy/alternate encodings (1/0, "true"/"false") still
+      // match — otherwise the form would render blank and silently drop
+      // the existing labels on save.
       const scale = live?.output_config?.scale ?? [];
-      const trueEntry = scale.find((e) => e.value === true);
-      const falseEntry = scale.find((e) => e.value === false);
+      const trueEntry = scale.find((e) => coerceBinaryValue(e.value) === true);
+      const falseEntry = scale.find(
+        (e) => coerceBinaryValue(e.value) === false,
+      );
       setNewVersionBinaryScale([
         {
           value: true,

--- a/src/app/evaluators/page.tsx
+++ b/src/app/evaluators/page.tsx
@@ -20,6 +20,10 @@ import {
 import { LLMSelectorModal } from "@/components/agent-tabs/LLMSelectorModal";
 import type { LLMModel } from "@/components/agent-tabs/constants/providers";
 import { CreateEvaluatorSidebar } from "@/components/evaluators/CreateEvaluatorSidebar";
+import {
+  defaultBinaryScale,
+  type BinaryScaleRow,
+} from "@/components/evaluators/BinaryScaleEditor";
 import { UseCasePickerDialog } from "@/components/evaluators/UseCasePickerDialog";
 import { extractVariableNames } from "@/lib/evaluatorVariables";
 import { useSidebarState } from "@/lib/sidebar";
@@ -38,6 +42,35 @@ type EvaluatorData = {
 };
 
 type EvaluatorTab = "default" | "mine";
+
+// Build the output_config payload for a binary evaluator. We only send a
+// `scale` when the user has actually overridden at least one label or
+// description — otherwise the backend defaults (Pass/Fail-shaped) stay in
+// effect. Returns either {} or { output_config: { scale: [...] } } so it
+// can be spread inline.
+function buildBinaryOutputConfig(rows: BinaryScaleRow[]): {
+  output_config?: {
+    scale: { value: boolean; name: string; description?: string }[];
+  };
+} {
+  const hasAnyOverride = rows.some(
+    (r) => r.name.trim().length > 0 || r.description.trim().length > 0,
+  );
+  if (!hasAnyOverride) return {};
+  return {
+    output_config: {
+      scale: rows.map((r) => ({
+        value: r.value,
+        name:
+          r.name.trim() ||
+          (r.value ? "Correct" : "Wrong"),
+        ...(r.description.trim()
+          ? { description: r.description.trim() }
+          : {}),
+      })),
+    },
+  };
+}
 
 const EVALUATOR_TYPE_TO_DATA_TYPE: Record<EvaluatorType, "text" | "audio"> = {
   tts: "audio",
@@ -198,6 +231,9 @@ function MetricsPageInner() {
     { value: 2, name: "", description: "" },
     { value: 3, name: "", description: "" },
   ]);
+  const [newEvaluatorBinaryScale, setNewEvaluatorBinaryScale] = useState<
+    BinaryScaleRow[]
+  >(defaultBinaryScale());
 
   // Delete confirmation state
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
@@ -357,6 +393,34 @@ function MetricsPageInner() {
           })),
         );
       }
+
+      // Seed the binary label editor when the use case's default ships a
+      // binary scale with custom labels. Otherwise leave the blank rows in
+      // place so placeholders fall back to Correct / Wrong.
+      if (
+        data.output_type === "binary" &&
+        data.output_config?.scale &&
+        data.output_config.scale.length >= 2
+      ) {
+        const trueEntry = data.output_config.scale.find(
+          (r) => r.value === true,
+        );
+        const falseEntry = data.output_config.scale.find(
+          (r) => r.value === false,
+        );
+        setNewEvaluatorBinaryScale([
+          {
+            value: true,
+            name: trueEntry?.name ?? "",
+            description: trueEntry?.description ?? "",
+          },
+          {
+            value: false,
+            name: falseEntry?.name ?? "",
+            description: falseEntry?.description ?? "",
+          },
+        ]);
+      }
     } catch (err) {
       console.error("Error prefilling default prompt:", err);
     }
@@ -483,6 +547,7 @@ function MetricsPageInner() {
       { value: 2, name: "", description: "" },
       { value: 3, name: "", description: "" },
     ]);
+    setNewEvaluatorBinaryScale(defaultBinaryScale());
   };
 
   // Check if the name already exists in the visible evaluator namespace.
@@ -570,7 +635,7 @@ function MetricsPageInner() {
                     })),
                   },
                 }
-              : {}),
+              : buildBinaryOutputConfig(newEvaluatorBinaryScale)),
           },
         }),
       });
@@ -984,6 +1049,7 @@ function MetricsPageInner() {
         evaluatorType={newEvaluatorType}
         evaluatorOutputType={newEvaluatorOutputType}
         evaluatorScale={newEvaluatorScale}
+        evaluatorBinaryScale={newEvaluatorBinaryScale}
         judgeModel={newEvaluatorJudgeModel}
         systemPrompt={newEvaluatorSystemPrompt}
         detectedPromptVariables={detectedPromptVariables}
@@ -1008,6 +1074,7 @@ function MetricsPageInner() {
         setEvaluatorDescription={setEvaluatorDescription}
         setEvaluatorOutputType={setNewEvaluatorOutputType}
         setEvaluatorScale={setNewEvaluatorScale}
+        setEvaluatorBinaryScale={setNewEvaluatorBinaryScale}
         setSystemPrompt={setNewEvaluatorSystemPrompt}
         setVariableDescriptions={setNewEvaluatorVariableDescriptions}
         setCreateNameError={setCreateNameError}

--- a/src/app/evaluators/page.tsx
+++ b/src/app/evaluators/page.tsx
@@ -24,6 +24,7 @@ import {
   defaultBinaryScale,
   type BinaryScaleRow,
 } from "@/components/evaluators/BinaryScaleEditor";
+import { defaultBinaryLabel } from "@/lib/binaryLabels";
 import { UseCasePickerDialog } from "@/components/evaluators/UseCasePickerDialog";
 import { extractVariableNames } from "@/lib/evaluatorVariables";
 import { useSidebarState } from "@/lib/sidebar";
@@ -61,9 +62,7 @@ function buildBinaryOutputConfig(rows: BinaryScaleRow[]): {
     output_config: {
       scale: rows.map((r) => ({
         value: r.value,
-        name:
-          r.name.trim() ||
-          (r.value ? "Correct" : "Wrong"),
+        name: r.name.trim() || defaultBinaryLabel(r.value),
         ...(r.description.trim()
           ? { description: r.description.trim() }
           : {}),

--- a/src/app/evaluators/page.tsx
+++ b/src/app/evaluators/page.tsx
@@ -394,33 +394,10 @@ function MetricsPageInner() {
         );
       }
 
-      // Seed the binary label editor when the use case's default ships a
-      // binary scale with custom labels. Otherwise leave the blank rows in
-      // place so placeholders fall back to Correct / Wrong.
-      if (
-        data.output_type === "binary" &&
-        data.output_config?.scale &&
-        data.output_config.scale.length >= 2
-      ) {
-        const trueEntry = data.output_config.scale.find(
-          (r) => r.value === true,
-        );
-        const falseEntry = data.output_config.scale.find(
-          (r) => r.value === false,
-        );
-        setNewEvaluatorBinaryScale([
-          {
-            value: true,
-            name: trueEntry?.name ?? "",
-            description: trueEntry?.description ?? "",
-          },
-          {
-            value: false,
-            name: falseEntry?.name ?? "",
-            description: falseEntry?.description ?? "",
-          },
-        ]);
-      }
+      // Intentionally do NOT seed the binary scale from the use case
+      // default. Correct / Wrong are the defaults — placeholders surface
+      // them so the user can override either and we only send a
+      // scale payload when they do.
     } catch (err) {
       console.error("Error prefilling default prompt:", err);
     }

--- a/src/app/human-alignment/tasks/[uuid]/evaluator-runs/[runUuid]/page.tsx
+++ b/src/app/human-alignment/tasks/[uuid]/evaluator-runs/[runUuid]/page.tsx
@@ -70,9 +70,23 @@ export default function EvaluatorRunDetailPage() {
 
   const [job, setJob] = useState<EvaluatorRunJob | null>(null);
   const [task, setTask] = useState<LabellingTaskFull | null>(null);
-  const [versionLabels, setVersionLabels] = useState<Record<string, string>>(
-    {},
-  );
+  // Version labels (`{ versionUuid: "v3" }`) are derived from the top-
+  // level `job.evaluators[]` block — each entry pins the version the
+  // job ran with and carries its `version_number`. The Re-run dialog
+  // lazy-loads the full version list itself when it opens (with its
+  // own spinner), so versions that didn't run on this job still get
+  // labelled there without pre-fetching here.
+  const versionLabels = useMemo<Record<string, string>>(() => {
+    const m: Record<string, string> = {};
+    for (const e of job?.evaluators ?? []) {
+      const id = e.evaluator_version_id;
+      const n = e.version_number;
+      if (id && typeof n === "number") {
+        m[id] = `v${n}`;
+      }
+    }
+    return m;
+  }, [job]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [exporting, setExporting] = useState(false);
@@ -167,41 +181,6 @@ export default function EvaluatorRunDetailPage() {
   }, [fetchJob]);
 
   // Lazily fetch version labels for evaluators referenced by the run.
-  // Keyed on the sorted list of evaluator IDs so the effect doesn't
-  // re-fire when the run polls.
-  const evaluatorIdsKey = (job?.details?.evaluators ?? [])
-    .map((e) => e.evaluator_id)
-    .filter(Boolean)
-    .slice()
-    .sort()
-    .join(",");
-  useEffect(() => {
-    if (!accessToken || !evaluatorIdsKey) return;
-    const evIds = evaluatorIdsKey.split(",");
-    let cancelled = false;
-    (async () => {
-      const merged: Record<string, string> = {};
-      await Promise.all(
-        evIds.map(async (evaluatorId) => {
-          try {
-            const versions = await apiClient<
-              Array<{ uuid: string; version_number: number }>
-            >(`/evaluators/${evaluatorId}/versions`, accessToken);
-            for (const v of versions) {
-              merged[v.uuid] = `v${v.version_number}`;
-            }
-          } catch {
-            // ignore
-          }
-        }),
-      );
-      if (!cancelled) setVersionLabels((prev) => ({ ...prev, ...merged }));
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, [accessToken, evaluatorIdsKey]);
-
   // Items in this run, derived the same way as the body view (used by export).
   const itemsForRun = useMemo<Item[]>(() => {
     if (!job) return [];
@@ -282,9 +261,17 @@ export default function EvaluatorRunDetailPage() {
     try {
       const ExcelJS = (await import("exceljs")).default;
       const wb = new ExcelJS.Workbook();
-      const evaluators = job.details?.evaluators ?? [];
+      const evaluators = (job.evaluators ?? []).map((e) => ({
+        evaluator_id: e.uuid,
+        evaluator_version_id: e.evaluator_version_id,
+        name: e.name,
+        output_type: e.output_type,
+      }));
 
       for (const ev of evaluators) {
+        const jobEvaluator = (job.evaluators ?? []).find(
+          (e) => e.uuid === ev.evaluator_id,
+        );
         const evName = evaluatorDisplayName(ev, evaluatorNamesById);
         const versionLabel = ev.evaluator_version_id
           ? (versionLabels[ev.evaluator_version_id] ?? null)
@@ -375,7 +362,7 @@ export default function EvaluatorRunDetailPage() {
             evReasoning = typeof reas === "string" ? reas : "";
           }
 
-          const outputType = runOutputType(run);
+          const outputType = runOutputType(run, jobEvaluator);
           const humanAgCell = agreementExportCell(
             evHumanData?.human_agreement,
             computeInterAnnotatorAgreement(
@@ -632,6 +619,7 @@ export default function EvaluatorRunDetailPage() {
         <RunEvaluatorsDialog
           isOpen={rerunOpen}
           accessToken={accessToken}
+          taskUuid={taskUuid}
           evaluators={(task.evaluators ?? []).map((e) => ({
             uuid: e.uuid,
             name: e.name,

--- a/src/app/human-alignment/tasks/[uuid]/page.tsx
+++ b/src/app/human-alignment/tasks/[uuid]/page.tsx
@@ -566,17 +566,21 @@ function LabelledByCell({
     );
   }
   const ids = Array.from(labellers);
-  const firstId = ids[0];
-  const firstName =
-    annotatorNameById.get(firstId) ?? firstId.slice(0, 8);
-  const remainingNames = ids
-    .slice(1)
-    .map((id) => annotatorNameById.get(id) ?? id.slice(0, 8));
+  const nameFor = (id: string) =>
+    annotatorNameById.get(id) ?? id.slice(0, 8);
+  const visibleIds = ids.length <= 2 ? ids : ids.slice(0, 1);
+  const remainingNames =
+    ids.length <= 2 ? [] : ids.slice(1).map(nameFor);
   return (
     <div className="flex flex-wrap gap-1 min-w-0">
-      <span className="inline-flex items-center px-2 py-0.5 rounded-md text-xs font-medium border border-border bg-muted/40 text-foreground">
-        {firstName}
-      </span>
+      {visibleIds.map((id) => (
+        <span
+          key={id}
+          className="inline-flex items-center px-2 py-0.5 rounded-md text-xs font-medium border border-border bg-muted/40 text-foreground"
+        >
+          {nameFor(id)}
+        </span>
+      ))}
       {remainingNames.length > 0 && (
         <span
           className="relative group inline-flex items-center px-2 py-0.5 rounded-md text-xs font-medium border border-border bg-muted/40 text-muted-foreground cursor-default"

--- a/src/app/human-alignment/tasks/[uuid]/page.tsx
+++ b/src/app/human-alignment/tasks/[uuid]/page.tsx
@@ -569,18 +569,30 @@ function LabelledByCell({
   const firstId = ids[0];
   const firstName =
     annotatorNameById.get(firstId) ?? firstId.slice(0, 8);
-  const remaining = ids.length - 1;
-  const allNames = ids
-    .map((id) => annotatorNameById.get(id) ?? id.slice(0, 8))
-    .join(", ");
+  const remainingNames = ids
+    .slice(1)
+    .map((id) => annotatorNameById.get(id) ?? id.slice(0, 8));
   return (
-    <div className="flex flex-wrap gap-1 min-w-0" title={allNames}>
+    <div className="flex flex-wrap gap-1 min-w-0">
       <span className="inline-flex items-center px-2 py-0.5 rounded-md text-xs font-medium border border-border bg-muted/40 text-foreground">
         {firstName}
       </span>
-      {remaining > 0 && (
-        <span className="inline-flex items-center px-2 py-0.5 rounded-md text-xs font-medium border border-border bg-muted/40 text-muted-foreground">
-          +{remaining} more
+      {remainingNames.length > 0 && (
+        <span
+          className="relative group inline-flex items-center px-2 py-0.5 rounded-md text-xs font-medium border border-border bg-muted/40 text-muted-foreground cursor-default"
+          onClick={(e) => e.stopPropagation()}
+        >
+          +{remainingNames.length} more
+          <span className="pointer-events-none absolute bottom-full left-1/2 -translate-x-1/2 mb-1 z-50 hidden group-hover:flex flex-wrap gap-1 px-2 py-1.5 rounded-lg bg-white shadow-lg border border-border max-w-64 w-max">
+            {remainingNames.map((n, i) => (
+              <span
+                key={i}
+                className="inline-flex items-center px-2 py-0.5 rounded-md text-xs font-medium border border-border bg-muted/40 text-foreground"
+              >
+                {n}
+              </span>
+            ))}
+          </span>
         </span>
       )}
     </div>

--- a/src/app/human-alignment/tasks/[uuid]/page.tsx
+++ b/src/app/human-alignment/tasks/[uuid]/page.tsx
@@ -63,11 +63,38 @@ type TaskAgreementResponse = {
 // order (union of every annotator with ≥1 annotation on the task);
 // each `rows[i].annotations[annotator_uuid]` is that annotator's
 // latest annotation for the slot, or null when they didn't label it.
+//
+// Per-row evaluator metadata (name, output_type, scale_min/max,
+// version_number, is_live_version) was moved to the top-level
+// `evaluators[]` block. The page looks each row's evaluator up by
+// `evaluator_id` (and `evaluator_version_id` for version-specific
+// fields).
 type SummaryAnnotator = { uuid: string; name: string };
 type SummaryEvaluator = {
-  evaluator_id: string;
+  uuid: string;
   name: string;
+  description?: string | null;
   output_type: "binary" | "rating";
+  evaluator_type?: string;
+  data_type?: string;
+  live_version_id?: string | null;
+  live_version_index?: number | null;
+  versions?: {
+    uuid: string;
+    version_number: number;
+    output_config?: {
+      scale?: {
+        value: boolean | number | string;
+        name?: string | null;
+        description?: string | null;
+        color?: string | null;
+      }[];
+    } | null;
+    scale_min?: number | null;
+    scale_max?: number | null;
+    is_live?: boolean;
+  }[];
+  run_count?: number;
 };
 type SummaryAnnotation = {
   value: boolean | number | null;
@@ -77,10 +104,9 @@ type SummaryRow = {
   item_id: string;
   payload: Record<string, unknown> | null;
   evaluator_id: string;
-  evaluator_name: string;
   evaluator_version_id?: string | null;
-  evaluator_version_number?: number | null;
   evaluator_value: boolean | number | null;
+  evaluator_value_name?: string | null;
   evaluator_reasoning?: string | null;
   // Aggregate agreement scores in [0, 1] for this (item, evaluator) slot.
   // human_agreement: null when <2 annotators labelled the slot.

--- a/src/app/human-alignment/tasks/[uuid]/page.tsx
+++ b/src/app/human-alignment/tasks/[uuid]/page.tsx
@@ -141,26 +141,36 @@ type EvaluatorRunMetricEntry = number | { type?: string; mean?: number | null };
 
 type EvaluatorRunJob = {
   uuid: string;
-  task_id: string;
   status: "queued" | "in_progress" | "completed" | "failed";
-  details: {
-    item_count?: number;
-    s3_prefix?: string;
-    metrics?: Record<string, EvaluatorRunMetricEntry>;
-  } | null;
-  // Top-level evaluators block. Each entry pins the version this run
-  // executed against and carries its `version_number` (used for the
-  // "v3" pills in the run list). Promoted from `details.evaluators`.
+  // Item count was promoted to the top level alongside the new
+  // evaluators block.
+  item_count?: number;
+  // Per-run evaluator refs — keys back into the response's top-level
+  // `evaluators[]` block via `(evaluator_id, evaluator_version_id)`.
+  // No name / version_number embedded here.
   evaluators?: {
-    uuid: string;
-    name: string;
-    evaluator_version_id?: string;
-    version_number?: number;
+    evaluator_id: string;
+    evaluator_version_id: string;
   }[];
-  error: string | null;
-  created_at: string;
   updated_at: string;
-  completed_at: string | null;
+};
+
+// Top-level evaluators[] entry on the runs-list response. One per
+// (evaluator, pinned version) tuple referenced across all runs. The
+// page builds a `(id, version_id) -> entry` lookup to resolve
+// per-run names / version numbers for the pills.
+type RunsListEvaluator = {
+  uuid: string;
+  name: string;
+  evaluator_version_id?: string;
+  version_number?: number;
+  output_type?: "binary" | "rating";
+  deleted?: boolean;
+};
+
+type EvaluatorRunsListResponse = {
+  evaluators?: RunsListEvaluator[];
+  runs: EvaluatorRunJob[];
 };
 
 function isTab(value: string | null): value is Tab {
@@ -331,17 +341,31 @@ function runStatusLabel(status: EvaluatorRunJob["status"]): string {
 
 function EvaluatorRunsList({
   runs,
+  evaluators,
   loading,
   error,
   onRequestDelete,
   onOpen,
 }: {
   runs: EvaluatorRunJob[];
+  /** Top-level evaluators[] block from the runs-list response. Keyed
+   * by `(uuid, evaluator_version_id)` for per-run pill rendering. */
+  evaluators: RunsListEvaluator[];
   loading: boolean;
   error: string | null;
   onRequestDelete: (runUuid: string) => void;
   onOpen: (runUuid: string) => void;
 }) {
+  // (evaluator_id, evaluator_version_id) -> top-level entry. Same
+  // evaluator can appear under multiple versions, so we key on both.
+  const evaluatorByKey = useMemo(() => {
+    const m = new Map<string, RunsListEvaluator>();
+    for (const e of evaluators) {
+      const vid = e.evaluator_version_id ?? "";
+      m.set(`${e.uuid}:${vid}`, e);
+    }
+    return m;
+  }, [evaluators]);
   if (loading) {
     return (
       <div className="flex items-center justify-center gap-2 py-8 text-sm text-muted-foreground">
@@ -409,21 +433,26 @@ function EvaluatorRunsList({
         <div />
       </div>
       {runs.map((run) => {
-        const itemCount = run.details?.item_count ?? 0;
-        const lastUpdated = run.updated_at || run.created_at;
-        // Per-run pinned evaluators live at the top level now (used to be
-        // `run.details.evaluators`). Each entry already carries the
-        // pinned version id + number — no version-labels lookup needed.
-        const evaluators = (run.evaluators ?? []).map((e) => ({
-          evaluator_id: e.uuid,
-          evaluator_version_id: e.evaluator_version_id,
-          name: e.name,
-          version_label:
-            typeof e.version_number === "number"
-              ? `v${e.version_number}`
-              : null,
-        }));
-        const evaluatorTitle = evaluators
+        const itemCount = run.item_count ?? 0;
+        const lastUpdated = run.updated_at;
+        // Per-run evaluator refs ([{evaluator_id, evaluator_version_id}])
+        // are resolved against the top-level evaluators[] block to get
+        // names and version numbers for the pills.
+        const runEvaluators = (run.evaluators ?? []).map((ref) => {
+          const ev = evaluatorByKey.get(
+            `${ref.evaluator_id}:${ref.evaluator_version_id ?? ""}`,
+          );
+          return {
+            evaluator_id: ref.evaluator_id,
+            evaluator_version_id: ref.evaluator_version_id,
+            name: ev?.name ?? "",
+            version_label:
+              typeof ev?.version_number === "number"
+                ? `v${ev.version_number}`
+                : null,
+          };
+        });
+        const evaluatorTitle = runEvaluators
           .map((e) => {
             const name = e.name || e.evaluator_id.slice(0, 8);
             return e.version_label ? `${name} (${e.version_label})` : name;
@@ -439,10 +468,10 @@ function EvaluatorRunsList({
               className="flex flex-wrap gap-1.5 min-w-0"
               title={evaluatorTitle}
             >
-              {evaluators.length === 0 ? (
+              {runEvaluators.length === 0 ? (
                 <span className="text-sm text-muted-foreground">—</span>
               ) : (
-                evaluators.map((e) => {
+                runEvaluators.map((e) => {
                   const name = e.name || e.evaluator_id.slice(0, 8);
                   return (
                     <span
@@ -912,6 +941,12 @@ function LabellingTaskPageInner() {
 
   // evaluators / agreement (declared before route-level effects that reset on uuid)
   const [runs, setRuns] = useState<EvaluatorRunJob[]>([]);
+  // Top-level evaluators[] block from the runs-list response. Used to
+  // resolve each run's evaluator refs (id, version_id) into display
+  // pills (name + version_number).
+  const [runsListEvaluators, setRunsListEvaluators] = useState<
+    RunsListEvaluator[]
+  >([]);
   const [runsLoading, setRunsLoading] = useState(false);
   const [runsError, setRunsError] = useState<string | null>(null);
   /** False until the first evaluator-runs list fetch finishes (avoids empty placeholder flash). */
@@ -978,6 +1013,7 @@ function LabellingTaskPageInner() {
     setTask(null);
     setError(null);
     setRuns([]);
+    setRunsListEvaluators([]);
     setRunsFetchCompleted(false);
     autoTabSwitchedRef.current = false;
   }, [uuid]);
@@ -1094,11 +1130,14 @@ function LabellingTaskPageInner() {
     setRunsLoading(true);
     setRunsError(null);
     try {
-      const data = await apiClient<EvaluatorRunJob[]>(
+      const data = await apiClient<EvaluatorRunsListResponse>(
         `/annotation-tasks/${uuid}/evaluator-runs`,
         accessToken,
       );
-      setRuns(Array.isArray(data) ? data : []);
+      setRuns(Array.isArray(data?.runs) ? data.runs : []);
+      setRunsListEvaluators(
+        Array.isArray(data?.evaluators) ? data.evaluators : [],
+      );
     } catch (err) {
       setRunsError(parseApiError(err, "Failed to load evaluator runs"));
     } finally {
@@ -2381,6 +2420,7 @@ function LabellingTaskPageInner() {
         {activeTab === "runs" && (
           <EvaluatorRunsList
             runs={runs}
+            evaluators={runsListEvaluators}
             loading={runsLoading || !runsFetchCompleted}
             error={runsError}
             onRequestDelete={(runUuid) => setDeletingRunUuid(runUuid)}

--- a/src/app/human-alignment/tasks/[uuid]/page.tsx
+++ b/src/app/human-alignment/tasks/[uuid]/page.tsx
@@ -565,16 +565,24 @@ function LabelledByCell({
       </div>
     );
   }
+  const ids = Array.from(labellers);
+  const firstId = ids[0];
+  const firstName =
+    annotatorNameById.get(firstId) ?? firstId.slice(0, 8);
+  const remaining = ids.length - 1;
+  const allNames = ids
+    .map((id) => annotatorNameById.get(id) ?? id.slice(0, 8))
+    .join(", ");
   return (
-    <div className="flex flex-wrap gap-1 min-w-0">
-      {Array.from(labellers).map((annId) => (
-        <span
-          key={annId}
-          className="inline-flex items-center px-2 py-0.5 rounded-md text-xs font-medium border border-border bg-muted/40 text-foreground"
-        >
-          {annotatorNameById.get(annId) ?? annId.slice(0, 8)}
+    <div className="flex flex-wrap gap-1 min-w-0" title={allNames}>
+      <span className="inline-flex items-center px-2 py-0.5 rounded-md text-xs font-medium border border-border bg-muted/40 text-foreground">
+        {firstName}
+      </span>
+      {remaining > 0 && (
+        <span className="inline-flex items-center px-2 py-0.5 rounded-md text-xs font-medium border border-border bg-muted/40 text-muted-foreground">
+          +{remaining} more
         </span>
-      ))}
+      )}
     </div>
   );
 }

--- a/src/app/human-alignment/tasks/[uuid]/page.tsx
+++ b/src/app/human-alignment/tasks/[uuid]/page.tsx
@@ -118,15 +118,19 @@ type EvaluatorRunJob = {
   task_id: string;
   status: "queued" | "in_progress" | "completed" | "failed";
   details: {
-    evaluators?: {
-      evaluator_id: string;
-      evaluator_version_id?: string;
-      name?: string;
-    }[];
     item_count?: number;
     s3_prefix?: string;
     metrics?: Record<string, EvaluatorRunMetricEntry>;
   } | null;
+  // Top-level evaluators block. Each entry pins the version this run
+  // executed against and carries its `version_number` (used for the
+  // "v3" pills in the run list). Promoted from `details.evaluators`.
+  evaluators?: {
+    uuid: string;
+    name: string;
+    evaluator_version_id?: string;
+    version_number?: number;
+  }[];
   error: string | null;
   created_at: string;
   updated_at: string;
@@ -303,14 +307,12 @@ function EvaluatorRunsList({
   runs,
   loading,
   error,
-  versionLabels,
   onRequestDelete,
   onOpen,
 }: {
   runs: EvaluatorRunJob[];
   loading: boolean;
   error: string | null;
-  versionLabels: Record<string, Record<string, string>>;
   onRequestDelete: (runUuid: string) => void;
   onOpen: (runUuid: string) => void;
 }) {
@@ -383,22 +385,22 @@ function EvaluatorRunsList({
       {runs.map((run) => {
         const itemCount = run.details?.item_count ?? 0;
         const lastUpdated = run.updated_at || run.created_at;
-        const evaluators = run.details?.evaluators ?? [];
-        const versionLabelFor = (
-          evaluatorId: string,
-          versionId: string | undefined,
-        ): string | null => {
-          if (!versionId) return null;
-          return versionLabels[evaluatorId]?.[versionId] ?? null;
-        };
+        // Per-run pinned evaluators live at the top level now (used to be
+        // `run.details.evaluators`). Each entry already carries the
+        // pinned version id + number — no version-labels lookup needed.
+        const evaluators = (run.evaluators ?? []).map((e) => ({
+          evaluator_id: e.uuid,
+          evaluator_version_id: e.evaluator_version_id,
+          name: e.name,
+          version_label:
+            typeof e.version_number === "number"
+              ? `v${e.version_number}`
+              : null,
+        }));
         const evaluatorTitle = evaluators
           .map((e) => {
             const name = e.name || e.evaluator_id.slice(0, 8);
-            const label = versionLabelFor(
-              e.evaluator_id,
-              e.evaluator_version_id,
-            );
-            return label ? `${name} (${label})` : name;
+            return e.version_label ? `${name} (${e.version_label})` : name;
           })
           .join(", ");
         return (
@@ -416,19 +418,15 @@ function EvaluatorRunsList({
               ) : (
                 evaluators.map((e) => {
                   const name = e.name || e.evaluator_id.slice(0, 8);
-                  const label = versionLabelFor(
-                    e.evaluator_id,
-                    e.evaluator_version_id,
-                  );
                   return (
                     <span
                       key={`${e.evaluator_id}-${e.evaluator_version_id ?? ""}`}
                       className="inline-flex items-center gap-1 px-2 py-0.5 rounded-md text-xs font-medium border border-border bg-background text-foreground"
                     >
                       <span>{name}</span>
-                      {label && (
+                      {e.version_label && (
                         <span className="font-mono text-[10px] text-muted-foreground">
-                          {label}
+                          {e.version_label}
                         </span>
                       )}
                     </span>
@@ -1065,12 +1063,6 @@ function LabellingTaskPageInner() {
     for (const a of taskSummary?.annotators ?? []) map.set(a.uuid, a.name);
     return map;
   }, [taskSummary]);
-  // Map evaluator_id -> { version_id: "v1" }, populated on demand from
-  // /evaluators/{uuid}/versions so we can label runs by version number.
-  const [versionLabels, setVersionLabels] = useState<
-    Record<string, Record<string, string>>
-  >({});
-
   const fetchRuns = useCallback(async () => {
     if (!accessToken || !uuid) return;
     setRunsLoading(true);
@@ -1093,47 +1085,6 @@ function LabellingTaskPageInner() {
     fetchRuns();
   }, [fetchRuns]);
   void activeTab;
-
-  // Fetch evaluator versions for any evaluator referenced by a run that we
-  // haven't already loaded.
-  useEffect(() => {
-    if (!accessToken) return;
-    const needed = new Set<string>();
-    for (const r of runs) {
-      for (const ev of r.details?.evaluators ?? []) {
-        if (ev.evaluator_id && !versionLabels[ev.evaluator_id]) {
-          needed.add(ev.evaluator_id);
-        }
-      }
-    }
-    if (needed.size === 0) return;
-    let cancelled = false;
-    (async () => {
-      const updates: Record<string, Record<string, string>> = {};
-      await Promise.all(
-        Array.from(needed).map(async (evaluatorId) => {
-          try {
-            const versions = await apiClient<
-              Array<{ uuid: string; version_number: number }>
-            >(`/evaluators/${evaluatorId}/versions`, accessToken);
-            const map: Record<string, string> = {};
-            for (const v of versions) {
-              map[v.uuid] = `v${v.version_number}`;
-            }
-            updates[evaluatorId] = map;
-          } catch {
-            updates[evaluatorId] = {};
-          }
-        }),
-      );
-      if (!cancelled) {
-        setVersionLabels((prev) => ({ ...prev, ...updates }));
-      }
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, [runs, accessToken, versionLabels]);
 
   const items = task?.items ?? [];
   const jobs = task?.jobs ?? [];
@@ -2406,7 +2357,6 @@ function LabellingTaskPageInner() {
             runs={runs}
             loading={runsLoading || !runsFetchCompleted}
             error={runsError}
-            versionLabels={versionLabels}
             onRequestDelete={(runUuid) => setDeletingRunUuid(runUuid)}
             onOpen={(runUuid) =>
               router.push(
@@ -2421,6 +2371,7 @@ function LabellingTaskPageInner() {
         <RunEvaluatorsDialog
           isOpen={runDialogOpen}
           accessToken={accessToken}
+          taskUuid={uuid}
           evaluators={(task?.evaluators ?? []).map((e) => ({
             uuid: e.uuid,
             name: e.name,

--- a/src/app/human-alignment/tasks/[uuid]/page.tsx
+++ b/src/app/human-alignment/tasks/[uuid]/page.tsx
@@ -506,16 +506,6 @@ function ItemRowActions({
           Label
         </button>
       )}
-      {onEdit && (
-        <button
-          type="button"
-          onClick={() => onEdit(itemUuid)}
-          aria-label="Edit"
-          className="h-8 px-3 rounded-md text-sm font-medium border border-border bg-background hover:bg-muted/50 transition-colors cursor-pointer"
-        >
-          Edit
-        </button>
-      )}
       {onEvaluate && (
         <button
           type="button"
@@ -524,6 +514,16 @@ function ItemRowActions({
           className="h-8 px-3 rounded-md text-sm font-medium border border-indigo-500/30 bg-indigo-500/10 text-indigo-600 dark:text-indigo-300 hover:bg-indigo-500/20 transition-colors cursor-pointer"
         >
           Evaluate
+        </button>
+      )}
+      {onEdit && (
+        <button
+          type="button"
+          onClick={() => onEdit(itemUuid)}
+          aria-label="Edit"
+          className="h-8 px-3 rounded-md text-sm font-medium border border-border bg-background hover:bg-muted/50 transition-colors cursor-pointer"
+        >
+          Edit
         </button>
       )}
       {/* Delete Button */}

--- a/src/app/human-alignment/tasks/[uuid]/page.tsx
+++ b/src/app/human-alignment/tasks/[uuid]/page.tsx
@@ -9,6 +9,7 @@ import {
   useRef,
   useState,
 } from "react";
+import { createPortal } from "react-dom";
 import Link from "next/link";
 import { useParams, useRouter, useSearchParams } from "next/navigation";
 import { toast } from "sonner";
@@ -582,24 +583,66 @@ function LabelledByCell({
         </span>
       ))}
       {remainingNames.length > 0 && (
-        <span
-          className="relative group inline-flex items-center px-2 py-0.5 rounded-md text-xs font-medium border border-border bg-muted/40 text-muted-foreground cursor-default"
-          onClick={(e) => e.stopPropagation()}
-        >
-          +{remainingNames.length} more
-          <span className="pointer-events-none absolute bottom-full left-1/2 -translate-x-1/2 mb-1 z-50 hidden group-hover:flex flex-wrap gap-1 px-2 py-1.5 rounded-lg bg-white shadow-lg border border-border max-w-64 w-max">
-            {remainingNames.map((n, i) => (
-              <span
-                key={i}
-                className="inline-flex items-center px-2 py-0.5 rounded-md text-xs font-medium border border-border bg-muted/40 text-foreground"
-              >
-                {n}
-              </span>
-            ))}
-          </span>
-        </span>
+        <MoreLabellersChip names={remainingNames} />
       )}
     </div>
+  );
+}
+
+function MoreLabellersChip({ names }: { names: string[] }) {
+  const triggerRef = useRef<HTMLSpanElement>(null);
+  const [open, setOpen] = useState(false);
+  const [pos, setPos] = useState<{ top: number; left: number } | null>(null);
+
+  useEffect(() => {
+    if (!open || !triggerRef.current) return;
+    const update = () => {
+      if (!triggerRef.current) return;
+      const r = triggerRef.current.getBoundingClientRect();
+      setPos({ top: r.top, left: r.left + r.width / 2 });
+    };
+    update();
+    window.addEventListener("scroll", update, true);
+    window.addEventListener("resize", update);
+    return () => {
+      window.removeEventListener("scroll", update, true);
+      window.removeEventListener("resize", update);
+    };
+  }, [open]);
+
+  return (
+    <>
+      <span
+        ref={triggerRef}
+        className="inline-flex items-center px-2 py-0.5 rounded-md text-xs font-medium border border-border bg-muted/40 text-muted-foreground cursor-default"
+        onMouseEnter={() => setOpen(true)}
+        onMouseLeave={() => setOpen(false)}
+        onClick={(e) => e.stopPropagation()}
+      >
+        +{names.length} more
+      </span>
+      {open &&
+        pos &&
+        typeof window !== "undefined" &&
+        createPortal(
+          <div
+            className="fixed z-[9999] -translate-x-1/2 -translate-y-full pointer-events-none"
+            style={{ top: pos.top - 6, left: pos.left }}
+          >
+            <div className="flex flex-wrap gap-1 px-2 py-1.5 rounded-lg bg-white shadow-lg border border-border max-w-64 w-max">
+              {names.map((n, i) => (
+                <span
+                  key={i}
+                  className="inline-flex items-center px-2 py-0.5 rounded-md text-xs font-medium border border-border bg-muted/40 text-foreground"
+                >
+                  {n}
+                </span>
+              ))}
+            </div>
+          </div>,
+          document.body,
+        )}
+    </>
   );
 }
 

--- a/src/app/human-alignment/tasks/[uuid]/page.tsx
+++ b/src/app/human-alignment/tasks/[uuid]/page.tsx
@@ -185,6 +185,14 @@ type LabellingTask = {
     output_type?: "binary" | "rating" | null;
     scale_min?: number | boolean | null;
     scale_max?: number | boolean | null;
+    output_config?: {
+      scale?: {
+        value: boolean | number | string;
+        name?: string | null;
+        description?: string | null;
+        color?: string | null;
+      }[];
+    } | null;
     variables?: EvaluatorVariableDef[] | null;
   }[];
   items?: LabellingItem[];

--- a/src/app/public/benchmark/[token]/page.tsx
+++ b/src/app/public/benchmark/[token]/page.tsx
@@ -5,6 +5,7 @@ import { useParams } from "next/navigation";
 import { PublicPageLayout, PublicNotFound, PublicLoading } from "@/components/PublicPageLayout";
 import { BenchmarkCombinedLeaderboard, BenchmarkOutputsPanel } from "@/components/eval-details";
 import type { BenchmarkModelResult } from "@/components/eval-details";
+import type { TestRunEvaluator } from "@/components/test-results/shared";
 import { ExportResultsButton } from "@/components/ExportResultsButton";
 import { buildBenchmarkCsv } from "@/lib/exportTestResults";
 
@@ -20,6 +21,8 @@ type BenchmarkStatusResponse = {
   status: string;
   model_results?: BenchmarkModelResult[];
   leaderboard_summary?: LeaderboardSummary[];
+  /** Top-level per-evaluator metadata block — see TestRunEvaluator. */
+  evaluators?: TestRunEvaluator[];
   error?: string;
 };
 
@@ -112,6 +115,9 @@ export default function PublicBenchmarkPage() {
                         judgeResults: tr.judge_results,
                       })),
                     ),
+                    Object.fromEntries(
+                      (data.evaluators ?? []).map((e) => [e.uuid, e]),
+                    ),
                   )
                 }
               />
@@ -141,6 +147,9 @@ export default function PublicBenchmarkPage() {
               onSelectTest={(model, testIndex) => setSelectedTest({ model, testIndex })}
               onClearSelection={() => setSelectedTest(null)}
               showControls={true}
+              evaluatorsByUuid={Object.fromEntries(
+                (data.evaluators ?? []).map((e) => [e.uuid, e]),
+              )}
               enableEvaluatorLinks={false}
             />
           </div>

--- a/src/app/public/test-run/[token]/page.tsx
+++ b/src/app/public/test-run/[token]/page.tsx
@@ -2,7 +2,12 @@
 
 import React, { useState, useEffect } from "react";
 import { useParams } from "next/navigation";
-import { TestCaseOutput, TestCaseData, JudgeResult } from "@/components/test-results/shared";
+import {
+  TestCaseOutput,
+  TestCaseData,
+  JudgeResult,
+  TestRunEvaluator,
+} from "@/components/test-results/shared";
 import { PublicPageLayout, PublicNotFound, PublicLoading } from "@/components/PublicPageLayout";
 import { TestRunOutputsPanel } from "@/components/eval-details";
 import { ExportResultsButton } from "@/components/ExportResultsButton";
@@ -30,6 +35,8 @@ type TestRunStatusResponse = {
   passed?: number;
   failed?: number;
   results?: TestCaseResult[];
+  /** Top-level per-evaluator metadata block — see TestRunEvaluator. */
+  evaluators?: TestRunEvaluator[];
   error?: string;
 };
 
@@ -112,6 +119,9 @@ export default function PublicTestRunPage() {
                     reasoning: r.reasoning,
                     judgeResults: r.judge_results,
                   })),
+                  Object.fromEntries(
+                    (data.evaluators ?? []).map((e) => [e.uuid, e]),
+                  ),
                 )
               }
             />
@@ -135,6 +145,9 @@ export default function PublicTestRunPage() {
               selectedId={selectedId}
               onSelect={setSelectedId}
               onClearSelection={() => setSelectedId(null)}
+              evaluatorsByUuid={Object.fromEntries(
+                (data.evaluators ?? []).map((e) => [e.uuid, e]),
+              )}
               enableEvaluatorLinks={false}
             />
           </div>

--- a/src/app/stt/[uuid]/page.tsx
+++ b/src/app/stt/[uuid]/page.tsx
@@ -304,146 +304,42 @@ export default function STTEvaluationDetailPage() {
     fetchEvaluators();
   }, [backendAccessToken]);
 
-  // Resolve the evaluators rendered in the About tab. Three sources, in
-  // priority order:
-  //   1) `evaluator_runs` from any provider in the response (new format) —
-  //      this carries the live `name`, stable `evaluator_uuid`, and an
-  //      `aggregate` block with `type` plus `scale_min` / `scale_max` for
-  //      rating evaluators. We can build the About rows directly from this
-  //      without hitting `/evaluators/{uuid}`.
-  //   2) Legacy `_info`-format payloads or `evaluator_uuids` lists. We take
-  //      the union of `evaluator_uuids` and any UUIDs resolved by name from
-  //      `${prefix}_info` keys in the first provider's `metrics`, then issue
-  //      one `GET /evaluators/{uuid}` per target so we can render the
-  //      "min - max" range for rating evaluators. The list endpoint isn't
-  //      guaranteed to ship the scale.
-  //   3) Truly legacy jobs (no runs, no `evaluator_uuids`, no `*_info`
-  //      keys): fall back to the default STT evaluators so the tab still
-  //      shows at least one row.
+  // Resolve the evaluators rendered in the About tab from the new-format
+  // payload — each provider result carries `evaluator_runs[]` with the
+  // live `name`, stable `evaluator_uuid`, and an `aggregate` block
+  // containing `type` plus `scale_min` / `scale_max` for rating
+  // evaluators. Legacy `*_info`-style payloads are no longer supported.
   useEffect(() => {
-    const fetchAboutEvaluators = async () => {
-      if (!evaluationResult) return;
+    if (!evaluationResult) return;
 
-      // (1) New format — derive directly from `evaluator_runs`.
-      const firstRuns = (evaluationResult.provider_results ?? [])
-        .map((pr) => pr.evaluator_runs)
-        .find((er): er is EvaluatorRun[] => Array.isArray(er) && er.length > 0);
+    const firstRuns = (evaluationResult.provider_results ?? [])
+      .map((pr) => pr.evaluator_runs)
+      .find((er): er is EvaluatorRun[] => Array.isArray(er) && er.length > 0);
 
-      if (firstRuns) {
-        const byUuid = new Map<string, EvaluatorAbout>();
-        for (const run of firstRuns) {
-          if (byUuid.has(run.evaluator_uuid)) continue;
-          const a = run.aggregate ?? {};
-          const scaleValues: number[] = [];
-          if (typeof a.scale_min === "number") scaleValues.push(a.scale_min);
-          if (typeof a.scale_max === "number" && a.scale_max !== a.scale_min) {
-            scaleValues.push(a.scale_max);
-          }
-          byUuid.set(run.evaluator_uuid, {
-            uuid: run.evaluator_uuid,
-            name: run.name ?? run.metric_key,
-            description: run.description ?? "",
-            outputType: a.type === "rating" ? "rating" : "binary",
-            scaleValues,
-          });
-        }
-        setAboutEvaluators(Array.from(byUuid.values()));
-        return;
+    if (!firstRuns) {
+      setAboutEvaluators([]);
+      return;
+    }
+
+    const byUuid = new Map<string, EvaluatorAbout>();
+    for (const run of firstRuns) {
+      if (byUuid.has(run.evaluator_uuid)) continue;
+      const a = run.aggregate ?? {};
+      const scaleValues: number[] = [];
+      if (typeof a.scale_min === "number") scaleValues.push(a.scale_min);
+      if (typeof a.scale_max === "number" && a.scale_max !== a.scale_min) {
+        scaleValues.push(a.scale_max);
       }
-
-      // (2) + (3) Legacy paths. Need the auth list first to validate UUIDs.
-      if (!backendAccessToken || sttEvaluators.length === 0) return;
-
-      const knownByUuid = new Set(sttEvaluators.map((e) => e.uuid));
-      const knownByName = new Map(sttEvaluators.map((e) => [e.name, e.uuid]));
-
-      const uuidSet = new Set<string>();
-      for (const u of evaluationResult.evaluator_uuids ?? []) {
-        if (knownByUuid.has(u)) uuidSet.add(u);
-      }
-
-      const firstMetrics = (evaluationResult.provider_results ?? [])
-        .map((pr) => pr.metrics)
-        .find((m): m is ProviderMetrics => !!m);
-      if (firstMetrics) {
-        for (const k of Object.keys(firstMetrics)) {
-          if (
-            k === "wer" ||
-            k === "string_similarity" ||
-            k === "llm_judge_score"
-          ) {
-            continue;
-          }
-          if (k.endsWith("_info")) {
-            const prefix = k.slice(0, -"_info".length);
-            const uuid = knownByName.get(prefix);
-            if (uuid) uuidSet.add(uuid);
-          }
-        }
-      }
-
-      let targetUuids: string[] = Array.from(uuidSet);
-      if (targetUuids.length === 0) {
-        targetUuids = sttEvaluators
-          .filter((e) => e.isDefault)
-          .map((e) => e.uuid);
-      }
-
-      if (targetUuids.length === 0) {
-        setAboutEvaluators([]);
-        return;
-      }
-
-      try {
-        const backendUrl = process.env.NEXT_PUBLIC_BACKEND_URL;
-        if (!backendUrl) return;
-
-        const results = await Promise.all(
-          targetUuids.map(async (uuid) => {
-            const response = await fetch(`${backendUrl}/evaluators/${uuid}`, {
-              method: "GET",
-              headers: {
-                accept: "application/json",
-                Authorization: `Bearer ${backendAccessToken}`,
-              },
-            });
-            if (!response.ok) return null;
-            const data: {
-              uuid: string;
-              name: string;
-              description?: string | null;
-              output_type: "binary" | "rating";
-              live_version?: {
-                output_config?: {
-                  scale?: { value: number | boolean | string }[];
-                } | null;
-              } | null;
-            } = await response.json();
-
-            const scaleValues = (data.live_version?.output_config?.scale ?? [])
-              .map((s) => Number(s.value))
-              .filter((v) => !Number.isNaN(v));
-
-            return {
-              uuid: data.uuid,
-              name: data.name,
-              description: data.description ?? "",
-              outputType: data.output_type,
-              scaleValues,
-            } satisfies EvaluatorAbout;
-          }),
-        );
-
-        setAboutEvaluators(
-          results.filter((e): e is EvaluatorAbout => e !== null),
-        );
-      } catch (err) {
-        console.error("Error fetching evaluator details:", err);
-      }
-    };
-
-    fetchAboutEvaluators();
-  }, [backendAccessToken, evaluationResult, sttEvaluators]);
+      byUuid.set(run.evaluator_uuid, {
+        uuid: run.evaluator_uuid,
+        name: run.name ?? run.metric_key,
+        description: run.description ?? "",
+        outputType: a.type === "rating" ? "rating" : "binary",
+        scaleValues,
+      });
+    }
+    setAboutEvaluators(Array.from(byUuid.values()));
+  }, [evaluationResult]);
 
   // Fetch evaluation result
   useEffect(() => {

--- a/src/app/tts/[uuid]/page.tsx
+++ b/src/app/tts/[uuid]/page.tsx
@@ -304,146 +304,42 @@ export default function TTSEvaluationDetailPage() {
     fetchEvaluators();
   }, [backendAccessToken]);
 
-  // Resolve the evaluators rendered in the About tab. Three sources, in
-  // priority order:
-  //   1) `evaluator_runs` from any provider in the response (new format) —
-  //      this carries the live `name`, stable `evaluator_uuid`, and an
-  //      `aggregate` block with `type` plus `scale_min` / `scale_max` for
-  //      rating evaluators. We can build the About rows directly from this
-  //      without hitting `/evaluators/{uuid}`.
-  //   2) Legacy `_info`-format payloads or `evaluator_uuids` lists. We take
-  //      the union of `evaluator_uuids` and any UUIDs resolved by name from
-  //      `${prefix}_info` keys in the first provider's `metrics`, then issue
-  //      one `GET /evaluators/{uuid}` per target so we can render the
-  //      "min - max" range for rating evaluators. The list endpoint isn't
-  //      guaranteed to ship the scale.
-  //   3) Truly legacy jobs (no runs, no `evaluator_uuids`, no `*_info`
-  //      keys): fall back to the default TTS evaluators so the tab still
-  //      shows at least one row.
+  // Resolve the evaluators rendered in the About tab from the new-format
+  // payload — each provider result carries `evaluator_runs[]` with the
+  // live `name`, stable `evaluator_uuid`, and an `aggregate` block
+  // containing `type` plus `scale_min` / `scale_max` for rating
+  // evaluators. Legacy `*_info`-style payloads are no longer supported.
   useEffect(() => {
-    const fetchAboutEvaluators = async () => {
-      if (!evaluationResult) return;
+    if (!evaluationResult) return;
 
-      // (1) New format — derive directly from `evaluator_runs`.
-      const firstRuns = (evaluationResult.provider_results ?? [])
-        .map((pr) => pr.evaluator_runs)
-        .find((er): er is EvaluatorRun[] => Array.isArray(er) && er.length > 0);
+    const firstRuns = (evaluationResult.provider_results ?? [])
+      .map((pr) => pr.evaluator_runs)
+      .find((er): er is EvaluatorRun[] => Array.isArray(er) && er.length > 0);
 
-      if (firstRuns) {
-        const byUuid = new Map<string, EvaluatorAbout>();
-        for (const run of firstRuns) {
-          if (byUuid.has(run.evaluator_uuid)) continue;
-          const a = run.aggregate ?? {};
-          const scaleValues: number[] = [];
-          if (typeof a.scale_min === "number") scaleValues.push(a.scale_min);
-          if (typeof a.scale_max === "number" && a.scale_max !== a.scale_min) {
-            scaleValues.push(a.scale_max);
-          }
-          byUuid.set(run.evaluator_uuid, {
-            uuid: run.evaluator_uuid,
-            name: run.name ?? run.metric_key,
-            description: run.description ?? "",
-            outputType: a.type === "rating" ? "rating" : "binary",
-            scaleValues,
-          });
-        }
-        setAboutEvaluators(Array.from(byUuid.values()));
-        return;
+    if (!firstRuns) {
+      setAboutEvaluators([]);
+      return;
+    }
+
+    const byUuid = new Map<string, EvaluatorAbout>();
+    for (const run of firstRuns) {
+      if (byUuid.has(run.evaluator_uuid)) continue;
+      const a = run.aggregate ?? {};
+      const scaleValues: number[] = [];
+      if (typeof a.scale_min === "number") scaleValues.push(a.scale_min);
+      if (typeof a.scale_max === "number" && a.scale_max !== a.scale_min) {
+        scaleValues.push(a.scale_max);
       }
-
-      // (2) + (3) Legacy paths. Need the auth list first to validate UUIDs.
-      if (!backendAccessToken || ttsEvaluators.length === 0) return;
-
-      const knownByUuid = new Set(ttsEvaluators.map((e) => e.uuid));
-      const knownByName = new Map(ttsEvaluators.map((e) => [e.name, e.uuid]));
-
-      const uuidSet = new Set<string>();
-      for (const u of evaluationResult.evaluator_uuids ?? []) {
-        if (knownByUuid.has(u)) uuidSet.add(u);
-      }
-
-      const firstMetrics = (evaluationResult.provider_results ?? [])
-        .map((pr) => pr.metrics)
-        .find((m): m is ProviderMetrics => !!m);
-      if (firstMetrics) {
-        for (const k of Object.keys(firstMetrics)) {
-          if (
-            k === "llm_judge_score" ||
-            k === "ttfb" ||
-            k === "processing_time"
-          ) {
-            continue;
-          }
-          if (k.endsWith("_info")) {
-            const prefix = k.slice(0, -"_info".length);
-            const uuid = knownByName.get(prefix);
-            if (uuid) uuidSet.add(uuid);
-          }
-        }
-      }
-
-      let targetUuids: string[] = Array.from(uuidSet);
-      if (targetUuids.length === 0) {
-        targetUuids = ttsEvaluators
-          .filter((e) => e.isDefault)
-          .map((e) => e.uuid);
-      }
-
-      if (targetUuids.length === 0) {
-        setAboutEvaluators([]);
-        return;
-      }
-
-      try {
-        const backendUrl = process.env.NEXT_PUBLIC_BACKEND_URL;
-        if (!backendUrl) return;
-
-        const results = await Promise.all(
-          targetUuids.map(async (uuid) => {
-            const response = await fetch(`${backendUrl}/evaluators/${uuid}`, {
-              method: "GET",
-              headers: {
-                accept: "application/json",
-                Authorization: `Bearer ${backendAccessToken}`,
-              },
-            });
-            if (!response.ok) return null;
-            const data: {
-              uuid: string;
-              name: string;
-              description?: string | null;
-              output_type: "binary" | "rating";
-              live_version?: {
-                output_config?: {
-                  scale?: { value: number | boolean | string }[];
-                } | null;
-              } | null;
-            } = await response.json();
-
-            const scaleValues = (data.live_version?.output_config?.scale ?? [])
-              .map((s) => Number(s.value))
-              .filter((v) => !Number.isNaN(v));
-
-            return {
-              uuid: data.uuid,
-              name: data.name,
-              description: data.description ?? "",
-              outputType: data.output_type,
-              scaleValues,
-            } satisfies EvaluatorAbout;
-          }),
-        );
-
-        setAboutEvaluators(
-          results.filter((e): e is EvaluatorAbout => e !== null),
-        );
-      } catch (err) {
-        console.error("Error fetching evaluator details:", err);
-      }
-    };
-
-    fetchAboutEvaluators();
-  }, [backendAccessToken, evaluationResult, ttsEvaluators]);
+      byUuid.set(run.evaluator_uuid, {
+        uuid: run.evaluator_uuid,
+        name: run.name ?? run.metric_key,
+        description: run.description ?? "",
+        outputType: a.type === "rating" ? "rating" : "binary",
+        scaleValues,
+      });
+    }
+    setAboutEvaluators(Array.from(byUuid.values()));
+  }, [evaluationResult]);
 
   // Fetch evaluation result
   useEffect(() => {

--- a/src/components/BenchmarkResultsDialog.tsx
+++ b/src/components/BenchmarkResultsDialog.tsx
@@ -4,6 +4,7 @@ import React, { useState, useEffect, useRef } from "react";
 import {
   CloseIcon,
   SpinnerIcon,
+  type TestRunEvaluator,
 } from "./test-results/shared";
 import {
   BenchmarkOutputsPanel,
@@ -35,6 +36,8 @@ type BenchmarkStatusResponse = {
   status: string;
   model_results?: BenchmarkModelResult[];
   leaderboard_summary?: LeaderboardSummary[];
+  /** Top-level per-evaluator metadata block — see TestRunEvaluator. */
+  evaluators?: TestRunEvaluator[];
   results_s3_prefix?: string;
   error?: string;
   is_public?: boolean;
@@ -96,6 +99,9 @@ export function BenchmarkResultsDialog({
   const [shareToken, setShareToken] = useState<string | null>(null);
   const [defaultNextReplyEvaluator, setDefaultNextReplyEvaluator] =
     useState<DefaultEvaluatorSummary | null>(null);
+  // Top-level evaluators block from the benchmark response. See the
+  // matching state in TestRunnerDialog for the same plumbing.
+  const [runEvaluators, setRunEvaluators] = useState<TestRunEvaluator[]>([]);
   const backendAccessToken = useAccessToken();
   const pollingIntervalRef = useRef<NodeJS.Timeout | null>(null);
   /** Once per dialog open: select first test of `models[0]` when its row exists. */
@@ -254,6 +260,9 @@ export function BenchmarkResultsDialog({
       if (result.name) setRunName(result.name);
       if (result.is_public !== undefined) setIsPublic(result.is_public);
       if (result.share_token !== undefined) setShareToken(result.share_token ?? null);
+      if (Array.isArray(result.evaluators)) {
+        setRunEvaluators(result.evaluators);
+      }
 
       // Update model results (intermediate or final)
       if (result.model_results) {
@@ -466,6 +475,9 @@ export function BenchmarkResultsDialog({
                           judgeResults: tr.judge_results,
                         })),
                       ),
+                      Object.fromEntries(
+                        runEvaluators.map((e) => [e.uuid, e]),
+                      ),
                     )
                   }
                 />
@@ -632,6 +644,9 @@ export function BenchmarkResultsDialog({
                 formatModelName={(n) => n.replace("__", "/")}
                 showControls={isDone}
                 showRunningSpinner={true}
+                evaluatorsByUuid={Object.fromEntries(
+                  runEvaluators.map((e) => [e.uuid, e]),
+                )}
                 legacyDefaultEvaluator={defaultNextReplyEvaluator}
               />
             )}

--- a/src/components/BenchmarkResultsDialog.tsx
+++ b/src/components/BenchmarkResultsDialog.tsx
@@ -144,6 +144,7 @@ export function BenchmarkResultsDialog({
       setTaskStatus("queued");
       setModelResults([]);
       setLeaderboardSummary(undefined);
+      setRunEvaluators([]);
       setError(null);
       setExpandedProviders(new Set(models.length > 0 ? [models[0]] : []));
       setSelectedTest(null);
@@ -260,9 +261,12 @@ export function BenchmarkResultsDialog({
       if (result.name) setRunName(result.name);
       if (result.is_public !== undefined) setIsPublic(result.is_public);
       if (result.share_token !== undefined) setShareToken(result.share_token ?? null);
-      if (Array.isArray(result.evaluators)) {
-        setRunEvaluators(result.evaluators);
-      }
+      // Always sync (including the empty case) so the previous
+      // benchmark's evaluator metadata can't leak into a new task in
+      // the same dialog lifecycle.
+      setRunEvaluators(
+        Array.isArray(result.evaluators) ? result.evaluators : [],
+      );
 
       // Update model results (intermediate or final)
       if (result.model_results) {

--- a/src/components/EvaluatorVerdictCard.tsx
+++ b/src/components/EvaluatorVerdictCard.tsx
@@ -54,6 +54,12 @@ type CommonProps = {
   /** Custom labels for binary verdicts. Defaults to Correct / Wrong. */
   trueLabel?: string | null;
   falseLabel?: string | null;
+  /** Rating-scale entries with per-level display names. When present we
+   * also show the label next to each rating button and beside the
+   * score / max pill so annotators see what each number means. */
+  ratingScale?:
+    | { value: number; name?: string | null }[]
+    | null;
 };
 
 type ReadProps = CommonProps & {
@@ -174,6 +180,7 @@ export function EvaluatorVerdictCard(props: EvaluatorVerdictCardProps) {
                 scaleMax={props.scaleMax}
                 trueLabel={props.trueLabel}
                 falseLabel={props.falseLabel}
+                ratingScale={props.ratingScale}
               />
             )}
             {toggleKind && (
@@ -203,6 +210,7 @@ export function EvaluatorVerdictCard(props: EvaluatorVerdictCardProps) {
             disabled={props.disabled}
             trueLabel={props.trueLabel}
             falseLabel={props.falseLabel}
+            ratingScale={props.ratingScale}
           />
           {hasVariables && (
             <VariableValuesBlock values={props.variableValues!} />
@@ -268,6 +276,7 @@ function ReadVerdictPill({
   scaleMax,
   trueLabel,
   falseLabel,
+  ratingScale,
 }: {
   outputType: EvaluatorOutputType;
   match?: boolean | null;
@@ -276,6 +285,7 @@ function ReadVerdictPill({
   scaleMax?: number;
   trueLabel?: string | null;
   falseLabel?: string | null;
+  ratingScale?: { value: number; name?: string | null }[] | null;
 }) {
   if (outputType === "binary") {
     if (match === null || match === undefined) return null;
@@ -312,12 +322,23 @@ function ReadVerdictPill({
       : tone === "red"
         ? "bg-red-500/15 text-red-600 dark:text-red-400"
         : "bg-amber-500/15 text-amber-600 dark:text-amber-400";
+  const ratingLabel =
+    ratingScale?.find((e) => e.value === score)?.name?.trim() || null;
   return (
-    <span
-      className={`flex-shrink-0 inline-flex items-center px-2 py-0.5 rounded-md text-[11px] font-medium ${toneClass}`}
-    >
-      {scaleMax !== undefined ? `${score} / ${scaleMax}` : `Score: ${score}`}
-    </span>
+    <>
+      <span
+        className={`flex-shrink-0 inline-flex items-center px-2 py-0.5 rounded-md text-[11px] font-medium ${toneClass}`}
+      >
+        {scaleMax !== undefined ? `${score} / ${scaleMax}` : `Score: ${score}`}
+      </span>
+      {ratingLabel && (
+        <span
+          className={`flex-shrink-0 inline-flex items-center px-2 py-0.5 rounded-md text-[11px] font-medium ${toneClass}`}
+        >
+          {ratingLabel}
+        </span>
+      )}
+    </>
   );
 }
 
@@ -330,6 +351,7 @@ function WriteControls({
   disabled,
   trueLabel,
   falseLabel,
+  ratingScale,
 }: {
   outputType: EvaluatorOutputType;
   scaleMin?: number;
@@ -339,6 +361,7 @@ function WriteControls({
   disabled?: boolean;
   trueLabel?: string | null;
   falseLabel?: string | null;
+  ratingScale?: { value: number; name?: string | null }[] | null;
 }) {
   if (outputType === "binary") {
     const baseBtn =
@@ -396,23 +419,39 @@ function WriteControls({
     { length: scaleMax - scaleMin + 1 },
     (_, i) => scaleMin + i,
   );
+  const hasLabels = !!ratingScale?.some((e) => e.name?.trim());
   return (
-    <div className="flex items-center gap-1.5 flex-wrap">
+    <div className="flex items-stretch gap-1.5 flex-wrap">
       {options.map((n) => {
         const active = value === n;
+        const label =
+          ratingScale?.find((e) => e.value === n)?.name?.trim() || null;
         return (
           <button
             key={n}
             type="button"
             disabled={disabled}
             onClick={() => onChange(n)}
-            className={`w-9 h-9 rounded-md border text-sm font-medium transition-colors cursor-pointer disabled:opacity-60 disabled:cursor-not-allowed ${
+            className={`${
+              hasLabels
+                ? "min-w-[3.25rem] px-2.5 h-auto py-1.5 flex flex-col items-center gap-0.5"
+                : "w-9 h-9"
+            } rounded-md border text-sm font-medium transition-colors cursor-pointer disabled:opacity-60 disabled:cursor-not-allowed ${
               active
                 ? "border-foreground bg-foreground text-background"
                 : "border-border bg-background hover:bg-muted/50"
             }`}
           >
-            {n}
+            <span>{n}</span>
+            {hasLabels && (
+              <span
+                className={`text-[10px] font-normal leading-tight ${
+                  active ? "text-background/80" : "text-muted-foreground"
+                }`}
+              >
+                {label ?? ""}
+              </span>
+            )}
           </button>
         );
       })}

--- a/src/components/EvaluatorVerdictCard.tsx
+++ b/src/components/EvaluatorVerdictCard.tsx
@@ -60,6 +60,11 @@ type CommonProps = {
   ratingScale?:
     | { value: number; name?: string | null }[]
     | null;
+  /** Pre-resolved label for the rating verdict pill. Wins over the
+   * `ratingScale` lookup so callers can surface a backend-resolved
+   * value (e.g. judge_results[].value_name) even if it disagrees with
+   * the current evaluator's scale. */
+  ratingLabel?: string | null;
 };
 
 type ReadProps = CommonProps & {
@@ -181,6 +186,7 @@ export function EvaluatorVerdictCard(props: EvaluatorVerdictCardProps) {
                 trueLabel={props.trueLabel}
                 falseLabel={props.falseLabel}
                 ratingScale={props.ratingScale}
+                ratingLabel={props.ratingLabel}
               />
             )}
             {toggleKind && (
@@ -277,6 +283,7 @@ function ReadVerdictPill({
   trueLabel,
   falseLabel,
   ratingScale,
+  ratingLabel,
 }: {
   outputType: EvaluatorOutputType;
   match?: boolean | null;
@@ -286,6 +293,7 @@ function ReadVerdictPill({
   trueLabel?: string | null;
   falseLabel?: string | null;
   ratingScale?: { value: number; name?: string | null }[] | null;
+  ratingLabel?: string | null;
 }) {
   if (outputType === "binary") {
     if (match === null || match === undefined) return null;
@@ -322,8 +330,13 @@ function ReadVerdictPill({
       : tone === "red"
         ? "bg-red-500/15 text-red-600 dark:text-red-400"
         : "bg-amber-500/15 text-amber-600 dark:text-amber-400";
-  const ratingLabel =
-    ratingScale?.find((e) => e.value === score)?.name?.trim() || null;
+  // Prefer the caller-provided pre-resolved label (e.g. backend's
+  // value_name) over the scale lookup so a stale local scale can't
+  // override the actually-recorded label.
+  const resolvedRatingLabel =
+    ratingLabel?.trim() ||
+    ratingScale?.find((e) => e.value === score)?.name?.trim() ||
+    null;
   return (
     <>
       <span
@@ -331,11 +344,11 @@ function ReadVerdictPill({
       >
         {scaleMax !== undefined ? `${score} / ${scaleMax}` : `Score: ${score}`}
       </span>
-      {ratingLabel && (
+      {resolvedRatingLabel && (
         <span
           className={`flex-shrink-0 inline-flex items-center px-2 py-0.5 rounded-md text-[11px] font-medium ${toneClass}`}
         >
-          {ratingLabel}
+          {resolvedRatingLabel}
         </span>
       )}
     </>

--- a/src/components/EvaluatorVerdictCard.tsx
+++ b/src/components/EvaluatorVerdictCard.tsx
@@ -22,6 +22,10 @@
 
 import Link from "next/link";
 import { useState } from "react";
+import {
+  DEFAULT_BINARY_FALSE_LABEL,
+  DEFAULT_BINARY_TRUE_LABEL,
+} from "@/lib/binaryLabels";
 
 export type EvaluatorOutputType = "binary" | "rating";
 
@@ -47,6 +51,9 @@ type CommonProps = {
   scaleMin?: number;
   /** Upper bound of a rating scale; rating buttons render 1..scaleMax. */
   scaleMax?: number;
+  /** Custom labels for binary verdicts. Defaults to Correct / Wrong. */
+  trueLabel?: string | null;
+  falseLabel?: string | null;
 };
 
 type ReadProps = CommonProps & {
@@ -165,6 +172,8 @@ export function EvaluatorVerdictCard(props: EvaluatorVerdictCardProps) {
                 score={props.score}
                 scaleMin={props.scaleMin}
                 scaleMax={props.scaleMax}
+                trueLabel={props.trueLabel}
+                falseLabel={props.falseLabel}
               />
             )}
             {toggleKind && (
@@ -192,6 +201,8 @@ export function EvaluatorVerdictCard(props: EvaluatorVerdictCardProps) {
             value={props.value}
             onChange={(v) => props.onValueChange?.(v)}
             disabled={props.disabled}
+            trueLabel={props.trueLabel}
+            falseLabel={props.falseLabel}
           />
           {hasVariables && (
             <VariableValuesBlock values={props.variableValues!} />
@@ -255,15 +266,22 @@ function ReadVerdictPill({
   score,
   scaleMin,
   scaleMax,
+  trueLabel,
+  falseLabel,
 }: {
   outputType: EvaluatorOutputType;
   match?: boolean | null;
   score?: number | null;
   scaleMin?: number;
   scaleMax?: number;
+  trueLabel?: string | null;
+  falseLabel?: string | null;
 }) {
   if (outputType === "binary") {
     if (match === null || match === undefined) return null;
+    const label = match
+      ? (trueLabel?.trim() || DEFAULT_BINARY_TRUE_LABEL)
+      : (falseLabel?.trim() || DEFAULT_BINARY_FALSE_LABEL);
     return (
       <span
         className={`flex-shrink-0 inline-flex items-center gap-1 px-2 py-0.5 rounded-md text-[11px] font-medium ${
@@ -277,7 +295,7 @@ function ReadVerdictPill({
         ) : (
           <XIcon className="w-3 h-3" />
         )}
-        {match ? "Correct" : "Wrong"}
+        {label}
       </span>
     );
   }
@@ -310,6 +328,8 @@ function WriteControls({
   value,
   onChange,
   disabled,
+  trueLabel,
+  falseLabel,
 }: {
   outputType: EvaluatorOutputType;
   scaleMin?: number;
@@ -317,6 +337,8 @@ function WriteControls({
   value?: boolean | number;
   onChange: (v: boolean | number) => void;
   disabled?: boolean;
+  trueLabel?: string | null;
+  falseLabel?: string | null;
 }) {
   if (outputType === "binary") {
     const baseBtn =
@@ -333,7 +355,7 @@ function WriteControls({
               : "border-border bg-background hover:bg-muted/50"
           }`}
         >
-          Correct
+          {trueLabel?.trim() || DEFAULT_BINARY_TRUE_LABEL}
         </button>
         <button
           type="button"
@@ -345,7 +367,7 @@ function WriteControls({
               : "border-border bg-background hover:bg-muted/50"
           }`}
         >
-          Wrong
+          {falseLabel?.trim() || DEFAULT_BINARY_FALSE_LABEL}
         </button>
       </div>
     );

--- a/src/components/TestRunnerDialog.tsx
+++ b/src/components/TestRunnerDialog.tsx
@@ -7,6 +7,7 @@ import {
   TestCaseOutput,
   TestCaseData,
   JudgeResult,
+  TestRunEvaluator,
   CloseIcon,
   TestStats,
 } from "./test-results/shared";
@@ -85,6 +86,12 @@ type TestRunStatusResponse = {
   passed?: number;
   failed?: number;
   results?: TestCaseResult[];
+  /** Top-level per-evaluator metadata block. Each entry pins the
+   * version the run executed against and carries name, description,
+   * output_config, scale_min, scale_max. Backend guarantees an entry
+   * for every uuid referenced by judge_results (synthesises stubs for
+   * legacy rows). */
+  evaluators?: TestRunEvaluator[];
   results_s3_prefix?: string;
   error?: string;
   is_public?: boolean;
@@ -142,6 +149,10 @@ export function TestRunnerDialog({
   const [shareToken, setShareToken] = useState<string | null>(null);
   const [defaultNextReplyEvaluator, setDefaultNextReplyEvaluator] =
     useState<DefaultEvaluatorSummary | null>(null);
+  // Top-level evaluators block from the run-status response. Built into
+  // a uuid-keyed map below and passed into TestRunOutputsPanel as the
+  // source of truth for per-evaluator metadata.
+  const [runEvaluators, setRunEvaluators] = useState<TestRunEvaluator[]>([]);
   const pollingIntervalRef = useRef<NodeJS.Timeout | null>(null);
   // Tracks whether the dialog has already auto-opened a completed test for
   // this open lifecycle. Set back to false on every dialog open / new run /
@@ -312,6 +323,9 @@ export function TestRunnerDialog({
       if (result.name) setRunName(result.name);
       if (result.is_public !== undefined) setIsPublic(result.is_public);
       if (result.share_token !== undefined) setShareToken(result.share_token ?? null);
+      if (Array.isArray(result.evaluators)) {
+        setRunEvaluators(result.evaluators);
+      }
 
       // Update test results based on polling response
       setTestResults((prev) => {
@@ -906,6 +920,9 @@ export function TestRunnerDialog({
                         reasoning: r.reasoning,
                         judgeResults: r.judgeResults,
                       })),
+                      Object.fromEntries(
+                        runEvaluators.map((e) => [e.uuid, e]),
+                      ),
                     )
                   }
                 />
@@ -978,6 +995,9 @@ export function TestRunnerDialog({
               selectedId={selectedTestUuid}
               onSelect={setSelectedTestUuid}
               onClearSelection={() => setSelectedTestUuid(null)}
+              evaluatorsByUuid={Object.fromEntries(
+                runEvaluators.map((e) => [e.uuid, e]),
+              )}
               legacyDefaultEvaluator={defaultNextReplyEvaluator}
             />
           </div>

--- a/src/components/TestRunnerDialog.tsx
+++ b/src/components/TestRunnerDialog.tsx
@@ -226,6 +226,7 @@ export function TestRunnerDialog({
     setSelectedTestUuid(null);
     hasAutoSelectedRef.current = false;
     setCurrentTaskId(taskId);
+    setRunEvaluators([]);
 
     const isInProgress =
       initialRunStatus === "pending" ||
@@ -271,6 +272,7 @@ export function TestRunnerDialog({
     setSelectedTestUuid(null);
     hasAutoSelectedRef.current = false;
     setCurrentTaskId(null);
+    setRunEvaluators([]);
     const initialResults: TestResult[] = tests.map((test) => ({
       test,
       status: "pending",
@@ -323,9 +325,12 @@ export function TestRunnerDialog({
       if (result.name) setRunName(result.name);
       if (result.is_public !== undefined) setIsPublic(result.is_public);
       if (result.share_token !== undefined) setShareToken(result.share_token ?? null);
-      if (Array.isArray(result.evaluators)) {
-        setRunEvaluators(result.evaluators);
-      }
+      // Always sync to the latest payload (including the empty case) so
+      // the prior run's evaluator metadata can't leak into a fresh run
+      // / past-run-view that omits the field.
+      setRunEvaluators(
+        Array.isArray(result.evaluators) ? result.evaluators : [],
+      );
 
       // Update test results based on polling response
       setTestResults((prev) => {

--- a/src/components/eval-details/BenchmarkOutputsPanel.tsx
+++ b/src/components/eval-details/BenchmarkOutputsPanel.tsx
@@ -3,6 +3,7 @@ import {
   TestCaseOutput,
   TestCaseData,
   JudgeResult,
+  TestRunEvaluator,
   StatusIcon,
   TestDetailView,
   EmptyStateView,
@@ -51,9 +52,10 @@ type BenchmarkOutputsPanelProps = {
   /** Show spinner for running tests */
   showRunningSpinner?: boolean;
   height?: string;
-  /** Optional rating-evaluator scale lookup (uuid → scale_max). Fallback
-   * only — newer judge_results entries carry `scale_max` inline. */
-  scaleByEvaluatorUuid?: Record<string, number | undefined>;
+  /** Top-level evaluators[] keyed by uuid. Threaded down into the
+   * per-evaluator cards as the source of truth for name, description,
+   * scale, and output_config. */
+  evaluatorsByUuid?: Record<string, TestRunEvaluator>;
   /** Disable evaluator detail links for public share pages. */
   enableEvaluatorLinks?: boolean;
   /** Default correctness evaluator used for legacy next-reply criteria. */
@@ -73,7 +75,7 @@ export function BenchmarkOutputsPanel({
   showControls = true,
   showRunningSpinner = false,
   height,
-  scaleByEvaluatorUuid,
+  evaluatorsByUuid,
   enableEvaluatorLinks = true,
   legacyDefaultEvaluator,
 }: BenchmarkOutputsPanelProps) {
@@ -207,7 +209,7 @@ export function BenchmarkOutputsPanel({
                 reasoning={selectedTestResult.reasoning}
                 evaluation={selectedTestResult.test_case?.evaluation}
                 judgeResults={selectedTestResult.judge_results}
-                scaleByEvaluatorUuid={scaleByEvaluatorUuid}
+                evaluatorsByUuid={evaluatorsByUuid}
                 enableEvaluatorLinks={enableEvaluatorLinks}
                 legacyDefaultEvaluator={legacyDefaultEvaluator}
               />
@@ -229,7 +231,7 @@ export function BenchmarkOutputsPanel({
               passed={selectedTestResult.passed}
               judgeResults={selectedTestResult.judge_results}
               reasoning={selectedTestResult.reasoning}
-              scaleByEvaluatorUuid={scaleByEvaluatorUuid}
+              evaluatorsByUuid={evaluatorsByUuid}
               enableEvaluatorLinks={enableEvaluatorLinks}
               legacyDefaultEvaluator={legacyDefaultEvaluator}
             />

--- a/src/components/eval-details/TestRunOutputsPanel.tsx
+++ b/src/components/eval-details/TestRunOutputsPanel.tsx
@@ -3,6 +3,7 @@ import {
   TestCaseOutput,
   TestCaseData,
   JudgeResult,
+  TestRunEvaluator,
   StatusIcon,
   TestDetailView as SharedTestDetailView,
   EmptyStateView,
@@ -31,9 +32,10 @@ type TestRunOutputsPanelProps = {
   onSelect: (id: string) => void;
   onClearSelection?: () => void;
   height?: string;
-  /** Optional rating-evaluator scale lookup (uuid → scale_max). Fallback
-   * only — newer judge_results entries carry `scale_max` inline. */
-  scaleByEvaluatorUuid?: Record<string, number | undefined>;
+  /** Top-level evaluators[] keyed by uuid. Threaded down into the
+   * per-evaluator cards as the source of truth for name, description,
+   * scale, and output_config. */
+  evaluatorsByUuid?: Record<string, TestRunEvaluator>;
   /** Disable evaluator detail links for public share pages. */
   enableEvaluatorLinks?: boolean;
   /** Default correctness evaluator used for legacy next-reply criteria. */
@@ -53,7 +55,7 @@ export function TestRunOutputsPanel({
   onSelect,
   onClearSelection,
   height,
-  scaleByEvaluatorUuid,
+  evaluatorsByUuid,
   enableEvaluatorLinks = true,
   legacyDefaultEvaluator,
 }: TestRunOutputsPanelProps) {
@@ -147,7 +149,7 @@ export function TestRunOutputsPanel({
             <div className="flex-1 overflow-y-auto">
               <TestResultDetail
                 result={selectedResult}
-                scaleByEvaluatorUuid={scaleByEvaluatorUuid}
+                evaluatorsByUuid={evaluatorsByUuid}
                 enableEvaluatorLinks={enableEvaluatorLinks}
                 legacyDefaultEvaluator={legacyDefaultEvaluator}
               />
@@ -175,7 +177,7 @@ export function TestRunOutputsPanel({
               }
               judgeResults={selectedResult.judgeResults}
               reasoning={selectedResult.reasoning}
-              scaleByEvaluatorUuid={scaleByEvaluatorUuid}
+              evaluatorsByUuid={evaluatorsByUuid}
               enableEvaluatorLinks={enableEvaluatorLinks}
               legacyDefaultEvaluator={legacyDefaultEvaluator}
             />
@@ -188,12 +190,12 @@ export function TestRunOutputsPanel({
 
 function TestResultDetail({
   result,
-  scaleByEvaluatorUuid,
+  evaluatorsByUuid,
   enableEvaluatorLinks,
   legacyDefaultEvaluator,
 }: {
   result: TestRunResult;
-  scaleByEvaluatorUuid?: Record<string, number | undefined>;
+  evaluatorsByUuid?: Record<string, TestRunEvaluator>;
   enableEvaluatorLinks: boolean;
   legacyDefaultEvaluator?: DefaultEvaluatorSummary | null;
 }) {
@@ -253,7 +255,7 @@ function TestResultDetail({
       reasoning={result.reasoning}
       evaluation={result.testCase?.evaluation}
       judgeResults={result.judgeResults}
-      scaleByEvaluatorUuid={scaleByEvaluatorUuid}
+      evaluatorsByUuid={evaluatorsByUuid}
       enableEvaluatorLinks={enableEvaluatorLinks}
       legacyDefaultEvaluator={legacyDefaultEvaluator}
     />

--- a/src/components/evaluators/BinaryScaleEditor.tsx
+++ b/src/components/evaluators/BinaryScaleEditor.tsx
@@ -72,8 +72,8 @@ export function BinaryScaleEditor({ rows, onChange }: Props) {
                   update(idx, { description: e.target.value })
                 }
                 placeholder="(optional) description for the response to receive this verdict; a detailed rubric helps the LLM judge evaluate more reliably"
-                rows={2}
-                className="mt-2 w-full px-3 py-2 rounded-md text-sm border border-border bg-background dark:bg-accent text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-accent focus:border-transparent resize-none"
+                rows={3}
+                className="mt-2 w-full px-3 py-2 rounded-md text-sm border border-border bg-background dark:bg-accent text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-accent focus:border-transparent resize-y min-h-[5rem]"
               />
             </div>
           );

--- a/src/components/evaluators/BinaryScaleEditor.tsx
+++ b/src/components/evaluators/BinaryScaleEditor.tsx
@@ -1,0 +1,84 @@
+import {
+  DEFAULT_BINARY_FALSE_LABEL,
+  DEFAULT_BINARY_TRUE_LABEL,
+} from "@/lib/binaryLabels";
+
+export type BinaryScaleRow = {
+  value: boolean;
+  name: string;
+  description: string;
+};
+
+export function defaultBinaryScale(): BinaryScaleRow[] {
+  return [
+    { value: true, name: "", description: "" },
+    { value: false, name: "", description: "" },
+  ];
+}
+
+type Props = {
+  rows: BinaryScaleRow[];
+  onChange: (rows: BinaryScaleRow[]) => void;
+};
+
+export function BinaryScaleEditor({ rows, onChange }: Props) {
+  const update = (idx: number, patch: Partial<BinaryScaleRow>) => {
+    const next = [...rows];
+    next[idx] = { ...next[idx], ...patch };
+    onChange(next);
+  };
+
+  return (
+    <div>
+      <label className="block text-xs md:text-sm font-medium mb-1">
+        Labels
+      </label>
+      <p className="text-xs md:text-sm text-muted-foreground mb-2">
+        Override the labels shown for each binary verdict. Leave blank to use
+        the defaults ({DEFAULT_BINARY_TRUE_LABEL} / {DEFAULT_BINARY_FALSE_LABEL}
+        ). The optional description is rubric text sent to the judge.
+      </p>
+      <div className="space-y-2">
+        {rows.map((row, idx) => {
+          const placeholder = row.value
+            ? DEFAULT_BINARY_TRUE_LABEL
+            : DEFAULT_BINARY_FALSE_LABEL;
+          return (
+            <div
+              key={String(row.value)}
+              className="border border-border rounded-md p-2 md:p-3 bg-muted/10 dark:bg-muted"
+            >
+              <div className="flex items-center gap-2">
+                <span
+                  className={`w-20 h-9 md:h-10 inline-flex items-center justify-center rounded-md text-sm md:text-base font-medium border ${
+                    row.value
+                      ? "border-green-500/30 bg-green-500/10 text-green-700 dark:text-green-400"
+                      : "border-red-500/30 bg-red-500/10 text-red-700 dark:text-red-400"
+                  }`}
+                >
+                  {row.value ? "True" : "False"}
+                </span>
+                <input
+                  type="text"
+                  value={row.name}
+                  onChange={(e) => update(idx, { name: e.target.value })}
+                  placeholder={placeholder}
+                  className="flex-1 h-9 md:h-10 px-3 rounded-md text-sm md:text-base border border-border bg-background dark:bg-accent text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-accent focus:border-transparent"
+                />
+              </div>
+              <textarea
+                value={row.description}
+                onChange={(e) =>
+                  update(idx, { description: e.target.value })
+                }
+                placeholder="(optional) description for the response to receive this verdict; a detailed rubric helps the LLM judge evaluate more reliably"
+                rows={2}
+                className="mt-2 w-full px-3 py-2 rounded-md text-sm border border-border bg-background dark:bg-accent text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-accent focus:border-transparent resize-none"
+              />
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/components/evaluators/CreateEvaluatorSidebar.tsx
+++ b/src/components/evaluators/CreateEvaluatorSidebar.tsx
@@ -11,6 +11,10 @@ import {
   RatingScaleEditor,
   type RatingScaleRow,
 } from "@/components/evaluators/RatingScaleEditor";
+import {
+  BinaryScaleEditor,
+  type BinaryScaleRow,
+} from "@/components/evaluators/BinaryScaleEditor";
 
 type CreateRatingScaleRow = RatingScaleRow & {
   value: number;
@@ -23,6 +27,7 @@ type CreateEvaluatorSidebarProps = {
   evaluatorType: EvaluatorType | null;
   evaluatorOutputType: "binary" | "rating";
   evaluatorScale: CreateRatingScaleRow[];
+  evaluatorBinaryScale: BinaryScaleRow[];
   judgeModel: LLMModel | null;
   systemPrompt: string;
   detectedPromptVariables: string[];
@@ -41,6 +46,7 @@ type CreateEvaluatorSidebarProps = {
   setEvaluatorDescription: (value: string) => void;
   setEvaluatorOutputType: (value: "binary" | "rating") => void;
   setEvaluatorScale: (value: CreateRatingScaleRow[]) => void;
+  setEvaluatorBinaryScale: (value: BinaryScaleRow[]) => void;
   setSystemPrompt: (value: string) => void;
   setVariableDescriptions: Dispatch<SetStateAction<Record<string, string>>>;
   setCreateNameError: (value: string | null) => void;
@@ -53,6 +59,7 @@ export function CreateEvaluatorSidebar({
   evaluatorType,
   evaluatorOutputType,
   evaluatorScale,
+  evaluatorBinaryScale,
   judgeModel,
   systemPrompt,
   detectedPromptVariables,
@@ -71,6 +78,7 @@ export function CreateEvaluatorSidebar({
   setEvaluatorDescription,
   setEvaluatorOutputType,
   setEvaluatorScale,
+  setEvaluatorBinaryScale,
   setSystemPrompt,
   setVariableDescriptions,
   setCreateNameError,
@@ -212,6 +220,13 @@ export function CreateEvaluatorSidebar({
                 : "Returns a score on a custom rating scale you define below."}
             </p>
           </div>
+
+          {evaluatorOutputType === "binary" && (
+            <BinaryScaleEditor
+              rows={evaluatorBinaryScale}
+              onChange={setEvaluatorBinaryScale}
+            />
+          )}
 
           {evaluatorOutputType === "rating" && (
             <RatingScaleEditor

--- a/src/components/evaluators/RatingScaleEditor.tsx
+++ b/src/components/evaluators/RatingScaleEditor.tsx
@@ -114,8 +114,8 @@ export function RatingScaleEditor<T extends RatingScaleRow>({
                   updateRow(idx, { description: e.target.value } as Partial<T>)
                 }
                 placeholder={descriptionPlaceholder}
-                rows={2}
-                className="mt-2 w-full px-3 py-2 rounded-md text-sm border border-border bg-background dark:bg-accent text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-accent focus:border-transparent resize-none"
+                rows={3}
+                className="mt-2 w-full px-3 py-2 rounded-md text-sm border border-border bg-background dark:bg-accent text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-accent focus:border-transparent resize-y min-h-[5rem]"
               />
             </div>
           );

--- a/src/components/evaluators/VersionCard.tsx
+++ b/src/components/evaluators/VersionCard.tsx
@@ -1,7 +1,11 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
 import { getBinaryLabel } from "@/lib/binaryLabels";
+
+// Pixel height used as the collapsed cap for prompt bodies. Matches the
+// max-h-[7.5rem] applied to the <pre> below (7.5rem at 16px root).
+const COLLAPSED_PROMPT_HEIGHT_PX = 120;
 
 type ScaleEntry = {
   value: boolean | number | string;
@@ -47,12 +51,27 @@ export function VersionCard({
   const [promptVisible, setPromptVisible] = useState(isLive || isDefault);
   const [copied, setCopied] = useState(false);
   const [promptExpanded, setPromptExpanded] = useState(false);
-  // Roughly 4 lines at the current leading. Used as the collapsed height
-  // and to decide whether the View more / View less toggle is needed.
-  const COLLAPSED_LINE_COUNT = 4;
-  const promptLineCount =
-    (version.system_prompt.match(/\n/g)?.length ?? 0) + 1;
-  const isPromptOverflowing = promptLineCount > COLLAPSED_LINE_COUNT;
+  // Whether the rendered prompt actually overflows the collapsed height.
+  // Measured (not derived from \n count) so prompts with long wrapping
+  // lines and no line breaks still get the toggle.
+  const [isPromptOverflowing, setIsPromptOverflowing] = useState(false);
+  const promptRef = useRef<HTMLPreElement>(null);
+
+  useLayoutEffect(() => {
+    if (!promptVisible) return;
+    const el = promptRef.current;
+    if (!el) return;
+    const measure = () => {
+      // Compare the natural scroll height (clamp ignored) against the
+      // collapsed cap. ResizeObserver re-fires on any layout change so
+      // we stay correct after font load, window resize, etc.
+      setIsPromptOverflowing(el.scrollHeight > COLLAPSED_PROMPT_HEIGHT_PX + 1);
+    };
+    measure();
+    const ro = new ResizeObserver(measure);
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, [promptVisible, version.system_prompt]);
 
   useEffect(() => {
     setPromptVisible(isLive || isDefault);
@@ -155,6 +174,7 @@ export function VersionCard({
         </div>
         <div className="relative">
           <pre
+            ref={promptRef}
             className={`border border-border rounded-md p-3 md:p-4 bg-muted/10 text-sm text-foreground whitespace-pre-wrap font-mono leading-relaxed overflow-x-auto ${
               isPromptOverflowing && !promptExpanded
                 ? "max-h-[7.5rem] overflow-hidden"

--- a/src/components/evaluators/VersionCard.tsx
+++ b/src/components/evaluators/VersionCard.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { getBinaryLabel } from "@/lib/binaryLabels";
 
 type ScaleEntry = {
   value: boolean | number | string;
@@ -45,6 +46,13 @@ export function VersionCard({
 }: VersionCardProps) {
   const [promptVisible, setPromptVisible] = useState(isLive || isDefault);
   const [copied, setCopied] = useState(false);
+  const [promptExpanded, setPromptExpanded] = useState(false);
+  // Roughly 4 lines at the current leading. Used as the collapsed height
+  // and to decide whether the View more / View less toggle is needed.
+  const COLLAPSED_LINE_COUNT = 4;
+  const promptLineCount =
+    (version.system_prompt.match(/\n/g)?.length ?? 0) + 1;
+  const isPromptOverflowing = promptLineCount > COLLAPSED_LINE_COUNT;
 
   useEffect(() => {
     setPromptVisible(isLive || isDefault);
@@ -145,9 +153,65 @@ export function VersionCard({
             </button>
           )}
         </div>
-        <pre className="border border-border rounded-md p-3 md:p-4 bg-muted/10 text-sm text-foreground whitespace-pre-wrap font-mono leading-relaxed overflow-x-auto">
-          {version.system_prompt}
-        </pre>
+        <div className="relative">
+          <pre
+            className={`border border-border rounded-md p-3 md:p-4 bg-muted/10 text-sm text-foreground whitespace-pre-wrap font-mono leading-relaxed overflow-x-auto ${
+              isPromptOverflowing && !promptExpanded
+                ? "max-h-[7.5rem] overflow-hidden"
+                : ""
+            }`}
+          >
+            {version.system_prompt}
+          </pre>
+          {isPromptOverflowing && !promptExpanded && (
+            <div className="pointer-events-none absolute inset-x-0 bottom-0 h-16 flex items-end justify-center rounded-b-md bg-gradient-to-t from-background via-background/85 to-transparent">
+              <button
+                type="button"
+                onClick={() => setPromptExpanded(true)}
+                className="pointer-events-auto mb-2 inline-flex items-center gap-1 px-2.5 py-1 rounded-md text-xs font-medium border border-border bg-background text-foreground hover:bg-muted transition-colors cursor-pointer shadow-sm"
+              >
+                View more
+                <svg
+                  className="w-3.5 h-3.5"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                  strokeWidth={2}
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    d="M19.5 8.25l-7.5 7.5-7.5-7.5"
+                  />
+                </svg>
+              </button>
+            </div>
+          )}
+        </div>
+        {isPromptOverflowing && promptExpanded && (
+          <div className="flex justify-center">
+            <button
+              type="button"
+              onClick={() => setPromptExpanded(false)}
+              className="inline-flex items-center gap-1 px-2.5 py-1 rounded-md text-xs font-medium border border-border bg-background text-foreground hover:bg-muted transition-colors cursor-pointer shadow-sm"
+            >
+              View less
+              <svg
+                className="w-3.5 h-3.5"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+                strokeWidth={2}
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M4.5 15.75l7.5-7.5 7.5 7.5"
+                />
+              </svg>
+            </button>
+          </div>
+        )}
       </div>}
 
       {version.variables?.length ? (
@@ -205,6 +269,56 @@ export function VersionCard({
           </div>
         </div>
       ) : null}
+
+      {promptVisible && outputType === "binary" ? (() => {
+        const scale = version.output_config?.scale ?? [];
+        const trueEntry = scale.find((e) => e.value === true);
+        const falseEntry = scale.find((e) => e.value === false);
+        const rows = [
+          {
+            value: true,
+            label: getBinaryLabel(scale, true),
+            description: trueEntry?.description,
+          },
+          {
+            value: false,
+            label: getBinaryLabel(scale, false),
+            description: falseEntry?.description,
+          },
+        ];
+        return (
+          <div className="space-y-2">
+            <div className="text-[11px] uppercase tracking-wide text-muted-foreground">
+              Output
+            </div>
+            <div className="border border-border rounded-md p-3 md:p-4 bg-muted/10 space-y-2">
+              {rows.map((row) => (
+                <div key={String(row.value)} className="flex items-start gap-3">
+                  <span
+                    className={`inline-flex items-center justify-center min-w-[48px] h-6 px-2 rounded-md text-xs font-semibold border ${
+                      row.value
+                        ? "border-green-500/30 bg-green-500/10 text-green-700 dark:text-green-400"
+                        : "border-red-500/30 bg-red-500/10 text-red-700 dark:text-red-400"
+                    }`}
+                  >
+                    {row.value ? "True" : "False"}
+                  </span>
+                  <div className="min-w-0">
+                    <div className="text-sm font-medium text-foreground">
+                      {row.label}
+                    </div>
+                    {row.description && (
+                      <div className="text-xs text-muted-foreground mt-0.5">
+                        {row.description}
+                      </div>
+                    )}
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        );
+      })() : null}
 
       {promptVisible && outputType === "rating" && version.output_config?.scale?.length ? (
         <div className="space-y-2">

--- a/src/components/human-labelling/AnnotationJobView.tsx
+++ b/src/components/human-labelling/AnnotationJobView.tsx
@@ -4,7 +4,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import confetti from "canvas-confetti";
 import { getBackendUrl } from "@/lib/api";
 import { EvaluatorVerdictCard } from "@/components/EvaluatorVerdictCard";
-import { getBinaryLabel } from "@/lib/binaryLabels";
+import { getBinaryLabel, toRatingScale } from "@/lib/binaryLabels";
 import { LlmItemPane } from "./item-panes/LlmItemPane";
 import { Section } from "./item-panes/shared";
 import { SimulationItemPane } from "./item-panes/SimulationItemPane";
@@ -917,14 +917,7 @@ function EvaluatorsPane({
         const falseLabel =
           outputType === "binary" ? getBinaryLabel(scale, false) : null;
         const ratingScale =
-          outputType === "rating" && scale
-            ? scale
-                .filter((e) => typeof e.value === "number")
-                .map((e) => ({
-                  value: e.value as number,
-                  name: e.name ?? null,
-                }))
-            : null;
+          outputType === "rating" ? toRatingScale(scale) : null;
 
         if (readOnly) {
           // Admin / "view submitted" surface — show the verdict the

--- a/src/components/human-labelling/AnnotationJobView.tsx
+++ b/src/components/human-labelling/AnnotationJobView.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import confetti from "canvas-confetti";
 import { getBackendUrl } from "@/lib/api";
 import { EvaluatorVerdictCard } from "@/components/EvaluatorVerdictCard";
+import { getBinaryLabel } from "@/lib/binaryLabels";
 import { LlmItemPane } from "./item-panes/LlmItemPane";
 import { Section } from "./item-panes/shared";
 import { SimulationItemPane } from "./item-panes/SimulationItemPane";
@@ -56,10 +57,19 @@ type Evaluator = {
   // buttons render `scale_min..scale_max` instead of the default 1..5.
   scale_min?: number | null;
   scale_max?: number | null;
-  // Custom labels for binary verdicts, surfaced from
-  // `output_config.scale`. Optional — fall back to Correct / Wrong.
-  true_label?: string | null;
-  false_label?: string | null;
+  // Full version output_config returned by the backend. For binary
+  // evaluators the two entries (value: true / value: false) carry the
+  // custom labels and per-level rubric descriptions; for rating
+  // evaluators the entries carry the per-level rubric. Optional —
+  // legacy rows may omit it entirely.
+  output_config?: {
+    scale?: {
+      value: boolean | number | string;
+      name?: string | null;
+      description?: string | null;
+      color?: string | null;
+    }[];
+  } | null;
 };
 
 export type Item = {
@@ -901,6 +911,20 @@ function EvaluatorsPane({
           typeof ev.scale_min === "number" ? ev.scale_min : undefined;
         const scaleMax =
           typeof ev.scale_max === "number" ? ev.scale_max : undefined;
+        const scale = ev.output_config?.scale ?? null;
+        const trueLabel =
+          outputType === "binary" ? getBinaryLabel(scale, true) : null;
+        const falseLabel =
+          outputType === "binary" ? getBinaryLabel(scale, false) : null;
+        const ratingScale =
+          outputType === "rating" && scale
+            ? scale
+                .filter((e) => typeof e.value === "number")
+                .map((e) => ({
+                  value: e.value as number,
+                  name: e.name ?? null,
+                }))
+            : null;
 
         if (readOnly) {
           // Admin / "view submitted" surface — show the verdict the
@@ -927,8 +951,9 @@ function EvaluatorsPane({
                   : null
               }
               reasoning={typeof f?.comment === "string" ? f.comment : null}
-              trueLabel={ev.true_label}
-              falseLabel={ev.false_label}
+              trueLabel={trueLabel}
+              falseLabel={falseLabel}
+              ratingScale={ratingScale}
             />
           );
         }
@@ -947,8 +972,9 @@ function EvaluatorsPane({
             comment={typeof f?.comment === "string" ? f.comment : ""}
             onValueChange={(v) => setField(k, { value: v })}
             onCommentChange={(s) => setField(k, { comment: s })}
-            trueLabel={ev.true_label}
-            falseLabel={ev.false_label}
+            trueLabel={trueLabel}
+            falseLabel={falseLabel}
+            ratingScale={ratingScale}
           />
         );
       })}

--- a/src/components/human-labelling/AnnotationJobView.tsx
+++ b/src/components/human-labelling/AnnotationJobView.tsx
@@ -56,6 +56,10 @@ type Evaluator = {
   // buttons render `scale_min..scale_max` instead of the default 1..5.
   scale_min?: number | null;
   scale_max?: number | null;
+  // Custom labels for binary verdicts, surfaced from
+  // `output_config.scale`. Optional — fall back to Correct / Wrong.
+  true_label?: string | null;
+  false_label?: string | null;
 };
 
 export type Item = {
@@ -923,6 +927,8 @@ function EvaluatorsPane({
                   : null
               }
               reasoning={typeof f?.comment === "string" ? f.comment : null}
+              trueLabel={ev.true_label}
+              falseLabel={ev.false_label}
             />
           );
         }
@@ -941,6 +947,8 @@ function EvaluatorsPane({
             comment={typeof f?.comment === "string" ? f.comment : ""}
             onValueChange={(v) => setField(k, { value: v })}
             onCommentChange={(s) => setField(k, { comment: s })}
+            trueLabel={ev.true_label}
+            falseLabel={ev.false_label}
           />
         );
       })}

--- a/src/components/human-labelling/EvaluatorRunDetailView.tsx
+++ b/src/components/human-labelling/EvaluatorRunDetailView.tsx
@@ -36,6 +36,8 @@ export type EvaluatorRunRow = {
     version_number?: number;
     scale_min?: number | null;
     scale_max?: number | null;
+    true_label?: string | null;
+    false_label?: string | null;
   } | null;
   evaluator?: {
     uuid?: string;
@@ -903,6 +905,8 @@ export function EvaluatorResultsPane({
               score={displayScore}
               scaleMin={scaleMin}
               scaleMax={scaleMax}
+              trueLabel={r.evaluator_version?.true_label ?? null}
+              falseLabel={r.evaluator_version?.false_label ?? null}
               reasoning={displayReasoning}
             />
           </div>
@@ -1140,6 +1144,8 @@ function GroupedEvaluatorCard({
         score={displayScore}
         scaleMin={scaleMin}
         scaleMax={scaleMax}
+        trueLabel={anchorRun?.evaluator_version?.true_label ?? null}
+        falseLabel={anchorRun?.evaluator_version?.false_label ?? null}
         reasoning={displayReasoning}
       />
     </div>

--- a/src/components/human-labelling/EvaluatorRunDetailView.tsx
+++ b/src/components/human-labelling/EvaluatorRunDetailView.tsx
@@ -11,6 +11,7 @@
 import React, { useMemo, useState } from "react";
 import Link from "next/link";
 import { EvaluatorVerdictCard } from "@/components/EvaluatorVerdictCard";
+import { getBinaryLabel } from "@/lib/binaryLabels";
 import {
   AgreementStatCard,
   agreementColor,
@@ -36,8 +37,14 @@ export type EvaluatorRunRow = {
     version_number?: number;
     scale_min?: number | null;
     scale_max?: number | null;
-    true_label?: string | null;
-    false_label?: string | null;
+    output_config?: {
+      scale?: {
+        value: boolean | number | string;
+        name?: string | null;
+        description?: string | null;
+        color?: string | null;
+      }[];
+    } | null;
   } | null;
   evaluator?: {
     uuid?: string;
@@ -905,8 +912,22 @@ export function EvaluatorResultsPane({
               score={displayScore}
               scaleMin={scaleMin}
               scaleMax={scaleMax}
-              trueLabel={r.evaluator_version?.true_label ?? null}
-              falseLabel={r.evaluator_version?.false_label ?? null}
+              trueLabel={getBinaryLabel(
+                r.evaluator_version?.output_config?.scale ?? null,
+                true,
+              )}
+              falseLabel={getBinaryLabel(
+                r.evaluator_version?.output_config?.scale ?? null,
+                false,
+              )}
+              ratingScale={
+                (r.evaluator_version?.output_config?.scale ?? null)
+                  ?.filter((e) => typeof e.value === "number")
+                  .map((e) => ({
+                    value: e.value as number,
+                    name: e.name ?? null,
+                  })) ?? null
+              }
               reasoning={displayReasoning}
             />
           </div>
@@ -1144,8 +1165,22 @@ function GroupedEvaluatorCard({
         score={displayScore}
         scaleMin={scaleMin}
         scaleMax={scaleMax}
-        trueLabel={anchorRun?.evaluator_version?.true_label ?? null}
-        falseLabel={anchorRun?.evaluator_version?.false_label ?? null}
+        trueLabel={getBinaryLabel(
+          anchorRun?.evaluator_version?.output_config?.scale ?? null,
+          true,
+        )}
+        falseLabel={getBinaryLabel(
+          anchorRun?.evaluator_version?.output_config?.scale ?? null,
+          false,
+        )}
+        ratingScale={
+          (anchorRun?.evaluator_version?.output_config?.scale ?? null)
+            ?.filter((e) => typeof e.value === "number")
+            .map((e) => ({
+              value: e.value as number,
+              name: e.name ?? null,
+            })) ?? null
+        }
         reasoning={displayReasoning}
       />
     </div>

--- a/src/components/human-labelling/EvaluatorRunDetailView.tsx
+++ b/src/components/human-labelling/EvaluatorRunDetailView.tsx
@@ -11,7 +11,7 @@
 import React, { useMemo, useState } from "react";
 import Link from "next/link";
 import { EvaluatorVerdictCard } from "@/components/EvaluatorVerdictCard";
-import { getBinaryLabel } from "@/lib/binaryLabels";
+import { getBinaryLabel, toRatingScale } from "@/lib/binaryLabels";
 import {
   AgreementStatCard,
   agreementColor,
@@ -32,26 +32,39 @@ export type EvaluatorRunRow = {
   status: string;
   created_at: string;
   completed_at: string | null;
-  evaluator_version?: {
-    uuid?: string;
-    version_number?: number;
-    scale_min?: number | null;
-    scale_max?: number | null;
-    output_config?: {
-      scale?: {
-        value: boolean | number | string;
-        name?: string | null;
-        description?: string | null;
-        color?: string | null;
-      }[];
-    } | null;
+};
+
+/**
+ * One entry in the run-job's top-level `evaluators[]`. Pinned to the
+ * version the job actually ran against. Mirrors the labelling-job
+ * viewer's shape so the same renderer code can consume both. The page
+ * builds a `Record<evaluator_id, JobEvaluator>` lookup once and reads
+ * scale / labels / name / description / variables from there instead of
+ * the (now removed) per-run `evaluator` and `evaluator_version` blobs.
+ */
+export type JobEvaluator = {
+  uuid: string;
+  name: string;
+  description?: string | null;
+  evaluator_type?: string;
+  output_type?: "binary" | "rating" | string;
+  evaluator_version_id?: string;
+  version_number?: number;
+  scale_min?: number | null;
+  scale_max?: number | null;
+  output_config?: {
+    scale?: {
+      value: boolean | number | string;
+      name?: string | null;
+      description?: string | null;
+      color?: string | null;
+    }[];
   } | null;
-  evaluator?: {
-    uuid?: string;
-    name?: string;
+  variables?: {
+    name: string;
     description?: string | null;
-    output_type?: string;
-  } | null;
+    default?: string | null;
+  }[] | null;
 };
 
 export type EvaluatorRunItemSnapshot = {
@@ -107,11 +120,6 @@ export type EvaluatorRunJob = {
   task_id: string;
   status: "queued" | "in_progress" | "completed" | "failed";
   details: {
-    evaluators?: {
-      evaluator_id: string;
-      evaluator_version_id?: string;
-      name?: string;
-    }[];
     item_count?: number;
     s3_prefix?: string;
     item_ids?: string[];
@@ -120,6 +128,10 @@ export type EvaluatorRunJob = {
   created_at: string;
   updated_at: string;
   completed_at: string | null;
+  /** Per-evaluator pinned-version metadata (output_config, scale_min,
+   * scale_max, variables, version_number). Promoted from
+   * `details.evaluators` to the top level. */
+  evaluators?: JobEvaluator[];
   runs: EvaluatorRunRow[];
   items?: EvaluatorRunItemSnapshot[];
   human_agreement?: HumanAgreement;
@@ -143,13 +155,8 @@ export type LabellingTaskFull = {
 export function evaluatorDisplayName(
   ev: { evaluator_id: string; name?: string },
   nameByEvaluatorId: Record<string, string>,
-  runRow?: EvaluatorRunRow | null,
 ): string {
-  for (const candidate of [
-    ev.name,
-    runRow?.evaluator?.name,
-    nameByEvaluatorId[ev.evaluator_id],
-  ]) {
+  for (const candidate of [ev.name, nameByEvaluatorId[ev.evaluator_id]]) {
     if (typeof candidate === "string" && candidate.trim().length > 0) {
       return candidate.trim();
     }
@@ -245,11 +252,12 @@ export function formatAgreement(value: number | null | undefined): string {
 
 export function runOutputType(
   run: EvaluatorRunRow | undefined,
+  evaluator?: JobEvaluator | null,
 ): "binary" | "rating" {
   const v = run?.value?.value;
   if (typeof v === "boolean") return "binary";
   if (typeof v === "number") return "rating";
-  if (run?.evaluator?.output_type === "rating") return "rating";
+  if (evaluator?.output_type === "rating") return "rating";
   return "binary";
 }
 
@@ -611,6 +619,7 @@ function SourcePill({
 export function EvaluatorResultsPane({
   evaluators,
   evaluatorNamesById,
+  getJobEvaluator,
   runs,
   versionLabels,
   jobStatus,
@@ -631,6 +640,18 @@ export function EvaluatorResultsPane({
     name?: string;
   }[];
   evaluatorNamesById: Record<string, string>;
+  /** Lookup helper: given a run row or evaluator descriptor, return the
+   * matching `JobEvaluator` entry (the pinned-version metadata block).
+   * Different versions of the same evaluator can carry different
+   * labels / rubrics, so this is keyed by (evaluator_id, version_id),
+   * not just evaluator_id. Source of truth for description /
+   * output_type / scale_min / scale_max / output_config / variables
+   * now that per-run `evaluator` and `evaluator_version` blobs are
+   * gone from the API. */
+  getJobEvaluator: (key: {
+    evaluator_id: string;
+    evaluator_version_id?: string;
+  }) => JobEvaluator | null;
   runs: EvaluatorRunRow[];
   versionLabels: Record<string, string>;
   jobStatus: EvaluatorRunJob["status"];
@@ -710,12 +731,13 @@ export function EvaluatorResultsPane({
             (!ev.evaluator_version_id ||
               x.evaluator_version_id === ev.evaluator_version_id),
         );
-        const displayName = evaluatorDisplayName(ev, evaluatorNamesById, r);
+        const jobEvaluator = getJobEvaluator(ev);
+        const displayName = evaluatorDisplayName(ev, evaluatorNamesById);
         // Prefer the evaluator's declared output type so annotations still
         // render with the right pill when the evaluator itself produced no
         // value yet (e.g. items labelled by humans before a run).
         let outputType: "binary" | "rating" =
-          r?.evaluator?.output_type === "rating" ? "rating" : "binary";
+          jobEvaluator?.output_type === "rating" ? "rating" : "binary";
         if (r) {
           const v = r.value?.value;
           if (typeof v === "boolean") outputType = "binary";
@@ -838,12 +860,12 @@ export function EvaluatorResultsPane({
           }));
 
         const scaleMin =
-          typeof r.evaluator_version?.scale_min === "number"
-            ? r.evaluator_version.scale_min
+          typeof jobEvaluator?.scale_min === "number"
+            ? jobEvaluator.scale_min
             : undefined;
         const scaleMax =
-          typeof r.evaluator_version?.scale_max === "number"
-            ? r.evaluator_version.scale_max
+          typeof jobEvaluator?.scale_max === "number"
+            ? jobEvaluator.scale_max
             : undefined;
 
         const {
@@ -900,7 +922,7 @@ export function EvaluatorResultsPane({
             <EvaluatorVerdictCard
               mode="read"
               name={evaluatorName}
-              description={r.evaluator?.description ?? null}
+              description={jobEvaluator?.description ?? null}
               versionLabel={showVersionInSourcePill ? null : versionLabel}
               outputType={outputType}
               evaluatorUuid={ev.evaluator_id}
@@ -913,21 +935,16 @@ export function EvaluatorResultsPane({
               scaleMin={scaleMin}
               scaleMax={scaleMax}
               trueLabel={getBinaryLabel(
-                r.evaluator_version?.output_config?.scale ?? null,
+                jobEvaluator?.output_config?.scale ?? null,
                 true,
               )}
               falseLabel={getBinaryLabel(
-                r.evaluator_version?.output_config?.scale ?? null,
+                jobEvaluator?.output_config?.scale ?? null,
                 false,
               )}
-              ratingScale={
-                (r.evaluator_version?.output_config?.scale ?? null)
-                  ?.filter((e) => typeof e.value === "number")
-                  .map((e) => ({
-                    value: e.value as number,
-                    name: e.name ?? null,
-                  })) ?? null
-              }
+              ratingScale={toRatingScale(
+                jobEvaluator?.output_config?.scale,
+              )}
               reasoning={displayReasoning}
             />
           </div>
@@ -955,6 +972,7 @@ export function EvaluatorResultsPane({
             runs={runs}
             versionLabels={versionLabels}
             evaluatorNamesById={evaluatorNamesById}
+            getJobEvaluator={getJobEvaluator}
             humanAgreementForItem={humanAgreementForItem}
             evaluatorVariablesByEvaluatorId={evaluatorVariablesByEvaluatorId}
             jobStatus={jobStatus}
@@ -986,6 +1004,7 @@ function GroupedEvaluatorCard({
   runs,
   versionLabels,
   evaluatorNamesById,
+  getJobEvaluator,
   humanAgreementForItem,
   evaluatorVariablesByEvaluatorId,
   jobStatus,
@@ -1000,6 +1019,10 @@ function GroupedEvaluatorCard({
   runs: EvaluatorRunRow[];
   versionLabels: Record<string, string>;
   evaluatorNamesById: Record<string, string>;
+  getJobEvaluator: (key: {
+    evaluator_id: string;
+    evaluator_version_id?: string;
+  }) => JobEvaluator | null;
   humanAgreementForItem: HumanAgreementItem | null;
   evaluatorVariablesByEvaluatorId: Record<string, Record<string, string>>;
   jobStatus: EvaluatorRunJob["status"];
@@ -1037,8 +1060,11 @@ function GroupedEvaluatorCard({
       ? (humansForEvaluator?.human_annotations ?? [])
       : [];
 
+  // Use the first evaluator entry (typically all share the same evaluator
+  // anyway, since this is grouped by evaluator_id) to resolve the
+  // declared output type.
   const outputType: "binary" | "rating" =
-    versions.find((x) => x.r?.evaluator?.output_type === "rating")
+    getJobEvaluator(evaluators[0])?.output_type === "rating"
       ? "rating"
       : "binary";
 
@@ -1081,22 +1107,28 @@ function GroupedEvaluatorCard({
     ? annotations.find((a) => `a:${a.annotator_id}` === selection) ?? null
     : null;
 
-  // The card's "anchor" run (for description, scale, output_type lookup) is
-  // either the selected version or the first version that has run data.
+  // The card's "anchor" run (for output value / reasoning) is either the
+  // selected version or the first version that has run data. Metadata
+  // (description / scale_min / scale_max / output_config) comes from the
+  // top-level jobEvaluatorById lookup, not the run row.
   const anchorRun =
     selectedVersion?.r ?? versions.find((x) => x.r)?.r ?? null;
+  // Resolve the JobEvaluator for the version actually being shown so
+  // labels / scale come from THIS version, not a sibling.
+  const anchorEv =
+    selectedVersion?.ev ?? versions.find((x) => x.r)?.ev ?? evaluators[0];
+  const jobEvaluator = getJobEvaluator(anchorEv);
   const evaluatorName = evaluatorDisplayName(
     evaluators[0],
     evaluatorNamesById,
-    anchorRun,
   );
   const scaleMin =
-    typeof anchorRun?.evaluator_version?.scale_min === "number"
-      ? anchorRun.evaluator_version.scale_min
+    typeof jobEvaluator?.scale_min === "number"
+      ? jobEvaluator.scale_min
       : undefined;
   const scaleMax =
-    typeof anchorRun?.evaluator_version?.scale_max === "number"
-      ? anchorRun.evaluator_version.scale_max
+    typeof jobEvaluator?.scale_max === "number"
+      ? jobEvaluator.scale_max
       : undefined;
 
   const {
@@ -1154,7 +1186,7 @@ function GroupedEvaluatorCard({
       <EvaluatorVerdictCard
         mode="read"
         name={evaluatorName}
-        description={anchorRun?.evaluator?.description ?? null}
+        description={jobEvaluator?.description ?? null}
         outputType={outputType}
         evaluatorUuid={evaluatorId}
         enableLink={linkEvaluators}
@@ -1166,21 +1198,14 @@ function GroupedEvaluatorCard({
         scaleMin={scaleMin}
         scaleMax={scaleMax}
         trueLabel={getBinaryLabel(
-          anchorRun?.evaluator_version?.output_config?.scale ?? null,
+          jobEvaluator?.output_config?.scale ?? null,
           true,
         )}
         falseLabel={getBinaryLabel(
-          anchorRun?.evaluator_version?.output_config?.scale ?? null,
+          jobEvaluator?.output_config?.scale ?? null,
           false,
         )}
-        ratingScale={
-          (anchorRun?.evaluator_version?.output_config?.scale ?? null)
-            ?.filter((e) => typeof e.value === "number")
-            .map((e) => ({
-              value: e.value as number,
-              name: e.name ?? null,
-            })) ?? null
-        }
+        ratingScale={toRatingScale(jobEvaluator?.output_config?.scale)}
         reasoning={displayReasoning}
       />
     </div>
@@ -1199,6 +1224,7 @@ export function ItemDetailPane({
   taskType,
   evaluators,
   evaluatorNamesById,
+  getJobEvaluator,
   runs,
   versionLabels,
   jobStatus,
@@ -1220,6 +1246,10 @@ export function ItemDetailPane({
     name?: string;
   }[];
   evaluatorNamesById: Record<string, string>;
+  getJobEvaluator: (key: {
+    evaluator_id: string;
+    evaluator_version_id?: string;
+  }) => JobEvaluator | null;
   runs: EvaluatorRunRow[];
   versionLabels: Record<string, string>;
   jobStatus: EvaluatorRunJob["status"];
@@ -1251,6 +1281,7 @@ export function ItemDetailPane({
         <EvaluatorResultsPane
           evaluators={evaluators}
           evaluatorNamesById={evaluatorNamesById}
+          getJobEvaluator={getJobEvaluator}
           runs={runs}
           versionLabels={versionLabels}
           jobStatus={jobStatus}
@@ -1432,6 +1463,51 @@ export function EvaluatorRunDetailView({
     return m;
   }, [task?.evaluators]);
 
+  // Top-level evaluators block (with pinned version + output_config +
+  // scale_min/max + variables). Source of truth for per-evaluator
+  // metadata now that per-run `evaluator` / `evaluator_version` blobs
+  // are gone from the API.
+  //
+  // Keyed by `${evaluator_id}:${evaluator_version_id}` so different
+  // versions of the same evaluator carry their own labels / rubrics.
+  // Falls back to a no-version key (`${evaluator_id}:`) so callers
+  // without a pinned version still resolve to *some* entry.
+  const getJobEvaluator = useMemo(() => {
+    const byCompositeKey = new Map<string, JobEvaluator>();
+    const byEvaluatorId = new Map<string, JobEvaluator>();
+    for (const e of job?.evaluators ?? []) {
+      if (e.evaluator_version_id) {
+        byCompositeKey.set(`${e.uuid}:${e.evaluator_version_id}`, e);
+      }
+      if (!byEvaluatorId.has(e.uuid)) byEvaluatorId.set(e.uuid, e);
+    }
+    return (key: {
+      evaluator_id: string;
+      evaluator_version_id?: string;
+    }): JobEvaluator | null => {
+      if (key.evaluator_version_id) {
+        const hit = byCompositeKey.get(
+          `${key.evaluator_id}:${key.evaluator_version_id}`,
+        );
+        if (hit) return hit;
+      }
+      return byEvaluatorId.get(key.evaluator_id) ?? null;
+    };
+  }, [job?.evaluators]);
+
+  // Shim that matches the legacy `details.evaluators` shape the rest of
+  // this file consumes — `{ evaluator_id, evaluator_version_id?, name? }`.
+  // Built from the new top-level `job.evaluators[]` payload.
+  const detailsEvaluators = useMemo(
+    () =>
+      (job?.evaluators ?? []).map((e) => ({
+        evaluator_id: e.uuid,
+        evaluator_version_id: e.evaluator_version_id,
+        name: e.name,
+      })),
+    [job?.evaluators],
+  );
+
   const itemsForRun = useMemo<Item[]>(() => {
     if (!job) return [];
     const taskId = task?.uuid ?? job.task_id;
@@ -1514,9 +1590,8 @@ export function EvaluatorRunDetailView({
   const itemDone = (itemId: string): boolean => {
     if (!job || job.status !== "completed") return false;
     const rs = runsByItem[itemId] ?? [];
-    const evaluators = job.details?.evaluators ?? [];
-    if (rs.length === 0 || evaluators.length === 0) return false;
-    return evaluators.every((e) =>
+    if (rs.length === 0 || detailsEvaluators.length === 0) return false;
+    return detailsEvaluators.every((e) =>
       rs.some(
         (r) =>
           r.evaluator_id === e.evaluator_id &&
@@ -1570,10 +1645,10 @@ export function EvaluatorRunDetailView({
         if (cardsWillRender) return null;
         return (
           <div className="flex items-center gap-2 flex-wrap min-w-0">
-            {(job.details?.evaluators ?? []).length === 0 ? (
+            {detailsEvaluators.length === 0 ? (
               <span className="text-sm text-muted-foreground">—</span>
             ) : (
-              (job.details?.evaluators ?? []).map((e) => {
+              detailsEvaluators.map((e) => {
                 const name = evaluatorDisplayName(e, evaluatorNamesById);
                 const label = e.evaluator_version_id
                   ? versionLabels[e.evaluator_version_id]
@@ -1621,7 +1696,7 @@ export function EvaluatorRunDetailView({
       <HumanAgreementSummary
         jobStatus={job.status}
         agreement={job.human_agreement}
-        evaluators={job.details?.evaluators ?? []}
+        evaluators={detailsEvaluators}
         evaluatorNamesById={evaluatorNamesById}
         versionLabels={versionLabels}
         linkEvaluators={linkEvaluators}
@@ -1745,8 +1820,9 @@ export function EvaluatorRunDetailView({
                 <ItemDetailPane
                   item={currentItem}
                   taskType={task.type}
-                  evaluators={job.details?.evaluators ?? []}
+                  evaluators={detailsEvaluators}
                   evaluatorNamesById={evaluatorNamesById}
+                  getJobEvaluator={getJobEvaluator}
                   runs={runsByItem[currentItem.uuid] ?? []}
                   versionLabels={versionLabels}
                   jobStatus={job.status}

--- a/src/components/human-labelling/ItemDetailDialog.tsx
+++ b/src/components/human-labelling/ItemDetailDialog.tsx
@@ -373,7 +373,10 @@ export function ItemDetailDialog({
         className="bg-background rounded-none md:rounded-xl w-full max-w-[92rem] h-full md:h-[92vh] flex flex-col shadow-2xl overflow-hidden"
       >
         <div className="relative flex items-center justify-between gap-3 px-4 md:px-6 py-3 md:py-4 border-b border-border">
-          <div className="flex-1 min-w-0 flex items-center gap-2">
+          <div
+            className="flex-1 min-w-0 flex items-center gap-2 md:max-w-[calc(50%-6rem)]"
+            title={itemTitle(item)}
+          >
             <h2 className="text-base md:text-lg font-semibold text-foreground truncate min-w-0">
               {itemTitle(item)}
             </h2>

--- a/src/components/human-labelling/ItemDetailDialog.tsx
+++ b/src/components/human-labelling/ItemDetailDialog.tsx
@@ -402,6 +402,34 @@ export function ItemDetailDialog({
       // card surfaces THIS version's label for THIS row's score; rows
       // without a resolved name fall back to the version-level
       // output_config or the task-level snapshot.
+      // Build the synthetic scale: start from the version's full scale
+      // (so labels for OTHER values are available when the user
+      // switches between human annotators that picked a different
+      // value) and, when present, override the matching entry's name
+      // with the per-row backend-resolved label. Adds a fresh entry if
+      // the row's value isn't represented in the scale.
+      const baseScale =
+        evVersion?.output_config?.scale ?? taskEv?.output_config?.scale ?? [];
+      const rowValue = row.evaluator_value;
+      const rowValueName = row.evaluator_value_name?.trim() || null;
+      const hasRowOverride = rowValue !== null && !!rowValueName;
+      const mergedScale = hasRowOverride
+        ? (() => {
+            let matched = false;
+            const next = baseScale.map((e) => {
+              if (e.value === rowValue) {
+                matched = true;
+                return { ...e, name: rowValueName };
+              }
+              return e;
+            });
+            if (!matched) {
+              next.push({ value: rowValue, name: rowValueName });
+            }
+            return next;
+          })()
+        : baseScale;
+
       jobEvaluators.push({
         uuid: row.evaluator_id,
         name: evName,
@@ -411,21 +439,7 @@ export function ItemDetailDialog({
         version_number: evVersion?.version_number,
         scale_min: scaleMin,
         scale_max: scaleMax,
-        output_config:
-          row.evaluator_value !== null &&
-          typeof row.evaluator_value_name === "string" &&
-          row.evaluator_value_name.length > 0
-            ? {
-                scale: [
-                  {
-                    value: row.evaluator_value,
-                    name: row.evaluator_value_name,
-                  },
-                ],
-              }
-            : evVersion?.output_config ??
-              taskEv?.output_config ??
-              null,
+        output_config: mergedScale.length > 0 ? { scale: mergedScale } : null,
       });
       haEvaluators.push({
         evaluator_id: row.evaluator_id,

--- a/src/components/human-labelling/ItemDetailDialog.tsx
+++ b/src/components/human-labelling/ItemDetailDialog.tsx
@@ -373,8 +373,8 @@ export function ItemDetailDialog({
         className="bg-background rounded-none md:rounded-xl w-full max-w-[92rem] h-full md:h-[92vh] flex flex-col shadow-2xl overflow-hidden"
       >
         <div className="relative flex items-center justify-between gap-3 px-4 md:px-6 py-3 md:py-4 border-b border-border">
-          <div className="min-w-0 flex items-center gap-2 flex-wrap">
-            <h2 className="text-base md:text-lg font-semibold text-foreground truncate">
+          <div className="flex-1 min-w-0 flex items-center gap-2">
+            <h2 className="text-base md:text-lg font-semibold text-foreground truncate min-w-0">
               {itemTitle(item)}
             </h2>
           </div>

--- a/src/components/human-labelling/ItemDetailDialog.tsx
+++ b/src/components/human-labelling/ItemDetailDialog.tsx
@@ -11,6 +11,7 @@ import {
   type EvaluatorRunRow,
   type HumanAgreementItem,
   type HumanAnnotation,
+  type JobEvaluator,
 } from "@/components/human-labelling/EvaluatorRunDetailView";
 
 type SummaryAnnotator = { uuid: string; name: string };
@@ -273,6 +274,10 @@ export function ItemDetailDialog({
     const versionLabels: Record<string, string> = {};
     const evaluatorNamesById: Record<string, string> = {};
     const haEvaluators: HumanAgreementItem["evaluators"] = [];
+    // Per-(evaluator_id, version_id) JobEvaluator entry. The dialog
+    // synthesises a one-entry scale from the per-row `evaluator_value_name`
+    // so different versions of the same evaluator render their own labels.
+    const jobEvaluators: JobEvaluator[] = [];
 
     for (const row of summary.rows) {
       const human_annotations: HumanAnnotation[] = [];
@@ -343,39 +348,37 @@ export function ItemDetailDialog({
         status: effectiveValue !== null ? "completed" : "pending",
         created_at: "",
         completed_at: null,
-        evaluator_version: {
-          uuid: row.evaluator_version_id ?? undefined,
-          version_number: row.evaluator_version_number ?? undefined,
-          scale_min: scaleMin,
-          scale_max: scaleMax,
-          // Prefer the per-row resolved label. The backend now sends
-          // `evaluator_value_name` per row, which is the label for THIS
-          // version's score — different versions of the same evaluator
-          // can have different labels. Synthesize a one-entry scale so
-          // the verdict pill / rating label uses it. Fall back to the
-          // task-level snapshot when the row doesn't carry a name.
-          output_config:
-            row.evaluator_value !== null &&
-            typeof row.evaluator_value_name === "string" &&
-            row.evaluator_value_name.length > 0
-              ? {
-                  scale: [
-                    {
-                      value: row.evaluator_value,
-                      name: row.evaluator_value_name,
-                    },
-                  ],
-                }
-              : row.evaluator_version_output_config ??
-                taskEv?.output_config ??
-                null,
-        },
-        evaluator: {
-          uuid: row.evaluator_id,
-          name: row.evaluator_name,
-          description: taskEv?.description ?? null,
-          output_type: row.output_type,
-        },
+      });
+
+      // One JobEvaluator per (evaluator_id, version_id). The per-row
+      // `evaluator_value_name` becomes a one-entry scale so the verdict
+      // card surfaces THIS version's label for THIS row's score; rows
+      // without a resolved name fall back to the version-level
+      // output_config or the task-level snapshot.
+      jobEvaluators.push({
+        uuid: row.evaluator_id,
+        name: row.evaluator_name,
+        description: taskEv?.description ?? null,
+        output_type: row.output_type,
+        evaluator_version_id: row.evaluator_version_id ?? undefined,
+        version_number: row.evaluator_version_number ?? undefined,
+        scale_min: scaleMin,
+        scale_max: scaleMax,
+        output_config:
+          row.evaluator_value !== null &&
+          typeof row.evaluator_value_name === "string" &&
+          row.evaluator_value_name.length > 0
+            ? {
+                scale: [
+                  {
+                    value: row.evaluator_value,
+                    name: row.evaluator_value_name,
+                  },
+                ],
+              }
+            : row.evaluator_version_output_config ??
+              taskEv?.output_config ??
+              null,
       });
       haEvaluators.push({
         evaluator_id: row.evaluator_id,
@@ -393,9 +396,34 @@ export function ItemDetailDialog({
       evaluators: haEvaluators,
     };
 
+    // Build a lookup keyed by (evaluator_id, evaluator_version_id) so the
+    // verdict card resolves THIS version's labels/scale, not a sibling
+    // version's. Falls back to any entry with a matching evaluator_id.
+    const byComposite = new Map<string, JobEvaluator>();
+    const byEvaluatorId = new Map<string, JobEvaluator>();
+    for (const e of jobEvaluators) {
+      if (e.evaluator_version_id) {
+        byComposite.set(`${e.uuid}:${e.evaluator_version_id}`, e);
+      }
+      if (!byEvaluatorId.has(e.uuid)) byEvaluatorId.set(e.uuid, e);
+    }
+    const getJobEvaluator = (key: {
+      evaluator_id: string;
+      evaluator_version_id?: string;
+    }): JobEvaluator | null => {
+      if (key.evaluator_version_id) {
+        const hit = byComposite.get(
+          `${key.evaluator_id}:${key.evaluator_version_id}`,
+        );
+        if (hit) return hit;
+      }
+      return byEvaluatorId.get(key.evaluator_id) ?? null;
+    };
+
     return {
       evaluators,
       evaluatorNamesById,
+      getJobEvaluator,
       runs,
       versionLabels,
       humanAgreementForItem,
@@ -630,6 +658,7 @@ export function ItemDetailDialog({
               taskType={task.type}
               evaluators={adapted.evaluators}
               evaluatorNamesById={adapted.evaluatorNamesById}
+              getJobEvaluator={adapted.getJobEvaluator}
               runs={adapted.runs}
               versionLabels={adapted.versionLabels}
               jobStatus="completed"

--- a/src/components/human-labelling/ItemDetailDialog.tsx
+++ b/src/components/human-labelling/ItemDetailDialog.tsx
@@ -325,8 +325,7 @@ export function ItemDetailDialog({
       // / scale (which the summary used to inline).
       const summaryEv = summaryEvaluatorByUuid.get(row.evaluator_id);
       const taskEv = taskEvaluatorByUuid.get(row.evaluator_id);
-      const evName =
-        summaryEv?.name ?? taskEv?.uuid ? (summaryEv?.name ?? "") : "";
+      const evName = summaryEv?.name ?? "";
       const evDescription =
         summaryEv?.description ?? taskEv?.description ?? null;
       const evOutputType =

--- a/src/components/human-labelling/ItemDetailDialog.tsx
+++ b/src/components/human-labelling/ItemDetailDialog.tsx
@@ -23,20 +23,23 @@ type SummaryRow = {
   item_id: string;
   payload: Record<string, unknown> | null;
   evaluator_id: string;
-  evaluator_name: string;
-  output_type: "binary" | "rating";
   evaluator_version_id?: string | null;
-  evaluator_version_number?: number | null;
   evaluator_value: boolean | number | null;
+  // Backend-resolved label for the row's score (e.g. "Helpful" for a
+  // rating of 4 against a custom-labelled rating evaluator).
   evaluator_value_name?: string | null;
   evaluator_reasoning?: string | null;
   human_agreement: number | null;
   evaluator_agreement: number | null;
   annotations: Record<string, SummaryAnnotation | null>;
-  // Per-version output_config — different versions of the same evaluator
-  // can carry different labels/rubrics on their scale entries. Falls back
-  // to the task-level evaluator snapshot when the row doesn't carry it.
-  evaluator_version_output_config?: {
+};
+// Top-level evaluator entry — carries name / description / output_type
+// and the full version history. Per-version scale + output_config live
+// inside `versions[]`; the row's `evaluator_version_id` keys back in.
+type SummaryEvaluatorVersion = {
+  uuid: string;
+  version_number: number;
+  output_config?: {
     scale?: {
       value: boolean | number | string;
       name?: string | null;
@@ -44,11 +47,20 @@ type SummaryRow = {
       color?: string | null;
     }[];
   } | null;
+  scale_min?: number | null;
+  scale_max?: number | null;
+  is_live?: boolean;
 };
 type SummaryEvaluator = {
-  evaluator_id: string;
-  name?: string;
-  output_type?: "binary" | "rating";
+  uuid: string;
+  name: string;
+  description?: string | null;
+  output_type: "binary" | "rating";
+  evaluator_type?: string;
+  data_type?: string;
+  live_version_id?: string | null;
+  live_version_index?: number | null;
+  versions?: SummaryEvaluatorVersion[];
   // Total runs for this evaluator across every version, restricted to the
   // items in scope. Unaffected by `live_only`.
   run_count?: number;
@@ -62,6 +74,7 @@ type TaskSummaryResponse = {
 type TaskEvaluatorDef = {
   uuid: string;
   description?: string | null;
+  output_type?: "binary" | "rating" | null;
   scale_min?: number | boolean | null;
   scale_max?: number | boolean | null;
   output_config?: {
@@ -260,6 +273,13 @@ export function ItemDetailDialog({
     const taskEvaluatorByUuid = new Map(
       (task.evaluators ?? []).map((e) => [e.uuid, e]),
     );
+    // Top-level evaluators block from the new summary response. Each
+    // entry carries the full version history; per-row evaluator metadata
+    // (name, output_type, version_number, scale) is resolved by uuid
+    // (and evaluator_version_id for version-level fields).
+    const summaryEvaluatorByUuid = new Map(
+      (summary.evaluators ?? []).map((e) => [e.uuid, e]),
+    );
     const annotatorNameById = new Map(
       (summary.annotators ?? []).map((a) => [a.uuid, a.name]),
     );
@@ -300,31 +320,59 @@ export function ItemDetailDialog({
       // drop rows that have no matching annotations.
       if (annotatorFilter && human_annotations.length === 0) continue;
 
+      // Resolve per-evaluator metadata from the top-level evaluators[]
+      // block. Falls back to the task-level evaluator def for description
+      // / scale (which the summary used to inline).
+      const summaryEv = summaryEvaluatorByUuid.get(row.evaluator_id);
+      const taskEv = taskEvaluatorByUuid.get(row.evaluator_id);
+      const evName =
+        summaryEv?.name ?? taskEv?.uuid ? (summaryEv?.name ?? "") : "";
+      const evDescription =
+        summaryEv?.description ?? taskEv?.description ?? null;
+      const evOutputType =
+        summaryEv?.output_type ?? (taskEv?.output_type as
+          | "binary"
+          | "rating"
+          | undefined);
+      const evVersion = row.evaluator_version_id
+        ? summaryEv?.versions?.find(
+            (v) => v.uuid === row.evaluator_version_id,
+          )
+        : undefined;
+
       const evKey = `${row.evaluator_id}-${row.evaluator_version_id ?? ""}`;
       if (!seenEvKey.has(evKey)) {
         seenEvKey.add(evKey);
         evaluators.push({
           evaluator_id: row.evaluator_id,
           evaluator_version_id: row.evaluator_version_id ?? undefined,
-          name: row.evaluator_name,
+          name: evName,
         });
       }
       if (
         row.evaluator_version_id &&
-        typeof row.evaluator_version_number === "number"
+        typeof evVersion?.version_number === "number"
       ) {
         versionLabels[row.evaluator_version_id] =
-          `v${row.evaluator_version_number}`;
+          `v${evVersion.version_number}`;
       }
-      if (!evaluatorNamesById[row.evaluator_id]) {
-        evaluatorNamesById[row.evaluator_id] = row.evaluator_name;
+      if (evName && !evaluatorNamesById[row.evaluator_id]) {
+        evaluatorNamesById[row.evaluator_id] = evName;
       }
 
-      const taskEv = taskEvaluatorByUuid.get(row.evaluator_id);
+      // Prefer the per-version scale; fall back to the task-level snapshot.
       const scaleMin =
-        typeof taskEv?.scale_min === "number" ? taskEv.scale_min : null;
+        typeof evVersion?.scale_min === "number"
+          ? evVersion.scale_min
+          : typeof taskEv?.scale_min === "number"
+            ? taskEv.scale_min
+            : null;
       const scaleMax =
-        typeof taskEv?.scale_max === "number" ? taskEv.scale_max : null;
+        typeof evVersion?.scale_max === "number"
+          ? evVersion.scale_max
+          : typeof taskEv?.scale_max === "number"
+            ? taskEv.scale_max
+            : null;
 
       const suppressEvaluator = annotatorFilter !== null;
       const effectiveValue = suppressEvaluator ? null : row.evaluator_value;
@@ -357,11 +405,11 @@ export function ItemDetailDialog({
       // output_config or the task-level snapshot.
       jobEvaluators.push({
         uuid: row.evaluator_id,
-        name: row.evaluator_name,
-        description: taskEv?.description ?? null,
-        output_type: row.output_type,
+        name: evName,
+        description: evDescription,
+        output_type: evOutputType,
         evaluator_version_id: row.evaluator_version_id ?? undefined,
-        version_number: row.evaluator_version_number ?? undefined,
+        version_number: evVersion?.version_number,
         scale_min: scaleMin,
         scale_max: scaleMax,
         output_config:
@@ -376,7 +424,7 @@ export function ItemDetailDialog({
                   },
                 ],
               }
-            : row.evaluator_version_output_config ??
+            : evVersion?.output_config ??
               taskEv?.output_config ??
               null,
       });

--- a/src/components/human-labelling/ItemDetailDialog.tsx
+++ b/src/components/human-labelling/ItemDetailDialog.tsx
@@ -27,10 +27,22 @@ type SummaryRow = {
   evaluator_version_id?: string | null;
   evaluator_version_number?: number | null;
   evaluator_value: boolean | number | null;
+  evaluator_value_name?: string | null;
   evaluator_reasoning?: string | null;
   human_agreement: number | null;
   evaluator_agreement: number | null;
   annotations: Record<string, SummaryAnnotation | null>;
+  // Per-version output_config — different versions of the same evaluator
+  // can carry different labels/rubrics on their scale entries. Falls back
+  // to the task-level evaluator snapshot when the row doesn't carry it.
+  evaluator_version_output_config?: {
+    scale?: {
+      value: boolean | number | string;
+      name?: string | null;
+      description?: string | null;
+      color?: string | null;
+    }[];
+  } | null;
 };
 type SummaryEvaluator = {
   evaluator_id: string;
@@ -51,6 +63,14 @@ type TaskEvaluatorDef = {
   description?: string | null;
   scale_min?: number | boolean | null;
   scale_max?: number | boolean | null;
+  output_config?: {
+    scale?: {
+      value: boolean | number | string;
+      name?: string | null;
+      description?: string | null;
+      color?: string | null;
+    }[];
+  } | null;
 };
 
 function itemTitle(item: Item | null): string {
@@ -328,6 +348,27 @@ export function ItemDetailDialog({
           version_number: row.evaluator_version_number ?? undefined,
           scale_min: scaleMin,
           scale_max: scaleMax,
+          // Prefer the per-row resolved label. The backend now sends
+          // `evaluator_value_name` per row, which is the label for THIS
+          // version's score — different versions of the same evaluator
+          // can have different labels. Synthesize a one-entry scale so
+          // the verdict pill / rating label uses it. Fall back to the
+          // task-level snapshot when the row doesn't carry a name.
+          output_config:
+            row.evaluator_value !== null &&
+            typeof row.evaluator_value_name === "string" &&
+            row.evaluator_value_name.length > 0
+              ? {
+                  scale: [
+                    {
+                      value: row.evaluator_value,
+                      name: row.evaluator_value_name,
+                    },
+                  ],
+                }
+              : row.evaluator_version_output_config ??
+                taskEv?.output_config ??
+                null,
         },
         evaluator: {
           uuid: row.evaluator_id,

--- a/src/components/human-labelling/RunEvaluatorsDialog.tsx
+++ b/src/components/human-labelling/RunEvaluatorsDialog.tsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo, useState } from "react";
 import { useHideFloatingButton } from "@/components/AppLayout";
 import { SingleSelectPicker } from "@/components/SingleSelectPicker";
 import { apiClient } from "@/lib/api";
+import { liveVersionOf } from "@/lib/evaluatorVersions";
 
 type LinkedEvaluator = { uuid: string; name: string };
 
@@ -15,7 +16,9 @@ type EvaluatorVersion = {
 type EvaluatorDetail = {
   uuid: string;
   live_version_id: string | null;
-  live_version: EvaluatorVersion | null;
+  // Index into `versions[]` for the live version. Replaces the
+  // previously flattened `live_version` blob.
+  live_version_index: number | null;
   versions?: EvaluatorVersion[];
 };
 
@@ -47,6 +50,10 @@ type EvaluatorVersionInfo = {
 type RunEvaluatorsDialogProps = {
   isOpen: boolean;
   accessToken: string;
+  /** Task uuid — used to fetch every linked evaluator (with versions and
+   * live_version) in one request via
+   * `GET /annotation-tasks/{taskUuid}/evaluators`. */
+  taskUuid: string;
   evaluators: LinkedEvaluator[];
   submitting: boolean;
   submitError: string | null;
@@ -77,6 +84,7 @@ function VersionLabel({
 export function RunEvaluatorsDialog({
   isOpen,
   accessToken,
+  taskUuid,
   evaluators,
   submitting,
   submitError,
@@ -113,36 +121,33 @@ export function RunEvaluatorsDialog({
     setLoadError(null);
     setPicked(Object.fromEntries(evaluators.map((e) => [e.uuid, true])));
     setChosenVersion({});
+    if (!taskUuid) return;
     let cancelled = false;
     const run = async () => {
-      if (evaluators.length === 0) return;
       setLoading(true);
       try {
-        const results = await Promise.all(
-          evaluators.map(async (e) => {
-            const data = await apiClient<EvaluatorDetail>(
-              `/evaluators/${e.uuid}`,
-              accessToken,
-            );
-            const all =
-              data.versions && data.versions.length > 0
-                ? [...data.versions]
-                : data.live_version
-                  ? [data.live_version]
-                  : [];
-            all.sort((a, b) => b.version_number - a.version_number);
-            const liveVersionId =
-              data.live_version_id ?? data.live_version?.uuid ?? null;
-            return [e.uuid, { versions: all, liveVersionId }] as const;
-          }),
+        // Single task-level call returns every linked evaluator as a full
+        // EvaluatorDetailResponse (versions[] + live_version[_id]). Replaces
+        // the previous N-parallel `/evaluators/{uuid}` fan-out.
+        const all = await apiClient<EvaluatorDetail[]>(
+          `/annotation-tasks/${taskUuid}/evaluators`,
+          accessToken,
         );
         if (cancelled) return;
         const next: Record<string, EvaluatorVersionInfo> = {};
         const initialChosen: Record<string, string> = {};
-        for (const [evUuid, val] of results) {
-          next[evUuid] = val;
-          const fallback = val.liveVersionId ?? val.versions[0]?.uuid ?? null;
-          if (fallback) initialChosen[evUuid] = fallback;
+        for (const data of all) {
+          // Resolve the live version BEFORE sorting so we hit the
+          // backend's `live_version_index` (an offset into the
+          // unsorted `versions[]`).
+          const liveVersion = liveVersionOf(data);
+          const versions = data.versions ? [...data.versions] : [];
+          versions.sort((a, b) => b.version_number - a.version_number);
+          const liveVersionId =
+            data.live_version_id ?? liveVersion?.uuid ?? null;
+          next[data.uuid] = { versions, liveVersionId };
+          const fallback = liveVersionId ?? versions[0]?.uuid ?? null;
+          if (fallback) initialChosen[data.uuid] = fallback;
         }
         setInfo(next);
         setChosenVersion(initialChosen);
@@ -161,7 +166,7 @@ export function RunEvaluatorsDialog({
     // `evaluatorIdsKey` instead. Including the array reference would
     // re-fire the effect on every parent render and wipe state.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isOpen, accessToken, evaluatorIdsKey]);
+  }, [isOpen, accessToken, taskUuid, evaluatorIdsKey]);
 
   const pickedCount = useMemo(
     () => Object.values(picked).filter(Boolean).length,

--- a/src/components/test-results/shared.tsx
+++ b/src/components/test-results/shared.tsx
@@ -17,6 +17,7 @@ import {
   ChevronDownIcon,
 } from "@/components/icons";
 import type { DefaultEvaluatorSummary } from "@/lib/defaultEvaluators";
+import { getBinaryLabel, toRatingScale } from "@/lib/binaryLabels";
 
 // Renders the evaluator name. Authenticated result pages can link to the
 // evaluator detail page; public share pages must render plain text because
@@ -113,36 +114,53 @@ export type TestCaseData = {
 // Per-evaluator verdict for response (next-reply) tests. Tool-call tests
 // always have `judge_results: null`. Mutually-exclusive `match` (binary)
 // and `score` (rating) — exactly one is set on a completed entry.
-// `evaluator_uuid` may be `null` for legacy runs that pre-date snapshot
-// capture; treat as "no canonical link, just display the name".
-// `name` is the CURRENT DB display name (refreshed on every read).
-// `description` is the snapshotted one-line evaluator description used by
-// the job; it may be null/absent for older snapshots.
 //
-// `variable_values`, `scale_min`, `scale_max` were added by the backend
-// after the initial judge_results rollout. They are surfaced inline on
-// every entry so the UI doesn't need a separate evaluator fetch to render
-// `score / scale_max` chips or the per-test variable substitutions:
-//  - `variable_values`: the `{{var}}` substitutions used for this evaluator
-//    on this specific test case (frozen at submission time). Empty maps are
-//    normalised to `null` server-side. Missing on legacy snapshots.
-//  - `scale_min` / `scale_max`: present only for rating evaluators (e.g.
-//    `1.0` / `5.0`); always `null` for binary evaluators or legacy rows.
+// As of the API change that moved per-evaluator metadata to a top-level
+// `evaluators[]` block, each judge_result row carries only the bits that
+// genuinely vary per test case:
+//  - `evaluator_uuid`: keys back into the top-level evaluators[] block
+//    (backend guarantees an entry, synthesising a stub for legacy rows).
+//  - `match` / `score`: the verdict.
+//  - `value_name`: backend-resolved display label for the row's value
+//    (e.g. "Pass" for `match: true` against a custom-labelled binary
+//    evaluator). Optional for the same reason — backend may omit when
+//    null. Empty string is treated like missing.
+//  - `reasoning`: judge's free-text explanation.
+//  - `variable_values`: the `{{var}}` substitutions used on this test
+//    case (frozen at submission time).
+//
+// Fields that used to be inlined here — `name`, `description`,
+// `scale_min`, `scale_max`, `true_label`, `false_label` — are now read
+// from the top-level evaluator entry indexed by `evaluator_uuid`.
 export type JudgeResult = {
   evaluator_uuid?: string | null;
-  name: string;
-  description?: string | null;
   reasoning?: string;
   match?: boolean | null;
   score?: number | null;
+  value_name?: string | null;
   variable_values?: Record<string, string> | null;
+};
+
+// Per-evaluator block returned at the top level of test-run / benchmark
+// responses. Each entry pins the version the run executed against;
+// per-evaluator metadata (name, description, output config, scale
+// bounds) lives here and is looked up by `evaluator_uuid` from each
+// `judge_results[]` row.
+export type TestRunEvaluator = {
+  uuid: string;
+  name: string;
+  description?: string | null;
+  output_type: "binary" | "rating";
+  output_config?: {
+    scale?: {
+      value: boolean | number | string;
+      name?: string | null;
+      description?: string | null;
+      color?: string | null;
+    }[];
+  } | null;
   scale_min?: number | null;
   scale_max?: number | null;
-  // Custom labels for binary verdicts, surfaced from
-  // `output_config.scale`. Optional/null for legacy rows or evaluators
-  // that haven't overridden the default Correct / Wrong labels.
-  true_label?: string | null;
-  false_label?: string | null;
 };
 
 function buildLegacyNextReplyJudgeResults({
@@ -156,16 +174,29 @@ function buildLegacyNextReplyJudgeResults({
 }): JudgeResult[] | null {
   const criteria = evaluation?.criteria;
   if (evaluation?.type === "tool_call" || !criteria) return null;
-
   return [
     {
       evaluator_uuid: defaultEvaluator?.uuid ?? null,
-      name: defaultEvaluator?.name ?? "Correctness",
-      description: defaultEvaluator?.description ?? null,
       reasoning,
       variable_values: { criteria },
     },
   ];
+}
+
+// Synthesise a top-level evaluators[] entry to pair with the legacy
+// next-reply judge_result above. The default-evaluator metadata is what
+// callers used to inline on the row; we now hand it back via the same
+// uuid-keyed lookup the rest of the code uses.
+function legacyEvaluatorEntry(
+  defaultEvaluator?: DefaultEvaluatorSummary | null,
+): TestRunEvaluator | null {
+  if (!defaultEvaluator?.uuid) return null;
+  return {
+    uuid: defaultEvaluator.uuid,
+    name: defaultEvaluator.name ?? "Correctness",
+    description: defaultEvaluator.description ?? null,
+    output_type: "binary",
+  };
 }
 
 // Shared Status Icon Component
@@ -388,33 +419,51 @@ function CollapsibleReasoningStrip({
 // older snapshots that don't carry it inline.
 function JudgeResultCard({
   result,
-  scaleMax,
+  evaluator,
   enableEvaluatorLinks,
 }: {
   result: JudgeResult;
-  scaleMax?: number;
+  /** Top-level evaluator entry resolved by `result.evaluator_uuid`. */
+  evaluator: TestRunEvaluator | null;
   enableEvaluatorLinks: boolean;
 }) {
   const isRating = result.score !== null && result.score !== undefined;
-  const effectiveScaleMax =
-    typeof result.scale_max === "number" ? result.scale_max : scaleMax;
-  const effectiveScaleMin =
-    typeof result.scale_min === "number" ? result.scale_min : undefined;
+  const scale = evaluator?.output_config?.scale ?? null;
+  const valueName = result.value_name?.trim() || null;
   return (
     <EvaluatorVerdictCard
       mode="read"
-      name={result.name}
-      description={result.description ?? null}
+      name={evaluator?.name ?? "Evaluator"}
+      description={evaluator?.description ?? null}
       outputType={isRating ? "rating" : "binary"}
       evaluatorUuid={result.evaluator_uuid ?? undefined}
       enableLink={enableEvaluatorLinks}
-      scaleMin={effectiveScaleMin}
-      scaleMax={effectiveScaleMax}
+      scaleMin={
+        typeof evaluator?.scale_min === "number"
+          ? evaluator.scale_min
+          : undefined
+      }
+      scaleMax={
+        typeof evaluator?.scale_max === "number"
+          ? evaluator.scale_max
+          : undefined
+      }
       match={result.match}
       score={result.score}
       reasoning={result.reasoning}
-      trueLabel={result.true_label}
-      falseLabel={result.false_label}
+      // Prefer the row-resolved `value_name` for the side that matches
+      // this verdict; fall back to the scale lookup for the other side.
+      trueLabel={
+        result.match === true && valueName
+          ? valueName
+          : getBinaryLabel(scale, true)
+      }
+      falseLabel={
+        result.match === false && valueName
+          ? valueName
+          : getBinaryLabel(scale, false)
+      }
+      ratingScale={toRatingScale(scale)}
     />
   );
 }
@@ -424,11 +473,15 @@ function JudgeResultCard({
 // should fall back to the legacy single-reasoning display.
 export function JudgeResultsList({
   results,
-  scaleByEvaluatorUuid,
+  evaluatorsByUuid,
   enableEvaluatorLinks = true,
 }: {
   results?: JudgeResult[] | null;
-  scaleByEvaluatorUuid?: Record<string, number | undefined>;
+  /** Top-level evaluators[] keyed by uuid. Source of truth for name,
+   * description, scale, and output_config. Backend guarantees an entry
+   * for every uuid in `results[].evaluator_uuid` (synthesises a stub
+   * for legacy rows). */
+  evaluatorsByUuid?: Record<string, TestRunEvaluator>;
   enableEvaluatorLinks?: boolean;
 }) {
   if (!results || results.length === 0) return null;
@@ -438,18 +491,19 @@ export function JudgeResultsList({
         Evaluators
       </div>
       <div className="space-y-2">
-        {results.map((r, i) => (
-          <JudgeResultCard
-            key={r.evaluator_uuid ?? `${r.name}-${i}`}
-            result={r}
-            scaleMax={
-              r.evaluator_uuid
-                ? scaleByEvaluatorUuid?.[r.evaluator_uuid]
-                : undefined
-            }
-            enableEvaluatorLinks={enableEvaluatorLinks}
-          />
-        ))}
+        {results.map((r, i) => {
+          const ev = r.evaluator_uuid
+            ? evaluatorsByUuid?.[r.evaluator_uuid] ?? null
+            : null;
+          return (
+            <JudgeResultCard
+              key={r.evaluator_uuid ?? `${i}`}
+              result={r}
+              evaluator={ev}
+              enableEvaluatorLinks={enableEvaluatorLinks}
+            />
+          );
+        })}
       </div>
     </div>
   );
@@ -477,7 +531,7 @@ export function TestDetailView({
   reasoning,
   evaluation,
   judgeResults,
-  scaleByEvaluatorUuid,
+  evaluatorsByUuid,
   legacyDefaultEvaluator,
   enableEvaluatorLinks = true,
   highlightEvalTarget = false,
@@ -491,9 +545,9 @@ export function TestDetailView({
    * for tool-call tests and for legacy response tests that pre-date
    * judge_results — those fall back to the legacy single-reasoning UI. */
   judgeResults?: JudgeResult[] | null;
-  /** Optional rating-evaluator scale lookup (uuid → scale_max). When
-   * provided, rating cards render `score / max` instead of just `score`. */
-  scaleByEvaluatorUuid?: Record<string, number | undefined>;
+  /** Top-level evaluators[] keyed by uuid. Source of truth for name,
+   * description, scale, and output_config. */
+  evaluatorsByUuid?: Record<string, TestRunEvaluator>;
   /** Default correctness evaluator used to render legacy response criteria
    * as evaluator variable values when `judgeResults` is absent. */
   legacyDefaultEvaluator?: DefaultEvaluatorSummary | null;
@@ -726,7 +780,15 @@ export function TestDetailView({
         <div className="md:hidden w-full">
           <JudgeResultsList
             results={effectiveJudgeResults}
-            scaleByEvaluatorUuid={scaleByEvaluatorUuid}
+            evaluatorsByUuid={
+              // For the legacy free-text fallback the JudgeResultsList
+              // also needs the synthetic top-level evaluator entry.
+              evaluatorsByUuid ??
+              (() => {
+                const legacy = legacyEvaluatorEntry(legacyDefaultEvaluator);
+                return legacy ? { [legacy.uuid]: legacy } : undefined;
+              })()
+            }
             enableEvaluatorLinks={enableEvaluatorLinks}
           />
         </div>
@@ -774,40 +836,56 @@ export function EmptyStateView({ message }: { message: string }) {
 //      scale_max map respectively).
 function EvaluatorPanelCard({
   result,
+  evaluator,
   variableValues,
-  scaleMax,
   enableEvaluatorLinks,
 }: {
   result: JudgeResult;
+  /** Top-level evaluator entry resolved by `result.evaluator_uuid`. */
+  evaluator: TestRunEvaluator | null;
   variableValues?: Record<string, string> | null;
-  scaleMax?: number;
   enableEvaluatorLinks: boolean;
 }) {
   const isRating = result.score !== null && result.score !== undefined;
-  const effectiveScaleMax =
-    typeof result.scale_max === "number" ? result.scale_max : scaleMax;
-  const effectiveScaleMin =
-    typeof result.scale_min === "number" ? result.scale_min : undefined;
   const effectiveVariables =
     result.variable_values && typeof result.variable_values === "object"
       ? result.variable_values
       : variableValues ?? null;
+  const scale = evaluator?.output_config?.scale ?? null;
+  const valueName = result.value_name?.trim() || null;
   return (
     <EvaluatorVerdictCard
       mode="read"
-      name={result.name}
-      description={result.description ?? null}
+      name={evaluator?.name ?? "Evaluator"}
+      description={evaluator?.description ?? null}
       outputType={isRating ? "rating" : "binary"}
       evaluatorUuid={result.evaluator_uuid ?? undefined}
       enableLink={enableEvaluatorLinks}
       variableValues={effectiveVariables}
-      scaleMin={effectiveScaleMin}
-      scaleMax={effectiveScaleMax}
+      scaleMin={
+        typeof evaluator?.scale_min === "number"
+          ? evaluator.scale_min
+          : undefined
+      }
+      scaleMax={
+        typeof evaluator?.scale_max === "number"
+          ? evaluator.scale_max
+          : undefined
+      }
       match={result.match}
       score={result.score}
       reasoning={result.reasoning}
-      trueLabel={result.true_label}
-      falseLabel={result.false_label}
+      trueLabel={
+        result.match === true && valueName
+          ? valueName
+          : getBinaryLabel(scale, true)
+      }
+      falseLabel={
+        result.match === false && valueName
+          ? valueName
+          : getBinaryLabel(scale, false)
+      }
+      ratingScale={toRatingScale(scale)}
     />
   );
 }
@@ -839,7 +917,7 @@ export function EvaluationCriteriaPanel({
   judgeResults,
   reasoning,
   testCaseEvaluators,
-  scaleByEvaluatorUuid,
+  evaluatorsByUuid,
   legacyDefaultEvaluator,
   enableEvaluatorLinks = true,
 }: {
@@ -860,10 +938,9 @@ export function EvaluationCriteriaPanel({
    * Used as a fallback for variable values when the judge_results entries
    * don't carry them inline (older snapshots). Optional. */
   testCaseEvaluators?: TestCaseEvaluatorRef[];
-  /** uuid → scale_max for rating evaluators. Fallback only — when an
-   * entry has `scale_max` inline on the `JudgeResult` (newer payloads)
-   * that takes priority. Optional. */
-  scaleByEvaluatorUuid?: Record<string, number | undefined>;
+  /** Top-level evaluators[] keyed by uuid. Source of truth for name,
+   * description, scale, and output_config. */
+  evaluatorsByUuid?: Record<string, TestRunEvaluator>;
   /** Default correctness evaluator used to render legacy response criteria
    * as evaluator variable values when `judgeResults` is absent. */
   legacyDefaultEvaluator?: DefaultEvaluatorSummary | null;
@@ -957,23 +1034,24 @@ export function EvaluationCriteriaPanel({
       {/* Response test, new format: per-evaluator cards. */}
       {!isToolCall && hasJudgeResults && (
         <div className="space-y-3">
-          {judgeResults!.map((jr, i) => (
-            <EvaluatorPanelCard
-              key={jr.evaluator_uuid ?? `${jr.name}-${i}`}
-              result={jr}
-              variableValues={
-                jr.evaluator_uuid
-                  ? variablesByUuid[jr.evaluator_uuid]
-                  : undefined
-              }
-              scaleMax={
-                jr.evaluator_uuid
-                  ? scaleByEvaluatorUuid?.[jr.evaluator_uuid]
-                  : undefined
-              }
-              enableEvaluatorLinks={enableEvaluatorLinks}
-            />
-          ))}
+          {judgeResults!.map((jr, i) => {
+            const ev = jr.evaluator_uuid
+              ? evaluatorsByUuid?.[jr.evaluator_uuid] ?? null
+              : null;
+            return (
+              <EvaluatorPanelCard
+                key={jr.evaluator_uuid ?? `${i}`}
+                result={jr}
+                evaluator={ev}
+                variableValues={
+                  jr.evaluator_uuid
+                    ? variablesByUuid[jr.evaluator_uuid]
+                    : undefined
+                }
+                enableEvaluatorLinks={enableEvaluatorLinks}
+              />
+            );
+          })}
         </div>
       )}
 
@@ -984,8 +1062,9 @@ export function EvaluationCriteriaPanel({
         <div className="space-y-3">
           {legacyJudgeResults!.map((jr, i) => (
             <EvaluatorPanelCard
-              key={jr.evaluator_uuid ?? `${jr.name}-${i}`}
+              key={jr.evaluator_uuid ?? `${i}`}
               result={jr}
+              evaluator={legacyEvaluatorEntry(legacyDefaultEvaluator)}
               enableEvaluatorLinks={enableEvaluatorLinks}
             />
           ))}

--- a/src/components/test-results/shared.tsx
+++ b/src/components/test-results/shared.tsx
@@ -464,6 +464,7 @@ function JudgeResultCard({
           : getBinaryLabel(scale, false)
       }
       ratingScale={toRatingScale(scale)}
+      ratingLabel={valueName}
     />
   );
 }
@@ -886,6 +887,7 @@ function EvaluatorPanelCard({
           : getBinaryLabel(scale, false)
       }
       ratingScale={toRatingScale(scale)}
+      ratingLabel={valueName}
     />
   );
 }

--- a/src/components/test-results/shared.tsx
+++ b/src/components/test-results/shared.tsx
@@ -138,6 +138,11 @@ export type JudgeResult = {
   variable_values?: Record<string, string> | null;
   scale_min?: number | null;
   scale_max?: number | null;
+  // Custom labels for binary verdicts, surfaced from
+  // `output_config.scale`. Optional/null for legacy rows or evaluators
+  // that haven't overridden the default Correct / Wrong labels.
+  true_label?: string | null;
+  false_label?: string | null;
 };
 
 function buildLegacyNextReplyJudgeResults({
@@ -408,6 +413,8 @@ function JudgeResultCard({
       match={result.match}
       score={result.score}
       reasoning={result.reasoning}
+      trueLabel={result.true_label}
+      falseLabel={result.false_label}
     />
   );
 }
@@ -799,6 +806,8 @@ function EvaluatorPanelCard({
       match={result.match}
       score={result.score}
       reasoning={result.reasoning}
+      trueLabel={result.true_label}
+      falseLabel={result.false_label}
     />
   );
 }

--- a/src/lib/binaryLabels.ts
+++ b/src/lib/binaryLabels.ts
@@ -4,6 +4,13 @@
 export const DEFAULT_BINARY_TRUE_LABEL = "Correct";
 export const DEFAULT_BINARY_FALSE_LABEL = "Wrong";
 
+// Default label for a given true/false value. Use this instead of
+// inlining the `value ? "Correct" : "Wrong"` ternary so the defaults
+// stay in one place.
+export function defaultBinaryLabel(value: boolean): string {
+  return value ? DEFAULT_BINARY_TRUE_LABEL : DEFAULT_BINARY_FALSE_LABEL;
+}
+
 export type BinaryScaleEntryLike = {
   value: boolean | number | string;
   name?: string | null;
@@ -19,4 +26,20 @@ export function getBinaryLabel(
   const name = entry?.name?.trim();
   if (name) return name;
   return value ? DEFAULT_BINARY_TRUE_LABEL : DEFAULT_BINARY_FALSE_LABEL;
+}
+
+// Reshape an `output_config.scale` array into the `ratingScale` prop
+// EvaluatorVerdictCard expects: numeric-valued entries with display
+// names. Returns null when there's no scale, so callers can pass the
+// result straight through without extra null checks.
+export function toRatingScale(
+  scale: readonly BinaryScaleEntryLike[] | null | undefined,
+): { value: number; name: string | null }[] | null {
+  if (!scale) return null;
+  return scale
+    .filter((e) => typeof e.value === "number")
+    .map((e) => ({
+      value: e.value as number,
+      name: e.name ?? null,
+    }));
 }

--- a/src/lib/binaryLabels.ts
+++ b/src/lib/binaryLabels.ts
@@ -1,0 +1,22 @@
+// Default labels for binary evaluator verdicts. Custom labels live on
+// each evaluator version's `output_config.scale` as two entries with
+// `value: true` and `value: false`.
+export const DEFAULT_BINARY_TRUE_LABEL = "Correct";
+export const DEFAULT_BINARY_FALSE_LABEL = "Wrong";
+
+export type BinaryScaleEntryLike = {
+  value: boolean | number | string;
+  name?: string | null;
+};
+
+// Pull the custom label for a true/false verdict out of a scale array.
+// Falls back to the default when the entry is missing or the name is blank.
+export function getBinaryLabel(
+  scale: readonly BinaryScaleEntryLike[] | null | undefined,
+  value: boolean,
+): string {
+  const entry = scale?.find((e) => e.value === value);
+  const name = entry?.name?.trim();
+  if (name) return name;
+  return value ? DEFAULT_BINARY_TRUE_LABEL : DEFAULT_BINARY_FALSE_LABEL;
+}

--- a/src/lib/binaryLabels.ts
+++ b/src/lib/binaryLabels.ts
@@ -16,13 +16,33 @@ export type BinaryScaleEntryLike = {
   name?: string | null;
 };
 
+// Coerce a scale entry's `value` to a boolean for matching. Backend
+// types allow boolean | number | string, so older / alternate snapshots
+// may encode binary verdicts as 1/0 or "true"/"false" (or "yes"/"no").
+// Normalise so the lookup catches them all.
+function coerceBinaryValue(v: unknown): boolean | null {
+  if (typeof v === "boolean") return v;
+  if (typeof v === "number") {
+    if (v === 1) return true;
+    if (v === 0) return false;
+    return null;
+  }
+  if (typeof v === "string") {
+    const t = v.trim().toLowerCase();
+    if (t === "true" || t === "yes" || t === "1") return true;
+    if (t === "false" || t === "no" || t === "0") return false;
+    return null;
+  }
+  return null;
+}
+
 // Pull the custom label for a true/false verdict out of a scale array.
 // Falls back to the default when the entry is missing or the name is blank.
 export function getBinaryLabel(
   scale: readonly BinaryScaleEntryLike[] | null | undefined,
   value: boolean,
 ): string {
-  const entry = scale?.find((e) => e.value === value);
+  const entry = scale?.find((e) => coerceBinaryValue(e.value) === value);
   const name = entry?.name?.trim();
   if (name) return name;
   return value ? DEFAULT_BINARY_TRUE_LABEL : DEFAULT_BINARY_FALSE_LABEL;

--- a/src/lib/binaryLabels.ts
+++ b/src/lib/binaryLabels.ts
@@ -20,7 +20,7 @@ export type BinaryScaleEntryLike = {
 // types allow boolean | number | string, so older / alternate snapshots
 // may encode binary verdicts as 1/0 or "true"/"false" (or "yes"/"no").
 // Normalise so the lookup catches them all.
-function coerceBinaryValue(v: unknown): boolean | null {
+export function coerceBinaryValue(v: unknown): boolean | null {
   if (typeof v === "boolean") return v;
   if (typeof v === "number") {
     if (v === 1) return true;

--- a/src/lib/evaluatorVersions.ts
+++ b/src/lib/evaluatorVersions.ts
@@ -1,0 +1,23 @@
+// Helpers for the EvaluatorDetailResponse / per-task evaluator entry
+// shape returned by `GET /evaluators/{uuid}` and
+// `GET /annotation-tasks/{task_uuid}/evaluators`.
+//
+// The backend replaced the flattened `live_version` blob with a
+// `live_version_index` offset into the `versions[]` array so the live
+// version isn't duplicated in the payload. Use `liveVersionOf` instead
+// of repeating the index lookup at each call site.
+
+export function liveVersionOf<V>(
+  evaluator:
+    | {
+        live_version_index?: number | null;
+        versions?: V[] | null;
+      }
+    | null
+    | undefined,
+): V | null {
+  if (!evaluator) return null;
+  const idx = evaluator.live_version_index;
+  if (typeof idx !== "number") return null;
+  return evaluator.versions?.[idx] ?? null;
+}

--- a/src/lib/exportTestResults.ts
+++ b/src/lib/exportTestResults.ts
@@ -83,12 +83,14 @@ function evaluatorVerdict(
   return "";
 }
 
-// Stable key for an evaluator. Always uses the uuid now that the backend
-// guarantees one on every judge_results row (synthesising stub entries
-// for legacy snapshots). Falls back to a positional placeholder only if
-// the uuid is missing entirely.
-function evaluatorKey(jr: JudgeResult): string {
-  return jr.evaluator_uuid ? `uuid:${jr.evaluator_uuid}` : `unknown`;
+// Stable key for an evaluator. Prefers the uuid (canonical across
+// runs); for legacy snapshots that omit `evaluator_uuid` falls back to
+// the evaluator's position within the row's judge_results array — this
+// keeps multi-evaluator legacy rows from collapsing into one CSV
+// column. Position is stable across rows because the backend emits
+// judge_results in the same evaluator order on every row.
+function evaluatorKey(jr: JudgeResult, indexInRow: number): string {
+  return jr.evaluator_uuid ? `uuid:${jr.evaluator_uuid}` : `pos:${indexInRow}`;
 }
 
 // Walk every row's `judgeResults` and build the union of evaluators present
@@ -116,8 +118,9 @@ function collectEvaluatorColumns(
   for (const row of rows) {
     const jrs = row.judgeResults;
     if (!Array.isArray(jrs)) continue;
-    for (const jr of jrs) {
-      const key = evaluatorKey(jr);
+    for (let i = 0; i < jrs.length; i++) {
+      const jr = jrs[i];
+      const key = evaluatorKey(jr, i);
       if (!seen.has(key)) {
         // Disambiguate when two distinct evaluators share a display name.
         const evName = jr.evaluator_uuid
@@ -177,7 +180,9 @@ function evaluatorCellsForRow(
 ): Record<string, string> {
   const byKey = new Map<string, JudgeResult>();
   if (Array.isArray(judgeResults)) {
-    for (const jr of judgeResults) byKey.set(evaluatorKey(jr), jr);
+    for (let i = 0; i < judgeResults.length; i++) {
+      byKey.set(evaluatorKey(judgeResults[i], i), judgeResults[i]);
+    }
   }
   const out: Record<string, string> = {};
   for (const c of cols) {

--- a/src/lib/exportTestResults.ts
+++ b/src/lib/exportTestResults.ts
@@ -3,6 +3,7 @@ import type {
   TestCaseHistory,
   TestCaseOutput,
   JudgeResult,
+  TestRunEvaluator,
 } from "@/components/test-results/shared";
 import type { ExportColumn } from "@/components/ExportResultsButton";
 
@@ -61,26 +62,33 @@ function isToolCallTest(
   return !!output?.tool_calls && output.tool_calls.length > 0;
 }
 
-// Format a single evaluator verdict: "true"/"false" for binary, "score/max"
-// for rating (or "score" when scale_max is unknown), empty string when the
-// evaluator has no result on this row.
-function evaluatorVerdict(jr: JudgeResult | undefined): string {
+// Format a single evaluator verdict: "true"/"false" for binary,
+// "score/max" for rating (or "score" when scale_max is unknown), empty
+// string when the evaluator has no result on this row. `scale_max` is
+// resolved from the top-level evaluator entry (now the source of truth
+// for evaluator metadata).
+function evaluatorVerdict(
+  jr: JudgeResult | undefined,
+  evaluator: TestRunEvaluator | undefined,
+): string {
   if (!jr) return "";
   if (jr.match !== null && jr.match !== undefined) {
     return jr.match ? "true" : "false";
   }
   if (jr.score !== null && jr.score !== undefined) {
-    return typeof jr.scale_max === "number"
-      ? `${jr.score}/${jr.scale_max}`
+    return typeof evaluator?.scale_max === "number"
+      ? `${jr.score}/${evaluator.scale_max}`
       : String(jr.score);
   }
   return "";
 }
 
-// Stable key for an evaluator: prefer uuid (canonical across runs), fall
-// back to name for legacy snapshots that pre-date uuid capture.
+// Stable key for an evaluator. Always uses the uuid now that the backend
+// guarantees one on every judge_results row (synthesising stub entries
+// for legacy snapshots). Falls back to a positional placeholder only if
+// the uuid is missing entirely.
 function evaluatorKey(jr: JudgeResult): string {
-  return jr.evaluator_uuid ? `uuid:${jr.evaluator_uuid}` : `name:${jr.name}`;
+  return jr.evaluator_uuid ? `uuid:${jr.evaluator_uuid}` : `unknown`;
 }
 
 // Walk every row's `judgeResults` and build the union of evaluators present
@@ -99,6 +107,7 @@ type EvaluatorColumn = {
 
 function collectEvaluatorColumns(
   rows: Array<{ judgeResults?: JudgeResult[] | null }>,
+  evaluatorsByUuid: Record<string, TestRunEvaluator>,
 ): EvaluatorColumn[] {
   const seen = new Map<string, EvaluatorColumn>();
   const variableSets = new Map<string, Set<string>>();
@@ -111,7 +120,10 @@ function collectEvaluatorColumns(
       const key = evaluatorKey(jr);
       if (!seen.has(key)) {
         // Disambiguate when two distinct evaluators share a display name.
-        const baseName = jr.name || "Evaluator";
+        const evName = jr.evaluator_uuid
+          ? evaluatorsByUuid[jr.evaluator_uuid]?.name
+          : undefined;
+        const baseName = evName || "Evaluator";
         const count = (nameCounts.get(baseName) ?? 0) + 1;
         nameCounts.set(baseName, count);
         const displayName = count === 1 ? baseName : `${baseName} (${count})`;
@@ -161,6 +173,7 @@ function buildEvaluatorColumnSpecs(cols: EvaluatorColumn[]): ExportColumn[] {
 function evaluatorCellsForRow(
   judgeResults: JudgeResult[] | null | undefined,
   cols: EvaluatorColumn[],
+  evaluatorsByUuid: Record<string, TestRunEvaluator>,
 ): Record<string, string> {
   const byKey = new Map<string, JudgeResult>();
   if (Array.isArray(judgeResults)) {
@@ -169,7 +182,10 @@ function evaluatorCellsForRow(
   const out: Record<string, string> = {};
   for (const c of cols) {
     const jr = byKey.get(c.matchKey);
-    out[c.valueKey] = evaluatorVerdict(jr);
+    const ev = jr?.evaluator_uuid
+      ? evaluatorsByUuid[jr.evaluator_uuid]
+      : undefined;
+    out[c.valueKey] = evaluatorVerdict(jr, ev);
     for (const varName of c.variableNames) {
       out[`eval:${c.matchKey}/var:${varName}`] =
         jr?.variable_values?.[varName] ?? "";
@@ -179,7 +195,10 @@ function evaluatorCellsForRow(
   return out;
 }
 
-export function buildTestRunCsv(results: ExportTestRow[]): {
+export function buildTestRunCsv(
+  results: ExportTestRow[],
+  evaluatorsByUuid: Record<string, TestRunEvaluator> = {},
+): {
   columns: ExportColumn[];
   rows: Record<string, unknown>[];
 } {
@@ -189,7 +208,7 @@ export function buildTestRunCsv(results: ExportTestRow[]): {
 
   const flags = filtered.map((r) => isToolCallTest(r.testCase, r.output));
   const hasToolCall = flags.some(Boolean);
-  const evalCols = collectEvaluatorColumns(filtered);
+  const evalCols = collectEvaluatorColumns(filtered, evaluatorsByUuid);
 
   const columns: ExportColumn[] = [
     { key: "name", header: "name" },
@@ -224,14 +243,21 @@ export function buildTestRunCsv(results: ExportTestRow[]): {
             tool_call_reasoning: isToolCall ? (r.reasoning ?? "") : "",
           }
         : {}),
-      ...evaluatorCellsForRow(isToolCall ? null : r.judgeResults, evalCols),
+      ...evaluatorCellsForRow(
+        isToolCall ? null : r.judgeResults,
+        evalCols,
+        evaluatorsByUuid,
+      ),
     };
   });
 
   return { columns, rows };
 }
 
-export function buildBenchmarkCsv(rows: ExportBenchmarkRow[]): {
+export function buildBenchmarkCsv(
+  rows: ExportBenchmarkRow[],
+  evaluatorsByUuid: Record<string, TestRunEvaluator> = {},
+): {
   columns: ExportColumn[];
   rows: Record<string, unknown>[];
 } {
@@ -239,7 +265,7 @@ export function buildBenchmarkCsv(rows: ExportBenchmarkRow[]): {
 
   const flags = filtered.map((r) => isToolCallTest(r.testCase, r.output));
   const hasToolCall = flags.some(Boolean);
-  const evalCols = collectEvaluatorColumns(filtered);
+  const evalCols = collectEvaluatorColumns(filtered, evaluatorsByUuid);
 
   const columns: ExportColumn[] = [
     { key: "model", header: "model" },
@@ -270,7 +296,11 @@ export function buildBenchmarkCsv(rows: ExportBenchmarkRow[]): {
             tool_call_reasoning: isToolCall ? (r.reasoning ?? "") : "",
           }
         : {}),
-      ...evaluatorCellsForRow(isToolCall ? null : r.judgeResults, evalCols),
+      ...evaluatorCellsForRow(
+        isToolCall ? null : r.judgeResults,
+        evalCols,
+        evaluatorsByUuid,
+      ),
     };
   });
 


### PR DESCRIPTION
Fixes #145 
Fixes #147 

## Summary

Three threads of polish on the labelling / evaluator surfaces:

**Custom labels for binary evaluators**
- New `BinaryScaleEditor` in the create-evaluator dialog and the new-version dialog on `/evaluators/[uuid]` so users can override the default `Correct` / `Wrong` labels (and supply optional rubric descriptions). The dialog only sends `output_config.scale` when the user actually overrides a label, so the backend default still applies otherwise.
- `EvaluatorVerdictCard` accepts optional `trueLabel` / `falseLabel` / `ratingScale` props. Read-mode pill picks up the custom label; write-mode buttons show the level label under each rating number.
- All consumers (annotator job UI, evaluator-run detail view, item-detail modal) now derive labels from `output_config.scale` — the form the backend actually returns. The item-detail modal uses each row's `evaluator_value_name` so different evaluator versions show their own labels.
- New-version dialog restructured to a 3-column layout (prompt / labels / settings) and widened to `max-w-[96rem]` so the labels editor isn't cramped.
- `VersionCard`: each prompt version now shows an Output section for binary evaluators too (True / False mapped to label + description). Prompt body collapses to ~4 lines with a View more / View less toggle anchored to the bottom edge of the prompt box.

**Item-detail dialog (labelling task)**
- Title truncates before overlapping the centered prev/next nav; full name on hover via `title`.
- `Labelled by` cell shows up to 2 annotator chips. With 3+, collapses to `first + +N more`, with the remaining names rendered as a portal-positioned pill cloud on hover so the table's overflow no longer clips it.
- Row actions reordered to `Label / Evaluate / Edit / Delete` (Edit sits next to Delete).

**Editor textareas** in `BinaryScaleEditor` / `RatingScaleEditor` switched to `rows={3}` + `min-h-[5rem]` + `resize-y` so the placeholder fits without clipping.

## Notes for reviewers

- The per-version labels in the item-detail dialog require the backend to send `evaluator_value_name` per row in the summary response. The frontend falls back to the task-level `output_config` when that field is absent.
- `EvaluatorRunDetailView` reads `output_config.scale` off `evaluator_version` (not flat `true_label`/`false_label`). If existing snapshots don't expose the per-version `output_config`, displays fall back to defaults — no breakage.

## Test plan

- [ ] Create a new binary evaluator with custom labels (e.g. `Safe` / `Unsafe`); confirm the labels are sent in `output_config.scale` only when at least one is overridden.
- [ ] Open the evaluator detail page → New version: labels editor sits in the middle column. Override / blank the labels and confirm the same payload behavior.
- [ ] Open the annotator UI for a labelling task that uses a binary evaluator with custom labels; confirm the Correct/Wrong write buttons render the custom labels, and the read-mode pill shows them.
- [ ] Same for rating evaluators with named scale entries: rating buttons in write mode show the label under each number; read mode shows an extra label pill alongside `score / max`.
- [ ] Open the item-detail modal on a task with multiple evaluator versions and confirm each row uses its own `evaluator_value_name` (not the same label across all versions).
- [ ] Long item names truncate in the item-detail header; `+N more` chip's popover floats above the table; row actions read `Label / Evaluate / Edit / Delete`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)