### PR TITLE
Items tab: export CSV + skip redundant summary fetches

### DIFF
--- a/src/app/human-alignment/tasks/[uuid]/page.tsx
+++ b/src/app/human-alignment/tasks/[uuid]/page.tsx
@@ -2207,18 +2207,18 @@ function LabellingTaskPageInner() {
               />
             ) : (
               <div className="space-y-2">
-                <div className="flex items-start justify-between gap-3">
-                  <div>
+                <div>
+                  <div className="flex items-center gap-2">
                     <h2 className="text-sm font-semibold">Agreement summary</h2>
-                    <p className="text-xs text-muted-foreground max-w-2xl mt-1">
-                      These cards show agreement between annotators and how
-                      closely each evaluator aligns with humans
-                    </p>
+                    <RefreshButton
+                      loading={agreementLoading}
+                      onClick={() => fetchAgreement()}
+                    />
                   </div>
-                  <RefreshButton
-                    loading={agreementLoading}
-                    onClick={() => fetchAgreement()}
-                  />
+                  <p className="text-xs text-muted-foreground max-w-2xl mt-1">
+                    These cards show agreement between annotators and how
+                    closely each evaluator aligns with humans
+                  </p>
                 </div>
                 <div className="flex flex-wrap items-stretch gap-3">
                   <AgreementStatCard

--- a/src/app/human-alignment/tasks/[uuid]/page.tsx
+++ b/src/app/human-alignment/tasks/[uuid]/page.tsx
@@ -1094,8 +1094,8 @@ function LabellingTaskPageInner() {
   }, [accessToken, uuid]);
 
   useEffect(() => {
-    if (activeTab === "overview") fetchAgreement();
-  }, [activeTab, fetchAgreement]);
+    fetchAgreement();
+  }, [fetchAgreement]);
 
   const [taskSummary, setTaskSummary] = useState<TaskSummaryResponse | null>(
     null,
@@ -1125,8 +1125,8 @@ function LabellingTaskPageInner() {
   }, [accessToken, uuid]);
 
   useEffect(() => {
-    if (activeTab === "overview" || activeTab === "items") fetchTaskSummary();
-  }, [activeTab, fetchTaskSummary]);
+    fetchTaskSummary();
+  }, [fetchTaskSummary]);
 
   useEffect(() => {
     if (autoTabSwitchedRef.current) return;

--- a/src/app/human-alignment/tasks/[uuid]/page.tsx
+++ b/src/app/human-alignment/tasks/[uuid]/page.tsx
@@ -26,6 +26,7 @@ import {
   ExportResultsButton,
   type ExportColumn,
 } from "@/components/ExportResultsButton";
+import { RefreshButton } from "@/components/RefreshButton";
 import { Tooltip } from "@/components/Tooltip";
 import { DeleteConfirmationDialog } from "@/components/DeleteConfirmationDialog";
 import { AddSttItemsDialog } from "@/components/human-labelling/AddSttItemsDialog";
@@ -2206,12 +2207,19 @@ function LabellingTaskPageInner() {
               />
             ) : (
               <div className="space-y-2">
-                <div>
-                  <h2 className="text-sm font-semibold">Agreement summary</h2>
-                  <p className="text-xs text-muted-foreground max-w-2xl mt-1">
-                    These cards show agreement between annotators and how
-                    closely each evaluator aligns with humans
-                  </p>
+                <div className="flex items-start justify-between gap-3">
+                  <div>
+                    <h2 className="text-sm font-semibold">Agreement summary</h2>
+                    <p className="text-xs text-muted-foreground max-w-2xl mt-1">
+                      These cards show agreement between annotators and how
+                      closely each evaluator aligns with humans
+                    </p>
+                  </div>
+                  <RefreshButton
+                    title="Refresh agreement"
+                    loading={agreementLoading}
+                    onClick={() => fetchAgreement()}
+                  />
                 </div>
                 <div className="flex flex-wrap items-stretch gap-3">
                   <AgreementStatCard
@@ -2297,7 +2305,16 @@ function LabellingTaskPageInner() {
             />
           ) : (
             <div ref={itemsSectionTopRef} className="space-y-3 scroll-mt-4">
-              <div className="flex items-center justify-end">
+              <div className="flex items-center justify-end gap-2">
+                <RefreshButton
+                  label="Refresh"
+                  title="Refresh items"
+                  loading={loading || summaryLoading}
+                  onClick={() => {
+                    fetchTask();
+                    fetchTaskSummary();
+                  }}
+                />
                 <ExportResultsButton
                   filename={`${sanitizeCsvName(task?.name ?? "labelling-task")}-items`}
                   label="Export CSV"

--- a/src/app/human-alignment/tasks/[uuid]/page.tsx
+++ b/src/app/human-alignment/tasks/[uuid]/page.tsx
@@ -287,9 +287,21 @@ function buildItemsCsv(
   const evaluators = taskSummary?.evaluators ?? [];
   const annotators = taskSummary?.annotators ?? [];
 
-  const rowByItemEval = new Map<string, SummaryRow>();
+  // Each (item, evaluator, version) tuple gets its own row in the
+  // summary response — keying without version_id would let later
+  // versions silently overwrite earlier ones in the export.
+  const rowByItemEvalVersion = new Map<string, SummaryRow>();
+  const versionsByEval = new Map<string, Set<string | null>>();
   for (const row of taskSummary?.rows ?? []) {
-    rowByItemEval.set(`${row.item_id}::${row.evaluator_id}`, row);
+    const vid = row.evaluator_version_id ?? null;
+    rowByItemEvalVersion.set(
+      `${row.item_id}::${row.evaluator_id}::${vid ?? "live"}`,
+      row,
+    );
+    if (!versionsByEval.has(row.evaluator_id)) {
+      versionsByEval.set(row.evaluator_id, new Set());
+    }
+    versionsByEval.get(row.evaluator_id)!.add(vid);
   }
 
   const versionNumberById = new Map<string, number>();
@@ -298,6 +310,20 @@ function buildItemsCsv(
       versionNumberById.set(v.uuid, v.version_number);
     }
   }
+
+  // For each evaluator, the list of version_ids (sorted by version_number
+  // ascending) that actually appear in the summary rows. Evaluators with
+  // no run data still get one entry (null → "live") so annotator columns
+  // are emitted even when the evaluator hasn't run yet.
+  const versionsForEvaluator = (ev: SummaryEvaluator): (string | null)[] => {
+    const set = versionsByEval.get(ev.uuid);
+    if (!set || set.size === 0) return [null];
+    return [...set].sort((a, b) => {
+      const an: number = (a ? versionNumberById.get(a) : undefined) ?? -Infinity;
+      const bn: number = (b ? versionNumberById.get(b) : undefined) ?? -Infinity;
+      return an - bn;
+    });
+  };
 
   const columns: ExportColumn[] = [{ key: "name", header: "name" }];
   if (taskType !== "stt") {
@@ -327,6 +353,9 @@ function buildItemsCsv(
 
   for (const ev of evaluators) {
     const evName = sanitizeCsvName(ev.name);
+    // Annotator columns are emitted once per (annotator × evaluator) —
+    // a human's label of an item against an evaluator doesn't depend on
+    // which version of the evaluator ran.
     for (const ann of annotators) {
       const annName = sanitizeCsvName(ann.name);
       const base = `${annName}_${evName}`;
@@ -339,20 +368,18 @@ function buildItemsCsv(
         header: `${base}/reasoning`,
       });
     }
-    const liveVid =
-      ev.live_version_id ?? ev.versions?.find((v) => v.is_live)?.uuid ?? null;
-    const versionNumber =
-      (liveVid ? versionNumberById.get(liveVid) : undefined) ??
-      ev.versions?.[0]?.version_number;
-    const verStr = versionNumber != null ? `v${versionNumber}` : "live";
-    columns.push({
-      key: `ev_${ev.uuid}_value`,
-      header: `evaluator_${evName}_${verStr}/value`,
-    });
-    columns.push({
-      key: `ev_${ev.uuid}_reasoning`,
-      header: `evaluator_${evName}_${verStr}/reasoning`,
-    });
+    for (const vid of versionsForEvaluator(ev)) {
+      const versionNumber = vid ? versionNumberById.get(vid) : undefined;
+      const verStr = versionNumber != null ? `v${versionNumber}` : "live";
+      columns.push({
+        key: `ev_${ev.uuid}_${vid ?? "live"}_value`,
+        header: `evaluator_${evName}_${verStr}/value`,
+      });
+      columns.push({
+        key: `ev_${ev.uuid}_${vid ?? "live"}_reasoning`,
+        header: `evaluator_${evName}_${verStr}/reasoning`,
+      });
+    }
   }
 
   const rows = items.map((item) => {
@@ -385,19 +412,41 @@ function buildItemsCsv(
     }
 
     for (const ev of evaluators) {
-      const row = rowByItemEval.get(`${item.uuid}::${ev.uuid}`);
+      const versionIds = versionsForEvaluator(ev);
+      // Annotations don't vary by version; take whichever version's row
+      // we find first that has a non-null annotation for each annotator.
+      const annotationSourceByAnn = new Map<string, SummaryAnnotation>();
+      for (const vid of versionIds) {
+        const row = rowByItemEvalVersion.get(
+          `${item.uuid}::${ev.uuid}::${vid ?? "live"}`,
+        );
+        if (!row) continue;
+        for (const ann of annotators) {
+          if (annotationSourceByAnn.has(ann.uuid)) continue;
+          const a = row.annotations?.[ann.uuid];
+          if (a && a.value !== null && a.value !== undefined) {
+            annotationSourceByAnn.set(ann.uuid, a);
+          }
+        }
+      }
       for (const ann of annotators) {
-        const a = row?.annotations?.[ann.uuid] ?? null;
+        const a = annotationSourceByAnn.get(ann.uuid) ?? null;
         out[`ann_${ann.uuid}_${ev.uuid}_value`] =
           a && a.value !== null && a.value !== undefined ? a.value : "";
         out[`ann_${ann.uuid}_${ev.uuid}_reasoning`] = a?.reasoning ?? "";
       }
-      out[`ev_${ev.uuid}_value`] =
-        row?.evaluator_value_name ??
-        (row?.evaluator_value !== null && row?.evaluator_value !== undefined
-          ? row.evaluator_value
-          : "");
-      out[`ev_${ev.uuid}_reasoning`] = row?.evaluator_reasoning ?? "";
+      for (const vid of versionIds) {
+        const row = rowByItemEvalVersion.get(
+          `${item.uuid}::${ev.uuid}::${vid ?? "live"}`,
+        );
+        out[`ev_${ev.uuid}_${vid ?? "live"}_value`] =
+          row?.evaluator_value_name ??
+          (row?.evaluator_value !== null && row?.evaluator_value !== undefined
+            ? row.evaluator_value
+            : "");
+        out[`ev_${ev.uuid}_${vid ?? "live"}_reasoning`] =
+          row?.evaluator_reasoning ?? "";
+      }
     }
     return out;
   });

--- a/src/app/human-alignment/tasks/[uuid]/page.tsx
+++ b/src/app/human-alignment/tasks/[uuid]/page.tsx
@@ -22,6 +22,10 @@ import {
 } from "@/components/AddTestDialog";
 import { AppLayout } from "@/components/AppLayout";
 import { EvaluatorTypePill } from "@/components/EvaluatorPills";
+import {
+  ExportResultsButton,
+  type ExportColumn,
+} from "@/components/ExportResultsButton";
 import { Tooltip } from "@/components/Tooltip";
 import { DeleteConfirmationDialog } from "@/components/DeleteConfirmationDialog";
 import { AddSttItemsDialog } from "@/components/human-labelling/AddSttItemsDialog";
@@ -268,6 +272,136 @@ function previewItemPayload(payload: unknown, kind: TaskKind): string {
   } catch {
     return "—";
   }
+}
+
+function sanitizeCsvName(s: string): string {
+  return s.replace(/[^A-Za-z0-9_-]+/g, "_").replace(/^_+|_+$/g, "") || "unnamed";
+}
+
+function buildItemsCsv(
+  items: LabellingItem[],
+  taskSummary: TaskSummaryResponse | null,
+  taskType: TaskKind,
+): { columns: ExportColumn[]; rows: Record<string, unknown>[] } {
+  const evaluators = taskSummary?.evaluators ?? [];
+  const annotators = taskSummary?.annotators ?? [];
+
+  const rowByItemEval = new Map<string, SummaryRow>();
+  for (const row of taskSummary?.rows ?? []) {
+    rowByItemEval.set(`${row.item_id}::${row.evaluator_id}`, row);
+  }
+
+  const versionNumberById = new Map<string, number>();
+  for (const ev of evaluators) {
+    for (const v of ev.versions ?? []) {
+      versionNumberById.set(v.uuid, v.version_number);
+    }
+  }
+
+  const columns: ExportColumn[] = [{ key: "name", header: "name" }];
+  if (taskType !== "stt") {
+    columns.push({ key: "description", header: "description" });
+  }
+  if (taskType === "simulation") {
+    columns.push({
+      key: "conversation_history",
+      header: "conversation_history",
+    });
+  } else if (taskType === "stt") {
+    columns.push({
+      key: "reference_transcript",
+      header: "reference_transcript",
+    });
+    columns.push({
+      key: "predicted_transcript",
+      header: "predicted_transcript",
+    });
+  } else if (taskType === "llm") {
+    columns.push({
+      key: "conversation_history",
+      header: "conversation_history",
+    });
+    columns.push({ key: "agent_response", header: "agent_response" });
+  }
+
+  for (const ev of evaluators) {
+    const evName = sanitizeCsvName(ev.name);
+    for (const ann of annotators) {
+      const annName = sanitizeCsvName(ann.name);
+      const base = `${annName}_${evName}`;
+      columns.push({
+        key: `ann_${ann.uuid}_${ev.uuid}_value`,
+        header: `${base}/value`,
+      });
+      columns.push({
+        key: `ann_${ann.uuid}_${ev.uuid}_reasoning`,
+        header: `${base}/reasoning`,
+      });
+    }
+    const liveVid =
+      ev.live_version_id ?? ev.versions?.find((v) => v.is_live)?.uuid ?? null;
+    const versionNumber =
+      (liveVid ? versionNumberById.get(liveVid) : undefined) ??
+      ev.versions?.[0]?.version_number;
+    const verStr = versionNumber != null ? `v${versionNumber}` : "live";
+    columns.push({
+      key: `ev_${ev.uuid}_value`,
+      header: `evaluator_${evName}_${verStr}/value`,
+    });
+    columns.push({
+      key: `ev_${ev.uuid}_reasoning`,
+      header: `evaluator_${evName}_${verStr}/reasoning`,
+    });
+  }
+
+  const rows = items.map((item) => {
+    const p = (item.payload ?? {}) as Record<string, unknown>;
+    const out: Record<string, unknown> = {
+      name: typeof p.name === "string" ? p.name : "",
+    };
+    if (taskType !== "stt") {
+      out.description = typeof p.description === "string" ? p.description : "";
+    }
+    if (taskType === "simulation") {
+      out.conversation_history = Array.isArray(p.transcript)
+        ? JSON.stringify(p.transcript)
+        : "";
+    } else if (taskType === "stt") {
+      out.reference_transcript =
+        typeof p.reference_transcript === "string"
+          ? p.reference_transcript
+          : "";
+      out.predicted_transcript =
+        typeof p.predicted_transcript === "string"
+          ? p.predicted_transcript
+          : "";
+    } else if (taskType === "llm") {
+      out.conversation_history = Array.isArray(p.chat_history)
+        ? JSON.stringify(p.chat_history)
+        : "";
+      out.agent_response =
+        typeof p.agent_response === "string" ? p.agent_response : "";
+    }
+
+    for (const ev of evaluators) {
+      const row = rowByItemEval.get(`${item.uuid}::${ev.uuid}`);
+      for (const ann of annotators) {
+        const a = row?.annotations?.[ann.uuid] ?? null;
+        out[`ann_${ann.uuid}_${ev.uuid}_value`] =
+          a && a.value !== null && a.value !== undefined ? a.value : "";
+        out[`ann_${ann.uuid}_${ev.uuid}_reasoning`] = a?.reasoning ?? "";
+      }
+      out[`ev_${ev.uuid}_value`] =
+        row?.evaluator_value_name ??
+        (row?.evaluator_value !== null && row?.evaluator_value !== undefined
+          ? row.evaluator_value
+          : "");
+      out[`ev_${ev.uuid}_reasoning`] = row?.evaluator_reasoning ?? "";
+    }
+    return out;
+  });
+
+  return { columns, rows };
 }
 
 function parseApiError(err: unknown, fallback: string): string {
@@ -2163,6 +2297,14 @@ function LabellingTaskPageInner() {
             />
           ) : (
             <div ref={itemsSectionTopRef} className="space-y-3 scroll-mt-4">
+              <div className="flex items-center justify-end">
+                <ExportResultsButton
+                  filename={`${sanitizeCsvName(task?.name ?? "labelling-task")}-items`}
+                  label="Export CSV"
+                  variant="neutral"
+                  getRows={() => buildItemsCsv(items, taskSummary, taskType)}
+                />
+              </div>
               {/* Bulk-action toolbar (shown when at least one row is selected) */}
               {selectedItemIds.size > 0 && (
                 <div className="flex items-center justify-between gap-3 rounded-md border border-border bg-muted/30 px-3 py-2">

--- a/src/app/human-alignment/tasks/[uuid]/page.tsx
+++ b/src/app/human-alignment/tasks/[uuid]/page.tsx
@@ -2365,6 +2365,7 @@ function LabellingTaskPageInner() {
                   filename={`${sanitizeCsvName(task?.name ?? "labelling-task")}-items`}
                   label="Export CSV"
                   variant="neutral"
+                  disabled={summaryLoading || !taskSummary}
                   getRows={() => buildItemsCsv(items, taskSummary, taskType)}
                 />
               </div>

--- a/src/app/human-alignment/tasks/[uuid]/page.tsx
+++ b/src/app/human-alignment/tasks/[uuid]/page.tsx
@@ -2216,7 +2216,6 @@ function LabellingTaskPageInner() {
                     </p>
                   </div>
                   <RefreshButton
-                    title="Refresh agreement"
                     loading={agreementLoading}
                     onClick={() => fetchAgreement()}
                   />
@@ -2307,8 +2306,6 @@ function LabellingTaskPageInner() {
             <div ref={itemsSectionTopRef} className="space-y-3 scroll-mt-4">
               <div className="flex items-center justify-end gap-2">
                 <RefreshButton
-                  label="Refresh"
-                  title="Refresh items"
                   loading={loading || summaryLoading}
                   onClick={() => {
                     fetchTask();

--- a/src/components/ExportResultsButton.tsx
+++ b/src/components/ExportResultsButton.tsx
@@ -64,10 +64,11 @@ export function ExportResultsButton({
     ];
     const csv = csvLines.join("\n");
 
-    // data: URI instead of a blob URL — Chrome silently blocks repeated
-    // blob-URL programmatic downloads as "multiple file downloads" once
-    // the per-site prompt is dismissed. data: URIs aren't subject to it.
-    const url = `data:text/csv;charset=utf-8,${encodeURIComponent(csv)}`;
+    // Blob URL (not data: URI) so large CSVs aren't capped by the
+    // browser URL-length limit. Revoke is deferred to give the browser
+    // time to consume the URL before we free it.
+    const blob = new Blob([csv], { type: "text/csv;charset=utf-8" });
+    const url = URL.createObjectURL(blob);
     const link = document.createElement("a");
     link.href = url;
     link.download = `${filename}.csv`;
@@ -76,6 +77,7 @@ export function ExportResultsButton({
     document.body.appendChild(link);
     link.click();
     document.body.removeChild(link);
+    setTimeout(() => URL.revokeObjectURL(url), 1000);
   };
 
   return (

--- a/src/components/ExportResultsButton.tsx
+++ b/src/components/ExportResultsButton.tsx
@@ -17,6 +17,15 @@ type ExportResultsButtonProps = {
   disabled?: boolean;
   label?: string;
   className?: string;
+  /** Color palette. "teal" is the default; "neutral" is a quiet outline
+   * for pages where teal already means something else. */
+  variant?: "teal" | "neutral";
+};
+
+const VARIANT_CLASSES: Record<"teal" | "neutral", string> = {
+  teal: "bg-teal-500/12 border-teal-500/45 text-teal-950 dark:text-teal-100 hover:bg-teal-500/22 dark:hover:bg-teal-500/18",
+  neutral:
+    "bg-slate-500/10 border-slate-500/30 text-slate-700 dark:text-slate-200 hover:bg-slate-500/20 dark:hover:bg-slate-500/25",
 };
 
 function escapeCell(value: unknown): string {
@@ -43,6 +52,7 @@ export function ExportResultsButton({
   disabled,
   label = "Export results",
   className,
+  variant = "teal",
 }: ExportResultsButtonProps) {
   const handleClick = () => {
     const { columns, rows } = getRows();
@@ -54,16 +64,18 @@ export function ExportResultsButton({
     ];
     const csv = csvLines.join("\n");
 
-    const blob = new Blob([csv], { type: "text/csv;charset=utf-8;" });
-    const url = URL.createObjectURL(blob);
+    // data: URI instead of a blob URL — Chrome silently blocks repeated
+    // blob-URL programmatic downloads as "multiple file downloads" once
+    // the per-site prompt is dismissed. data: URIs aren't subject to it.
+    const url = `data:text/csv;charset=utf-8,${encodeURIComponent(csv)}`;
     const link = document.createElement("a");
     link.href = url;
     link.download = `${filename}.csv`;
+    link.rel = "noopener";
     link.style.visibility = "hidden";
     document.body.appendChild(link);
     link.click();
     document.body.removeChild(link);
-    URL.revokeObjectURL(url);
   };
 
   return (
@@ -72,7 +84,7 @@ export function ExportResultsButton({
       onClick={handleClick}
       disabled={disabled}
       title="Export results as CSV"
-      className={`flex items-center gap-2 h-8 px-2 md:px-3 rounded-lg text-xs md:text-sm font-medium border cursor-pointer transition-colors disabled:opacity-50 disabled:cursor-not-allowed bg-teal-500/12 border-teal-500/45 text-teal-950 dark:text-teal-100 hover:bg-teal-500/22 dark:hover:bg-teal-500/18 ${className ?? ""}`}
+      className={`flex items-center gap-2 h-8 px-2 md:px-3 rounded-lg text-xs md:text-sm font-medium border cursor-pointer transition-colors disabled:opacity-50 disabled:cursor-not-allowed ${VARIANT_CLASSES[variant]} ${className ?? ""}`}
     >
       <svg
         className="w-4 h-4"

--- a/src/components/RefreshButton.tsx
+++ b/src/components/RefreshButton.tsx
@@ -38,7 +38,12 @@ export function RefreshButton({
           <path
             strokeLinecap="round"
             strokeLinejoin="round"
-            d="M4 4v6h6M20 20v-6h-6M20 9A8 8 0 006.34 6.34M4 15a8 8 0 0013.66 2.66"
+            d="M21 12a9 9 0 11-9-9c2.52 0 4.93 1 6.74 2.74L21 8"
+          />
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M21 3v5h-5"
           />
         </svg>
       </button>

--- a/src/components/RefreshButton.tsx
+++ b/src/components/RefreshButton.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+type RefreshButtonProps = {
+  onClick: () => void;
+  loading?: boolean;
+  disabled?: boolean;
+  /** When set, renders an icon + label pill. Otherwise renders as an
+   *  icon-only square button (for use next to a heading). */
+  label?: string;
+  title?: string;
+  className?: string;
+};
+
+export function RefreshButton({
+  onClick,
+  loading,
+  disabled,
+  label,
+  title = "Refresh",
+  className,
+}: RefreshButtonProps) {
+  const isDisabled = disabled || loading;
+  const base =
+    "flex items-center justify-center gap-2 rounded-lg font-medium border cursor-pointer transition-colors disabled:opacity-50 disabled:cursor-not-allowed bg-slate-500/10 border-slate-500/30 text-slate-700 dark:text-slate-200 hover:bg-slate-500/20 dark:hover:bg-slate-500/25";
+  const sizing = label ? "h-8 px-2 md:px-3 text-xs md:text-sm" : "h-7 w-7";
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={isDisabled}
+      title={title}
+      aria-label={title}
+      className={`${base} ${sizing} ${className ?? ""}`}
+    >
+      <svg
+        className={`w-4 h-4 ${loading ? "animate-spin" : ""}`}
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke="currentColor"
+        strokeWidth={2}
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          d="M4 4v6h6M20 20v-6h-6M20 9A8 8 0 006.34 6.34M4 15a8 8 0 0013.66 2.66"
+        />
+      </svg>
+      {label}
+    </button>
+  );
+}

--- a/src/components/RefreshButton.tsx
+++ b/src/components/RefreshButton.tsx
@@ -1,13 +1,12 @@
 "use client";
 
+import { Tooltip } from "@/components/Tooltip";
+
 type RefreshButtonProps = {
   onClick: () => void;
   loading?: boolean;
   disabled?: boolean;
-  /** When set, renders an icon + label pill. Otherwise renders as an
-   *  icon-only square button (for use next to a heading). */
-  label?: string;
-  title?: string;
+  tooltip?: string;
   className?: string;
 };
 
@@ -15,38 +14,34 @@ export function RefreshButton({
   onClick,
   loading,
   disabled,
-  label,
-  title = "Refresh",
+  tooltip = "Refresh",
   className,
 }: RefreshButtonProps) {
   const isDisabled = disabled || loading;
-  const base =
-    "flex items-center justify-center gap-2 rounded-lg font-medium border cursor-pointer transition-colors disabled:opacity-50 disabled:cursor-not-allowed bg-slate-500/10 border-slate-500/30 text-slate-700 dark:text-slate-200 hover:bg-slate-500/20 dark:hover:bg-slate-500/25";
-  const sizing = label ? "h-8 px-2 md:px-3 text-xs md:text-sm" : "h-7 w-7";
 
   return (
-    <button
-      type="button"
-      onClick={onClick}
-      disabled={isDisabled}
-      title={title}
-      aria-label={title}
-      className={`${base} ${sizing} ${className ?? ""}`}
-    >
-      <svg
-        className={`w-4 h-4 ${loading ? "animate-spin" : ""}`}
-        fill="none"
-        viewBox="0 0 24 24"
-        stroke="currentColor"
-        strokeWidth={2}
+    <Tooltip content={tooltip} position="top">
+      <button
+        type="button"
+        onClick={onClick}
+        disabled={isDisabled}
+        aria-label={tooltip}
+        className={`flex items-center justify-center h-7 w-7 rounded-lg border cursor-pointer transition-colors disabled:opacity-50 disabled:cursor-not-allowed bg-slate-500/10 border-slate-500/30 text-slate-700 dark:text-slate-200 hover:bg-slate-500/20 dark:hover:bg-slate-500/25 ${className ?? ""}`}
       >
-        <path
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          d="M4 4v6h6M20 20v-6h-6M20 9A8 8 0 006.34 6.34M4 15a8 8 0 0013.66 2.66"
-        />
-      </svg>
-      {label}
-    </button>
+        <svg
+          className={`w-4 h-4 ${loading ? "animate-spin" : ""}`}
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+          strokeWidth={2}
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M4 4v6h6M20 20v-6h-6M20 9A8 8 0 006.34 6.34M4 15a8 8 0 0013.66 2.66"
+          />
+        </svg>
+      </button>
+    </Tooltip>
   );
 }


### PR DESCRIPTION
Fix https://github.com/ARTPARK-SAHAI-ORG/calibrate-frontend/issues/115
Fix https://github.com/ARTPARK-SAHAI-ORG/calibrate-frontend/issues/156

## Summary
- Add **Export CSV** button on the labelling-task items tab. One row per item; columns: name, description (where applicable), task-type-specific payload (STT ref+pred transcript, LLM chat history + agent response, simulation transcript), and per (annotator × evaluator) value+reasoning plus per-evaluator value+reasoning keyed by evaluator name + version.
- Add a `neutral` variant to `ExportResultsButton` (tinted slate) so the button doesn't collide visually with the teal "Add item" pill. Other call sites keep the teal default.
- Switch the download from `blob:` URL to `data:` URI — Chrome silently blocks repeated programmatic blob-URL downloads once the per-site "multiple files" prompt is dismissed; data URIs aren't subject to that block.
- Stop refetching `/annotation-tasks/{uuid}/summary` and `/annotation-tasks/{uuid}/agreement` on every tab switch. Both now fetch once per task load; mutations that touch annotations already call `fetchTaskSummary()` explicitly.

## Test plan
- [ ] Open a labelling task (LLM / STT / simulation) → Items tab shows an **Export CSV** button in the top-right.
- [ ] Click Export CSV → CSV downloads with one row per item and all annotator/evaluator columns populated.
- [ ] Open a task with no annotations yet → CSV still downloads with the payload columns and no annotator columns.
- [ ] Switch between Overview ↔ Items tabs in DevTools Network panel → no repeat `/summary` or `/agreement` calls.
- [ ] After adding/deleting/relabelling an item, the items table + agreement still refresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)