### PR TITLE
Labelling jobs: item-level annotator comments

### DIFF
--- a/src/app/human-alignment/tasks/[uuid]/page.tsx
+++ b/src/app/human-alignment/tasks/[uuid]/page.tsx
@@ -126,6 +126,10 @@ type TaskSummaryResponse = {
   evaluators: SummaryEvaluator[];
   annotators: SummaryAnnotator[];
   rows: SummaryRow[];
+  /** Sparse per-(item, annotator) free-text comments — the
+   * `evaluator_id IS NULL` annotation slot. Items / annotators
+   * without a non-empty comment don't appear. */
+  item_comments?: { [item_id: string]: { [annotator_uuid: string]: string } };
 };
 
 const TABS: Tab[] = ["overview", "items", "jobs", "runs"];
@@ -382,6 +386,19 @@ function buildItemsCsv(
     }
   }
 
+  // Item-level free-text comments — one column per annotator, not tied
+  // to any evaluator (`evaluator_id IS NULL` slot). Placed after all
+  // evaluator/annotator columns so the per-evaluator block stays
+  // contiguous and downstream consumers don't have to special-case
+  // mid-stream comment columns.
+  for (const ann of annotators) {
+    const annName = sanitizeCsvName(ann.name);
+    columns.push({
+      key: `ann_${ann.uuid}_comment`,
+      header: `${annName}/comment`,
+    });
+  }
+
   const rows = items.map((item) => {
     const p = (item.payload ?? {}) as Record<string, unknown>;
     const out: Record<string, unknown> = {
@@ -447,6 +464,10 @@ function buildItemsCsv(
         out[`ev_${ev.uuid}_${vid ?? "live"}_reasoning`] =
           row?.evaluator_reasoning ?? "";
       }
+    }
+    const commentsForItem = taskSummary?.item_comments?.[item.uuid];
+    for (const ann of annotators) {
+      out[`ann_${ann.uuid}_comment`] = commentsForItem?.[ann.uuid] ?? "";
     }
     return out;
   });

