### PR TITLE
Items tab: sortable Updated at column + fix overview redirect

### DIFF
--- a/src/app/human-alignment/tasks/[uuid]/page.tsx
+++ b/src/app/human-alignment/tasks/[uuid]/page.tsx
@@ -2175,7 +2175,7 @@ function LabellingTaskPageInner() {
 
               {taskType === "stt" ? (
                 <div className="border border-border rounded-xl overflow-hidden">
-                  <div className="grid grid-cols-[40px_minmax(0,0.6fr)_minmax(0,1fr)_minmax(0,1fr)_180px_180px_360px] gap-4 px-4 py-2 border-b border-border bg-muted/30 items-center">
+                  <div className="grid grid-cols-[40px_minmax(0,0.6fr)_minmax(0,1fr)_minmax(0,1fr)_240px_180px_300px] gap-4 px-4 py-2 border-b border-border bg-muted/30 items-center">
                     <input
                       type="checkbox"
                       checked={allSelected}
@@ -2228,7 +2228,7 @@ function LabellingTaskPageInner() {
                       <Fragment key={item.uuid}>
                         <div
                           onClick={() => openItemDetail(item.uuid)}
-                          className={`grid grid-cols-[40px_minmax(0,0.6fr)_minmax(0,1fr)_minmax(0,1fr)_180px_180px_360px] gap-4 px-4 py-3 border-b border-border last:border-b-0 transition-colors items-center cursor-pointer ${
+                          className={`grid grid-cols-[40px_minmax(0,0.6fr)_minmax(0,1fr)_minmax(0,1fr)_240px_180px_300px] gap-4 px-4 py-3 border-b border-border last:border-b-0 transition-colors items-center cursor-pointer ${
                             isSelected ? "bg-muted/30" : "hover:bg-muted/20"
                           }`}
                         >
@@ -2298,7 +2298,7 @@ function LabellingTaskPageInner() {
                 </div>
               ) : (
                 <div className="border border-border rounded-xl overflow-hidden">
-                  <div className="grid grid-cols-[40px_minmax(0,1fr)_minmax(0,1.2fr)_180px_180px_360px] gap-4 px-4 py-2 border-b border-border bg-muted/30 items-center">
+                  <div className="grid grid-cols-[40px_minmax(0,1fr)_minmax(0,1.2fr)_240px_180px_300px] gap-4 px-4 py-2 border-b border-border bg-muted/30 items-center">
                     <input
                       type="checkbox"
                       checked={allSelected}
@@ -2347,7 +2347,7 @@ function LabellingTaskPageInner() {
                       <Fragment key={item.uuid}>
                         <div
                           onClick={() => openItemDetail(item.uuid)}
-                          className={`grid grid-cols-[40px_minmax(0,1fr)_minmax(0,1.2fr)_180px_180px_360px] gap-4 px-4 py-3 border-b border-border last:border-b-0 transition-colors items-center cursor-pointer ${
+                          className={`grid grid-cols-[40px_minmax(0,1fr)_minmax(0,1.2fr)_240px_180px_300px] gap-4 px-4 py-3 border-b border-border last:border-b-0 transition-colors items-center cursor-pointer ${
                             isSelected ? "bg-muted/30" : "hover:bg-muted/20"
                           }`}
                         >

--- a/src/app/human-alignment/tasks/[uuid]/page.tsx
+++ b/src/app/human-alignment/tasks/[uuid]/page.tsx
@@ -123,18 +123,6 @@ type TaskSummaryResponse = {
   rows: SummaryRow[];
 };
 
-// A summary row is "empty" when no value column has anything to show:
-// no evaluator value, no agreement scores, and no annotator label.
-function summaryRowHasAnyValue(r: SummaryRow): boolean {
-  if (r.evaluator_value !== null) return true;
-  if (r.human_agreement !== null) return true;
-  if (r.evaluator_agreement !== null) return true;
-  for (const v of Object.values(r.annotations ?? {})) {
-    if (v && v.value !== null && v.value !== undefined) return true;
-  }
-  return false;
-}
-
 const TABS: Tab[] = ["overview", "items", "jobs", "runs"];
 
 type EvaluatorRunMetricEntry = number | { type?: string; mean?: number | null };
@@ -1140,20 +1128,17 @@ function LabellingTaskPageInner() {
       handleTabChange("items");
       return;
     }
-    // Items exist — peek at overview's data sources to decide if the
-    // overview would just be empty states. If both the agreement panel
-    // and the per-item summary table have nothing to show, jump straight
-    // to the items tab. Wait for both fetches to complete first.
+    // Items exist — overview only renders the agreement panel, so if
+    // there's no agreement data the overview is just an empty state.
+    // Skip straight to the items tab in that case. Wait for the
+    // agreement fetch to complete first.
     if (!agreementFetchCompleted) return;
-    if (taskSummary === null) return;
     const agreementEmpty =
       !agreement ||
       ((agreement.human_human?.pair_count ?? 0) === 0 &&
         (agreement.evaluators ?? []).every((e) => (e.pair_count ?? 0) === 0));
-    const summaryEmpty =
-      (taskSummary.rows ?? []).filter(summaryRowHasAnyValue).length === 0;
     autoTabSwitchedRef.current = true;
-    if (agreementEmpty && summaryEmpty) {
+    if (agreementEmpty) {
       handleTabChange("items");
     }
   }, [
@@ -1162,7 +1147,6 @@ function LabellingTaskPageInner() {
     handleTabChange,
     agreement,
     agreementFetchCompleted,
-    taskSummary,
   ]);
 
   // Map item_id -> annotator uuids who have at least one labelled annotation

--- a/src/app/human-alignment/tasks/[uuid]/page.tsx
+++ b/src/app/human-alignment/tasks/[uuid]/page.tsx
@@ -192,6 +192,7 @@ type LabellingItem = {
   task_id: string;
   payload: unknown;
   created_at: string;
+  updated_at?: string;
   deleted_at: string | null;
   agreement?: ItemAgreement;
 };
@@ -537,6 +538,42 @@ function EvaluatorRunsList({
       })}
     </div>
   );
+}
+
+function SortIndicator({
+  direction,
+}: {
+  direction: "asc" | "desc" | null;
+}) {
+  return (
+    <svg
+      className={`w-3 h-3 transition-transform ${
+        direction === "asc" ? "rotate-180" : ""
+      } ${direction ? "text-foreground" : "text-muted-foreground/40"}`}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      aria-hidden="true"
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M19 9l-7 7-7-7"
+      />
+    </svg>
+  );
+}
+
+function formatItemUpdatedAt(item: {
+  updated_at?: string;
+  created_at?: string;
+}): string {
+  const raw = item.updated_at ?? item.created_at;
+  if (!raw) return "—";
+  const d = new Date(raw.replace(" ", "T") + "Z");
+  if (isNaN(d.getTime())) return "—";
+  return d.toLocaleString();
 }
 
 function ItemRowActions({
@@ -984,6 +1021,30 @@ function LabellingTaskPageInner() {
   const [savingLlmItem, setSavingLlmItem] = useState(false);
   const [editLlmError, setEditLlmError] = useState<string | null>(null);
 
+  // Sort direction for the items table's Updated at column. Persisted in
+  // localStorage so the user's choice carries across visits. `null` means
+  // no explicit sort — fall back to the API's default order.
+  const [itemsSort, setItemsSort] = useState<"asc" | "desc" | null>(null);
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const stored = window.localStorage.getItem(
+      "calibrate:items-sort-updated-at",
+    );
+    if (stored === "asc" || stored === "desc") setItemsSort(stored);
+  }, []);
+  const toggleItemsSort = () => {
+    setItemsSort((prev) => {
+      const next = prev === "desc" ? "asc" : "desc";
+      if (typeof window !== "undefined") {
+        window.localStorage.setItem(
+          "calibrate:items-sort-updated-at",
+          next,
+        );
+      }
+      return next;
+    });
+  };
+
   useEffect(() => {
     if (task?.name) document.title = `${task.name} | Calibrate`;
   }, [task?.name]);
@@ -1151,7 +1212,21 @@ function LabellingTaskPageInner() {
   }, [fetchRuns]);
   void activeTab;
 
-  const items = task?.items ?? [];
+  const rawItems = task?.items ?? [];
+  const items = itemsSort
+    ? [...rawItems].sort((a, b) => {
+        const av = a.updated_at ?? a.created_at ?? "";
+        const bv = b.updated_at ?? b.created_at ?? "";
+        if (av === bv) return 0;
+        return itemsSort === "asc"
+          ? av < bv
+            ? -1
+            : 1
+          : av < bv
+            ? 1
+            : -1;
+      })
+    : rawItems;
   const jobs = task?.jobs ?? [];
   const itemsLoading = loading || !taskFetchCompleted;
   const itemsError = error;
@@ -2116,7 +2191,7 @@ function LabellingTaskPageInner() {
 
               {taskType === "stt" ? (
                 <div className="border border-border rounded-xl overflow-hidden">
-                  <div className="grid grid-cols-[40px_minmax(0,0.6fr)_minmax(0,1fr)_minmax(0,1fr)_180px_360px] gap-4 px-4 py-2 border-b border-border bg-muted/30 items-center">
+                  <div className="grid grid-cols-[40px_minmax(0,0.6fr)_minmax(0,1fr)_minmax(0,1fr)_180px_140px_360px] gap-4 px-4 py-2 border-b border-border bg-muted/30 items-center">
                     <input
                       type="checkbox"
                       checked={allSelected}
@@ -2139,6 +2214,15 @@ function LabellingTaskPageInner() {
                     <div className="text-sm font-medium text-muted-foreground">
                       Labelled by
                     </div>
+                    <button
+                      type="button"
+                      onClick={toggleItemsSort}
+                      className="flex items-center gap-1 text-sm font-medium text-muted-foreground hover:text-foreground transition-colors cursor-pointer text-left"
+                      aria-label="Sort by updated at"
+                    >
+                      <span>Updated at</span>
+                      <SortIndicator direction={itemsSort} />
+                    </button>
                     <div className="text-sm font-medium text-muted-foreground text-center">
                       Actions
                     </div>
@@ -2160,7 +2244,7 @@ function LabellingTaskPageInner() {
                       <Fragment key={item.uuid}>
                         <div
                           onClick={() => openItemDetail(item.uuid)}
-                          className={`grid grid-cols-[40px_minmax(0,0.6fr)_minmax(0,1fr)_minmax(0,1fr)_180px_360px] gap-4 px-4 py-3 border-b border-border last:border-b-0 transition-colors items-center cursor-pointer ${
+                          className={`grid grid-cols-[40px_minmax(0,0.6fr)_minmax(0,1fr)_minmax(0,1fr)_180px_140px_360px] gap-4 px-4 py-3 border-b border-border last:border-b-0 transition-colors items-center cursor-pointer ${
                             isSelected ? "bg-muted/30" : "hover:bg-muted/20"
                           }`}
                         >
@@ -2185,6 +2269,9 @@ function LabellingTaskPageInner() {
                             labellers={labellerIds}
                             annotatorNameById={annotatorNameById}
                           />
+                          <div className="text-sm text-muted-foreground">
+                            {formatItemUpdatedAt(item)}
+                          </div>
                           <ItemRowActions
                             itemUuid={item.uuid}
                             onDelete={requestDeleteOneItem}
@@ -2227,7 +2314,7 @@ function LabellingTaskPageInner() {
                 </div>
               ) : (
                 <div className="border border-border rounded-xl overflow-hidden">
-                  <div className="grid grid-cols-[40px_minmax(0,1fr)_minmax(0,1.2fr)_180px_360px] gap-4 px-4 py-2 border-b border-border bg-muted/30 items-center">
+                  <div className="grid grid-cols-[40px_minmax(0,1fr)_minmax(0,1.2fr)_180px_140px_360px] gap-4 px-4 py-2 border-b border-border bg-muted/30 items-center">
                     <input
                       type="checkbox"
                       checked={allSelected}
@@ -2247,6 +2334,15 @@ function LabellingTaskPageInner() {
                     <div className="text-sm font-medium text-muted-foreground">
                       Labelled by
                     </div>
+                    <button
+                      type="button"
+                      onClick={toggleItemsSort}
+                      className="flex items-center gap-1 text-sm font-medium text-muted-foreground hover:text-foreground transition-colors cursor-pointer text-left"
+                      aria-label="Sort by updated at"
+                    >
+                      <span>Updated at</span>
+                      <SortIndicator direction={itemsSort} />
+                    </button>
                     <div className="text-sm font-medium text-muted-foreground text-center">
                       Actions
                     </div>
@@ -2267,7 +2363,7 @@ function LabellingTaskPageInner() {
                       <Fragment key={item.uuid}>
                         <div
                           onClick={() => openItemDetail(item.uuid)}
-                          className={`grid grid-cols-[40px_minmax(0,1fr)_minmax(0,1.2fr)_180px_360px] gap-4 px-4 py-3 border-b border-border last:border-b-0 transition-colors items-center cursor-pointer ${
+                          className={`grid grid-cols-[40px_minmax(0,1fr)_minmax(0,1.2fr)_180px_140px_360px] gap-4 px-4 py-3 border-b border-border last:border-b-0 transition-colors items-center cursor-pointer ${
                             isSelected ? "bg-muted/30" : "hover:bg-muted/20"
                           }`}
                         >
@@ -2296,6 +2392,9 @@ function LabellingTaskPageInner() {
                             labellers={labellerIds}
                             annotatorNameById={annotatorNameById}
                           />
+                          <div className="text-sm text-muted-foreground">
+                            {formatItemUpdatedAt(item)}
+                          </div>
                           <ItemRowActions
                             itemUuid={item.uuid}
                             onDelete={requestDeleteOneItem}

--- a/src/app/human-alignment/tasks/[uuid]/page.tsx
+++ b/src/app/human-alignment/tasks/[uuid]/page.tsx
@@ -1131,12 +1131,18 @@ function LabellingTaskPageInner() {
     // Items exist — overview only renders the agreement panel, so if
     // there's no agreement data the overview is just an empty state.
     // Skip straight to the items tab in that case. Wait for the
-    // agreement fetch to complete first.
+    // agreement fetch to complete first. If the fetch errored, stay on
+    // overview so the user sees the error rather than getting silently
+    // bounced off the tab.
     if (!agreementFetchCompleted) return;
+    if (agreementError) {
+      autoTabSwitchedRef.current = true;
+      return;
+    }
+    if (!agreement) return;
     const agreementEmpty =
-      !agreement ||
-      ((agreement.human_human?.pair_count ?? 0) === 0 &&
-        (agreement.evaluators ?? []).every((e) => (e.pair_count ?? 0) === 0));
+      (agreement.human_human?.pair_count ?? 0) === 0 &&
+      (agreement.evaluators ?? []).every((e) => (e.pair_count ?? 0) === 0);
     autoTabSwitchedRef.current = true;
     if (agreementEmpty) {
       handleTabChange("items");
@@ -1146,6 +1152,7 @@ function LabellingTaskPageInner() {
     initialTab,
     handleTabChange,
     agreement,
+    agreementError,
     agreementFetchCompleted,
   ]);
 

--- a/src/app/human-alignment/tasks/[uuid]/page.tsx
+++ b/src/app/human-alignment/tasks/[uuid]/page.tsx
@@ -2175,7 +2175,7 @@ function LabellingTaskPageInner() {
 
               {taskType === "stt" ? (
                 <div className="border border-border rounded-xl overflow-hidden">
-                  <div className="grid grid-cols-[40px_minmax(0,0.6fr)_minmax(0,1fr)_minmax(0,1fr)_180px_140px_360px] gap-4 px-4 py-2 border-b border-border bg-muted/30 items-center">
+                  <div className="grid grid-cols-[40px_minmax(0,0.6fr)_minmax(0,1fr)_minmax(0,1fr)_180px_180px_360px] gap-4 px-4 py-2 border-b border-border bg-muted/30 items-center">
                     <input
                       type="checkbox"
                       checked={allSelected}
@@ -2228,7 +2228,7 @@ function LabellingTaskPageInner() {
                       <Fragment key={item.uuid}>
                         <div
                           onClick={() => openItemDetail(item.uuid)}
-                          className={`grid grid-cols-[40px_minmax(0,0.6fr)_minmax(0,1fr)_minmax(0,1fr)_180px_140px_360px] gap-4 px-4 py-3 border-b border-border last:border-b-0 transition-colors items-center cursor-pointer ${
+                          className={`grid grid-cols-[40px_minmax(0,0.6fr)_minmax(0,1fr)_minmax(0,1fr)_180px_180px_360px] gap-4 px-4 py-3 border-b border-border last:border-b-0 transition-colors items-center cursor-pointer ${
                             isSelected ? "bg-muted/30" : "hover:bg-muted/20"
                           }`}
                         >
@@ -2253,7 +2253,7 @@ function LabellingTaskPageInner() {
                             labellers={labellerIds}
                             annotatorNameById={annotatorNameById}
                           />
-                          <div className="text-sm text-muted-foreground">
+                          <div className="text-sm text-muted-foreground whitespace-nowrap">
                             {formatItemUpdatedAt(item)}
                           </div>
                           <ItemRowActions
@@ -2298,7 +2298,7 @@ function LabellingTaskPageInner() {
                 </div>
               ) : (
                 <div className="border border-border rounded-xl overflow-hidden">
-                  <div className="grid grid-cols-[40px_minmax(0,1fr)_minmax(0,1.2fr)_180px_140px_360px] gap-4 px-4 py-2 border-b border-border bg-muted/30 items-center">
+                  <div className="grid grid-cols-[40px_minmax(0,1fr)_minmax(0,1.2fr)_180px_180px_360px] gap-4 px-4 py-2 border-b border-border bg-muted/30 items-center">
                     <input
                       type="checkbox"
                       checked={allSelected}
@@ -2347,7 +2347,7 @@ function LabellingTaskPageInner() {
                       <Fragment key={item.uuid}>
                         <div
                           onClick={() => openItemDetail(item.uuid)}
-                          className={`grid grid-cols-[40px_minmax(0,1fr)_minmax(0,1.2fr)_180px_140px_360px] gap-4 px-4 py-3 border-b border-border last:border-b-0 transition-colors items-center cursor-pointer ${
+                          className={`grid grid-cols-[40px_minmax(0,1fr)_minmax(0,1.2fr)_180px_180px_360px] gap-4 px-4 py-3 border-b border-border last:border-b-0 transition-colors items-center cursor-pointer ${
                             isSelected ? "bg-muted/30" : "hover:bg-muted/20"
                           }`}
                         >
@@ -2376,7 +2376,7 @@ function LabellingTaskPageInner() {
                             labellers={labellerIds}
                             annotatorNameById={annotatorNameById}
                           />
-                          <div className="text-sm text-muted-foreground">
+                          <div className="text-sm text-muted-foreground whitespace-nowrap">
                             {formatItemUpdatedAt(item)}
                           </div>
                           <ItemRowActions


### PR DESCRIPTION
## Summary
- Add an **Updated at** column to the labelling task items table (both STT and LLM/simulation variants), sortable by clicking the header. Direction persists in `localStorage` so the choice carries across visits.
- Fix the auto-redirect on task page load: it was gated on a stale per-item summary table check, so tasks with evaluator runs but no annotator agreement would land on an empty overview instead of dropping to items.
- Rebalance items-table column widths so dates stay on one line and the Actions cluster sits closer to the right edge.

## Test plan
- [ ] Open a task with multiple items — Items tab shows a new Updated at column with formatted timestamps
- [ ] Click the Updated at header — rows reorder asc/desc; arrow indicator flips
- [ ] Reload the page — sort direction is preserved
- [ ] Open a task that has items + an evaluator run but no annotator labels — page lands on Items tab automatically (not on an empty Overview)
- [ ] Open a task with `?tab=overview` in the URL — stays on Overview (URL pin still respected)
- [ ] Confirm dates render on a single line and the action buttons sit near the right edge

🤖 Generated with [Claude Code](https://claude.com/claude-code)