### PR TITLE
Human alignment: rename evaluator types, shift+click selection, smarter landing

### DIFF
--- a/src/app/evaluators/page.tsx
+++ b/src/app/evaluators/page.tsx
@@ -96,13 +96,13 @@ const EVALUATOR_TYPE_OPTIONS: {
   },
   {
     value: "llm",
-    title: "LLM response",
+    title: "Single LLM response",
     description:
       "Given a conversation history, evaluate the agent's next response",
   },
   {
     value: "simulation",
-    title: "Simulation",
+    title: "Full conversation",
     description:
       "Evaluate the agent's performance during a complete conversation",
   },

--- a/src/app/human-alignment/page.tsx
+++ b/src/app/human-alignment/page.tsx
@@ -435,6 +435,45 @@ function HumanLabellingPageInner() {
   const tasksCount = tasks.length;
   const annotatorsCount = annotators.length;
 
+  /**
+   * Mirrors the `hasNoAgreementData` check inside <AgreementOverview/>: true
+   * when there are no human-human pairs and no evaluator pairs to show.
+   * Lifted here so we can auto-switch off the Overview tab when it would
+   * render an empty state.
+   */
+  const overviewIsEmpty =
+    !agreement ||
+    ((agreement.human_human?.current ?? null) == null &&
+      (agreement.human_human?.pair_count ?? 0) === 0 &&
+      (agreement.evaluators ?? []).every(
+        (e) => (e.current ?? null) == null && (e.pair_count ?? 0) === 0,
+      ));
+
+  /**
+   * On a fresh visit to `/human-alignment` (no explicit `?tab=...`), skip
+   * past an empty Overview and land on Tasks — that's where the user can
+   * actually act. Only fires once we know the overview is empty (post-fetch)
+   * and only when the user didn't deep-link into Overview.
+   */
+  const [autoSwitchedAway, setAutoSwitchedAway] = useState(false);
+  useEffect(() => {
+    if (autoSwitchedAway) return;
+    if (activeTab !== "overview") return;
+    if (!agreementFetchCompleted || agreementLoading) return;
+    if (isTab(initialTab)) return; // respect explicit ?tab= choice
+    if (!overviewIsEmpty) return;
+    setAutoSwitchedAway(true);
+    handleTabChange("tasks");
+  }, [
+    autoSwitchedAway,
+    activeTab,
+    agreementFetchCompleted,
+    agreementLoading,
+    initialTab,
+    overviewIsEmpty,
+    handleTabChange,
+  ]);
+
   return (
     <AppLayout
       activeItem="human-alignment"

--- a/src/app/human-alignment/tasks/[uuid]/evaluator-runs/[runUuid]/page.tsx
+++ b/src/app/human-alignment/tasks/[uuid]/evaluator-runs/[runUuid]/page.tsx
@@ -230,7 +230,15 @@ export default function EvaluatorRunDetailPage() {
       setRerunError(null);
       try {
         const body: Record<string, unknown> = { evaluators: selections };
-        if (rerunItemIds.length > 0) body.item_ids = rerunItemIds;
+        // Target the same items the original job covered. If we couldn't
+        // resolve them, fall back to select_all — the backend no longer
+        // treats an omitted item_ids as "all" (it 400s), so the intent
+        // must be explicit.
+        if (rerunItemIds.length > 0) {
+          body.item_ids = rerunItemIds;
+        } else {
+          body.select_all = true;
+        }
         const result = await apiClient<{
           job_uuid: string;
           status: string;

--- a/src/app/human-alignment/tasks/[uuid]/page.tsx
+++ b/src/app/human-alignment/tasks/[uuid]/page.tsx
@@ -1611,6 +1611,23 @@ function LabellingTaskPageInner() {
   const canAddItem =
     taskType === "llm" || taskType === "simulation" || taskType === "stt";
 
+  /**
+   * Anchor for shift+click range selection — the uuid of the most
+   * recently clicked row/checkbox. Cleared if it drops out of `items`.
+   */
+  const [lastSelectedItemUuid, setLastSelectedItemUuid] = useState<
+    string | null
+  >(null);
+
+  /**
+   * `onChange` on a checkbox doesn't carry `shiftKey`, and calling
+   * `e.preventDefault()` on the checkbox's `onClick` desyncs React's
+   * controlled `checked` prop from the DOM (state updates but the visual
+   * tick doesn't appear). So we capture shift state on `mousedown` into a
+   * ref and read it inside `onChange`, leaving the native toggle alone.
+   */
+  const pendingShiftRef = useRef(false);
+
   const toggleItem = (uuid: string) => {
     setSelectedItemIds((prev) => {
       const next = new Set(prev);
@@ -1618,6 +1635,36 @@ function LabellingTaskPageInner() {
       else next.add(uuid);
       return next;
     });
+    setLastSelectedItemUuid(uuid);
+  };
+
+  /**
+   * Shift+click range selection: adds every item between the anchor
+   * (`lastSelectedItemUuid`) and `targetUuid` — inclusive, in the current
+   * sorted order — to the selection. Falls back to a plain toggle if
+   * the anchor is missing.
+   */
+  const selectRangeTo = (targetUuid: string) => {
+    if (!lastSelectedItemUuid || lastSelectedItemUuid === targetUuid) {
+      toggleItem(targetUuid);
+      return;
+    }
+    const anchorIdx = items.findIndex((i) => i.uuid === lastSelectedItemUuid);
+    const targetIdx = items.findIndex((i) => i.uuid === targetUuid);
+    if (anchorIdx === -1 || targetIdx === -1) {
+      toggleItem(targetUuid);
+      return;
+    }
+    const [start, end] =
+      anchorIdx <= targetIdx
+        ? [anchorIdx, targetIdx]
+        : [targetIdx, anchorIdx];
+    setSelectedItemIds((prev) => {
+      const next = new Set(prev);
+      for (let i = start; i <= end; i++) next.add(items[i].uuid);
+      return next;
+    });
+    setLastSelectedItemUuid(targetUuid);
   };
 
   /**
@@ -1662,15 +1709,18 @@ function LabellingTaskPageInner() {
 
   // Drop selections that no longer exist in the items list (after delete or refetch).
   useEffect(() => {
+    const ids = new Set(items.map((i) => i.uuid));
     setSelectedItemIds((prev) => {
       if (prev.size === 0) return prev;
-      const ids = new Set(items.map((i) => i.uuid));
       const next = new Set<string>();
       prev.forEach((id) => {
         if (ids.has(id)) next.add(id);
       });
       return next.size === prev.size ? prev : next;
     });
+    setLastSelectedItemUuid((prev) =>
+      prev && !ids.has(prev) ? null : prev,
+    );
   }, [items]);
 
   const toggleJob = (jobUuid: string) => {
@@ -2858,7 +2908,7 @@ function LabellingTaskPageInner() {
                       }}
                       onChange={toggleSelectAll}
                       aria-label="Select all"
-                      className="w-4 h-4 cursor-pointer accent-foreground"
+                      className="w-5 h-5 cursor-pointer accent-foreground"
                     />
                     <div className="text-sm font-medium text-muted-foreground">
                       Name
@@ -2901,7 +2951,19 @@ function LabellingTaskPageInner() {
                     return (
                       <Fragment key={item.uuid}>
                         <div
-                          onClick={() => openItemDetail(item.uuid)}
+                          onMouseDown={(e) => {
+                            // Shift+click on text triggers a browser text-selection
+                            // range; suppress it so range-selecting rows stays clean.
+                            if (e.shiftKey) e.preventDefault();
+                          }}
+                          onClick={(e) => {
+                            if (e.shiftKey) {
+                              e.preventDefault();
+                              selectRangeTo(item.uuid);
+                              return;
+                            }
+                            openItemDetail(item.uuid);
+                          }}
                           className={`grid grid-cols-[40px_minmax(0,0.6fr)_minmax(0,1fr)_minmax(0,1fr)_200px_180px_300px] gap-6 px-4 py-3 border-b border-border last:border-b-0 transition-colors items-center cursor-pointer ${
                             isSelected ? "bg-muted/30" : "hover:bg-muted/20"
                           }`}
@@ -2909,10 +2971,20 @@ function LabellingTaskPageInner() {
                           <input
                             type="checkbox"
                             checked={isSelected}
-                            onChange={() => toggleItem(item.uuid)}
+                            onMouseDown={(e) => {
+                              pendingShiftRef.current = e.shiftKey;
+                            }}
+                            onChange={() => {
+                              if (pendingShiftRef.current) {
+                                selectRangeTo(item.uuid);
+                              } else {
+                                toggleItem(item.uuid);
+                              }
+                              pendingShiftRef.current = false;
+                            }}
                             onClick={(e) => e.stopPropagation()}
                             aria-label={`Select item ${item.id}`}
-                            className="w-4 h-4 cursor-pointer accent-foreground"
+                            className="w-5 h-5 cursor-pointer accent-foreground"
                           />
                           <p className="text-sm text-foreground line-clamp-2">
                             {name || "—"}
@@ -2981,7 +3053,7 @@ function LabellingTaskPageInner() {
                       }}
                       onChange={toggleSelectAll}
                       aria-label="Select all"
-                      className="w-4 h-4 cursor-pointer accent-foreground"
+                      className="w-5 h-5 cursor-pointer accent-foreground"
                     />
                     <div className="text-sm font-medium text-muted-foreground">
                       Name
@@ -3020,7 +3092,19 @@ function LabellingTaskPageInner() {
                     return (
                       <Fragment key={item.uuid}>
                         <div
-                          onClick={() => openItemDetail(item.uuid)}
+                          onMouseDown={(e) => {
+                            // Shift+click on text triggers a browser text-selection
+                            // range; suppress it so range-selecting rows stays clean.
+                            if (e.shiftKey) e.preventDefault();
+                          }}
+                          onClick={(e) => {
+                            if (e.shiftKey) {
+                              e.preventDefault();
+                              selectRangeTo(item.uuid);
+                              return;
+                            }
+                            openItemDetail(item.uuid);
+                          }}
                           className={`grid grid-cols-[40px_minmax(0,1fr)_minmax(0,1.2fr)_200px_180px_300px] gap-6 px-4 py-3 border-b border-border last:border-b-0 transition-colors items-center cursor-pointer ${
                             isSelected ? "bg-muted/30" : "hover:bg-muted/20"
                           }`}
@@ -3028,10 +3112,20 @@ function LabellingTaskPageInner() {
                           <input
                             type="checkbox"
                             checked={isSelected}
-                            onChange={() => toggleItem(item.uuid)}
+                            onMouseDown={(e) => {
+                              pendingShiftRef.current = e.shiftKey;
+                            }}
+                            onChange={() => {
+                              if (pendingShiftRef.current) {
+                                selectRangeTo(item.uuid);
+                              } else {
+                                toggleItem(item.uuid);
+                              }
+                              pendingShiftRef.current = false;
+                            }}
                             onClick={(e) => e.stopPropagation()}
                             aria-label={`Select item ${item.id}`}
-                            className="w-4 h-4 cursor-pointer accent-foreground"
+                            className="w-5 h-5 cursor-pointer accent-foreground"
                           />
                           <p className="text-sm text-foreground line-clamp-1">
                             {previewItemPayload(item.payload, taskType)}

--- a/src/app/human-alignment/tasks/[uuid]/page.tsx
+++ b/src/app/human-alignment/tasks/[uuid]/page.tsx
@@ -1641,6 +1641,18 @@ function LabellingTaskPageInner() {
   const [selectAllTotal, setSelectAllTotal] = useState(false);
 
   const toggleItem = (uuid: string) => {
+    if (selectAllTotal) {
+      // Leaving "select all across pages": the backend can't express
+      // "all except this one", so collapse to an explicit selection of
+      // the current page (every visible row was shown ticked) and drop
+      // the row the user just unticked.
+      const next = new Set(items.map((i) => i.uuid));
+      next.delete(uuid);
+      setSelectedItemIds(next);
+      setSelectAllTotal(false);
+      setLastSelectedItemUuid(uuid);
+      return;
+    }
     setSelectedItemIds((prev) => {
       const next = new Set(prev);
       if (next.has(uuid)) next.delete(uuid);
@@ -1648,8 +1660,6 @@ function LabellingTaskPageInner() {
       return next;
     });
     setLastSelectedItemUuid(uuid);
-    // Per-row interaction exits "select all across pages" mode.
-    setSelectAllTotal(false);
   };
 
   /**
@@ -1659,6 +1669,13 @@ function LabellingTaskPageInner() {
    * the anchor is missing.
    */
   const selectRangeTo = (targetUuid: string) => {
+    // In "select all across pages" mode every row is already ticked, so a
+    // shift+click degrades to a single toggle (which materialises the page
+    // selection and drops select-all).
+    if (selectAllTotal) {
+      toggleItem(targetUuid);
+      return;
+    }
     if (!lastSelectedItemUuid || lastSelectedItemUuid === targetUuid) {
       toggleItem(targetUuid);
       return;
@@ -1713,17 +1730,19 @@ function LabellingTaskPageInner() {
     });
   };
 
-  const allSelected = items.length > 0 && selectedItemIds.size === items.length;
-  const someSelected = selectedItemIds.size > 0 && !allSelected;
+  const allSelected =
+    selectAllTotal ||
+    (items.length > 0 && selectedItemIds.size === items.length);
+  const someSelected =
+    !selectAllTotal && selectedItemIds.size > 0 && !allSelected;
   const toggleSelectAll = () => {
-    setSelectedItemIds((prev) =>
-      prev.size === items.length
-        ? new Set()
-        : new Set(items.map((i) => i.uuid)),
-    );
-    // Header-checkbox toggle only acts on the current page; if the user
-    // was in "select all across pages" mode, drop back to page scope.
-    setSelectAllTotal(false);
+    if (allSelected) {
+      // Everything (current page, or all-across-pages) is selected → clear.
+      setSelectedItemIds(new Set());
+      setSelectAllTotal(false);
+    } else {
+      setSelectedItemIds(new Set(items.map((i) => i.uuid)));
+    }
   };
 
   /**
@@ -3050,7 +3069,8 @@ function LabellingTaskPageInner() {
                       typeof p.predicted_transcript === "string"
                         ? p.predicted_transcript
                         : "";
-                    const isSelected = selectedItemIds.has(item.uuid);
+                    const isSelected =
+                      selectAllTotal || selectedItemIds.has(item.uuid);
                     const labellerIds = labellersByItem.get(item.uuid);
                     return (
                       <Fragment key={item.uuid}>
@@ -3182,7 +3202,8 @@ function LabellingTaskPageInner() {
                     </div>
                   </div>
                   {items.map((item) => {
-                    const isSelected = selectedItemIds.has(item.uuid);
+                    const isSelected =
+                      selectAllTotal || selectedItemIds.has(item.uuid);
                     const labellerIds = labellersByItem.get(item.uuid);
                     const itemPayloadObj =
                       item.payload && typeof item.payload === "object"

--- a/src/app/human-alignment/tasks/[uuid]/page.tsx
+++ b/src/app/human-alignment/tasks/[uuid]/page.tsx
@@ -2887,40 +2887,51 @@ function LabellingTaskPageInner() {
               {/* Bulk-action toolbar (shown when at least one row is selected,
                   or when "select all across pages" is active). */}
               {(selectedItemIds.size > 0 || selectAllTotal) && (
-                <div className="flex items-center justify-between gap-3 rounded-md border border-border bg-muted/30 px-3 py-2">
-                  <span className="text-sm">
-                    <span className="font-medium">
-                      {selectAllTotal ? itemsTotal : selectedItemIds.size}
-                    </span>{" "}
-                    item
-                    {(selectAllTotal ? itemsTotal : selectedItemIds.size) === 1
-                      ? ""
-                      : "s"}{" "}
-                    selected
-                    {selectAllTotal && itemsSearch ? (
-                      <span className="text-muted-foreground">
-                        {" "}
-                        matching &ldquo;{itemsSearch}&rdquo;
-                      </span>
-                    ) : null}
+                <div
+                  className={`flex items-center justify-between gap-3 rounded-md border px-3 py-2 transition-colors ${
+                    selectAllTotal
+                      ? "border-amber-500/50 bg-amber-500/10"
+                      : "border-border bg-muted/30"
+                  }`}
+                >
+                  <div
+                    className={`flex items-center gap-2 text-sm ${
+                      selectAllTotal
+                        ? "text-amber-700 dark:text-amber-300"
+                        : ""
+                    }`}
+                  >
+                    <span>
+                      <span className="font-medium">
+                        {selectAllTotal ? itemsTotal : selectedItemIds.size}
+                      </span>{" "}
+                      item
+                      {(selectAllTotal
+                        ? itemsTotal
+                        : selectedItemIds.size) === 1
+                        ? ""
+                        : "s"}{" "}
+                      selected
+                      {selectAllTotal && itemsSearch ? (
+                        <span className="opacity-80">
+                          {" "}
+                          matching &ldquo;{itemsSearch}&rdquo;
+                        </span>
+                      ) : null}
+                    </span>
                     {!selectAllTotal &&
                       allSelected &&
                       itemsTotal > items.length && (
-                        <>
-                          .{" "}
-                          <button
-                            onClick={() => setSelectAllTotal(true)}
-                            className="font-medium text-foreground underline underline-offset-2 hover:opacity-80 cursor-pointer"
-                          >
-                            Select all {itemsTotal} item
-                            {itemsTotal === 1 ? "" : "s"}
-                            {itemsSearch
-                              ? ` matching "${itemsSearch}"`
-                              : ""}
-                          </button>
-                        </>
+                        <button
+                          onClick={() => setSelectAllTotal(true)}
+                          className="inline-flex items-center h-7 px-2.5 rounded-md text-xs font-medium border border-amber-500/40 bg-amber-500/10 text-amber-700 dark:text-amber-300 hover:bg-amber-500/20 hover:border-amber-500/60 transition-colors cursor-pointer whitespace-nowrap"
+                        >
+                          Select all {itemsTotal} item
+                          {itemsTotal === 1 ? "" : "s"}
+                          {itemsSearch ? ` matching "${itemsSearch}"` : ""}
+                        </button>
                       )}
-                  </span>
+                  </div>
                   <div className="flex items-center gap-2">
                     <button
                       onClick={() => {

--- a/src/app/human-alignment/tasks/[uuid]/page.tsx
+++ b/src/app/human-alignment/tasks/[uuid]/page.tsx
@@ -1628,6 +1628,18 @@ function LabellingTaskPageInner() {
    */
   const pendingShiftRef = useRef(false);
 
+  /**
+   * "Select all N rows across pages" mode. When true, bulk actions send
+   * `{ select_all: true, q? }` to the backend instead of an explicit
+   * `item_ids` list — so they apply to every item matching the current
+   * filter, not just the rows currently in `selectedItemIds`. Entered
+   * via the inline CTA in the bulk-action toolbar once the current
+   * page's "Select all" is checked AND there's more than one page;
+   * exited by any per-row interaction, by the Clear button, by a
+   * search change, or on action success.
+   */
+  const [selectAllTotal, setSelectAllTotal] = useState(false);
+
   const toggleItem = (uuid: string) => {
     setSelectedItemIds((prev) => {
       const next = new Set(prev);
@@ -1636,6 +1648,8 @@ function LabellingTaskPageInner() {
       return next;
     });
     setLastSelectedItemUuid(uuid);
+    // Per-row interaction exits "select all across pages" mode.
+    setSelectAllTotal(false);
   };
 
   /**
@@ -1665,6 +1679,8 @@ function LabellingTaskPageInner() {
       return next;
     });
     setLastSelectedItemUuid(targetUuid);
+    // Range selection is an explicit per-row gesture; drop "select all".
+    setSelectAllTotal(false);
   };
 
   /**
@@ -1705,7 +1721,20 @@ function LabellingTaskPageInner() {
         ? new Set()
         : new Set(items.map((i) => i.uuid)),
     );
+    // Header-checkbox toggle only acts on the current page; if the user
+    // was in "select all across pages" mode, drop back to page scope.
+    setSelectAllTotal(false);
   };
+
+  /**
+   * A change to the search query redefines what "all" means, so the
+   * across-pages select needs to be re-confirmed by the user. Pagination
+   * (`itemsOffset`) does NOT reset it — navigating between pages of the
+   * same filter shouldn't clear the user's "select all" intent.
+   */
+  useEffect(() => {
+    setSelectAllTotal(false);
+  }, [itemsSearch]);
 
   // Drop selections that no longer exist in the items list (after delete or refetch).
   useEffect(() => {
@@ -1760,23 +1789,41 @@ function LabellingTaskPageInner() {
   const [runDialogItemUuids, setRunDialogItemUuids] = useState<string[] | null>(
     null,
   );
+  /**
+   * When the user evaluated via the "select all across pages" CTA, we
+   * remember that here so `submitRunEvaluators` sends
+   * `{ select_all: true, q? }` instead of `item_ids`. Reset every time
+   * the run dialog is opened so a stale flag doesn't leak between flows.
+   */
+  const [runDialogSelectAll, setRunDialogSelectAll] = useState<{
+    q?: string;
+  } | null>(null);
   const [runDialogSubmitError, setRunDialogSubmitError] = useState<
     string | null
   >(null);
 
-  const handleRunEvaluators = (itemUuids?: string[] | string) => {
+  const handleRunEvaluators = (
+    target?: string[] | string | { selectAll: true; q?: string },
+  ) => {
     if (!accessToken || !uuid || startingRun) return;
     const linked = task?.evaluators ?? [];
     if (linked.length === 0) {
       toast.error("Link at least one evaluator before running.");
       return;
     }
-    const ids = Array.isArray(itemUuids)
-      ? itemUuids
-      : itemUuids
-        ? [itemUuids]
-        : null;
-    setRunDialogItemUuids(ids);
+    if (
+      target &&
+      typeof target === "object" &&
+      !Array.isArray(target) &&
+      "selectAll" in target
+    ) {
+      setRunDialogItemUuids(null);
+      setRunDialogSelectAll({ q: target.q });
+    } else {
+      const ids = Array.isArray(target) ? target : target ? [target] : null;
+      setRunDialogItemUuids(ids);
+      setRunDialogSelectAll(null);
+    }
     setRunDialogSubmitError(null);
     setRunDialogOpen(true);
   };
@@ -1786,11 +1833,17 @@ function LabellingTaskPageInner() {
   ) => {
     if (!accessToken || !uuid || startingRun) return;
     const ids = runDialogItemUuids;
+    const selectAll = runDialogSelectAll;
     setStartingRun(true);
     setRunDialogSubmitError(null);
     try {
       const body: Record<string, unknown> = { evaluators: selections };
-      if (ids && ids.length > 0) body.item_ids = ids;
+      if (selectAll) {
+        body.select_all = true;
+        if (selectAll.q) body.q = selectAll.q;
+      } else if (ids && ids.length > 0) {
+        body.item_ids = ids;
+      }
       const result = await apiClient<{
         job_uuid: string;
         status: string;
@@ -1918,19 +1971,24 @@ function LabellingTaskPageInner() {
   };
 
   const handleDeleteSelected = async () => {
-    if (selectedItemIds.size === 0 || !accessToken) return;
+    if ((selectedItemIds.size === 0 && !selectAllTotal) || !accessToken)
+      return;
     setDeletingSelected(true);
     try {
+      const body: Record<string, unknown> = selectAllTotal
+        ? {
+            select_all: true,
+            ...(itemsSearch ? { q: itemsSearch } : {}),
+          }
+        : { item_ids: Array.from(selectedItemIds) };
       await apiClient<{ deleted_count: number }>(
         `/annotation-tasks/${uuid}/items`,
         accessToken,
-        {
-          method: "DELETE",
-          body: { item_ids: Array.from(selectedItemIds) },
-        },
+        { method: "DELETE", body },
       );
       setDeleteSelectedOpen(false);
       setSelectedItemIds(new Set());
+      setSelectAllTotal(false);
       await Promise.all([fetchTask(), fetchTaskSummary()]);
     } catch (err) {
       setError(parseApiError(err, "Failed to delete items"));
@@ -2090,21 +2148,29 @@ function LabellingTaskPageInner() {
   }, []);
 
   const handleAssignAnnotators = async (annotatorIds: string[]) => {
-    if (selectedItemIds.size === 0 || annotatorIds.length === 0 || !accessToken)
+    if (
+      (selectedItemIds.size === 0 && !selectAllTotal) ||
+      annotatorIds.length === 0 ||
+      !accessToken
+    )
       return;
+    const body: Record<string, unknown> = {
+      annotator_ids: annotatorIds,
+      ...(selectAllTotal
+        ? {
+            select_all: true,
+            ...(itemsSearch ? { q: itemsSearch } : {}),
+          }
+        : { item_ids: Array.from(selectedItemIds) }),
+    };
     const result = await apiClient<{ count: number; jobs: CreatedJob[] }>(
       `/annotation-tasks/${uuid}/jobs`,
       accessToken,
-      {
-        method: "POST",
-        body: {
-          annotator_ids: annotatorIds,
-          item_ids: Array.from(selectedItemIds),
-        },
-      },
+      { method: "POST", body },
     );
     setAssignOpen(false);
     setSelectedItemIds(new Set());
+    setSelectAllTotal(false);
     setCreatedJobs(result.jobs ?? []);
     setJobsCreatedOpen(true);
     fetchTask();
@@ -2818,16 +2884,49 @@ function LabellingTaskPageInner() {
                   />
                 </div>
               </div>
-              {/* Bulk-action toolbar (shown when at least one row is selected) */}
-              {selectedItemIds.size > 0 && (
+              {/* Bulk-action toolbar (shown when at least one row is selected,
+                  or when "select all across pages" is active). */}
+              {(selectedItemIds.size > 0 || selectAllTotal) && (
                 <div className="flex items-center justify-between gap-3 rounded-md border border-border bg-muted/30 px-3 py-2">
                   <span className="text-sm">
-                    <span className="font-medium">{selectedItemIds.size}</span>{" "}
-                    item{selectedItemIds.size === 1 ? "" : "s"} selected
+                    <span className="font-medium">
+                      {selectAllTotal ? itemsTotal : selectedItemIds.size}
+                    </span>{" "}
+                    item
+                    {(selectAllTotal ? itemsTotal : selectedItemIds.size) === 1
+                      ? ""
+                      : "s"}{" "}
+                    selected
+                    {selectAllTotal && itemsSearch ? (
+                      <span className="text-muted-foreground">
+                        {" "}
+                        matching &ldquo;{itemsSearch}&rdquo;
+                      </span>
+                    ) : null}
+                    {!selectAllTotal &&
+                      allSelected &&
+                      itemsTotal > items.length && (
+                        <>
+                          .{" "}
+                          <button
+                            onClick={() => setSelectAllTotal(true)}
+                            className="font-medium text-foreground underline underline-offset-2 hover:opacity-80 cursor-pointer"
+                          >
+                            Select all {itemsTotal} item
+                            {itemsTotal === 1 ? "" : "s"}
+                            {itemsSearch
+                              ? ` matching "${itemsSearch}"`
+                              : ""}
+                          </button>
+                        </>
+                      )}
                   </span>
                   <div className="flex items-center gap-2">
                     <button
-                      onClick={() => setSelectedItemIds(new Set())}
+                      onClick={() => {
+                        setSelectedItemIds(new Set());
+                        setSelectAllTotal(false);
+                      }}
                       className="h-8 px-3 rounded-md text-sm font-medium text-muted-foreground hover:text-foreground hover:bg-muted transition-colors cursor-pointer"
                     >
                       Clear
@@ -2840,19 +2939,13 @@ function LabellingTaskPageInner() {
                     </button>
                     <button
                       onClick={() => {
-                        const selected = Array.from(selectedItemIds);
-                        // Omit item_ids when every item in the entire
-                        // task is selected (selection is page-scoped, so
-                        // we only hit this when the task has ≤ one
-                        // page and every row on it is selected).
-                        if (
-                          itemsTotal > 0 &&
-                          selected.length === itemsTotal &&
-                          selected.length === items.length
-                        ) {
-                          handleRunEvaluators();
+                        if (selectAllTotal) {
+                          handleRunEvaluators({
+                            selectAll: true,
+                            q: itemsSearch || undefined,
+                          });
                         } else {
-                          handleRunEvaluators(selected);
+                          handleRunEvaluators(Array.from(selectedItemIds));
                         }
                       }}
                       disabled={startingRun}
@@ -3006,7 +3099,7 @@ function LabellingTaskPageInner() {
                             itemUuid={item.uuid}
                             onDelete={requestDeleteOneItem}
                             onLabel={
-                              selectedItemIds.size === 0
+                              selectedItemIds.size === 0 && !selectAllTotal
                                 ? (uuid) => {
                                     // Sole row → skip the select-then-bulk
                                     // dance and open the assign dialog
@@ -3025,7 +3118,7 @@ function LabellingTaskPageInner() {
                               setEditSttItemsOpen(true);
                             }}
                             onEvaluate={
-                              selectedItemIds.size === 0
+                              selectedItemIds.size === 0 && !selectAllTotal
                                 ? (uuid) => {
                                     if (items.length === 1) {
                                       setSelectedItemIds(new Set([uuid]));
@@ -3151,7 +3244,7 @@ function LabellingTaskPageInner() {
                             itemUuid={item.uuid}
                             onDelete={requestDeleteOneItem}
                             onLabel={
-                              selectedItemIds.size === 0
+                              selectedItemIds.size === 0 && !selectAllTotal
                                 ? (uuid) => {
                                     // Sole row → skip the select-then-bulk
                                     // dance and open the assign dialog
@@ -3167,7 +3260,7 @@ function LabellingTaskPageInner() {
                             }
                             onEdit={(uuid) => setEditLlmItemUuid(uuid)}
                             onEvaluate={
-                              selectedItemIds.size === 0
+                              selectedItemIds.size === 0 && !selectAllTotal
                                 ? (uuid) => {
                                     if (items.length === 1) {
                                       setSelectedItemIds(new Set([uuid]));
@@ -3824,6 +3917,7 @@ function LabellingTaskPageInner() {
           setEditSttItemsOpen(false);
           setEditSttSingleItemUuid(null);
           setSelectedItemIds(new Set());
+          setSelectAllTotal(false);
         }}
       />
 
@@ -3831,7 +3925,9 @@ function LabellingTaskPageInner() {
         <AssignAnnotatorsDialog
           isOpen={assignOpen}
           accessToken={accessToken}
-          selectedItemCount={selectedItemIds.size}
+          selectedItemCount={
+            selectAllTotal ? itemsTotal : selectedItemIds.size
+          }
           onClose={() => setAssignOpen(false)}
           onConfirm={handleAssignAnnotators}
         />
@@ -3850,7 +3946,19 @@ function LabellingTaskPageInner() {
         }}
         onConfirm={handleDeleteSelected}
         title="Delete items"
-        message={`Delete ${selectedItemIds.size} item${selectedItemIds.size === 1 ? "" : "s"}? Any annotations on ${selectedItemIds.size === 1 ? "this item" : "these items"} will also be lost. This cannot be undone.`}
+        message={(() => {
+          const count = selectAllTotal ? itemsTotal : selectedItemIds.size;
+          const itemWord = count === 1 ? "item" : "items";
+          const annotationsClause =
+            count === 1
+              ? "Any annotations on this item will also be lost."
+              : "Any annotations on these items will also be lost.";
+          const scopeClause =
+            selectAllTotal && itemsSearch
+              ? ` matching "${itemsSearch}"`
+              : "";
+          return `Delete ${count} ${itemWord}${scopeClause}? ${annotationsClause} This cannot be undone.`;
+        })()}
         confirmText="Delete"
         isDeleting={deletingSelected}
       />

--- a/src/components/AddTestDialog.tsx
+++ b/src/components/AddTestDialog.tsx
@@ -1371,31 +1371,43 @@ export function AddTestDialog({
       <div className="relative w-full max-w-7xl h-[95vh] md:h-[85vh] mx-2 md:mx-4 bg-background rounded-xl md:rounded-2xl shadow-2xl flex flex-col md:flex-row overflow-hidden border border-border">
         {/* Left Column - Form */}
         <div className="w-full md:w-2/5 flex flex-col border-b md:border-b-0 md:border-r border-border">
-          {/* Tabs — hidden in labelItem mode (always next-reply) */}
-          {!isLabelItem && (
-            <div className="flex border-b border-border">
-              <button
-                onClick={() => setActiveTab("next-reply")}
-                className={`flex-1 py-3 md:py-4 text-sm md:text-base font-medium transition-colors cursor-pointer ${
-                  activeTab === "next-reply"
-                    ? "text-foreground border-b-2 border-foreground"
-                    : "text-muted-foreground hover:text-foreground"
-                }`}
-              >
-                Next reply test
-              </button>
-              <button
-                onClick={() => setActiveTab("tool-invocation")}
-                className={`flex-1 py-3 md:py-4 text-sm md:text-base font-medium transition-colors cursor-pointer ${
-                  activeTab === "tool-invocation"
-                    ? "text-foreground border-b-2 border-foreground"
-                    : "text-muted-foreground hover:text-foreground"
-                }`}
-              >
-                Tool invocation test
-              </button>
-            </div>
-          )}
+          {/* Tabs — hidden in labelItem mode (always next-reply). When
+              editing an existing test the type is fixed (the backend no
+              longer allows changing a test's type), so we show only the
+              matching view's label as a static, non-switchable header. */}
+          {!isLabelItem &&
+            (isEditing ? (
+              <div className="flex border-b border-border">
+                <div className="flex-1 py-3 md:py-4 text-sm md:text-base font-medium text-foreground border-b-2 border-foreground text-center">
+                  {activeTab === "tool-invocation"
+                    ? "Tool invocation test"
+                    : "Next reply test"}
+                </div>
+              </div>
+            ) : (
+              <div className="flex border-b border-border">
+                <button
+                  onClick={() => setActiveTab("next-reply")}
+                  className={`flex-1 py-3 md:py-4 text-sm md:text-base font-medium transition-colors cursor-pointer ${
+                    activeTab === "next-reply"
+                      ? "text-foreground border-b-2 border-foreground"
+                      : "text-muted-foreground hover:text-foreground"
+                  }`}
+                >
+                  Next reply test
+                </button>
+                <button
+                  onClick={() => setActiveTab("tool-invocation")}
+                  className={`flex-1 py-3 md:py-4 text-sm md:text-base font-medium transition-colors cursor-pointer ${
+                    activeTab === "tool-invocation"
+                      ? "text-foreground border-b-2 border-foreground"
+                      : "text-muted-foreground hover:text-foreground"
+                  }`}
+                >
+                  Tool invocation test
+                </button>
+              </div>
+            ))}
 
           {/* Content */}
           <div className="flex-1 overflow-y-auto overflow-x-visible p-4 md:p-6">

--- a/src/components/EvaluatorPills.tsx
+++ b/src/components/EvaluatorPills.tsx
@@ -21,8 +21,8 @@ export function DefaultPill() {
 export const EVALUATOR_TYPE_LABELS: Record<EvaluatorType, string> = {
   tts: "Text to Speech",
   stt: "Speech to Text",
-  llm: "LLM Response",
-  simulation: "Simulation",
+  llm: "Single LLM response",
+  simulation: "Full conversation",
 };
 
 export const EVALUATOR_TYPE_TOOLTIPS: Record<EvaluatorType, string> = {

--- a/src/components/human-labelling/CreateLabellingTaskDialog.tsx
+++ b/src/components/human-labelling/CreateLabellingTaskDialog.tsx
@@ -20,7 +20,7 @@ const TASK_TYPE_OPTIONS: {
 }[] = [
   {
     value: "llm",
-    title: "LLM response",
+    title: "Single LLM response",
     description:
       "Given a conversation history, evaluate the agent's next response.",
   },
@@ -31,7 +31,7 @@ const TASK_TYPE_OPTIONS: {
   },
   {
     value: "simulation",
-    title: "Simulation",
+    title: "Full conversation",
     description:
       "Evaluate the agent's performance during a complete conversation.",
   },


### PR DESCRIPTION
Fix #164 
Fix #167 
Fix #170

## Summary

A handful of small human-alignment UX fixes, bundled:

- **Rename evaluator/task types** for clarity: *LLM response* → **Single LLM response**, *Simulation* → **Full conversation**. Applied in the evaluator type picker, the labelling task picker, and the type pill — same labels everywhere users see them.
- **Shift+click range selection** on labelling items. Track the most recently clicked row as an anchor; shift+click on another row's checkbox (or anywhere on the row) selects the inclusive range in the current sorted order. Captures `shiftKey` on `mousedown` via a ref so the native `onChange` flow stays intact and the controlled `checked` prop doesn't desync.
- **Bigger checkboxes** on the items tables (`w-4` → `w-5`) — easier hit target. Jobs table unchanged.
- **Skip empty Overview** on `/human-alignment`. When the agreement overview would render its empty state and the user didn't deep-link `?tab=overview`, auto-switch to the Tasks tab so they land on something actionable. Fires once per session, respects explicit URLs.

## Test plan

- [ ] On `/evaluators` and inside the create-labelling-task dialog, the type picker shows **Single LLM response** and **Full conversation**; evaluator pills on existing evaluators read the new labels.
- [ ] On `/human-alignment/tasks/<uuid>`:
  - [ ] Click a row's checkbox → that row's tick appears, toolbar shows "1 item selected".
  - [ ] Click another row's checkbox while holding shift → all rows between the two are selected, *including* both endpoints. Try landing the shift+click directly on the checkbox and on the row body.
  - [ ] Shift+click on a row body doesn't open the item detail dialog and doesn't leave a stray text-selection range.
  - [ ] Plain row click still opens the item detail dialog.
  - [ ] Checkboxes look noticeably larger than before.
- [ ] Visit `/human-alignment` fresh with no agreement data → land on the Tasks tab automatically; URL becomes `?tab=tasks`.
- [ ] Visit `/human-alignment?tab=overview` directly → stay on Overview even when empty.
- [ ] Visit `/human-alignment` with existing agreement data → still land on Overview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)