--- a/src/components/human-labelling/AnnotationJobView.tsx
+++ b/src/components/human-labelling/AnnotationJobView.tsx
@@ -221,6 +221,14 @@ export function AnnotationJobView({
   const [currentIndex, setCurrentIndex] = useState(0);
   const [fields, setFields] = useState<Record<FieldKey, FieldValue>>({});
   const [savedKeys, setSavedKeys] = useState<Set<FieldKey>>(new Set());
+  // Per-item free-text comments, stored against the `evaluator_id IS NULL`
+  // slot for each (job, item). `itemComments` holds the current editor
+  // value; `savedComments` snapshots what the server has so we only POST
+  // when it actually changed.
+  const [itemComments, setItemComments] = useState<Record<string, string>>({});
+  const [savedComments, setSavedComments] = useState<Record<string, string>>(
+    {},
+  );
   const [submitting, setSubmitting] = useState(false);
   const [topError, setTopError] = useState<string | null>(null);
 
@@ -230,8 +238,13 @@ export function AnnotationJobView({
     (data: JobResponse) => {
       const next: Record<FieldKey, FieldValue> = {};
       const saved = new Set<FieldKey>();
+      const comments: Record<string, string> = {};
       for (const a of data.annotations) {
-        if (!a.evaluator_id) continue;
+        if (!a.evaluator_id) {
+          const c = readSavedComment(a.value);
+          if (c) comments[a.item_id] = c;
+          continue;
+        }
         const k = fieldKey(a.item_id, a.evaluator_id);
         next[k] = {
           value: readSavedValue(a.value),
@@ -241,6 +254,8 @@ export function AnnotationJobView({
       }
       setFields(next);
       setSavedKeys(saved);
+      setItemComments(comments);
+      setSavedComments(comments);
 
       // Read-only views (admin, public-readonly) always start on the first
       // item — they're reviewing what's been labelled, not picking up where
@@ -391,6 +406,10 @@ export function AnnotationJobView({
       setFields={setFields}
       savedKeys={savedKeys}
       setSavedKeys={setSavedKeys}
+      itemComments={itemComments}
+      setItemComments={setItemComments}
+      savedComments={savedComments}
+      setSavedComments={setSavedComments}
       submitting={submitting}
       setSubmitting={setSubmitting}
       topError={topError}
@@ -414,6 +433,12 @@ type ViewProps = {
   setFields: React.Dispatch<React.SetStateAction<Record<FieldKey, FieldValue>>>;
   savedKeys: Set<FieldKey>;
   setSavedKeys: React.Dispatch<React.SetStateAction<Set<FieldKey>>>;
+  itemComments: Record<string, string>;
+  setItemComments: React.Dispatch<React.SetStateAction<Record<string, string>>>;
+  savedComments: Record<string, string>;
+  setSavedComments: React.Dispatch<
+    React.SetStateAction<Record<string, string>>
+  >;
   submitting: boolean;
   setSubmitting: (b: boolean) => void;
   topError: string | null;
@@ -434,6 +459,10 @@ function AnnotateView({
   setFields,
   savedKeys,
   setSavedKeys,
+  itemComments,
+  setItemComments,
+  savedComments,
+  setSavedComments,
   submitting,
   setSubmitting,
   topError,
@@ -480,7 +509,7 @@ function AnnotateView({
     setTopError(null);
 
     const annotationsBody: {
-      evaluator_id: string;
+      evaluator_id: string | null;
       value: Record<string, unknown>;
     }[] = [];
     for (const ev of evaluators) {
@@ -495,6 +524,21 @@ function AnnotateView({
           value: f.value,
           ...(f.comment ? { reasoning: f.comment } : {}),
         },
+      });
+    }
+
+    // Item-level free-text comment lives on the `evaluator_id IS NULL`
+    // slot. Only send when it actually changed since the last save — the
+    // backend overwrites whatever's there, so an unchanged value is wasted
+    // work, and we'd erase a saved comment if we sent an empty string for
+    // an item that never had one edited.
+    const currentComment = (itemComments[currentItem.uuid] ?? "").trim();
+    const savedComment = (savedComments[currentItem.uuid] ?? "").trim();
+    const commentChanged = currentComment !== savedComment;
+    if (commentChanged) {
+      annotationsBody.push({
+        evaluator_id: null,
+        value: { comment: currentComment },
       });
     }
 
@@ -529,6 +573,12 @@ function AnnotateView({
         justSaved.forEach((k) => next.add(k));
         return next;
       });
+      if (commentChanged) {
+        setSavedComments((prev) => ({
+          ...prev,
+          [currentItem.uuid]: currentComment,
+        }));
+      }
 
       if (result.data.status === "completed") {
         onJobUpdate({
@@ -766,6 +816,13 @@ function AnnotateView({
                 fields={fields}
                 setField={setField}
                 readOnly={isAdmin}
+                itemComment={itemComments[currentItem.uuid] ?? ""}
+                onItemCommentChange={(s) =>
+                  setItemComments((prev) => ({
+                    ...prev,
+                    [currentItem.uuid]: s,
+                  }))
+                }
               />
             </div>
           ) : (
@@ -792,6 +849,13 @@ function AnnotateView({
                   fields={fields}
                   setField={setField}
                   readOnly={isAdmin}
+                  itemComment={itemComments[currentItem.uuid] ?? ""}
+                  onItemCommentChange={(s) =>
+                    setItemComments((prev) => ({
+                      ...prev,
+                      [currentItem.uuid]: s,
+                    }))
+                  }
                 />
               </div>
             </>
@@ -832,12 +896,18 @@ function EvaluatorsPane({
   fields,
   setField,
   readOnly,
+  itemComment,
+  onItemCommentChange,
 }: {
   evaluators: Evaluator[];
   item: Item;
   fields: Record<FieldKey, FieldValue>;
   setField: (key: FieldKey, partial: Partial<FieldValue>) => void;
   readOnly: boolean;
+  /** Current free-text comment for this item — backed by the
+   * `evaluator_id IS NULL` annotation slot. */
+  itemComment: string;
+  onItemCommentChange: (s: string) => void;
 }) {
   // Per-item, per-evaluator variable values live on
   // `payload.evaluator_variables[<evaluator_uuid>]`. Surface them on
@@ -854,10 +924,34 @@ function EvaluatorsPane({
     </p>
   ) : null;
 
+  const trimmedComment = itemComment.trim();
+  const showCommentBlock = readOnly ? trimmedComment.length > 0 : true;
+  const commentBlock = showCommentBlock ? (
+    <div className="border border-border rounded-xl p-4 space-y-2">
+      <h3 className="text-sm font-semibold">
+        Comments {readOnly ? "" : "(optional)"}
+      </h3>
+      {readOnly ? (
+        <p className="text-sm text-foreground whitespace-pre-wrap break-words">
+          {trimmedComment}
+        </p>
+      ) : (
+        <textarea
+          value={itemComment}
+          onChange={(e) => onItemCommentChange(e.target.value)}
+          placeholder="Add any notes about this item"
+          rows={2}
+          className="w-full text-sm rounded-md border border-border bg-background px-3 py-2 resize-y focus:outline-none focus:ring-2 focus:ring-foreground/20"
+        />
+      )}
+    </div>
+  ) : null;
+
   if (evaluators.length === 0) {
     return (
       <div className="space-y-3">
         {descriptionBlock}
+        {commentBlock}
         <div className="border border-border rounded-xl p-4 text-sm text-muted-foreground">
           No evaluators are attached to this task.
         </div>
@@ -885,6 +979,7 @@ function EvaluatorsPane({
   return (
     <div className="space-y-3 pb-4 md:pb-6">
       {descriptionBlock}
+      {commentBlock}
       {evaluators.map((ev) => {
         const k = fieldKey(item.uuid, ev.uuid);
         const f = fields[k];

--- a/src/components/human-labelling/AnnotationJobView.tsx
+++ b/src/components/human-labelling/AnnotationJobView.tsx
@@ -930,16 +930,15 @@ function EvaluatorsPane({
   const trimmedComment = itemComment.trim();
   const showCommentBlock = readOnly ? trimmedComment.length > 0 : true;
   const commentBlock = showCommentBlock ? (
-    readOnly ? (
-      <div className="space-y-1.5">
-        <h3 className="text-sm font-semibold">Comments</h3>
+    <div className="space-y-1.5">
+      <h3 className="text-sm font-semibold">
+        Comments {readOnly ? "" : "(optional)"}
+      </h3>
+      {readOnly ? (
         <p className="text-sm text-foreground whitespace-pre-wrap break-words">
           {trimmedComment}
         </p>
-      </div>
-    ) : (
-      <div className="border border-border rounded-xl p-4 space-y-2">
-        <h3 className="text-sm font-semibold">Comments (optional)</h3>
+      ) : (
         <textarea
           value={itemComment}
           onChange={(e) => onItemCommentChange(e.target.value)}
@@ -947,8 +946,8 @@ function EvaluatorsPane({
           rows={2}
           className="w-full text-sm rounded-md border border-border bg-background px-3 py-2 resize-y focus:outline-none focus:ring-2 focus:ring-foreground/20"
         />
-      </div>
-    )
+      )}
+    </div>
   ) : null;
 
   if (evaluators.length === 0) {

--- a/src/components/human-labelling/AnnotationJobView.tsx
+++ b/src/components/human-labelling/AnnotationJobView.tsx
@@ -919,9 +919,12 @@ function EvaluatorsPane({
       ? (itemPayload.description as string).trim()
       : "";
   const descriptionBlock = itemDescription ? (
-    <p className="text-sm text-foreground whitespace-pre-wrap break-words">
-      {itemDescription}
-    </p>
+    <div className="space-y-1.5">
+      <h3 className="text-sm font-semibold">Description</h3>
+      <p className="text-sm text-foreground whitespace-pre-wrap break-words">
+        {itemDescription}
+      </p>
+    </div>
   ) : null;
 
   const trimmedComment = itemComment.trim();

--- a/src/components/human-labelling/AnnotationJobView.tsx
+++ b/src/components/human-labelling/AnnotationJobView.tsx
@@ -927,15 +927,16 @@ function EvaluatorsPane({
   const trimmedComment = itemComment.trim();
   const showCommentBlock = readOnly ? trimmedComment.length > 0 : true;
   const commentBlock = showCommentBlock ? (
-    <div className="border border-border rounded-xl p-4 space-y-2">
-      <h3 className="text-sm font-semibold">
-        Comments {readOnly ? "" : "(optional)"}
-      </h3>
-      {readOnly ? (
+    readOnly ? (
+      <div className="space-y-1.5">
+        <h3 className="text-sm font-semibold">Comments</h3>
         <p className="text-sm text-foreground whitespace-pre-wrap break-words">
           {trimmedComment}
         </p>
-      ) : (
+      </div>
+    ) : (
+      <div className="border border-border rounded-xl p-4 space-y-2">
+        <h3 className="text-sm font-semibold">Comments (optional)</h3>
         <textarea
           value={itemComment}
           onChange={(e) => onItemCommentChange(e.target.value)}
@@ -943,8 +944,8 @@ function EvaluatorsPane({
           rows={2}
           className="w-full text-sm rounded-md border border-border bg-background px-3 py-2 resize-y focus:outline-none focus:ring-2 focus:ring-foreground/20"
         />
-      )}
-    </div>
+      </div>
+    )
   ) : null;
 
   if (evaluators.length === 0) {

--- a/src/components/human-labelling/EvaluatorRunDetailView.tsx
+++ b/src/components/human-labelling/EvaluatorRunDetailView.tsx
@@ -633,6 +633,7 @@ export function EvaluatorResultsPane({
   showVersionInSourcePill = false,
   groupVersionsByEvaluator = false,
   annotatorFilterActive = false,
+  singleAnnotatorFiltered = false,
   itemComments = [],
 }: {
   evaluators: {
@@ -673,6 +674,11 @@ export function EvaluatorResultsPane({
   /** Parent has narrowed annotations to a subset — lets grouped cards
    *  hide a solitary annotator pill when only one annotation remains. */
   annotatorFilterActive?: boolean;
+  /** True when the annotator filter is narrowed to exactly one
+   * annotator. Drives the comments-block pill hide rule (we drop the
+   * solitary pill regardless of how many annotators actually have
+   * comments for the item). */
+  singleAnnotatorFiltered?: boolean;
   /** Per-annotator item-level free-text comments (the
    * `evaluator_id IS NULL` slot). Already filtered by the parent's
    * annotator picker; ordered by the summary's annotator list. */
@@ -696,7 +702,7 @@ export function EvaluatorResultsPane({
     itemComments.length > 0 ? (
       <CommentsBlock
         comments={itemComments}
-        annotatorFilterActive={annotatorFilterActive}
+        singleAnnotatorFiltered={singleAnnotatorFiltered}
       />
     ) : null;
 
@@ -1017,20 +1023,23 @@ export function EvaluatorResultsPane({
  * Item-level "Comments" block — heading + per-annotator pills that
  * switch the displayed comment. Matches the source-pill UX on the
  * evaluator cards: clicking a pill highlights it and swaps the body
- * text. When the parent has filtered to a single annotator we drop
- * the solitary pill (same rule as the annotator pill on each
- * evaluator card) and just show the body.
+ * text. We hide the pill row only when the parent's filter has
+ * narrowed selection to exactly one annotator — i.e. the user has
+ * already committed to a specific annotator at the dialog level.
+ * If the filter has multiple annotators selected but only one of
+ * them actually commented, the pill still shows so the reader
+ * knows whose comment they're looking at.
  */
 function CommentsBlock({
   comments,
-  annotatorFilterActive,
+  singleAnnotatorFiltered,
 }: {
   comments: {
     annotator_id: string;
     annotator_name: string;
     comment: string;
   }[];
-  annotatorFilterActive: boolean;
+  singleAnnotatorFiltered: boolean;
 }) {
   const [selected, setSelected] = useState<string | null>(null);
 
@@ -1044,7 +1053,7 @@ function CommentsBlock({
   const active = comments.find((c) => c.annotator_id === activeId) ?? null;
   if (!active) return null;
 
-  const showPills = !(annotatorFilterActive && comments.length === 1);
+  const showPills = !singleAnnotatorFiltered;
 
   return (
     <div className="space-y-1.5">
@@ -1313,6 +1322,7 @@ export function ItemDetailPane({
   showVersionInSourcePill = false,
   groupVersionsByEvaluator = false,
   annotatorFilterActive = false,
+  singleAnnotatorFiltered = false,
   itemComments = [],
 }: {
   item: Item;
@@ -1339,6 +1349,12 @@ export function ItemDetailPane({
   showVersionInSourcePill?: boolean;
   groupVersionsByEvaluator?: boolean;
   annotatorFilterActive?: boolean;
+  /** True when the annotator filter has narrowed selection to exactly
+   * one annotator. Used to hide the solitary pill row on the comments
+   * block — the user has already committed to that annotator at the
+   * dialog level. Distinct from `annotatorFilterActive` (any subset
+   * selected). */
+  singleAnnotatorFiltered?: boolean;
   /** Per-annotator item-level free-text comments to surface in the
    * results pane. Empty = no comments for this item. */
   itemComments?: {
@@ -1379,6 +1395,7 @@ export function ItemDetailPane({
           showVersionInSourcePill={showVersionInSourcePill}
           groupVersionsByEvaluator={groupVersionsByEvaluator}
           annotatorFilterActive={annotatorFilterActive}
+          singleAnnotatorFiltered={singleAnnotatorFiltered}
           itemComments={itemComments}
         />
       </div>

--- a/src/components/human-labelling/EvaluatorRunDetailView.tsx
+++ b/src/components/human-labelling/EvaluatorRunDetailView.tsx
@@ -633,6 +633,7 @@ export function EvaluatorResultsPane({
   showVersionInSourcePill = false,
   groupVersionsByEvaluator = false,
   annotatorFilterActive = false,
+  itemComments = [],
 }: {
   evaluators: {
     evaluator_id: string;
@@ -672,6 +673,14 @@ export function EvaluatorResultsPane({
   /** Parent has narrowed annotations to a subset — lets grouped cards
    *  hide a solitary annotator pill when only one annotation remains. */
   annotatorFilterActive?: boolean;
+  /** Per-annotator item-level free-text comments (the
+   * `evaluator_id IS NULL` slot). Already filtered by the parent's
+   * annotator picker; ordered by the summary's annotator list. */
+  itemComments?: {
+    annotator_id: string;
+    annotator_name: string;
+    comment: string;
+  }[];
 }) {
   const [selectionByEvaluator, setSelectionByEvaluator] = useState<
     Record<string, string>
@@ -683,10 +692,19 @@ export function EvaluatorResultsPane({
     </p>
   ) : null;
 
+  const commentsBlock =
+    itemComments.length > 0 ? (
+      <CommentsBlock
+        comments={itemComments}
+        annotatorFilterActive={annotatorFilterActive}
+      />
+    ) : null;
+
   if (evaluators.length === 0) {
     return (
       <div className="space-y-3">
         {descriptionBlock}
+        {commentsBlock}
         <div className="border border-border rounded-xl p-4 text-sm text-muted-foreground">
           No evaluators in this run.
         </div>
@@ -712,6 +730,7 @@ export function EvaluatorResultsPane({
     return (
       <div className="space-y-3">
         {descriptionBlock}
+        {commentsBlock}
         <div className="border border-border rounded-xl p-4 text-sm text-muted-foreground">
           All evaluators agree with human annotations on this item.
         </div>
@@ -965,6 +984,7 @@ export function EvaluatorResultsPane({
     return (
       <div className="space-y-4">
         {descriptionBlock}
+        {commentsBlock}
         {order.map((id) => (
           <GroupedEvaluatorCard
             key={id}
@@ -987,7 +1007,63 @@ export function EvaluatorResultsPane({
   return (
     <div className="space-y-4">
       {descriptionBlock}
+      {commentsBlock}
       {visibleEvaluators.map((ev) => renderEvaluatorCard(ev))}
+    </div>
+  );
+}
+
+/**
+ * Item-level "Comments" block — heading + per-annotator pills that
+ * switch the displayed comment. Matches the source-pill UX on the
+ * evaluator cards: clicking a pill highlights it and swaps the body
+ * text. When the parent has filtered to a single annotator we drop
+ * the solitary pill (same rule as the annotator pill on each
+ * evaluator card) and just show the body.
+ */
+function CommentsBlock({
+  comments,
+  annotatorFilterActive,
+}: {
+  comments: {
+    annotator_id: string;
+    annotator_name: string;
+    comment: string;
+  }[];
+  annotatorFilterActive: boolean;
+}) {
+  const [selected, setSelected] = useState<string | null>(null);
+
+  // Clamp the selection whenever the list of comments changes (e.g.
+  // the annotator filter narrows). Falls back to the first available
+  // annotator so the body text is never empty.
+  const activeId =
+    selected && comments.some((c) => c.annotator_id === selected)
+      ? selected
+      : (comments[0]?.annotator_id ?? null);
+  const active = comments.find((c) => c.annotator_id === activeId) ?? null;
+  if (!active) return null;
+
+  const showPills = !(annotatorFilterActive && comments.length === 1);
+
+  return (
+    <div className="space-y-1.5">
+      <h3 className="text-sm font-semibold">Comments</h3>
+      {showPills && (
+        <div className="flex flex-wrap items-center gap-1.5">
+          {comments.map((c) => (
+            <SourcePill
+              key={c.annotator_id}
+              primaryLabel={c.annotator_name || "Annotator"}
+              selected={c.annotator_id === active.annotator_id}
+              onClick={() => setSelected(c.annotator_id)}
+            />
+          ))}
+        </div>
+      )}
+      <p className="text-sm text-foreground whitespace-pre-wrap break-words">
+        {active.comment}
+      </p>
     </div>
   );
 }
@@ -1237,6 +1313,7 @@ export function ItemDetailPane({
   showVersionInSourcePill = false,
   groupVersionsByEvaluator = false,
   annotatorFilterActive = false,
+  itemComments = [],
 }: {
   item: Item;
   taskType: LabellingTaskFull["type"];
@@ -1262,6 +1339,13 @@ export function ItemDetailPane({
   showVersionInSourcePill?: boolean;
   groupVersionsByEvaluator?: boolean;
   annotatorFilterActive?: boolean;
+  /** Per-annotator item-level free-text comments to surface in the
+   * results pane. Empty = no comments for this item. */
+  itemComments?: {
+    annotator_id: string;
+    annotator_name: string;
+    comment: string;
+  }[];
 }) {
   const itemPayload =
     item.payload && typeof item.payload === "object"
@@ -1295,6 +1379,7 @@ export function ItemDetailPane({
           showVersionInSourcePill={showVersionInSourcePill}
           groupVersionsByEvaluator={groupVersionsByEvaluator}
           annotatorFilterActive={annotatorFilterActive}
+          itemComments={itemComments}
         />
       </div>
     </div>

--- a/src/components/human-labelling/ItemDetailDialog.tsx
+++ b/src/components/human-labelling/ItemDetailDialog.tsx
@@ -227,8 +227,10 @@ export function ItemDetailDialog({
     [item],
   );
 
-  // Annotators who actually labelled this item across any evaluator/version.
-  // We only surface the filter when this list is non-empty.
+  // Annotators who left any signal on this item — either an evaluator
+  // annotation in any row, OR a comment in `item_comments`. Comment-only
+  // annotators (no evaluator labels) need to be filterable too, otherwise
+  // the picker can't isolate their Comments block entry.
   const availableAnnotators = useMemo<PickerItem[]>(() => {
     if (!summary) return [];
     const seen = new Set<string>();
@@ -239,10 +241,16 @@ export function ItemDetailDialog({
         }
       }
     }
+    if (item) {
+      const byAnn = summary.item_comments?.[item.uuid] ?? {};
+      for (const [annUuid, c] of Object.entries(byAnn)) {
+        if (typeof c === "string" && c.trim()) seen.add(annUuid);
+      }
+    }
     return (summary.annotators ?? [])
       .filter((a) => seen.has(a.uuid))
       .map((a) => ({ uuid: a.uuid, name: a.name }));
-  }, [summary]);
+  }, [summary, item]);
 
   // Drop selections that no longer correspond to an annotator with data
   // (e.g. after the modal re-fetches with different filters) at render

--- a/src/components/human-labelling/ItemDetailDialog.tsx
+++ b/src/components/human-labelling/ItemDetailDialog.tsx
@@ -69,6 +69,16 @@ type TaskSummaryResponse = {
   annotators: SummaryAnnotator[];
   evaluators?: SummaryEvaluator[];
   rows: SummaryRow[];
+  /** Item-level free-text comments, sourced from the `evaluator_id IS NULL`
+   * annotation slot. Sparse: only `(item, annotator)` pairs with a
+   * non-empty comment appear. */
+  item_comments?: { [item_id: string]: { [annotator_uuid: string]: string } };
+};
+
+export type ItemCommentEntry = {
+  annotator_id: string;
+  annotator_name: string;
+  comment: string;
 };
 
 type TaskEvaluatorDef = {
@@ -256,6 +266,29 @@ export function ItemDetailDialog({
     if (effectiveSelectedAnnotators.length === 0) return null;
     return new Set(effectiveSelectedAnnotators.map((a) => a.uuid));
   }, [effectiveSelectedAnnotators]);
+
+  // Item-level comments for the current item, preserving annotator order
+  // from the summary's `annotators[]` block and dropping anyone outside
+  // the active annotator filter.
+  const itemCommentEntries = useMemo<ItemCommentEntry[]>(() => {
+    if (!summary || !item) return [];
+    const byAnn = summary.item_comments?.[item.uuid];
+    if (!byAnn) return [];
+    const entries: ItemCommentEntry[] = [];
+    for (const ann of summary.annotators ?? []) {
+      const raw = byAnn[ann.uuid];
+      if (typeof raw !== "string") continue;
+      const trimmed = raw.trim();
+      if (!trimmed) continue;
+      if (annotatorFilter && !annotatorFilter.has(ann.uuid)) continue;
+      entries.push({
+        annotator_id: ann.uuid,
+        annotator_name: ann.name,
+        comment: trimmed,
+      });
+    }
+    return entries;
+  }, [summary, item, annotatorFilter]);
 
   const hasAnyLabel = useMemo(() => {
     if (!summary) return false;
@@ -732,6 +765,7 @@ export function ItemDetailDialog({
               showVersionInSourcePill
               groupVersionsByEvaluator
               annotatorFilterActive={annotatorFilter !== null}
+              itemComments={itemCommentEntries}
             />
           )}
         </div>

--- a/src/components/human-labelling/ItemDetailDialog.tsx
+++ b/src/components/human-labelling/ItemDetailDialog.tsx
@@ -773,6 +773,7 @@ export function ItemDetailDialog({
               showVersionInSourcePill
               groupVersionsByEvaluator
               annotatorFilterActive={annotatorFilter !== null}
+              singleAnnotatorFiltered={effectiveSelectedAnnotators.length === 1}
               itemComments={itemCommentEntries}
             />
           )}


### PR DESCRIPTION
## Summary

- **Labeller view** — adds a free-text "Comments (optional)" textarea above the first evaluator on every labelling job item. Saved against the `evaluator_id IS NULL` annotation slot in the existing batched submit, only when the value changed since the last save (avoids re-POSTing unchanged comments or wiping a saved comment with an empty string).
- **Read-only views (admin + public viewer)** — surface the saved comment as a bare "Comments" header + body (no surrounding card). Also adds a "Description" header above the item description block.
- **Admin item-detail dialog** — reads the new `summary.item_comments[item_id][annotator_uuid]` map and renders a "Comments" block above the evaluator cards: per-annotator SourcePill row (click to switch), filtered through the dialog's existing annotator picker. The pill row is hidden only when the picker narrows selection to exactly one annotator. Comment-only annotators are now also surfaced in the picker.
- **Items-tab CSV export** — one `<annotator>/comment` column per annotator appended at the end of the export, sourced from the same `item_comments` block. Keeps the existing per-evaluator block contiguous.

## Backend contract relied on

`GET /annotation-tasks/{uuid}/summary` returns a sparse `item_comments: { [item_id]: { [annotator_uuid]: string } }`. The `annotators[]` union includes annotators who only left a comment. Comments are written via the existing annotation upsert with `evaluator_id: null` and `value: { comment }`.

https://github.com/ARTPARK-SAHAI-ORG/calibrate-backend/pull/62

## Test plan

- [ ] Labeller view: type a comment, submit alongside evaluator answers, refresh — comment persists. Clear it and resubmit — overwrite works.
- [ ] Submit without typing a comment — no `evaluator_id: null` annotation hits the backend.
- [ ] Admin job viewer + public read-only viewer: previously-saved comment renders as a plain "Comments" header + body, no card.
- [ ] Item detail dialog: open an item with multi-annotator comments; click each pill, body switches. Open the picker, narrow to one annotator → pill row hidden. Narrow to two annotators where only one commented → pill row still shown.
- [ ] Filter to a comment-only annotator (no evaluator labels) — they appear in the picker, comments block renders, evaluator cards drop.
- [ ] CSV export: items with no comments emit empty cells; items with multi-annotator comments emit one cell per annotator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)