### PR TITLE
Add Conversation test type with simulation-evaluator picker

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -96,3 +96,25 @@ body {
     animation: none;
   }
 }
+
+/* Dialog entrance: scale + fade (e.g. AddTestDialog create-phase intro) */
+@keyframes scale-in {
+  from {
+    opacity: 0;
+    transform: scale(0.95);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+.animate-in-scale {
+  animation: scale-in 0.2s ease-out;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .animate-in-scale {
+    animation: none;
+  }
+}

--- a/src/app/tests/page.tsx
+++ b/src/app/tests/page.tsx
@@ -44,7 +44,7 @@ type TestData = {
   uuid: string;
   name: string;
   description: string;
-  type: "response" | "tool_call";
+  type: "response" | "tool_call" | "conversation";
   config: Record<string, any>;
   evaluators?: TestEvaluatorRow[] | null;
   created_at: string;
@@ -169,7 +169,7 @@ function LLMPageInner() {
   const [isLoadingTest, setIsLoadingTest] = useState(false);
   const [validationAttempted, setValidationAttempted] = useState(false);
   const [initialTab, setInitialTab] = useState<
-    "next-reply" | "tool-invocation" | undefined
+    "next-reply" | "tool-invocation" | "conversation" | undefined
   >(undefined);
   const [initialConfig, setInitialConfig] = useState<TestConfig | undefined>(
     undefined
@@ -608,7 +608,9 @@ function LLMPageInner() {
         throw new Error("BACKEND_URL environment variable is not set");
       }
 
-      const isResponse = config.evaluation.type === "response";
+      const evalType = config.evaluation.type;
+      const usesEvaluators =
+        evalType === "response" || evalType === "conversation";
       const testItem: {
         name: string;
         conversation_history: TestConfig["history"];
@@ -618,7 +620,7 @@ function LLMPageInner() {
         name: newTestName.trim(),
         conversation_history: config.history,
       };
-      if (isResponse) {
+      if (usesEvaluators) {
         testItem.evaluators = evaluators;
       } else {
         testItem.tool_calls = config.evaluation.tool_calls ?? [];
@@ -726,7 +728,11 @@ function LLMPageInner() {
       );
       // Set initial tab based on test type
       setInitialTab(
-        testData.type === "tool_call" ? "tool-invocation" : "next-reply"
+        testData.type === "tool_call"
+          ? "tool-invocation"
+          : testData.type === "conversation"
+          ? "conversation"
+          : "next-reply"
       );
       // Set initial config to populate dialog fields
       if (testData.config) {
@@ -776,12 +782,13 @@ function LLMPageInner() {
         throw new Error("BACKEND_URL environment variable is not set");
       }
 
-      // For next-reply tests we send `evaluators` so the backend replaces the
-      // whole pivot set. For tool-invocation tests we omit `evaluators`
-      // entirely so existing links (if any) are left untouched.
+      // For next-reply / conversation tests we send `evaluators` so the
+      // backend replaces the whole pivot set. For tool-invocation tests we
+      // omit `evaluators` entirely so existing links (if any) are left
+      // untouched.
       const body: {
         name: string;
-        type: "response" | "tool_call";
+        type: "response" | "tool_call" | "conversation";
         config: TestConfig;
         evaluators?: EvaluatorRefPayload[];
       } = {
@@ -789,7 +796,10 @@ function LLMPageInner() {
         type: config.evaluation.type,
         config: config,
       };
-      if (config.evaluation.type === "response") {
+      if (
+        config.evaluation.type === "response" ||
+        config.evaluation.type === "conversation"
+      ) {
         body.evaluators = evaluators;
       }
 
@@ -1155,6 +1165,8 @@ function LLMPageInner() {
                       ? "Next Reply"
                       : test.type === "tool_call"
                       ? "Tool Call"
+                      : test.type === "conversation"
+                      ? "Conversation"
                       : "—"}
                   </p>
                   <div className="flex items-center gap-1">

--- a/src/app/tests/page.tsx
+++ b/src/app/tests/page.tsx
@@ -23,6 +23,7 @@ import {
 } from "@/components/AddTestDialog";
 import { BulkUploadTestsModal } from "@/components/BulkUploadTestsModal";
 import { useSidebarState } from "@/lib/sidebar";
+import { testTypeLabel } from "@/lib/testTypes";
 import { POLLING_INTERVAL_MS } from "@/constants/polling";
 import {
   readBulkNameConflictMessage,
@@ -1161,13 +1162,7 @@ function LLMPageInner() {
                     </p>
                   </div>
                   <p className="text-sm text-muted-foreground">
-                    {test.type === "response"
-                      ? "Next Reply"
-                      : test.type === "tool_call"
-                      ? "Tool Call"
-                      : test.type === "conversation"
-                      ? "Conversation"
-                      : "—"}
+                    {testTypeLabel(test.type, "—")}
                   </p>
                   <div className="flex items-center gap-1">
                     {/* Play Button */}
@@ -1267,11 +1262,7 @@ function LLMPageInner() {
                           {test.name}
                         </div>
                         <div className="text-xs text-muted-foreground">
-                          {test.type === "response"
-                            ? "Next Reply"
-                            : test.type === "tool_call"
-                            ? "Tool Call"
-                            : "—"}
+                          {testTypeLabel(test.type, "—")}
                         </div>
                       </div>
                     </div>

--- a/src/components/AddTestDialog.tsx
+++ b/src/components/AddTestDialog.tsx
@@ -54,6 +54,40 @@ export type TestConfig = {
 // Evaluator type for the conversation tab — picker is filtered to this.
 const CONVERSATION_EVALUATOR_TYPE = "simulation";
 
+type TestTab = "next-reply" | "tool-invocation" | "conversation";
+
+// The three selectable test types, shared by the create-phase intro picker
+// (large cards) and the compact in-dialog type switcher (top-left boxes) so
+// both surfaces stay in sync. `label` is the short box label; `title` is the
+// full heading; `description` is the one-liner shown on the intro cards.
+const TEST_TYPE_OPTIONS: Array<{
+  tab: TestTab;
+  label: string;
+  title: string;
+  description: string;
+}> = [
+  {
+    tab: "next-reply",
+    label: "Next reply",
+    title: "Next reply test",
+    description: "Evaluate the agent's response given a conversation history.",
+  },
+  {
+    tab: "tool-invocation",
+    label: "Tool call",
+    title: "Tool call test",
+    description:
+      "Check whether the agent invokes the correct tool with the right arguments.",
+  },
+  {
+    tab: "conversation",
+    label: "Conversation",
+    title: "Conversation test",
+    description:
+      "Generate the agent's reply, then grade the full conversation as a whole.",
+  },
+];
+
 export type EvaluatorVariableDef = {
   name: string;
   description?: string;
@@ -174,14 +208,50 @@ export function AddTestDialog({
   const ItemNoun = isLabelItem ? "Item" : "Test";
 
   const backendAccessToken = useAccessToken();
-  const [activeTab, setActiveTab] = useState<
-    "next-reply" | "tool-invocation" | "conversation"
-  >(isLabelItem ? "next-reply" : initialTab || "next-reply");
+  const [activeTab, setActiveTab] = useState<TestTab>(
+    isLabelItem ? "next-reply" : initialTab || "next-reply",
+  );
   // Tabs that pair the conversation history with attached evaluators (vs. the
   // tool-invocation tab, which uses a tool picker instead). Used to gate the
   // shared evaluator-related UI and validation paths below.
   const isEvaluatorTab =
     activeTab === "next-reply" || activeTab === "conversation";
+
+  // Two-phase create flow: when creating a brand-new test we first show a
+  // centred type picker (the same three boxes as the bulk-upload modal),
+  // then animate into the full editor. Editing (type is immutable) and
+  // labelItem mode skip the intro entirely. `typeChosen` gates which phase
+  // renders; `editorEntered` drives the entrance transition once chosen.
+  const showTypeIntroFlow = !isLabelItem && !isEditing;
+  const [typeChosen, setTypeChosen] = useState<boolean>(!showTypeIntroFlow);
+  const [editorEntered, setEditorEntered] = useState<boolean>(!showTypeIntroFlow);
+
+  // Reset the phase whenever the dialog (re)opens so a fresh create always
+  // starts on the picker and an edit always lands straight in the editor.
+  useEffect(() => {
+    if (!isOpen) return;
+    const skipIntro = isLabelItem || isEditing;
+    setTypeChosen(skipIntro);
+    setEditorEntered(skipIntro);
+  }, [isOpen, isLabelItem, isEditing]);
+
+  // Drive the editor's scale/opacity entrance on the frame after the type is
+  // chosen, so the swap from the intro picker reads as an animation.
+  useEffect(() => {
+    if (!typeChosen) {
+      setEditorEntered(false);
+      return;
+    }
+    if (editorEntered) return;
+    const raf = requestAnimationFrame(() => setEditorEntered(true));
+    return () => cancelAnimationFrame(raf);
+  }, [typeChosen, editorEntered]);
+
+  // Pick a type from the intro picker and slide into the full editor.
+  const chooseTestType = (tab: TestTab) => {
+    setActiveTab(tab);
+    setTypeChosen(true);
+  };
 
   // Available tools state - declared early so it's available for initialConfig parsing
   const [availableTools, setAvailableTools] = useState<AvailableTool[]>([]);
@@ -1345,13 +1415,72 @@ export function AddTestDialog({
 
   if (!isOpen) return null;
 
+  // During the intro picker nothing has been entered yet, so a backdrop
+  // click can close immediately without the "discard changes?" guard.
+  const handleBackdropDismiss = typeChosen ? handleBackdropClick : onClose;
+
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center">
       {/* Backdrop */}
       <div
         className="absolute inset-0 bg-black/50 backdrop-blur-sm"
-        onClick={handleBackdropClick}
+        onClick={handleBackdropDismiss}
       />
+
+      {/* Create-phase intro: centred type picker (the same three boxes the
+          bulk-upload modal uses). Selecting a box animates into the full
+          editor, where a compact version of the same boxes stays in the
+          top-left so the type can still be switched while creating. */}
+      {!typeChosen && (
+        <div className="relative w-full max-w-2xl mx-4 bg-background rounded-2xl shadow-2xl border border-border flex flex-col overflow-hidden animate-in-scale">
+          <div className="flex items-center justify-between px-6 py-4 border-b border-border">
+            <h2 className="text-lg font-semibold text-foreground">
+              Create a test
+            </h2>
+            <button
+              onClick={onClose}
+              className="w-8 h-8 flex items-center justify-center rounded-lg text-muted-foreground hover:text-foreground hover:bg-muted transition-colors cursor-pointer"
+              aria-label="Close"
+            >
+              <svg
+                className="w-5 h-5"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+                strokeWidth={2}
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M6 18L18 6M6 6l12 12"
+                />
+              </svg>
+            </button>
+          </div>
+          <div className="px-6 py-5">
+            <label className="block text-sm font-medium text-foreground mb-3">
+              Select the type of test
+            </label>
+            <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+              {TEST_TYPE_OPTIONS.map((opt) => (
+                <button
+                  key={opt.tab}
+                  type="button"
+                  onClick={() => chooseTestType(opt.tab)}
+                  className="text-left px-4 py-3 rounded-lg border border-border bg-background hover:bg-muted/50 hover:border-foreground/40 transition-colors cursor-pointer"
+                >
+                  <div className="text-sm font-medium mb-0.5 text-foreground">
+                    {opt.title}
+                  </div>
+                  <div className="text-xs leading-snug text-muted-foreground">
+                    {opt.description}
+                  </div>
+                </button>
+              ))}
+            </div>
+          </div>
+        </div>
+      )}
 
       {/* Close Confirmation Dialog */}
       {showCloseConfirmation && (
@@ -1387,7 +1516,12 @@ export function AddTestDialog({
       )}
 
       {/* Dialog */}
-      <div className="relative w-full max-w-7xl h-[95vh] md:h-[85vh] mx-2 md:mx-4 bg-background rounded-xl md:rounded-2xl shadow-2xl flex flex-col md:flex-row overflow-hidden border border-border">
+      {typeChosen && (
+      <div
+        className={`relative w-full max-w-7xl h-[95vh] md:h-[85vh] mx-2 md:mx-4 bg-background rounded-xl md:rounded-2xl shadow-2xl flex flex-col md:flex-row overflow-hidden border border-border transition-all duration-300 ease-out ${
+          editorEntered ? "opacity-100 scale-100" : "opacity-0 scale-95"
+        }`}
+      >
         {/* Left Column - Form */}
         <div className="w-full md:w-2/5 flex flex-col border-b md:border-b-0 md:border-r border-border">
           {/* Tabs — hidden in labelItem mode (always next-reply). When
@@ -1399,44 +1533,31 @@ export function AddTestDialog({
               <div className="flex border-b border-border">
                 <div className="flex-1 py-3 md:py-4 text-sm md:text-base font-medium text-foreground border-b-2 border-foreground text-center">
                   {activeTab === "tool-invocation"
-                    ? "Tool invocation test"
+                    ? "Tool call test"
                     : activeTab === "conversation"
                       ? "Conversation test"
                       : "Next reply test"}
                 </div>
               </div>
             ) : (
-              <div className="flex border-b border-border">
-                <button
-                  onClick={() => setActiveTab("next-reply")}
-                  className={`flex-1 py-3 md:py-4 text-sm md:text-base font-medium transition-colors cursor-pointer ${
-                    activeTab === "next-reply"
-                      ? "text-foreground border-b-2 border-foreground"
-                      : "text-muted-foreground hover:text-foreground"
-                  }`}
-                >
-                  Next reply test
-                </button>
-                <button
-                  onClick={() => setActiveTab("tool-invocation")}
-                  className={`flex-1 py-3 md:py-4 text-sm md:text-base font-medium transition-colors cursor-pointer ${
-                    activeTab === "tool-invocation"
-                      ? "text-foreground border-b-2 border-foreground"
-                      : "text-muted-foreground hover:text-foreground"
-                  }`}
-                >
-                  Tool invocation test
-                </button>
-                <button
-                  onClick={() => setActiveTab("conversation")}
-                  className={`flex-1 py-3 md:py-4 text-sm md:text-base font-medium transition-colors cursor-pointer ${
-                    activeTab === "conversation"
-                      ? "text-foreground border-b-2 border-foreground"
-                      : "text-muted-foreground hover:text-foreground"
-                  }`}
-                >
-                  Conversation test
-                </button>
+              // Create phase: the same three boxes from the intro picker,
+              // rendered compactly in the top-left so the type can still be
+              // switched mid-create.
+              <div className="flex gap-2 p-3 border-b border-border">
+                {TEST_TYPE_OPTIONS.map((opt) => (
+                  <button
+                    key={opt.tab}
+                    onClick={() => setActiveTab(opt.tab)}
+                    title={opt.title}
+                    className={`flex-1 min-w-0 px-2 py-2 rounded-lg border text-xs md:text-sm font-medium transition-colors cursor-pointer truncate ${
+                      activeTab === opt.tab
+                        ? "bg-foreground text-background border-foreground"
+                        : "bg-background border-border text-muted-foreground hover:bg-muted/50 hover:text-foreground"
+                    }`}
+                  >
+                    {opt.label}
+                  </button>
+                ))}
               </div>
             ))}
 
@@ -3088,6 +3209,7 @@ export function AddTestDialog({
           </div>
         </div>
       </div>
+      )}
     </div>
   );
 }

--- a/src/components/AddTestDialog.tsx
+++ b/src/components/AddTestDialog.tsx
@@ -2266,10 +2266,10 @@ export function AddTestDialog({
                   {requireAssistantLastMessage
                     ? "Your evaluators read this whole conversation and evaluate the last agent message (the one highlighted) against the evaluators. Only that final reply is scored."
                     : activeTab === "conversation"
-                      ? "The agent generates its reply given the conversation and the entire conversation is then graded against the evaluators"
+                      ? "Given the conversation history, the agent generates a response and the full updated conversation is graded using the evaluators added to the test"
                       : activeTab === "tool-invocation"
-                        ? "The tool call the agent makes in response to the last user message, given the conversation history, will be checked against the expected tool calls configured for this test"
-                        : "The agent's response to the last user message, given the conversation history, will be evaluated against the evaluators added to the test"}
+                        ? "Given the conversation history, the agent makes a tool call which is checked against the expected tool calls configured for this test"
+                        : "Given the conversation history, the agent generates a response which is graded using the evaluators added to the test"}
                 </p>
               </div>
             </div>
@@ -2938,7 +2938,7 @@ export function AddTestDialog({
                                             addChatMessage("user");
                                             setAddMessageDropdownOpen(false);
                                           }}
-                                          className="w-full px-3 py-1.5 flex items-center gap-2 transition-colors cursor-pointer bg-amber-500/15 text-amber-900 dark:bg-amber-500/20 dark:text-amber-100 hover:bg-amber-500/25 dark:hover:bg-amber-500/30"
+                                          className="w-full px-3 py-1.5 flex items-center gap-2 transition-colors cursor-pointer bg-amber-500/10 text-amber-700 dark:bg-amber-500/12 dark:text-amber-200 hover:bg-amber-500/18 dark:hover:bg-amber-500/20"
                                         >
                                           <svg
                                             className="w-4 h-4"
@@ -2962,7 +2962,7 @@ export function AddTestDialog({
                                             addChatMessage("agent");
                                             setAddMessageDropdownOpen(false);
                                           }}
-                                          className="w-full px-3 py-1.5 flex items-center gap-2 transition-colors cursor-pointer bg-sky-500/15 text-sky-900 dark:bg-sky-500/20 dark:text-sky-100 hover:bg-sky-500/25 dark:hover:bg-sky-500/30"
+                                          className="w-full px-3 py-1.5 flex items-center gap-2 transition-colors cursor-pointer bg-sky-500/10 text-sky-700 dark:bg-sky-500/12 dark:text-sky-200 hover:bg-sky-500/18 dark:hover:bg-sky-500/20"
                                         >
                                           <svg
                                             className="w-4 h-4"
@@ -2986,7 +2986,7 @@ export function AddTestDialog({
                                             setAddMessageDropdownOpen(false);
                                             setToolCallDropdownOpen(true);
                                           }}
-                                          className="w-full px-3 py-1.5 flex items-center gap-2 transition-colors cursor-pointer bg-fuchsia-500/15 text-fuchsia-900 dark:bg-fuchsia-500/20 dark:text-fuchsia-100 hover:bg-fuchsia-500/25 dark:hover:bg-fuchsia-500/30"
+                                          className="w-full px-3 py-1.5 flex items-center gap-2 transition-colors cursor-pointer bg-fuchsia-500/10 text-fuchsia-700 dark:bg-fuchsia-500/12 dark:text-fuchsia-200 hover:bg-fuchsia-500/18 dark:hover:bg-fuchsia-500/20"
                                         >
                                           <svg
                                             className="w-4 h-4"

--- a/src/components/AddTestDialog.tsx
+++ b/src/components/AddTestDialog.tsx
@@ -455,13 +455,15 @@ export function AddTestDialog({
       // since that's the message being graded.
       return [u("1"), a("2")];
     }
-    if (allowAgentLastMessage || activeTab === "conversation") {
-      // Simulation add-item / conversation test: a short but complete
-      // conversation transcript (any role can be last).
+    if (allowAgentLastMessage) {
+      // Simulation add-item: a short but complete conversation transcript
+      // (any role can be last).
       return [u("1"), a("2"), u("3"), a("4"), u("5"), a("6")];
     }
-    // Default test: user → agent → user (final user turn is what the agent
-    // will reply to when the test runs).
+    // Default test (next-reply AND conversation): user → agent → user. The
+    // final user turn is what the agent will reply to when the test runs —
+    // conversation tests also generate the agent's next reply live, then
+    // judge the full conversation, so they must end on a user turn too.
     return [u("1"), a("2"), u("3")];
   });
 
@@ -2050,12 +2052,12 @@ export function AddTestDialog({
                 if (requireAssistantLastMessage) {
                   isLastMessageInvalid =
                     isEmpty || lastMessage?.role !== "agent";
-                } else if (
-                  allowAgentLastMessage ||
-                  activeTab === "conversation"
-                ) {
+                } else if (allowAgentLastMessage) {
                   isLastMessageInvalid = isEmpty;
                 } else {
+                  // Next-reply AND conversation tests run the agent against
+                  // the trailing user turn, so the history must end on a
+                  // user message, not an agent one.
                   isLastMessageInvalid =
                     isEmpty || lastMessage?.role === "agent";
                 }
@@ -2141,7 +2143,7 @@ export function AddTestDialog({
                 {requireAssistantLastMessage
                   ? "Your evaluators read this whole conversation and evaluate the last agent message (the one highlighted) against the evaluators. Only that final reply is scored."
                   : activeTab === "conversation"
-                    ? "Your evaluators read the entire conversation history and grade it as a whole against the evaluators added to the test."
+                    ? "The agent generates its reply to the last user message; the full conversation (history plus that generated reply) is then graded against the evaluators added to the test."
                     : "The agent's response to the last user message, given the conversation history, will be evaluated against the evaluators added to the test"}
               </p>
             </div>

--- a/src/components/AddTestDialog.tsx
+++ b/src/components/AddTestDialog.tsx
@@ -40,7 +40,7 @@ export type TestConfig = {
     created_at?: string;
   }>;
   evaluation: {
-    type: "tool_call" | "response";
+    type: "tool_call" | "response" | "conversation";
     tool_calls?: Array<{
       tool: string;
       arguments: Record<string, any>;
@@ -50,6 +50,9 @@ export type TestConfig = {
     criteria?: string;
   };
 };
+
+// Evaluator type for the conversation tab — picker is filtered to this.
+const CONVERSATION_EVALUATOR_TYPE = "simulation";
 
 export type EvaluatorVariableDef = {
   name: string;
@@ -93,6 +96,8 @@ type LLMEvaluatorOption = {
   slug: string | null;
   owner_user_id: string | null;
   variables: EvaluatorVariableDef[];
+  /** "llm" for next-reply tab, "simulation" for conversation tab. */
+  evaluator_type?: string;
 };
 
 type AddTestDialogProps = {
@@ -114,7 +119,7 @@ type AddTestDialogProps = {
   setItemDescription?: (description: string) => void;
   validationAttempted: boolean;
   onSubmit: (config: TestConfig, evaluators: EvaluatorRefPayload[]) => void;
-  initialTab?: "next-reply" | "tool-invocation";
+  initialTab?: "next-reply" | "tool-invocation" | "conversation";
   initialConfig?: TestConfig;
   initialEvaluators?: AttachedEvaluatorInit[];
   /**
@@ -169,9 +174,14 @@ export function AddTestDialog({
   const ItemNoun = isLabelItem ? "Item" : "Test";
 
   const backendAccessToken = useAccessToken();
-  const [activeTab, setActiveTab] = useState<"next-reply" | "tool-invocation">(
-    isLabelItem ? "next-reply" : initialTab || "next-reply",
-  );
+  const [activeTab, setActiveTab] = useState<
+    "next-reply" | "tool-invocation" | "conversation"
+  >(isLabelItem ? "next-reply" : initialTab || "next-reply");
+  // Tabs that pair the conversation history with attached evaluators (vs. the
+  // tool-invocation tab, which uses a tool picker instead). Used to gate the
+  // shared evaluator-related UI and validation paths below.
+  const isEvaluatorTab =
+    activeTab === "next-reply" || activeTab === "conversation";
 
   // Available tools state - declared early so it's available for initialConfig parsing
   const [availableTools, setAvailableTools] = useState<AvailableTool[]>([]);
@@ -445,8 +455,9 @@ export function AddTestDialog({
       // since that's the message being graded.
       return [u("1"), a("2")];
     }
-    if (allowAgentLastMessage) {
-      // Simulation add-item: a short but complete conversation transcript.
+    if (allowAgentLastMessage || activeTab === "conversation") {
+      // Simulation add-item / conversation test: a short but complete
+      // conversation transcript (any role can be last).
       return [u("1"), a("2"), u("3"), a("4"), u("5"), a("6")];
     }
     // Default test: user → agent → user (final user turn is what the agent
@@ -686,13 +697,18 @@ export function AddTestDialog({
         }> = await response.json();
 
         const llm: LLMEvaluatorOption[] = raw
-          .filter((e) => e.evaluator_type === "llm")
+          .filter(
+            (e) =>
+              e.evaluator_type === "llm" ||
+              e.evaluator_type === CONVERSATION_EVALUATOR_TYPE,
+          )
           .map((e) => ({
             uuid: e.uuid,
             name: e.name,
             description: e.description,
             slug: e.slug,
             owner_user_id: e.owner_user_id,
+            evaluator_type: e.evaluator_type,
             variables: Array.isArray(e.live_version?.variables)
               ? (e.live_version!.variables as EvaluatorVariableDef[])
               : [],
@@ -1174,12 +1190,12 @@ export function AddTestDialog({
         };
       }
     } else {
-      // next-reply test. The legacy free-text `criteria` field is no longer
-      // sent — the user-supplied criteria now lives on the attached
-      // correctness evaluator's `variable_values.criteria` (sent separately
-      // on the POST/PUT body's `evaluators` array).
+      // Evaluator-based tests (next-reply or conversation). The legacy
+      // free-text `criteria` field is no longer sent — the user-supplied
+      // criteria now lives on the attached evaluator's `variable_values`
+      // (sent separately on the POST/PUT body's `evaluators` array).
       evaluation = {
-        type: "response",
+        type: activeTab === "conversation" ? "conversation" : "response",
       };
     }
 
@@ -1187,10 +1203,11 @@ export function AddTestDialog({
   };
 
   // Build the EvaluatorRef[] payload sent alongside `config` on POST/PUT
-  // /tests. Only relevant for next-reply tests. We omit `variable_values`
-  // entirely when the evaluator has no variables to keep the payload lean.
+  // /tests. Relevant for both next-reply and conversation tests. We omit
+  // `variable_values` entirely when the evaluator has no variables to keep
+  // the payload lean.
   const buildEvaluatorsPayload = (): EvaluatorRefPayload[] => {
-    if (activeTab !== "next-reply") return [];
+    if (!isEvaluatorTab) return [];
     return attachedEvaluators.map((e) => {
       const ref: EvaluatorRefPayload = { evaluator_uuid: e.evaluator_uuid };
       if (e.variables.length > 0) {
@@ -1203,7 +1220,7 @@ export function AddTestDialog({
   // Returns true if any attached evaluator has at least one variable whose
   // value is empty (after trim). Used to gate the Save button.
   const hasUnfilledEvaluatorVariables = () => {
-    if (activeTab !== "next-reply") return false;
+    if (!isEvaluatorTab) return false;
     for (const e of attachedEvaluators) {
       for (const v of e.variables) {
         const value = e.variable_values[v.name];
@@ -1250,7 +1267,7 @@ export function AddTestDialog({
     }
 
     // Validate required fields based on test type
-    if (activeTab === "next-reply") {
+    if (isEvaluatorTab) {
       if (!testName.trim()) {
         return; // Don't submit if validation fails
       }
@@ -1381,7 +1398,9 @@ export function AddTestDialog({
                 <div className="flex-1 py-3 md:py-4 text-sm md:text-base font-medium text-foreground border-b-2 border-foreground text-center">
                   {activeTab === "tool-invocation"
                     ? "Tool invocation test"
-                    : "Next reply test"}
+                    : activeTab === "conversation"
+                      ? "Conversation test"
+                      : "Next reply test"}
                 </div>
               </div>
             ) : (
@@ -1405,6 +1424,16 @@ export function AddTestDialog({
                   }`}
                 >
                   Tool invocation test
+                </button>
+                <button
+                  onClick={() => setActiveTab("conversation")}
+                  className={`flex-1 py-3 md:py-4 text-sm md:text-base font-medium transition-colors cursor-pointer ${
+                    activeTab === "conversation"
+                      ? "text-foreground border-b-2 border-foreground"
+                      : "text-muted-foreground hover:text-foreground"
+                  }`}
+                >
+                  Conversation test
                 </button>
               </div>
             ))}
@@ -1433,7 +1462,7 @@ export function AddTestDialog({
                   ></path>
                 </svg>
               </div>
-            ) : activeTab === "next-reply" ? (
+            ) : isEvaluatorTab ? (
               <div className="space-y-6">
                 {/* Name */}
                 <div>
@@ -1448,7 +1477,7 @@ export function AddTestDialog({
                     className={`w-full h-11 px-4 rounded-lg text-base bg-background text-foreground placeholder:text-muted-foreground border focus:outline-none focus:ring-2 focus:ring-accent ${
                       nameError ||
                       (localValidationAttempted &&
-                        activeTab === "next-reply" &&
+                        isEvaluatorTab &&
                         !testName.trim())
                         ? "border-red-500"
                         : "border-border"
@@ -1458,7 +1487,7 @@ export function AddTestDialog({
                     <p className="text-xs text-red-500 mt-1">{nameError}</p>
                   ) : (
                     localValidationAttempted &&
-                    activeTab === "next-reply" &&
+                    isEvaluatorTab &&
                     !testName.trim() && (
                       <p className="text-xs text-red-500 mt-1">
                         {ItemNoun} name cannot be empty
@@ -1495,7 +1524,11 @@ export function AddTestDialog({
                           (o) =>
                             !attachedEvaluators.some(
                               (a) => a.evaluator_uuid === o.uuid,
-                            ),
+                            ) &&
+                            (activeTab === "conversation"
+                              ? o.evaluator_type ===
+                                CONVERSATION_EVALUATOR_TYPE
+                              : o.evaluator_type === "llm"),
                         );
                         const noOptionsLeft = remainingOptions.length === 0;
                         return (
@@ -1515,7 +1548,7 @@ export function AddTestDialog({
                             // error state overrides border/text to red.
                             className={`px-3 py-1.5 text-sm font-medium rounded-lg border cursor-pointer transition-colors disabled:opacity-50 disabled:cursor-not-allowed bg-violet-500/12 border-violet-500/45 text-violet-950 dark:text-violet-100 hover:bg-violet-500/22 dark:hover:bg-violet-500/18 ${
                               localValidationAttempted &&
-                              activeTab === "next-reply" &&
+                              isEvaluatorTab &&
                               attachedEvaluators.length === 0
                                 ? "!border-red-500 !text-red-500 !bg-red-500/10"
                                 : ""
@@ -1554,7 +1587,11 @@ export function AddTestDialog({
                               (o) =>
                                 !attachedEvaluators.some(
                                   (a) => a.evaluator_uuid === o.uuid,
-                                ),
+                                ) &&
+                                (activeTab === "conversation"
+                                  ? o.evaluator_type ===
+                                    CONVERSATION_EVALUATOR_TYPE
+                                  : o.evaluator_type === "llm"),
                             );
                             if (remaining.length === 0) {
                               return (
@@ -1664,13 +1701,14 @@ export function AddTestDialog({
                   {!evaluatorsLoading && attachedEvaluators.length === 0 && (
                     <div
                       className={`text-sm py-4 ${
-                        localValidationAttempted && activeTab === "next-reply"
+                        localValidationAttempted && isEvaluatorTab
                           ? "text-red-500"
                           : "text-muted-foreground"
                       }`}
                     >
-                      Add at least one evaluator to grade the agent&apos;s next
-                      reply.
+                      {activeTab === "conversation"
+                        ? "Add at least one evaluator to grade the full conversation."
+                        : "Add at least one evaluator to grade the agent's next reply."}
                     </div>
                   )}
 
@@ -1735,7 +1773,7 @@ export function AddTestDialog({
                               const value = ev.variable_values[v.name] ?? "";
                               const isMissing =
                                 localValidationAttempted &&
-                                activeTab === "next-reply" &&
+                                isEvaluatorTab &&
                                 value.trim().length === 0;
                               return (
                                 <div key={v.name}>
@@ -2012,7 +2050,10 @@ export function AddTestDialog({
                 if (requireAssistantLastMessage) {
                   isLastMessageInvalid =
                     isEmpty || lastMessage?.role !== "agent";
-                } else if (allowAgentLastMessage) {
+                } else if (
+                  allowAgentLastMessage ||
+                  activeTab === "conversation"
+                ) {
                   isLastMessageInvalid = isEmpty;
                 } else {
                   isLastMessageInvalid =
@@ -2099,7 +2140,9 @@ export function AddTestDialog({
               <p className="text-sm text-foreground leading-relaxed">
                 {requireAssistantLastMessage
                   ? "Your evaluators read this whole conversation and evaluate the last agent message (the one highlighted) against the evaluators. Only that final reply is scored."
-                  : "The agent's response to the last user message, given the conversation history, will be evaluated against the evaluators added to the test"}
+                  : activeTab === "conversation"
+                    ? "Your evaluators read the entire conversation history and grade it as a whole against the evaluators added to the test."
+                    : "The agent's response to the last user message, given the conversation history, will be evaluated against the evaluators added to the test"}
               </p>
             </div>
           </div>

--- a/src/components/AddTestDialog.tsx
+++ b/src/components/AddTestDialog.tsx
@@ -2952,23 +2952,20 @@ export function AddTestDialog({
                                               : "left-0 bottom-full mb-2"
                                         }`}
                                       >
-                                        {/* Three clearly separated hues so
-                                          adjacent rows don't read as the
-                                          same family: amber (warm yellow)
-                                          for User, sky (cool blue) for
-                                          Agent, fuchsia (pink-magenta)
-                                          for Agent tool call — also
-                                          distinct from the violet
-                                          "Add evaluator" button above. */}
+                                        {/* Neutral rows (no bright fills) —
+                                          the three options stay visually
+                                          distinct via their icons (person /
+                                          chip / crossed tools) and labels
+                                          rather than colour. */}
                                         <button
                                           onClick={() => {
                                             addChatMessage("user");
                                             setAddMessageDropdownOpen(false);
                                           }}
-                                          className="w-full px-3 py-1.5 flex items-center gap-2 transition-colors cursor-pointer bg-amber-500/10 text-amber-700 dark:bg-amber-500/12 dark:text-amber-200 hover:bg-amber-500/18 dark:hover:bg-amber-500/20"
+                                          className="w-full px-3 py-1.5 flex items-center gap-2 transition-colors cursor-pointer text-foreground hover:bg-muted"
                                         >
                                           <svg
-                                            className="w-4 h-4"
+                                            className="w-4 h-4 text-muted-foreground"
                                             fill="none"
                                             viewBox="0 0 24 24"
                                             stroke="currentColor"
@@ -2989,10 +2986,10 @@ export function AddTestDialog({
                                             addChatMessage("agent");
                                             setAddMessageDropdownOpen(false);
                                           }}
-                                          className="w-full px-3 py-1.5 flex items-center gap-2 transition-colors cursor-pointer bg-sky-500/10 text-sky-700 dark:bg-sky-500/12 dark:text-sky-200 hover:bg-sky-500/18 dark:hover:bg-sky-500/20"
+                                          className="w-full px-3 py-1.5 flex items-center gap-2 transition-colors cursor-pointer text-foreground hover:bg-muted"
                                         >
                                           <svg
-                                            className="w-4 h-4"
+                                            className="w-4 h-4 text-muted-foreground"
                                             fill="none"
                                             viewBox="0 0 24 24"
                                             stroke="currentColor"
@@ -3013,10 +3010,10 @@ export function AddTestDialog({
                                             setAddMessageDropdownOpen(false);
                                             setToolCallDropdownOpen(true);
                                           }}
-                                          className="w-full px-3 py-1.5 flex items-center gap-2 transition-colors cursor-pointer bg-fuchsia-500/10 text-fuchsia-700 dark:bg-fuchsia-500/12 dark:text-fuchsia-200 hover:bg-fuchsia-500/18 dark:hover:bg-fuchsia-500/20"
+                                          className="w-full px-3 py-1.5 flex items-center gap-2 transition-colors cursor-pointer text-foreground hover:bg-muted"
                                         >
                                           <svg
-                                            className="w-4 h-4"
+                                            className="w-4 h-4 text-muted-foreground"
                                             fill="none"
                                             viewBox="0 0 24 24"
                                             stroke="currentColor"

--- a/src/components/AddTestDialog.tsx
+++ b/src/components/AddTestDialog.tsx
@@ -70,21 +70,20 @@ const TEST_TYPE_OPTIONS: Array<{
     tab: "next-reply",
     label: "Next reply",
     title: "Next reply test",
-    description: "Evaluate the agent's response given a conversation history.",
+    description: "Evaluate the agent's response given a conversation history",
   },
   {
     tab: "tool-invocation",
     label: "Tool call",
     title: "Tool call test",
     description:
-      "Check whether the agent invokes the correct tool with the right arguments.",
+      "Check whether the agent invokes the correct tool with the right arguments",
   },
   {
     tab: "conversation",
     label: "Conversation",
     title: "Conversation test",
-    description:
-      "Generate the agent's reply, then grade the full conversation as a whole.",
+    description: "Generate the agent's reply, then grade the full conversation",
   },
 ];
 
@@ -224,7 +223,8 @@ export function AddTestDialog({
   // renders; `editorEntered` drives the entrance transition once chosen.
   const showTypeIntroFlow = !isLabelItem && !isEditing;
   const [typeChosen, setTypeChosen] = useState<boolean>(!showTypeIntroFlow);
-  const [editorEntered, setEditorEntered] = useState<boolean>(!showTypeIntroFlow);
+  const [editorEntered, setEditorEntered] =
+    useState<boolean>(!showTypeIntroFlow);
 
   // Reset the phase whenever the dialog (re)opens so a fresh create always
   // starts on the picker and an edit always lands straight in the editor.
@@ -1517,196 +1517,134 @@ export function AddTestDialog({
 
       {/* Dialog */}
       {typeChosen && (
-      <div
-        className={`relative w-full max-w-7xl h-[95vh] md:h-[85vh] mx-2 md:mx-4 bg-background rounded-xl md:rounded-2xl shadow-2xl flex flex-col md:flex-row overflow-hidden border border-border transition-all duration-300 ease-out ${
-          editorEntered ? "opacity-100 scale-100" : "opacity-0 scale-95"
-        }`}
-      >
-        {/* Left Column - Form */}
-        <div className="w-full md:w-2/5 flex flex-col border-b md:border-b-0 md:border-r border-border">
-          {/* Tabs — hidden in labelItem mode (always next-reply). When
+        <div
+          className={`relative w-full max-w-7xl h-[95vh] md:h-[85vh] mx-2 md:mx-4 bg-background rounded-xl md:rounded-2xl shadow-2xl flex flex-col md:flex-row overflow-hidden border border-border transition-all duration-300 ease-out ${
+            editorEntered ? "opacity-100 scale-100" : "opacity-0 scale-95"
+          }`}
+        >
+          {/* Left Column - Form */}
+          <div className="w-full md:w-2/5 flex flex-col border-b md:border-b-0 md:border-r border-border">
+            {/* Tabs — hidden in labelItem mode (always next-reply). When
               editing an existing test the type is fixed (the backend no
               longer allows changing a test's type), so we show only the
               matching view's label as a static, non-switchable header. */}
-          {!isLabelItem &&
-            (isEditing ? (
-              <div className="flex border-b border-border">
-                <div className="flex-1 py-3 md:py-4 text-sm md:text-base font-medium text-foreground border-b-2 border-foreground text-center">
-                  {activeTab === "tool-invocation"
-                    ? "Tool call test"
-                    : activeTab === "conversation"
-                      ? "Conversation test"
-                      : "Next reply test"}
+            {!isLabelItem &&
+              (isEditing ? (
+                <div className="flex border-b border-border">
+                  <div className="flex-1 py-3 md:py-4 text-sm md:text-base font-medium text-foreground border-b-2 border-foreground text-center">
+                    {activeTab === "tool-invocation"
+                      ? "Tool call test"
+                      : activeTab === "conversation"
+                        ? "Conversation test"
+                        : "Next reply test"}
+                  </div>
                 </div>
-              </div>
-            ) : (
-              // Create phase: the same three boxes from the intro picker,
-              // rendered compactly in the top-left so the type can still be
-              // switched mid-create.
-              <div className="flex gap-2 p-3 border-b border-border">
-                {TEST_TYPE_OPTIONS.map((opt) => (
-                  <button
-                    key={opt.tab}
-                    onClick={() => setActiveTab(opt.tab)}
-                    title={opt.title}
-                    className={`flex-1 min-w-0 px-2 py-2 rounded-lg border text-xs md:text-sm font-medium transition-colors cursor-pointer truncate ${
-                      activeTab === opt.tab
-                        ? "bg-foreground text-background border-foreground"
-                        : "bg-background border-border text-muted-foreground hover:bg-muted/50 hover:text-foreground"
-                    }`}
+              ) : (
+                // Create phase: the same three boxes from the intro picker,
+                // rendered compactly in the top-left so the type can still be
+                // switched mid-create.
+                <div className="flex gap-2 p-3 border-b border-border">
+                  {TEST_TYPE_OPTIONS.map((opt) => (
+                    <button
+                      key={opt.tab}
+                      onClick={() => setActiveTab(opt.tab)}
+                      title={opt.title}
+                      className={`flex-1 min-w-0 px-2 py-2 rounded-lg border text-xs md:text-sm font-medium transition-colors cursor-pointer truncate ${
+                        activeTab === opt.tab
+                          ? "bg-foreground text-background border-foreground"
+                          : "bg-background border-border text-muted-foreground hover:bg-muted/50 hover:text-foreground"
+                      }`}
+                    >
+                      {opt.label}
+                    </button>
+                  ))}
+                </div>
+              ))}
+
+            {/* Content */}
+            <div className="flex-1 overflow-y-auto overflow-x-visible p-4 md:p-6">
+              {isLoading ? (
+                <div className="flex items-center justify-center py-12">
+                  <svg
+                    className="w-6 h-6 animate-spin text-foreground"
+                    fill="none"
+                    viewBox="0 0 24 24"
                   >
-                    {opt.label}
-                  </button>
-                ))}
-              </div>
-            ))}
-
-          {/* Content */}
-          <div className="flex-1 overflow-y-auto overflow-x-visible p-4 md:p-6">
-            {isLoading ? (
-              <div className="flex items-center justify-center py-12">
-                <svg
-                  className="w-6 h-6 animate-spin text-foreground"
-                  fill="none"
-                  viewBox="0 0 24 24"
-                >
-                  <circle
-                    className="opacity-25"
-                    cx="12"
-                    cy="12"
-                    r="10"
-                    stroke="currentColor"
-                    strokeWidth="4"
-                  ></circle>
-                  <path
-                    className="opacity-75"
-                    fill="currentColor"
-                    d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
-                  ></path>
-                </svg>
-              </div>
-            ) : isEvaluatorTab ? (
-              <div className="space-y-6">
-                {/* Name */}
-                <div>
-                  <label className="block text-base font-medium text-foreground mb-2">
-                    {ItemNoun} name
-                  </label>
-                  <input
-                    type="text"
-                    value={testName}
-                    onChange={(e) => setTestName(e.target.value)}
-                    placeholder={`Your ${itemNoun} name`}
-                    className={`w-full h-11 px-4 rounded-lg text-base bg-background text-foreground placeholder:text-muted-foreground border focus:outline-none focus:ring-2 focus:ring-accent ${
-                      nameError ||
-                      (localValidationAttempted &&
-                        isEvaluatorTab &&
-                        !testName.trim())
-                        ? "border-red-500"
-                        : "border-border"
-                    }`}
-                  />
-                  {nameError ? (
-                    <p className="text-xs text-red-500 mt-1">{nameError}</p>
-                  ) : (
-                    localValidationAttempted &&
-                    isEvaluatorTab &&
-                    !testName.trim() && (
-                      <p className="text-xs text-red-500 mt-1">
-                        {ItemNoun} name cannot be empty
-                      </p>
-                    )
-                  )}
+                    <circle
+                      className="opacity-25"
+                      cx="12"
+                      cy="12"
+                      r="10"
+                      stroke="currentColor"
+                      strokeWidth="4"
+                    ></circle>
+                    <path
+                      className="opacity-75"
+                      fill="currentColor"
+                      d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+                    ></path>
+                  </svg>
                 </div>
-
-                {/* Description (labelling items only) */}
-                {isLabelItem && setItemDescription && (
+              ) : isEvaluatorTab ? (
+                <div className="space-y-6">
+                  {/* Name */}
                   <div>
                     <label className="block text-base font-medium text-foreground mb-2">
-                      Description
+                      {ItemNoun} name
                     </label>
-                    <textarea
-                      value={itemDescription ?? ""}
-                      onChange={(e) => setItemDescription(e.target.value)}
-                      placeholder="Optional — what is this item about? Shown to annotators alongside the evaluators."
-                      rows={3}
-                      className="w-full px-4 py-2.5 rounded-lg text-base bg-background text-foreground placeholder:text-muted-foreground border border-border focus:outline-none focus:ring-2 focus:ring-accent resize-y"
+                    <input
+                      type="text"
+                      value={testName}
+                      onChange={(e) => setTestName(e.target.value)}
+                      placeholder={`Your ${itemNoun} name`}
+                      className={`w-full h-11 px-4 rounded-lg text-base bg-background text-foreground placeholder:text-muted-foreground border focus:outline-none focus:ring-2 focus:ring-accent ${
+                        nameError ||
+                        (localValidationAttempted &&
+                          isEvaluatorTab &&
+                          !testName.trim())
+                          ? "border-red-500"
+                          : "border-border"
+                      }`}
                     />
-                  </div>
-                )}
-
-                {/* Evaluators (next-reply tab only) */}
-                <div className="relative">
-                  <div className="flex items-center justify-between mb-2">
-                    <label className="text-base font-medium text-foreground">
-                      Evaluators
-                    </label>
-                    {!isLabelItem &&
-                      (() => {
-                        const remainingOptions = availableLLMEvaluators.filter(
-                          (o) =>
-                            !attachedEvaluators.some(
-                              (a) => a.evaluator_uuid === o.uuid,
-                            ) &&
-                            (activeTab === "conversation"
-                              ? o.evaluator_type ===
-                                CONVERSATION_EVALUATOR_TYPE
-                              : o.evaluator_type === "llm"),
-                        );
-                        const noOptionsLeft = remainingOptions.length === 0;
-                        return (
-                          <button
-                            onClick={() => {
-                              if (evaluatorPickerOpen) {
-                                closeEvaluatorPicker();
-                              } else {
-                                setEvaluatorPickerOpen(true);
-                              }
-                            }}
-                            disabled={
-                              evaluatorsLoading || isLoading || noOptionsLeft
-                            }
-                            // Tinted violet so the action stands out from
-                            // the neutral form chrome around it. Validation
-                            // error state overrides border/text to red.
-                            className={`px-3 py-1.5 text-sm font-medium rounded-lg border cursor-pointer transition-colors disabled:opacity-50 disabled:cursor-not-allowed bg-violet-500/12 border-violet-500/45 text-violet-950 dark:text-violet-100 hover:bg-violet-500/22 dark:hover:bg-violet-500/18 ${
-                              localValidationAttempted &&
-                              isEvaluatorTab &&
-                              attachedEvaluators.length === 0
-                                ? "!border-red-500 !text-red-500 !bg-red-500/10"
-                                : ""
-                            }`}
-                          >
-                            Add evaluator
-                          </button>
-                        );
-                      })()}
+                    {nameError ? (
+                      <p className="text-xs text-red-500 mt-1">{nameError}</p>
+                    ) : (
+                      localValidationAttempted &&
+                      isEvaluatorTab &&
+                      !testName.trim() && (
+                        <p className="text-xs text-red-500 mt-1">
+                          {ItemNoun} name cannot be empty
+                        </p>
+                      )
+                    )}
                   </div>
 
-                  {/* Evaluator picker dropdown */}
-                  {evaluatorPickerOpen && (
-                    <>
-                      <div
-                        className="fixed inset-0 z-[99]"
-                        onClick={closeEvaluatorPicker}
+                  {/* Description (labelling items only) */}
+                  {isLabelItem && setItemDescription && (
+                    <div>
+                      <label className="block text-base font-medium text-foreground mb-2">
+                        Description
+                      </label>
+                      <textarea
+                        value={itemDescription ?? ""}
+                        onChange={(e) => setItemDescription(e.target.value)}
+                        placeholder="Optional — what is this item about? Shown to annotators alongside the evaluators."
+                        rows={3}
+                        className="w-full px-4 py-2.5 rounded-lg text-base bg-background text-foreground placeholder:text-muted-foreground border border-border focus:outline-none focus:ring-2 focus:ring-accent resize-y"
                       />
-                      <div className="absolute right-0 top-9 mt-1 w-80 max-h-80 flex flex-col bg-background border border-border rounded-xl shadow-2xl z-[100] overflow-hidden">
-                        {/* Sticky search bar */}
-                        <div className="p-2 border-b border-border bg-background">
-                          <input
-                            type="text"
-                            value={evaluatorPickerSearch}
-                            onChange={(e) =>
-                              setEvaluatorPickerSearch(e.target.value)
-                            }
-                            placeholder="Search evaluators"
-                            autoFocus
-                            className="w-full h-9 px-3 rounded-md text-sm bg-background text-foreground placeholder:text-muted-foreground border border-border focus:outline-none focus:ring-1 focus:ring-accent"
-                          />
-                        </div>
-                        <div className="flex-1 overflow-y-auto">
-                          {(() => {
-                            const remaining = availableLLMEvaluators.filter(
+                    </div>
+                  )}
+
+                  {/* Evaluators (next-reply tab only) */}
+                  <div className="relative">
+                    <div className="flex items-center justify-between mb-2">
+                      <label className="text-base font-medium text-foreground">
+                        Evaluators
+                      </label>
+                      {!isLabelItem &&
+                        (() => {
+                          const remainingOptions =
+                            availableLLMEvaluators.filter(
                               (o) =>
                                 !attachedEvaluators.some(
                                   (a) => a.evaluator_uuid === o.uuid,
@@ -1716,336 +1654,400 @@ export function AddTestDialog({
                                     CONVERSATION_EVALUATOR_TYPE
                                   : o.evaluator_type === "llm"),
                             );
-                            if (remaining.length === 0) {
-                              return (
-                                <div className="px-4 py-6 text-sm text-muted-foreground text-center">
-                                  No more LLM evaluators to add.
-                                </div>
-                              );
-                            }
-                            // Case-insensitive substring match against both
-                            // name and description so users can search by
-                            // either label or rubric snippet.
-                            const query = evaluatorPickerSearch
-                              .trim()
-                              .toLowerCase();
-                            const matches = query
-                              ? remaining.filter((o) => {
-                                  const name = o.name.toLowerCase();
-                                  const desc = (
-                                    o.description ?? ""
-                                  ).toLowerCase();
-                                  return (
-                                    name.includes(query) || desc.includes(query)
-                                  );
-                                })
-                              : remaining;
-                            if (matches.length === 0) {
-                              return (
-                                <div className="px-4 py-6 text-sm text-muted-foreground text-center">
-                                  No evaluators match &ldquo;
-                                  {evaluatorPickerSearch}&rdquo;.
-                                </div>
-                              );
-                            }
-                            const defaults = matches.filter(
-                              (o) => o.owner_user_id === null,
-                            );
-                            const mine = matches.filter(
-                              (o) => o.owner_user_id !== null,
-                            );
-                            const renderRow = (o: LLMEvaluatorOption) => (
-                              <button
-                                key={o.uuid}
-                                onClick={() => attachEvaluatorFromOption(o)}
-                                className="w-full text-left px-4 py-2.5 hover:bg-muted transition-colors cursor-pointer"
-                              >
-                                <div className="text-sm font-medium text-foreground">
-                                  {o.name}
-                                </div>
-                                {o.description && (
-                                  <div className="text-xs text-muted-foreground line-clamp-2 mt-0.5">
-                                    {o.description}
-                                  </div>
-                                )}
-                              </button>
-                            );
-                            return (
-                              <>
-                                {defaults.length > 0 && (
-                                  <div>
-                                    <div className="px-4 pt-3 pb-1 text-[11px] uppercase tracking-wide text-muted-foreground">
-                                      Default
-                                    </div>
-                                    {defaults.map(renderRow)}
-                                  </div>
-                                )}
-                                {mine.length > 0 && (
-                                  <div>
-                                    <div className="px-4 pt-3 pb-1 text-[11px] uppercase tracking-wide text-muted-foreground">
-                                      My evaluators
-                                    </div>
-                                    {mine.map(renderRow)}
-                                  </div>
-                                )}
-                              </>
-                            );
-                          })()}
-                        </div>
-                      </div>
-                    </>
-                  )}
-
-                  {/* Empty / loading state */}
-                  {evaluatorsLoading && attachedEvaluators.length === 0 && (
-                    <div className="flex items-center gap-2 text-sm text-muted-foreground py-4">
-                      <svg
-                        className="w-4 h-4 animate-spin"
-                        fill="none"
-                        viewBox="0 0 24 24"
-                      >
-                        <circle
-                          className="opacity-25"
-                          cx="12"
-                          cy="12"
-                          r="10"
-                          stroke="currentColor"
-                          strokeWidth="4"
-                        />
-                        <path
-                          className="opacity-75"
-                          fill="currentColor"
-                          d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
-                        />
-                      </svg>
-                      Loading evaluators
-                    </div>
-                  )}
-                  {!evaluatorsLoading && attachedEvaluators.length === 0 && (
-                    <div
-                      className={`text-sm py-4 ${
-                        localValidationAttempted && isEvaluatorTab
-                          ? "text-red-500"
-                          : "text-muted-foreground"
-                      }`}
-                    >
-                      {activeTab === "conversation"
-                        ? "Add at least one evaluator to grade the full conversation."
-                        : "Add at least one evaluator to grade the agent's next reply."}
-                    </div>
-                  )}
-
-                  {/* Attached evaluator cards */}
-                  <div className="space-y-4">
-                    {attachedEvaluators.map((ev) => (
-                      <div
-                        key={ev.evaluator_uuid}
-                        className="border border-border rounded-lg p-4 bg-background"
-                      >
-                        <div className="flex items-start justify-between gap-2 mb-3">
-                          <div className="min-w-0 flex-1">
-                            <div className="text-sm font-semibold text-foreground">
-                              {ev.name}
-                            </div>
-                            {ev.description && (
-                              <div className="text-xs text-muted-foreground mt-0.5 line-clamp-2">
-                                {ev.description}
-                              </div>
-                            )}
-                          </div>
-                          {!isLabelItem && (
+                          const noOptionsLeft = remainingOptions.length === 0;
+                          return (
                             <button
-                              onClick={() =>
-                                removeAttachedEvaluator(ev.evaluator_uuid)
+                              onClick={() => {
+                                if (evaluatorPickerOpen) {
+                                  closeEvaluatorPicker();
+                                } else {
+                                  setEvaluatorPickerOpen(true);
+                                }
+                              }}
+                              disabled={
+                                evaluatorsLoading || isLoading || noOptionsLeft
                               }
-                              className="text-muted-foreground hover:text-red-500 transition-colors cursor-pointer"
-                              aria-label={`Remove ${ev.name}`}
-                            >
-                              <svg
-                                className="w-4 h-4"
-                                fill="none"
-                                viewBox="0 0 24 24"
-                                stroke="currentColor"
-                                strokeWidth={2}
-                              >
-                                <path
-                                  strokeLinecap="round"
-                                  strokeLinejoin="round"
-                                  d="M6 18L18 6M6 6l12 12"
-                                />
-                              </svg>
-                            </button>
-                          )}
-                        </div>
-
-                        {ev.variables.length > 0 && (
-                          <div className="space-y-3">
-                            {ev.variables.map((v) => {
-                              // Uniform rendering for every evaluator variable:
-                              // a small `{{name}}` monospace hint + textarea
-                              // whose placeholder is the variable's
-                              // `description` (falling back to `default`, then
-                              // a generic prompt). No special-case label —
-                              // the description carries the user-facing copy.
-                              const placeholder =
-                                v.description && v.description.length > 0
-                                  ? v.description
-                                  : v.default && v.default.length > 0
-                                    ? v.default
-                                    : `Enter value for {{${v.name}}}`;
-                              const value = ev.variable_values[v.name] ?? "";
-                              const isMissing =
+                              // Tinted violet so the action stands out from
+                              // the neutral form chrome around it. Validation
+                              // error state overrides border/text to red.
+                              className={`px-3 py-1.5 text-sm font-medium rounded-lg border cursor-pointer transition-colors disabled:opacity-50 disabled:cursor-not-allowed bg-violet-500/12 border-violet-500/45 text-violet-950 dark:text-violet-100 hover:bg-violet-500/22 dark:hover:bg-violet-500/18 ${
                                 localValidationAttempted &&
                                 isEvaluatorTab &&
-                                value.trim().length === 0;
-                              return (
-                                <div key={v.name}>
-                                  <div className="text-xs text-muted-foreground mb-1.5">
-                                    <code className="font-mono">{`{{${v.name}}}`}</code>
-                                  </div>
-                                  <textarea
-                                    value={value}
-                                    onChange={(e) =>
-                                      updateEvaluatorVariableValue(
-                                        ev.evaluator_uuid,
-                                        v.name,
-                                        e.target.value,
-                                      )
-                                    }
-                                    placeholder={placeholder}
-                                    rows={4}
-                                    className={`w-full px-4 py-3 rounded-lg text-base bg-background text-foreground placeholder:text-muted-foreground border focus:outline-none focus:ring-2 focus:ring-accent resize-none ${
-                                      isMissing
-                                        ? "border-red-500"
-                                        : "border-border"
-                                    }`}
-                                  />
-                                  {isMissing && (
-                                    <p className="text-xs text-red-500 mt-1">
-                                      Value cannot be empty
-                                    </p>
-                                  )}
-                                </div>
-                              );
-                            })}
+                                attachedEvaluators.length === 0
+                                  ? "!border-red-500 !text-red-500 !bg-red-500/10"
+                                  : ""
+                              }`}
+                            >
+                              Add evaluator
+                            </button>
+                          );
+                        })()}
+                    </div>
+
+                    {/* Evaluator picker dropdown */}
+                    {evaluatorPickerOpen && (
+                      <>
+                        <div
+                          className="fixed inset-0 z-[99]"
+                          onClick={closeEvaluatorPicker}
+                        />
+                        <div className="absolute right-0 top-9 mt-1 w-80 max-h-80 flex flex-col bg-background border border-border rounded-xl shadow-2xl z-[100] overflow-hidden">
+                          {/* Sticky search bar */}
+                          <div className="p-2 border-b border-border bg-background">
+                            <input
+                              type="text"
+                              value={evaluatorPickerSearch}
+                              onChange={(e) =>
+                                setEvaluatorPickerSearch(e.target.value)
+                              }
+                              placeholder="Search evaluators"
+                              autoFocus
+                              className="w-full h-9 px-3 rounded-md text-sm bg-background text-foreground placeholder:text-muted-foreground border border-border focus:outline-none focus:ring-1 focus:ring-accent"
+                            />
                           </div>
-                        )}
+                          <div className="flex-1 overflow-y-auto">
+                            {(() => {
+                              const remaining = availableLLMEvaluators.filter(
+                                (o) =>
+                                  !attachedEvaluators.some(
+                                    (a) => a.evaluator_uuid === o.uuid,
+                                  ) &&
+                                  (activeTab === "conversation"
+                                    ? o.evaluator_type ===
+                                      CONVERSATION_EVALUATOR_TYPE
+                                    : o.evaluator_type === "llm"),
+                              );
+                              if (remaining.length === 0) {
+                                return (
+                                  <div className="px-4 py-6 text-sm text-muted-foreground text-center">
+                                    No more LLM evaluators to add.
+                                  </div>
+                                );
+                              }
+                              // Case-insensitive substring match against both
+                              // name and description so users can search by
+                              // either label or rubric snippet.
+                              const query = evaluatorPickerSearch
+                                .trim()
+                                .toLowerCase();
+                              const matches = query
+                                ? remaining.filter((o) => {
+                                    const name = o.name.toLowerCase();
+                                    const desc = (
+                                      o.description ?? ""
+                                    ).toLowerCase();
+                                    return (
+                                      name.includes(query) ||
+                                      desc.includes(query)
+                                    );
+                                  })
+                                : remaining;
+                              if (matches.length === 0) {
+                                return (
+                                  <div className="px-4 py-6 text-sm text-muted-foreground text-center">
+                                    No evaluators match &ldquo;
+                                    {evaluatorPickerSearch}&rdquo;.
+                                  </div>
+                                );
+                              }
+                              const defaults = matches.filter(
+                                (o) => o.owner_user_id === null,
+                              );
+                              const mine = matches.filter(
+                                (o) => o.owner_user_id !== null,
+                              );
+                              const renderRow = (o: LLMEvaluatorOption) => (
+                                <button
+                                  key={o.uuid}
+                                  onClick={() => attachEvaluatorFromOption(o)}
+                                  className="w-full text-left px-4 py-2.5 hover:bg-muted transition-colors cursor-pointer"
+                                >
+                                  <div className="text-sm font-medium text-foreground">
+                                    {o.name}
+                                  </div>
+                                  {o.description && (
+                                    <div className="text-xs text-muted-foreground line-clamp-2 mt-0.5">
+                                      {o.description}
+                                    </div>
+                                  )}
+                                </button>
+                              );
+                              return (
+                                <>
+                                  {defaults.length > 0 && (
+                                    <div>
+                                      <div className="px-4 pt-3 pb-1 text-[11px] uppercase tracking-wide text-muted-foreground">
+                                        Default
+                                      </div>
+                                      {defaults.map(renderRow)}
+                                    </div>
+                                  )}
+                                  {mine.length > 0 && (
+                                    <div>
+                                      <div className="px-4 pt-3 pb-1 text-[11px] uppercase tracking-wide text-muted-foreground">
+                                        My evaluators
+                                      </div>
+                                      {mine.map(renderRow)}
+                                    </div>
+                                  )}
+                                </>
+                              );
+                            })()}
+                          </div>
+                        </div>
+                      </>
+                    )}
+
+                    {/* Empty / loading state */}
+                    {evaluatorsLoading && attachedEvaluators.length === 0 && (
+                      <div className="flex items-center gap-2 text-sm text-muted-foreground py-4">
+                        <svg
+                          className="w-4 h-4 animate-spin"
+                          fill="none"
+                          viewBox="0 0 24 24"
+                        >
+                          <circle
+                            className="opacity-25"
+                            cx="12"
+                            cy="12"
+                            r="10"
+                            stroke="currentColor"
+                            strokeWidth="4"
+                          />
+                          <path
+                            className="opacity-75"
+                            fill="currentColor"
+                            d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+                          />
+                        </svg>
+                        Loading evaluators
                       </div>
-                    ))}
+                    )}
+                    {!evaluatorsLoading && attachedEvaluators.length === 0 && (
+                      <div
+                        className={`text-sm py-4 ${
+                          localValidationAttempted && isEvaluatorTab
+                            ? "text-red-500"
+                            : "text-muted-foreground"
+                        }`}
+                      >
+                        {activeTab === "conversation"
+                          ? "Add at least one evaluator to grade the full conversation"
+                          : "Add at least one evaluator to grade the agent's next reply"}
+                      </div>
+                    )}
+
+                    {/* Attached evaluator cards */}
+                    <div className="space-y-4">
+                      {attachedEvaluators.map((ev) => (
+                        <div
+                          key={ev.evaluator_uuid}
+                          className="border border-border rounded-lg p-4 bg-background"
+                        >
+                          <div className="flex items-start justify-between gap-2 mb-3">
+                            <div className="min-w-0 flex-1">
+                              <div className="text-sm font-semibold text-foreground">
+                                {ev.name}
+                              </div>
+                              {ev.description && (
+                                <div className="text-xs text-muted-foreground mt-0.5 line-clamp-2">
+                                  {ev.description}
+                                </div>
+                              )}
+                            </div>
+                            {!isLabelItem && (
+                              <button
+                                onClick={() =>
+                                  removeAttachedEvaluator(ev.evaluator_uuid)
+                                }
+                                className="text-muted-foreground hover:text-red-500 transition-colors cursor-pointer"
+                                aria-label={`Remove ${ev.name}`}
+                              >
+                                <svg
+                                  className="w-4 h-4"
+                                  fill="none"
+                                  viewBox="0 0 24 24"
+                                  stroke="currentColor"
+                                  strokeWidth={2}
+                                >
+                                  <path
+                                    strokeLinecap="round"
+                                    strokeLinejoin="round"
+                                    d="M6 18L18 6M6 6l12 12"
+                                  />
+                                </svg>
+                              </button>
+                            )}
+                          </div>
+
+                          {ev.variables.length > 0 && (
+                            <div className="space-y-3">
+                              {ev.variables.map((v) => {
+                                // Uniform rendering for every evaluator variable:
+                                // a small `{{name}}` monospace hint + textarea
+                                // whose placeholder is the variable's
+                                // `description` (falling back to `default`, then
+                                // a generic prompt). No special-case label —
+                                // the description carries the user-facing copy.
+                                const placeholder =
+                                  v.description && v.description.length > 0
+                                    ? v.description
+                                    : v.default && v.default.length > 0
+                                      ? v.default
+                                      : `Enter value for {{${v.name}}}`;
+                                const value = ev.variable_values[v.name] ?? "";
+                                const isMissing =
+                                  localValidationAttempted &&
+                                  isEvaluatorTab &&
+                                  value.trim().length === 0;
+                                return (
+                                  <div key={v.name}>
+                                    <div className="text-xs text-muted-foreground mb-1.5">
+                                      <code className="font-mono">{`{{${v.name}}}`}</code>
+                                    </div>
+                                    <textarea
+                                      value={value}
+                                      onChange={(e) =>
+                                        updateEvaluatorVariableValue(
+                                          ev.evaluator_uuid,
+                                          v.name,
+                                          e.target.value,
+                                        )
+                                      }
+                                      placeholder={placeholder}
+                                      rows={4}
+                                      className={`w-full px-4 py-3 rounded-lg text-base bg-background text-foreground placeholder:text-muted-foreground border focus:outline-none focus:ring-2 focus:ring-accent resize-none ${
+                                        isMissing
+                                          ? "border-red-500"
+                                          : "border-border"
+                                      }`}
+                                    />
+                                    {isMissing && (
+                                      <p className="text-xs text-red-500 mt-1">
+                                        Value cannot be empty
+                                      </p>
+                                    )}
+                                  </div>
+                                );
+                              })}
+                            </div>
+                          )}
+                        </div>
+                      ))}
+                    </div>
                   </div>
                 </div>
-              </div>
-            ) : (
-              <div className="space-y-6">
-                {/* Test Name */}
-                <div>
-                  <label className="block text-base font-medium text-foreground mb-2">
-                    Test name
-                  </label>
-                  <input
-                    type="text"
-                    value={testName}
-                    onChange={(e) => setTestName(e.target.value)}
-                    placeholder="Your test name"
-                    className={`w-full h-11 px-4 rounded-lg text-base bg-background text-foreground placeholder:text-muted-foreground border focus:outline-none focus:ring-2 focus:ring-accent ${
-                      nameError ||
-                      (localValidationAttempted &&
-                        activeTab === "tool-invocation" &&
-                        !testName.trim())
-                        ? "border-red-500"
-                        : "border-border"
-                    }`}
-                  />
-                  {nameError && (
-                    <p className="text-xs text-red-500 mt-1">{nameError}</p>
-                  )}
-                </div>
-
-                {/* Tools to test */}
-                <div className="relative">
-                  <div className="flex items-center justify-between mb-2">
-                    <label className="text-base font-medium text-foreground">
-                      Tools to test
+              ) : (
+                <div className="space-y-6">
+                  {/* Test Name */}
+                  <div>
+                    <label className="block text-base font-medium text-foreground mb-2">
+                      Test name
                     </label>
-                    <button
-                      onClick={() => setToolDropdownOpen(!toolDropdownOpen)}
-                      className={`px-3 py-1.5 text-sm font-medium bg-background text-foreground rounded-lg hover:bg-muted transition-colors cursor-pointer border ${
-                        localValidationAttempted &&
-                        activeTab === "tool-invocation" &&
-                        selectedTools.length === 0
-                          ? "border-red-500 text-red-400"
+                    <input
+                      type="text"
+                      value={testName}
+                      onChange={(e) => setTestName(e.target.value)}
+                      placeholder="Your test name"
+                      className={`w-full h-11 px-4 rounded-lg text-base bg-background text-foreground placeholder:text-muted-foreground border focus:outline-none focus:ring-2 focus:ring-accent ${
+                        nameError ||
+                        (localValidationAttempted &&
+                          activeTab === "tool-invocation" &&
+                          !testName.trim())
+                          ? "border-red-500"
                           : "border-border"
                       }`}
-                    >
-                      Add tool
-                    </button>
+                    />
+                    {nameError && (
+                      <p className="text-xs text-red-500 mt-1">{nameError}</p>
+                    )}
                   </div>
 
-                  {/* Tool Dropdown */}
-                  {toolDropdownOpen && (
-                    <>
-                      <div
-                        className="fixed inset-0 z-[99]"
-                        onClick={() => {
-                          setToolDropdownOpen(false);
-                        }}
-                      />
-                      <div className="absolute right-0 top-8 mt-2 w-72 bg-background border border-border rounded-xl shadow-2xl z-[100] overflow-hidden">
-                        <ToolPicker
-                          availableTools={availableTools}
-                          isLoading={availableToolsLoading}
-                          onSelectInbuiltTool={(toolId, toolName) => {
-                            selectInbuiltTool(toolId, toolName);
-                          }}
-                          onSelectCustomTool={(tool) => {
-                            addToolFromSelection(tool);
-                          }}
-                          selectedToolIds={selectedTools.map((t) => t.id)}
-                        />
-                      </div>
-                    </>
-                  )}
-
-                  {selectedTools.length === 0 ? (
-                    <div className="bg-muted rounded-lg p-8 text-center ">
-                      <p className="text-muted-foreground text-sm">
-                        If you leave this empty, the test will check that no
-                        tool has been called.
-                      </p>
+                  {/* Tools to test */}
+                  <div className="relative">
+                    <div className="flex items-center justify-between mb-2">
+                      <label className="text-base font-medium text-foreground">
+                        Tools to test
+                      </label>
+                      <button
+                        onClick={() => setToolDropdownOpen(!toolDropdownOpen)}
+                        className={`px-3 py-1.5 text-sm font-medium bg-background text-foreground rounded-lg hover:bg-muted transition-colors cursor-pointer border ${
+                          localValidationAttempted &&
+                          activeTab === "tool-invocation" &&
+                          selectedTools.length === 0
+                            ? "border-red-500 text-red-400"
+                            : "border-border"
+                        }`}
+                      >
+                        Add tool
+                      </button>
                     </div>
-                  ) : (
-                    <div className="space-y-4">
-                      {selectedTools.map((tool) => (
-                        <div
-                          key={tool.id}
-                          className="bg-muted rounded-lg p-4 border border-border"
-                        >
-                          {/* Tool header with name and delete button */}
-                          <div className="flex items-center gap-2 mb-3">
-                            <div className="flex-1 h-10 px-4 rounded-lg text-base bg-background text-foreground border border-border flex items-center">
-                              {tool.name}
-                            </div>
-                            <button
-                              onClick={() => removeTool(tool.id)}
-                              className="w-10 h-10 flex items-center justify-center rounded-lg text-muted-foreground hover:text-foreground hover:bg-accent transition-colors cursor-pointer"
-                            >
-                              <svg
-                                className="w-5 h-5"
-                                fill="none"
-                                viewBox="0 0 24 24"
-                                stroke="currentColor"
-                                strokeWidth={2}
-                              >
-                                <path
-                                  strokeLinecap="round"
-                                  strokeLinejoin="round"
-                                  d="M14.74 9l-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 01-2.244 2.077H8.084a2.25 2.25 0 01-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 00-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 013.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 00-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 00-7.5 0"
-                                />
-                              </svg>
-                            </button>
-                          </div>
 
-                          {/* Expectation indicator. The "should not have been
+                    {/* Tool Dropdown */}
+                    {toolDropdownOpen && (
+                      <>
+                        <div
+                          className="fixed inset-0 z-[99]"
+                          onClick={() => {
+                            setToolDropdownOpen(false);
+                          }}
+                        />
+                        <div className="absolute right-0 top-8 mt-2 w-72 bg-background border border-border rounded-xl shadow-2xl z-[100] overflow-hidden">
+                          <ToolPicker
+                            availableTools={availableTools}
+                            isLoading={availableToolsLoading}
+                            onSelectInbuiltTool={(toolId, toolName) => {
+                              selectInbuiltTool(toolId, toolName);
+                            }}
+                            onSelectCustomTool={(tool) => {
+                              addToolFromSelection(tool);
+                            }}
+                            selectedToolIds={selectedTools.map((t) => t.id)}
+                          />
+                        </div>
+                      </>
+                    )}
+
+                    {selectedTools.length === 0 ? (
+                      <div className="bg-muted rounded-lg p-8 text-center ">
+                        <p className="text-muted-foreground text-sm">
+                          If you leave this empty, the test will check that no
+                          tool has been called.
+                        </p>
+                      </div>
+                    ) : (
+                      <div className="space-y-4">
+                        {selectedTools.map((tool) => (
+                          <div
+                            key={tool.id}
+                            className="bg-muted rounded-lg p-4 border border-border"
+                          >
+                            {/* Tool header with name and delete button */}
+                            <div className="flex items-center gap-2 mb-3">
+                              <div className="flex-1 h-10 px-4 rounded-lg text-base bg-background text-foreground border border-border flex items-center">
+                                {tool.name}
+                              </div>
+                              <button
+                                onClick={() => removeTool(tool.id)}
+                                className="w-10 h-10 flex items-center justify-center rounded-lg text-muted-foreground hover:text-foreground hover:bg-accent transition-colors cursor-pointer"
+                              >
+                                <svg
+                                  className="w-5 h-5"
+                                  fill="none"
+                                  viewBox="0 0 24 24"
+                                  stroke="currentColor"
+                                  strokeWidth={2}
+                                >
+                                  <path
+                                    strokeLinecap="round"
+                                    strokeLinejoin="round"
+                                    d="M14.74 9l-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 01-2.244 2.077H8.084a2.25 2.25 0 01-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 00-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 013.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 00-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 00-7.5 0"
+                                  />
+                                </svg>
+                              </button>
+                            </div>
+
+                            {/* Expectation indicator. The "should not have been
                               called" option is intentionally hidden for now
                               and the dialog assumes "should have been called"
                               on every save (see the tool_calls payload
@@ -2053,519 +2055,732 @@ export function AddTestDialog({
                               selected-state pill for visual consistency with
                               the rest of the dialog rather than a real
                               segmented control. */}
-                          <div
-                            className="w-full py-2.5 rounded-lg border border-border bg-foreground text-background text-sm font-medium text-center"
-                            aria-label="Expected behaviour"
-                          >
-                            Should have been called
+                            <div
+                              className="w-full py-2.5 rounded-lg border border-border bg-foreground text-background text-sm font-medium text-center"
+                              aria-label="Expected behaviour"
+                            >
+                              Should have been called
+                            </div>
+
+                            {/* Accept any parameter values checkbox - show when "should call" is selected and tool has parameters */}
+                            {tool.expectation === "should-call" &&
+                              toolHasParams(tool.id, tool.name) && (
+                                <div className="mt-4 flex items-center gap-3">
+                                  <button
+                                    onClick={() =>
+                                      updateToolConfig(tool.id, {
+                                        acceptAnyParameterValues:
+                                          !tool.acceptAnyParameterValues,
+                                      })
+                                    }
+                                    className={`w-5 h-5 rounded border-2 flex-shrink-0 flex items-center justify-center transition-colors cursor-pointer ${
+                                      tool.acceptAnyParameterValues
+                                        ? "bg-foreground border-foreground"
+                                        : "bg-background border-muted-foreground hover:border-foreground"
+                                    }`}
+                                  >
+                                    {tool.acceptAnyParameterValues && (
+                                      <svg
+                                        className="w-3 h-3 text-background"
+                                        fill="none"
+                                        viewBox="0 0 24 24"
+                                        stroke="currentColor"
+                                        strokeWidth={3}
+                                      >
+                                        <path
+                                          strokeLinecap="round"
+                                          strokeLinejoin="round"
+                                          d="M4.5 12.75l6 6 9-13.5"
+                                        />
+                                      </svg>
+                                    )}
+                                  </button>
+                                  <span className="text-sm font-medium text-foreground">
+                                    Accept any values for the parameters
+                                  </span>
+                                </div>
+                              )}
+
+                            {/* Expected parameters section - only show when "should call" is selected and toggle is off */}
+                            {tool.expectation === "should-call" &&
+                              tool.expectedParameters.length > 0 &&
+                              !tool.acceptAnyParameterValues && (
+                                <div className="mt-4">
+                                  <div className="mb-3">
+                                    <h4 className="text-sm font-medium text-foreground">
+                                      Expected extracted parameters
+                                    </h4>
+                                    <p className="text-xs text-muted-foreground mt-1">
+                                      Configure how each parameter should be
+                                      evaluated when the agent calls this tool
+                                    </p>
+                                  </div>
+
+                                  <div className="space-y-3">
+                                    {tool.expectedParameters.map((param) => (
+                                      <div key={param.id}>
+                                        <label className="block text-sm font-medium text-muted-foreground mb-1.5">
+                                          {param.name}
+                                        </label>
+                                        <input
+                                          type="text"
+                                          value={param.value}
+                                          onChange={(e) =>
+                                            updateToolParameterValue(
+                                              tool.id,
+                                              param.id,
+                                              e.target.value,
+                                            )
+                                          }
+                                          placeholder="Expected value"
+                                          className={`w-full h-10 px-4 rounded-lg text-sm bg-background text-foreground placeholder:text-muted-foreground border focus:outline-none focus:ring-2 focus:ring-accent ${
+                                            localValidationAttempted &&
+                                            activeTab === "tool-invocation" &&
+                                            !param.value.trim()
+                                              ? "border-red-500"
+                                              : "border-border"
+                                          }`}
+                                        />
+                                      </div>
+                                    ))}
+                                  </div>
+                                </div>
+                              )}
                           </div>
-
-                          {/* Accept any parameter values checkbox - show when "should call" is selected and tool has parameters */}
-                          {tool.expectation === "should-call" &&
-                            toolHasParams(tool.id, tool.name) && (
-                              <div className="mt-4 flex items-center gap-3">
-                                <button
-                                  onClick={() =>
-                                    updateToolConfig(tool.id, {
-                                      acceptAnyParameterValues:
-                                        !tool.acceptAnyParameterValues,
-                                    })
-                                  }
-                                  className={`w-5 h-5 rounded border-2 flex-shrink-0 flex items-center justify-center transition-colors cursor-pointer ${
-                                    tool.acceptAnyParameterValues
-                                      ? "bg-foreground border-foreground"
-                                      : "bg-background border-muted-foreground hover:border-foreground"
-                                  }`}
-                                >
-                                  {tool.acceptAnyParameterValues && (
-                                    <svg
-                                      className="w-3 h-3 text-background"
-                                      fill="none"
-                                      viewBox="0 0 24 24"
-                                      stroke="currentColor"
-                                      strokeWidth={3}
-                                    >
-                                      <path
-                                        strokeLinecap="round"
-                                        strokeLinejoin="round"
-                                        d="M4.5 12.75l6 6 9-13.5"
-                                      />
-                                    </svg>
-                                  )}
-                                </button>
-                                <span className="text-sm font-medium text-foreground">
-                                  Accept any values for the parameters
-                                </span>
-                              </div>
-                            )}
-
-                          {/* Expected parameters section - only show when "should call" is selected and toggle is off */}
-                          {tool.expectation === "should-call" &&
-                            tool.expectedParameters.length > 0 &&
-                            !tool.acceptAnyParameterValues && (
-                              <div className="mt-4">
-                                <div className="mb-3">
-                                  <h4 className="text-sm font-medium text-foreground">
-                                    Expected extracted parameters
-                                  </h4>
-                                  <p className="text-xs text-muted-foreground mt-1">
-                                    Configure how each parameter should be
-                                    evaluated when the agent calls this tool
-                                  </p>
-                                </div>
-
-                                <div className="space-y-3">
-                                  {tool.expectedParameters.map((param) => (
-                                    <div key={param.id}>
-                                      <label className="block text-sm font-medium text-muted-foreground mb-1.5">
-                                        {param.name}
-                                      </label>
-                                      <input
-                                        type="text"
-                                        value={param.value}
-                                        onChange={(e) =>
-                                          updateToolParameterValue(
-                                            tool.id,
-                                            param.id,
-                                            e.target.value,
-                                          )
-                                        }
-                                        placeholder="Expected value"
-                                        className={`w-full h-10 px-4 rounded-lg text-sm bg-background text-foreground placeholder:text-muted-foreground border focus:outline-none focus:ring-2 focus:ring-accent ${
-                                          localValidationAttempted &&
-                                          activeTab === "tool-invocation" &&
-                                          !param.value.trim()
-                                            ? "border-red-500"
-                                            : "border-border"
-                                        }`}
-                                      />
-                                    </div>
-                                  ))}
-                                </div>
-                              </div>
-                            )}
-                        </div>
-                      ))}
-                    </div>
-                  )}
-                </div>
-              </div>
-            )}
-          </div>
-
-          {/* Footer */}
-          <div className="px-4 md:px-6 py-3 md:py-4 bg-background">
-            {createError && (
-              <p className="text-sm text-red-500 mb-3">{createError}</p>
-            )}
-            <div className="flex items-center justify-between gap-2">
-              <button
-                onClick={onClose}
-                disabled={isCreating || isLoading}
-                className="h-9 md:h-10 px-4 md:px-5 rounded-lg text-sm md:text-base font-medium bg-background text-foreground hover:bg-muted transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed border border-border"
-              >
-                Back
-              </button>
-              {(() => {
-                const lastMessage = chatMessages[chatMessages.length - 1];
-                const isEmpty = chatMessages.length === 0;
-                let isLastMessageInvalid: boolean;
-                if (requireAssistantLastMessage) {
-                  isLastMessageInvalid =
-                    isEmpty || lastMessage?.role !== "agent";
-                } else if (allowAgentLastMessage) {
-                  isLastMessageInvalid = isEmpty;
-                } else {
-                  // Next-reply AND conversation tests run the agent against
-                  // the trailing user turn, so the history must end on a
-                  // user message, not an agent one.
-                  isLastMessageInvalid =
-                    isEmpty || lastMessage?.role === "agent";
-                }
-                const isLastMessageAgent = isLastMessageInvalid;
-                const tooltipMessage = requireAssistantLastMessage
-                  ? `The conversation history should end with an agent message, not a user message`
-                  : `The conversation history should end with a user message, not an agent message`;
-                const isButtonDisabled =
-                  isCreating || isLoading || isLastMessageInvalid;
-
-                return (
-                  <div className="relative group">
-                    <button
-                      onClick={handleSubmit}
-                      disabled={isButtonDisabled}
-                      className="h-9 md:h-10 px-4 md:px-5 rounded-lg text-sm md:text-base font-medium bg-foreground text-background hover:opacity-90 transition-opacity cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2"
-                    >
-                      {isCreating ? (
-                        <>
-                          <svg
-                            className="w-4 h-4 animate-spin"
-                            fill="none"
-                            viewBox="0 0 24 24"
-                          >
-                            <circle
-                              className="opacity-25"
-                              cx="12"
-                              cy="12"
-                              r="10"
-                              stroke="currentColor"
-                              strokeWidth="4"
-                            ></circle>
-                            <path
-                              className="opacity-75"
-                              fill="currentColor"
-                              d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
-                            ></path>
-                          </svg>
-                          {isEditing ? "Saving..." : "Creating..."}
-                        </>
-                      ) : isEditing ? (
-                        "Save"
-                      ) : (
-                        "Create"
-                      )}
-                    </button>
-                    {/* Tooltip for disabled state */}
-                    {isLastMessageAgent && !isCreating && !isLoading && (
-                      <div className="absolute bottom-full mb-2 right-0 opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none z-50">
-                        <div className="px-3 py-2 text-sm bg-background text-foreground border border-border rounded-lg shadow-lg w-72">
-                          {tooltipMessage}
-                        </div>
-                        {/* Arrow */}
-                        <div className="absolute top-full right-4 -mt-1 w-0 h-0 border-l-[6px] border-l-transparent border-r-[6px] border-r-transparent border-t-[6px] border-t-border"></div>
+                        ))}
                       </div>
                     )}
                   </div>
-                );
-              })()}
-            </div>
-          </div>
-        </div>
-
-        {/* Right Column - Chat Messages */}
-        <div className="w-full md:w-3/5 flex flex-col bg-muted/30 overflow-visible">
-          {/* Info banner */}
-          <div className="px-4 md:px-6 py-3 md:py-4 border-b border-border bg-blue-500/5">
-            <div className="flex items-start gap-3">
-              <svg
-                className="w-5 h-5 text-blue-600 dark:text-blue-400 mt-0.5 flex-shrink-0"
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke="currentColor"
-                strokeWidth={2}
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  d="M11.25 11.25l.041-.02a.75.75 0 011.063.852l-.708 2.836a.75.75 0 001.063.853l.041-.021M21 12a9 9 0 11-18 0 9 9 0 0118 0zm-9-3.75h.008v.008H12V8.25z"
-                />
-              </svg>
-              <p className="text-sm text-foreground leading-relaxed">
-                {requireAssistantLastMessage
-                  ? "Your evaluators read this whole conversation and evaluate the last agent message (the one highlighted) against the evaluators. Only that final reply is scored."
-                  : activeTab === "conversation"
-                    ? "The agent generates its reply to the last user message; the full conversation (history plus that generated reply) is then graded against the evaluators added to the test."
-                    : "The agent's response to the last user message, given the conversation history, will be evaluated against the evaluators added to the test"}
-              </p>
-            </div>
-          </div>
-          {/* Chat Messages Area */}
-          <div className="flex-1 overflow-y-auto overflow-x-visible p-4 md:p-6">
-            {chatMessages.length === 0 ? (
-              /* Empty State Placeholder */
-              <div className="h-full flex flex-col items-center justify-center text-center px-8">
-                {/* Globe with chat icon */}
-                <div className="mb-6">
-                  <svg
-                    className="w-24 h-24 text-muted-foreground"
-                    viewBox="0 0 100 100"
-                    fill="none"
-                  >
-                    {/* Globe */}
-                    <circle
-                      cx="45"
-                      cy="50"
-                      r="30"
-                      stroke="currentColor"
-                      strokeWidth="2"
-                      fill="none"
-                    />
-                    <ellipse
-                      cx="45"
-                      cy="50"
-                      rx="12"
-                      ry="30"
-                      stroke="currentColor"
-                      strokeWidth="1.5"
-                      fill="none"
-                    />
-                    <path
-                      d="M15 50 Q45 35 75 50"
-                      stroke="currentColor"
-                      strokeWidth="1.5"
-                      fill="none"
-                    />
-                    <path
-                      d="M15 50 Q45 65 75 50"
-                      stroke="currentColor"
-                      strokeWidth="1.5"
-                      fill="none"
-                    />
-                    {/* Chat bubbles */}
-                    <circle
-                      cx="70"
-                      cy="30"
-                      r="12"
-                      className="fill-muted"
-                      stroke="currentColor"
-                      strokeWidth="2"
-                    />
-                    <circle cx="66" cy="30" r="1.5" fill="currentColor" />
-                    <circle cx="70" cy="30" r="1.5" fill="currentColor" />
-                    <circle cx="74" cy="30" r="1.5" fill="currentColor" />
-                    {/* Shadow */}
-                    <ellipse
-                      cx="45"
-                      cy="88"
-                      rx="18"
-                      ry="4"
-                      fill="currentColor"
-                      opacity="0.2"
-                    />
-                  </svg>
                 </div>
+              )}
+            </div>
 
-                <h3 className="text-xl font-semibold text-foreground mb-3">
-                  No conversation context
-                </h3>
+            {/* Footer */}
+            <div className="px-4 md:px-6 py-3 md:py-4 bg-background">
+              {createError && (
+                <p className="text-sm text-red-500 mb-3">{createError}</p>
+              )}
+              <div className="flex items-center justify-between gap-2">
+                <button
+                  onClick={onClose}
+                  disabled={isCreating || isLoading}
+                  className="h-9 md:h-10 px-4 md:px-5 rounded-lg text-sm md:text-base font-medium bg-background text-foreground hover:bg-muted transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed border border-border"
+                >
+                  Back
+                </button>
+                {(() => {
+                  const lastMessage = chatMessages[chatMessages.length - 1];
+                  const isEmpty = chatMessages.length === 0;
+                  let isLastMessageInvalid: boolean;
+                  if (requireAssistantLastMessage) {
+                    isLastMessageInvalid =
+                      isEmpty || lastMessage?.role !== "agent";
+                  } else if (allowAgentLastMessage) {
+                    isLastMessageInvalid = isEmpty;
+                  } else {
+                    // Next-reply AND conversation tests run the agent against
+                    // the trailing user turn, so the history must end on a
+                    // user message, not an agent one.
+                    isLastMessageInvalid =
+                      isEmpty || lastMessage?.role === "agent";
+                  }
+                  const isLastMessageAgent = isLastMessageInvalid;
+                  const tooltipMessage = requireAssistantLastMessage
+                    ? `The conversation history should end with an agent message, not a user message`
+                    : `The conversation history should end with a user message, not an agent message`;
+                  const isButtonDisabled =
+                    isCreating || isLoading || isLastMessageInvalid;
 
-                <p className="text-muted-foreground text-sm mb-6 max-w-md leading-relaxed">
-                  The agent&apos;s response to the last user message will be
-                  evaluated against the success criteria using examples
-                  provided. Previous messages will be passed as context.
-                </p>
-
-                <p className="text-muted-foreground text-sm mb-4">
-                  Create conversation context starting with
-                </p>
-
-                {/* Conversation starter buttons. Semantic tint per role so
-                    they match the per-row +-menu items below — agent = sky,
-                    user = amber. */}
-                <div className="flex items-center gap-3">
-                  <button
-                    onClick={() => addChatMessage("agent")}
-                    className="px-4 py-2.5 rounded-xl border cursor-pointer transition-colors flex items-center gap-2 bg-sky-500/12 border-sky-500/45 text-sky-950 dark:text-sky-100 hover:bg-sky-500/22 dark:hover:bg-sky-500/18"
-                  >
-                    <svg
-                      className="w-5 h-5"
-                      fill="none"
-                      viewBox="0 0 24 24"
-                      stroke="currentColor"
-                      strokeWidth={1.5}
-                    >
-                      <path
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        d="M8.25 3v1.5M4.5 8.25H3m18 0h-1.5M4.5 12H3m18 0h-1.5m-15 3.75H3m18 0h-1.5M8.25 19.5V21M12 3v1.5m0 15V21m3.75-18v1.5m0 15V21m-9-1.5h10.5a2.25 2.25 0 002.25-2.25V6.75a2.25 2.25 0 00-2.25-2.25H6.75A2.25 2.25 0 004.5 6.75v10.5a2.25 2.25 0 002.25 2.25zm.75-12h9v9h-9v-9z"
-                      />
-                    </svg>
-                    <span className="text-sm font-medium">Agent message</span>
-                  </button>
-                  <button
-                    onClick={() => addChatMessage("user")}
-                    className="px-4 py-2.5 rounded-xl border cursor-pointer transition-colors flex items-center gap-2 bg-amber-500/12 border-amber-500/45 text-amber-950 dark:text-amber-100 hover:bg-amber-500/22 dark:hover:bg-amber-500/18"
-                  >
-                    <svg
-                      className="w-5 h-5"
-                      fill="none"
-                      viewBox="0 0 24 24"
-                      stroke="currentColor"
-                      strokeWidth={1.5}
-                    >
-                      <path
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        d="M15.75 6a3.75 3.75 0 11-7.5 0 3.75 3.75 0 017.5 0zM4.501 20.118a7.5 7.5 0 0114.998 0A17.933 17.933 0 0112 21.75c-2.676 0-5.216-.584-7.499-1.632z"
-                      />
-                    </svg>
-                    <span className="text-sm font-medium">User message</span>
-                  </button>
-                </div>
-              </div>
-            ) : (
-              <div className="space-y-4">
-                {chatMessages.map((message, index) => {
-                  const evalTargetIndex =
-                    requireAssistantLastMessage &&
-                    chatMessages.length > 0 &&
-                    chatMessages[chatMessages.length - 1].role === "agent"
-                      ? chatMessages.length - 1
-                      : -1;
-                  const isEvalTarget = index === evalTargetIndex;
-                  const lastNonToolResponseIndex =
-                    chatMessages.length -
-                    1 -
-                    (chatMessages[chatMessages.length - 1]?.role ===
-                    "tool_response"
-                      ? 1
-                      : 0);
-                  const isLastNonToolResponse =
-                    index === lastNonToolResponseIndex;
-                  const showInlineDelete =
-                    message.role !== "tool_response" && !isLastNonToolResponse;
-                  const turnTimestamp = formatTurnTimestamp(message.createdAt);
                   return (
-                    <div
-                      key={message.id}
-                      className={`space-y-2 ${
-                        message.role === "user" ? "flex flex-col items-end" : ""
-                      } ${
-                        isEvalTarget
-                          ? "border-l-2 border-blue-500 pl-4 -ml-4"
-                          : ""
-                      }`}
-                    >
-                      {/* Message Header - show for agent messages and tool calls */}
-                      {(message.role === "agent" ||
-                        message.role === "tool_call") && (
-                        <div className="flex items-center gap-2 flex-wrap">
-                          <span className="text-sm font-medium text-foreground">
-                            {message.role === "tool_call"
-                              ? "Agent Tool Call"
-                              : "Agent"}
-                          </span>
-                          {isEvalTarget && (
-                            <span className="inline-flex items-center px-2 py-0.5 rounded-md text-[10px] font-medium uppercase tracking-wide bg-blue-500/10 text-blue-600 dark:text-blue-400">
-                              Evaluation target
-                            </span>
-                          )}
+                    <div className="relative group">
+                      <button
+                        onClick={handleSubmit}
+                        disabled={isButtonDisabled}
+                        className="h-9 md:h-10 px-4 md:px-5 rounded-lg text-sm md:text-base font-medium bg-foreground text-background hover:opacity-90 transition-opacity cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2"
+                      >
+                        {isCreating ? (
+                          <>
+                            <svg
+                              className="w-4 h-4 animate-spin"
+                              fill="none"
+                              viewBox="0 0 24 24"
+                            >
+                              <circle
+                                className="opacity-25"
+                                cx="12"
+                                cy="12"
+                                r="10"
+                                stroke="currentColor"
+                                strokeWidth="4"
+                              ></circle>
+                              <path
+                                className="opacity-75"
+                                fill="currentColor"
+                                d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+                              ></path>
+                            </svg>
+                            {isEditing ? "Saving..." : "Creating..."}
+                          </>
+                        ) : isEditing ? (
+                          "Save"
+                        ) : (
+                          "Create"
+                        )}
+                      </button>
+                      {/* Tooltip for disabled state */}
+                      {isLastMessageAgent && !isCreating && !isLoading && (
+                        <div className="absolute bottom-full mb-2 right-0 opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none z-50">
+                          <div className="px-3 py-2 text-sm bg-background text-foreground border border-border rounded-lg shadow-lg w-72">
+                            {tooltipMessage}
+                          </div>
+                          {/* Arrow */}
+                          <div className="absolute top-full right-4 -mt-1 w-0 h-0 border-l-[6px] border-l-transparent border-r-[6px] border-r-transparent border-t-[6px] border-t-border"></div>
                         </div>
                       )}
+                    </div>
+                  );
+                })()}
+              </div>
+            </div>
+          </div>
 
-                      {/* Message Bubble - for agent and user messages */}
-                      {(message.role === "agent" || message.role === "user") &&
-                        (() => {
-                          const isEmpty =
-                            localValidationAttempted && !message.content.trim();
-                          const inlineDeleteBtn = showInlineDelete ? (
-                            <button
-                              onClick={() => removeChatMessage(message.id)}
-                              className="w-8 h-8 flex-shrink-0 rounded-lg border flex items-center justify-center cursor-pointer transition-colors bg-red-500/10 border-red-500/40 text-red-500 hover:bg-red-500/20 hover:border-red-500/60"
-                              title="Remove message"
-                            >
-                              <svg
-                                className="w-4 h-4"
-                                fill="none"
-                                viewBox="0 0 24 24"
-                                stroke="currentColor"
-                                strokeWidth={2}
+          {/* Right Column - Chat Messages */}
+          <div className="w-full md:w-3/5 flex flex-col bg-muted/30 overflow-visible">
+            {/* Info banner */}
+            <div className="px-4 md:px-6 py-3 md:py-4 border-b border-border bg-blue-500/5">
+              <div className="flex items-start gap-3">
+                <svg
+                  className="w-5 h-5 text-blue-600 dark:text-blue-400 mt-0.5 flex-shrink-0"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                  strokeWidth={2}
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    d="M11.25 11.25l.041-.02a.75.75 0 011.063.852l-.708 2.836a.75.75 0 001.063.853l.041-.021M21 12a9 9 0 11-18 0 9 9 0 0118 0zm-9-3.75h.008v.008H12V8.25z"
+                  />
+                </svg>
+                <p className="text-sm text-foreground leading-relaxed">
+                  {requireAssistantLastMessage
+                    ? "Your evaluators read this whole conversation and evaluate the last agent message (the one highlighted) against the evaluators. Only that final reply is scored."
+                    : activeTab === "conversation"
+                      ? "The agent generates its reply given the conversation and the entire conversation is then graded against the evaluators"
+                      : activeTab === "tool-invocation"
+                        ? "The tool call the agent makes in response to the last user message, given the conversation history, will be checked against the expected tool calls configured for this test"
+                        : "The agent's response to the last user message, given the conversation history, will be evaluated against the evaluators added to the test"}
+                </p>
+              </div>
+            </div>
+            {/* Chat Messages Area */}
+            <div className="flex-1 overflow-y-auto overflow-x-visible p-4 md:p-6">
+              {chatMessages.length === 0 ? (
+                /* Empty State Placeholder */
+                <div className="h-full flex flex-col items-center justify-center text-center px-8">
+                  {/* Globe with chat icon */}
+                  <div className="mb-6">
+                    <svg
+                      className="w-24 h-24 text-muted-foreground"
+                      viewBox="0 0 100 100"
+                      fill="none"
+                    >
+                      {/* Globe */}
+                      <circle
+                        cx="45"
+                        cy="50"
+                        r="30"
+                        stroke="currentColor"
+                        strokeWidth="2"
+                        fill="none"
+                      />
+                      <ellipse
+                        cx="45"
+                        cy="50"
+                        rx="12"
+                        ry="30"
+                        stroke="currentColor"
+                        strokeWidth="1.5"
+                        fill="none"
+                      />
+                      <path
+                        d="M15 50 Q45 35 75 50"
+                        stroke="currentColor"
+                        strokeWidth="1.5"
+                        fill="none"
+                      />
+                      <path
+                        d="M15 50 Q45 65 75 50"
+                        stroke="currentColor"
+                        strokeWidth="1.5"
+                        fill="none"
+                      />
+                      {/* Chat bubbles */}
+                      <circle
+                        cx="70"
+                        cy="30"
+                        r="12"
+                        className="fill-muted"
+                        stroke="currentColor"
+                        strokeWidth="2"
+                      />
+                      <circle cx="66" cy="30" r="1.5" fill="currentColor" />
+                      <circle cx="70" cy="30" r="1.5" fill="currentColor" />
+                      <circle cx="74" cy="30" r="1.5" fill="currentColor" />
+                      {/* Shadow */}
+                      <ellipse
+                        cx="45"
+                        cy="88"
+                        rx="18"
+                        ry="4"
+                        fill="currentColor"
+                        opacity="0.2"
+                      />
+                    </svg>
+                  </div>
+
+                  <h3 className="text-xl font-semibold text-foreground mb-3">
+                    No conversation context
+                  </h3>
+
+                  <p className="text-muted-foreground text-sm mb-6 max-w-md leading-relaxed">
+                    The agent&apos;s response to the last user message will be
+                    evaluated against the success criteria using examples
+                    provided. Previous messages will be passed as context.
+                  </p>
+
+                  <p className="text-muted-foreground text-sm mb-4">
+                    Create conversation context starting with
+                  </p>
+
+                  {/* Conversation starter buttons. Semantic tint per role so
+                    they match the per-row +-menu items below — agent = sky,
+                    user = amber. */}
+                  <div className="flex items-center gap-3">
+                    <button
+                      onClick={() => addChatMessage("agent")}
+                      className="px-4 py-2.5 rounded-xl border cursor-pointer transition-colors flex items-center gap-2 bg-sky-500/12 border-sky-500/45 text-sky-950 dark:text-sky-100 hover:bg-sky-500/22 dark:hover:bg-sky-500/18"
+                    >
+                      <svg
+                        className="w-5 h-5"
+                        fill="none"
+                        viewBox="0 0 24 24"
+                        stroke="currentColor"
+                        strokeWidth={1.5}
+                      >
+                        <path
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          d="M8.25 3v1.5M4.5 8.25H3m18 0h-1.5M4.5 12H3m18 0h-1.5m-15 3.75H3m18 0h-1.5M8.25 19.5V21M12 3v1.5m0 15V21m3.75-18v1.5m0 15V21m-9-1.5h10.5a2.25 2.25 0 002.25-2.25V6.75a2.25 2.25 0 00-2.25-2.25H6.75A2.25 2.25 0 004.5 6.75v10.5a2.25 2.25 0 002.25 2.25zm.75-12h9v9h-9v-9z"
+                        />
+                      </svg>
+                      <span className="text-sm font-medium">Agent message</span>
+                    </button>
+                    <button
+                      onClick={() => addChatMessage("user")}
+                      className="px-4 py-2.5 rounded-xl border cursor-pointer transition-colors flex items-center gap-2 bg-amber-500/12 border-amber-500/45 text-amber-950 dark:text-amber-100 hover:bg-amber-500/22 dark:hover:bg-amber-500/18"
+                    >
+                      <svg
+                        className="w-5 h-5"
+                        fill="none"
+                        viewBox="0 0 24 24"
+                        stroke="currentColor"
+                        strokeWidth={1.5}
+                      >
+                        <path
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          d="M15.75 6a3.75 3.75 0 11-7.5 0 3.75 3.75 0 017.5 0zM4.501 20.118a7.5 7.5 0 0114.998 0A17.933 17.933 0 0112 21.75c-2.676 0-5.216-.584-7.499-1.632z"
+                        />
+                      </svg>
+                      <span className="text-sm font-medium">User message</span>
+                    </button>
+                  </div>
+                </div>
+              ) : (
+                <div className="space-y-4">
+                  {chatMessages.map((message, index) => {
+                    const evalTargetIndex =
+                      requireAssistantLastMessage &&
+                      chatMessages.length > 0 &&
+                      chatMessages[chatMessages.length - 1].role === "agent"
+                        ? chatMessages.length - 1
+                        : -1;
+                    const isEvalTarget = index === evalTargetIndex;
+                    const lastNonToolResponseIndex =
+                      chatMessages.length -
+                      1 -
+                      (chatMessages[chatMessages.length - 1]?.role ===
+                      "tool_response"
+                        ? 1
+                        : 0);
+                    const isLastNonToolResponse =
+                      index === lastNonToolResponseIndex;
+                    const showInlineDelete =
+                      message.role !== "tool_response" &&
+                      !isLastNonToolResponse;
+                    const turnTimestamp = formatTurnTimestamp(
+                      message.createdAt,
+                    );
+                    return (
+                      <div
+                        key={message.id}
+                        className={`space-y-2 ${
+                          message.role === "user"
+                            ? "flex flex-col items-end"
+                            : ""
+                        } ${
+                          isEvalTarget
+                            ? "border-l-2 border-blue-500 pl-4 -ml-4"
+                            : ""
+                        }`}
+                      >
+                        {/* Message Header - show for agent messages and tool calls */}
+                        {(message.role === "agent" ||
+                          message.role === "tool_call") && (
+                          <div className="flex items-center gap-2 flex-wrap">
+                            <span className="text-sm font-medium text-foreground">
+                              {message.role === "tool_call"
+                                ? "Agent Tool Call"
+                                : "Agent"}
+                            </span>
+                            {isEvalTarget && (
+                              <span className="inline-flex items-center px-2 py-0.5 rounded-md text-[10px] font-medium uppercase tracking-wide bg-blue-500/10 text-blue-600 dark:text-blue-400">
+                                Evaluation target
+                              </span>
+                            )}
+                          </div>
+                        )}
+
+                        {/* Message Bubble - for agent and user messages */}
+                        {(message.role === "agent" ||
+                          message.role === "user") &&
+                          (() => {
+                            const isEmpty =
+                              localValidationAttempted &&
+                              !message.content.trim();
+                            const inlineDeleteBtn = showInlineDelete ? (
+                              <button
+                                onClick={() => removeChatMessage(message.id)}
+                                className="w-8 h-8 flex-shrink-0 rounded-lg border flex items-center justify-center cursor-pointer transition-colors bg-red-500/10 border-red-500/40 text-red-500 hover:bg-red-500/20 hover:border-red-500/60"
+                                title="Remove message"
                               >
-                                <path
-                                  strokeLinecap="round"
-                                  strokeLinejoin="round"
-                                  d="M14.74 9l-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 01-2.244 2.077H8.084a2.25 2.25 0 01-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 00-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 013.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 00-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 00-7.5 0"
-                                />
-                              </svg>
-                            </button>
-                          ) : null;
-                          return (
-                            <div
-                              className={`flex w-full items-start gap-2 ${
-                                message.role === "user"
-                                  ? "flex-row-reverse"
-                                  : ""
-                              }`}
-                            >
-                              {inlineDeleteBtn}
-                              <div className="w-fit max-w-[50%] min-w-[180px] flex flex-col">
-                                <textarea
-                                  value={message.content}
-                                  placeholder={
-                                    message.role === "agent"
-                                      ? "Enter agent message"
-                                      : "Enter user message"
-                                  }
-                                  onChange={(e) => {
-                                    updateChatMessage(
-                                      message.id,
-                                      e.target.value,
-                                    );
-                                    // Auto-resize textarea
-                                    e.target.style.height = "auto";
-                                    e.target.style.height = `${e.target.scrollHeight}px`;
-                                  }}
-                                  onInput={(e) => {
-                                    // Auto-resize on initial render and paste
-                                    const target =
-                                      e.target as HTMLTextAreaElement;
-                                    target.style.height = "auto";
-                                    target.style.height = `${target.scrollHeight}px`;
-                                  }}
-                                  ref={autoSizeOnMount}
-                                  data-msg-id={message.id}
-                                  rows={1}
-                                  className={`[field-sizing:content] min-w-[180px] max-w-full px-4 py-2 rounded-xl text-sm text-foreground border focus:outline-none focus:ring-1 resize-none overflow-hidden placeholder:text-muted-foreground ${
-                                    isEmpty
-                                      ? "border-red-500 focus:ring-red-500"
-                                      : "focus:ring-accent " +
-                                        (message.role === "agent"
-                                          ? "bg-background border-border"
-                                          : "bg-accent border-border")
-                                  }`}
-                                />
-                                {isEmpty && (
-                                  <p className="text-xs text-red-500 mt-1">
-                                    Message cannot be empty
-                                  </p>
-                                )}
-                                {turnTimestamp && (
-                                  <span
-                                    className={`text-[11px] text-muted-foreground tabular-nums mt-1 ${
-                                      message.role === "user"
-                                        ? "self-start"
-                                        : "self-end"
+                                <svg
+                                  className="w-4 h-4"
+                                  fill="none"
+                                  viewBox="0 0 24 24"
+                                  stroke="currentColor"
+                                  strokeWidth={2}
+                                >
+                                  <path
+                                    strokeLinecap="round"
+                                    strokeLinejoin="round"
+                                    d="M14.74 9l-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 01-2.244 2.077H8.084a2.25 2.25 0 01-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 00-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 013.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 00-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 00-7.5 0"
+                                  />
+                                </svg>
+                              </button>
+                            ) : null;
+                            return (
+                              <div
+                                className={`flex w-full items-start gap-2 ${
+                                  message.role === "user"
+                                    ? "flex-row-reverse"
+                                    : ""
+                                }`}
+                              >
+                                {inlineDeleteBtn}
+                                <div className="w-fit max-w-[50%] min-w-[180px] flex flex-col">
+                                  <textarea
+                                    value={message.content}
+                                    placeholder={
+                                      message.role === "agent"
+                                        ? "Enter agent message"
+                                        : "Enter user message"
+                                    }
+                                    onChange={(e) => {
+                                      updateChatMessage(
+                                        message.id,
+                                        e.target.value,
+                                      );
+                                      // Auto-resize textarea
+                                      e.target.style.height = "auto";
+                                      e.target.style.height = `${e.target.scrollHeight}px`;
+                                    }}
+                                    onInput={(e) => {
+                                      // Auto-resize on initial render and paste
+                                      const target =
+                                        e.target as HTMLTextAreaElement;
+                                      target.style.height = "auto";
+                                      target.style.height = `${target.scrollHeight}px`;
+                                    }}
+                                    ref={autoSizeOnMount}
+                                    data-msg-id={message.id}
+                                    rows={1}
+                                    className={`[field-sizing:content] min-w-[180px] max-w-full px-4 py-2 rounded-xl text-sm text-foreground border focus:outline-none focus:ring-1 resize-none overflow-hidden placeholder:text-muted-foreground ${
+                                      isEmpty
+                                        ? "border-red-500 focus:ring-red-500"
+                                        : "focus:ring-accent " +
+                                          (message.role === "agent"
+                                            ? "bg-background border-border"
+                                            : "bg-accent border-border")
                                     }`}
-                                  >
-                                    {turnTimestamp}
-                                  </span>
-                                )}
+                                  />
+                                  {isEmpty && (
+                                    <p className="text-xs text-red-500 mt-1">
+                                      Message cannot be empty
+                                    </p>
+                                  )}
+                                  {turnTimestamp && (
+                                    <span
+                                      className={`text-[11px] text-muted-foreground tabular-nums mt-1 ${
+                                        message.role === "user"
+                                          ? "self-start"
+                                          : "self-end"
+                                      }`}
+                                    >
+                                      {turnTimestamp}
+                                    </span>
+                                  )}
+                                </div>
                               </div>
-                            </div>
-                          );
-                        })()}
+                            );
+                          })()}
 
-                      {/* Tool Call Display */}
-                      {message.role === "tool_call" && (
-                        <div className="flex w-full items-start gap-2">
-                          {/* Delete button on the LEFT of the tool-call card
+                        {/* Tool Call Display */}
+                        {message.role === "tool_call" && (
+                          <div className="flex w-full items-start gap-2">
+                            {/* Delete button on the LEFT of the tool-call card
                               so it aligns with how previous agent message
                               rows place it (tool calls are always an agent
                               action, never a user one). Rendered first in
                               source order so flexbox lays it out at the
                               start of the row. */}
-                          {showInlineDelete && (
-                            <button
-                              onClick={() => removeChatMessage(message.id)}
-                              className="w-8 h-8 flex-shrink-0 rounded-lg border flex items-center justify-center cursor-pointer transition-colors bg-red-500/10 border-red-500/40 text-red-500 hover:bg-red-500/20 hover:border-red-500/60"
-                              title="Remove message"
-                            >
-                              <svg
-                                className="w-4 h-4"
-                                fill="none"
-                                viewBox="0 0 24 24"
-                                stroke="currentColor"
-                                strokeWidth={2}
+                            {showInlineDelete && (
+                              <button
+                                onClick={() => removeChatMessage(message.id)}
+                                className="w-8 h-8 flex-shrink-0 rounded-lg border flex items-center justify-center cursor-pointer transition-colors bg-red-500/10 border-red-500/40 text-red-500 hover:bg-red-500/20 hover:border-red-500/60"
+                                title="Remove message"
                               >
-                                <path
-                                  strokeLinecap="round"
-                                  strokeLinejoin="round"
-                                  d="M14.74 9l-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 01-2.244 2.077H8.084a2.25 2.25 0 01-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 00-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 013.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 00-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 00-7.5 0"
-                                />
-                              </svg>
-                            </button>
-                          )}
-                          <div className="w-1/2 flex flex-col">
+                                <svg
+                                  className="w-4 h-4"
+                                  fill="none"
+                                  viewBox="0 0 24 24"
+                                  stroke="currentColor"
+                                  strokeWidth={2}
+                                >
+                                  <path
+                                    strokeLinecap="round"
+                                    strokeLinejoin="round"
+                                    d="M14.74 9l-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 01-2.244 2.077H8.084a2.25 2.25 0 01-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 00-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 013.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 00-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 00-7.5 0"
+                                  />
+                                </svg>
+                              </button>
+                            )}
+                            <div className="w-1/2 flex flex-col">
+                              <div className="bg-muted border border-border rounded-2xl p-4">
+                                <div className="flex items-center gap-2 mb-2">
+                                  <svg
+                                    className="w-4 h-4 text-muted-foreground"
+                                    fill="none"
+                                    viewBox="0 0 24 24"
+                                    stroke="currentColor"
+                                    strokeWidth={1.5}
+                                  >
+                                    <path
+                                      strokeLinecap="round"
+                                      strokeLinejoin="round"
+                                      d="M11.42 15.17L17.25 21A2.652 2.652 0 0021 17.25l-5.877-5.877M11.42 15.17l2.496-3.03c.317-.384.74-.626 1.208-.766M11.42 15.17l-4.655 5.653a2.548 2.548 0 11-3.586-3.586l6.837-5.63m5.108-.233c.55-.164 1.163-.188 1.743-.14a4.5 4.5 0 004.486-6.336l-3.276 3.277a3.004 3.004 0 01-2.25-2.25l3.276-3.276a4.5 4.5 0 00-6.336 4.486c.091 1.076-.071 2.264-.904 2.95l-.102.085m-1.745 1.437L5.909 7.5H4.5L2.25 3.75l1.5-1.5L7.5 4.5v1.409l4.26 4.26m-1.745 1.437l1.745-1.437m6.615 8.206L15.75 15.75M4.867 19.125h.008v.008h-.008v-.008z"
+                                    />
+                                  </svg>
+                                  <span className="text-sm font-medium text-foreground">
+                                    {message.toolName}
+                                  </span>
+                                  {message.isWebhook && (
+                                    <span className="text-xs text-muted-foreground bg-background px-2 py-0.5 rounded">
+                                      Webhook
+                                    </span>
+                                  )}
+                                </div>
+                                {message.toolParams &&
+                                  message.toolParams.length > 0 && (
+                                    <div className="space-y-3 mt-3">
+                                      {/* Group parameters by type for webhook tools */}
+                                      {message.isWebhook ? (
+                                        <>
+                                          {/* Query Parameters */}
+                                          {message.toolParams.filter(
+                                            (p) => p.group === "query",
+                                          ).length > 0 && (
+                                            <div className="bg-background border border-border rounded-xl p-3">
+                                              <h5 className="text-xs font-medium text-muted-foreground mb-3 uppercase tracking-wide">
+                                                Query
+                                              </h5>
+                                              <div className="space-y-3">
+                                                {message.toolParams
+                                                  .filter(
+                                                    (p) => p.group === "query",
+                                                  )
+                                                  .map((param, idx) => {
+                                                    const isEmpty =
+                                                      !param.value.trim();
+                                                    const showError =
+                                                      localValidationAttempted &&
+                                                      isEmpty;
+                                                    return (
+                                                      <div key={idx}>
+                                                        <label className="block text-sm font-medium text-foreground mb-1.5">
+                                                          {param.name}
+                                                        </label>
+                                                        <input
+                                                          type="text"
+                                                          value={param.value}
+                                                          onChange={(e) =>
+                                                            updateToolCallParam(
+                                                              message.id,
+                                                              param.name,
+                                                              e.target.value,
+                                                              param.group,
+                                                            )
+                                                          }
+                                                          placeholder={`Enter ${param.name}`}
+                                                          data-tool-call-id={
+                                                            message.id
+                                                          }
+                                                          className={`w-full h-10 px-3 rounded-lg text-sm bg-muted text-foreground placeholder:text-muted-foreground border focus:outline-none focus:ring-2 focus:ring-accent ${
+                                                            showError
+                                                              ? "border-red-500"
+                                                              : "border-border"
+                                                          }`}
+                                                        />
+                                                        {showError && (
+                                                          <p className="text-xs text-red-500 mt-1">
+                                                            This field cannot be
+                                                            empty
+                                                          </p>
+                                                        )}
+                                                      </div>
+                                                    );
+                                                  })}
+                                              </div>
+                                            </div>
+                                          )}
+                                          {/* Body Parameters */}
+                                          {message.toolParams.filter(
+                                            (p) => p.group === "body",
+                                          ).length > 0 && (
+                                            <div className="bg-background border border-border rounded-xl p-3">
+                                              <h5 className="text-xs font-medium text-muted-foreground mb-3 uppercase tracking-wide">
+                                                Body
+                                              </h5>
+                                              <div className="space-y-3">
+                                                {message.toolParams
+                                                  .filter(
+                                                    (p) => p.group === "body",
+                                                  )
+                                                  .map((param, idx) => {
+                                                    const isEmpty =
+                                                      !param.value.trim();
+                                                    const showError =
+                                                      localValidationAttempted &&
+                                                      isEmpty;
+                                                    return (
+                                                      <div key={idx}>
+                                                        <label className="block text-sm font-medium text-foreground mb-1.5">
+                                                          {param.name}
+                                                        </label>
+                                                        <input
+                                                          type="text"
+                                                          value={param.value}
+                                                          onChange={(e) =>
+                                                            updateToolCallParam(
+                                                              message.id,
+                                                              param.name,
+                                                              e.target.value,
+                                                              param.group,
+                                                            )
+                                                          }
+                                                          placeholder={`Enter ${param.name}`}
+                                                          data-tool-call-id={
+                                                            message.id
+                                                          }
+                                                          className={`w-full h-10 px-3 rounded-lg text-sm bg-muted text-foreground placeholder:text-muted-foreground border focus:outline-none focus:ring-2 focus:ring-accent ${
+                                                            showError
+                                                              ? "border-red-500"
+                                                              : "border-border"
+                                                          }`}
+                                                        />
+                                                        {showError && (
+                                                          <p className="text-xs text-red-500 mt-1">
+                                                            This field cannot be
+                                                            empty
+                                                          </p>
+                                                        )}
+                                                      </div>
+                                                    );
+                                                  })}
+                                              </div>
+                                            </div>
+                                          )}
+                                        </>
+                                      ) : (
+                                        /* Regular tool parameters */
+                                        <div className="space-y-3">
+                                          {message.toolParams.map(
+                                            (param, idx) => {
+                                              const isEmpty =
+                                                !param.value.trim();
+                                              const showError =
+                                                localValidationAttempted &&
+                                                isEmpty;
+                                              return (
+                                                <div key={idx}>
+                                                  <label className="block text-sm font-medium text-foreground mb-1.5">
+                                                    {param.name}
+                                                  </label>
+                                                  <input
+                                                    type="text"
+                                                    value={param.value}
+                                                    onChange={(e) =>
+                                                      updateToolCallParam(
+                                                        message.id,
+                                                        param.name,
+                                                        e.target.value,
+                                                        param.group,
+                                                      )
+                                                    }
+                                                    placeholder={`Enter ${param.name}`}
+                                                    className={`w-full h-10 px-4 rounded-lg text-sm bg-background text-foreground placeholder:text-muted-foreground border focus:outline-none focus:ring-2 focus:ring-accent ${
+                                                      showError
+                                                        ? "border-red-500"
+                                                        : "border-border"
+                                                    }`}
+                                                  />
+                                                  {showError && (
+                                                    <p className="text-xs text-red-500 mt-1">
+                                                      This field cannot be empty
+                                                    </p>
+                                                  )}
+                                                </div>
+                                              );
+                                            },
+                                          )}
+                                        </div>
+                                      )}
+                                    </div>
+                                  )}
+                              </div>
+                              {turnTimestamp && (
+                                <span className="self-end text-[11px] text-muted-foreground tabular-nums mt-1">
+                                  {turnTimestamp}
+                                </span>
+                              )}
+                            </div>
+                          </div>
+                        )}
+
+                        {/* Tool Response Display (for webhook tools) */}
+                        {message.role === "tool_response" && (
+                          <div className="w-1/2">
                             <div className="bg-muted border border-border rounded-2xl p-4">
                               <div className="flex items-center gap-2 mb-2">
                                 <svg
@@ -2578,339 +2793,139 @@ export function AddTestDialog({
                                   <path
                                     strokeLinecap="round"
                                     strokeLinejoin="round"
-                                    d="M11.42 15.17L17.25 21A2.652 2.652 0 0021 17.25l-5.877-5.877M11.42 15.17l2.496-3.03c.317-.384.74-.626 1.208-.766M11.42 15.17l-4.655 5.653a2.548 2.548 0 11-3.586-3.586l6.837-5.63m5.108-.233c.55-.164 1.163-.188 1.743-.14a4.5 4.5 0 004.486-6.336l-3.276 3.277a3.004 3.004 0 01-2.25-2.25l3.276-3.276a4.5 4.5 0 00-6.336 4.486c.091 1.076-.071 2.264-.904 2.95l-.102.085m-1.745 1.437L5.909 7.5H4.5L2.25 3.75l1.5-1.5L7.5 4.5v1.409l4.26 4.26m-1.745 1.437l1.745-1.437m6.615 8.206L15.75 15.75M4.867 19.125h.008v.008h-.008v-.008z"
+                                    d="M9 12.75L11.25 15 15 9.75M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
                                   />
                                 </svg>
                                 <span className="text-sm font-medium text-foreground">
-                                  {message.toolName}
+                                  Tool Response
                                 </span>
-                                {message.isWebhook && (
-                                  <span className="text-xs text-muted-foreground bg-background px-2 py-0.5 rounded">
-                                    Webhook
-                                  </span>
-                                )}
+                                <span className="text-xs text-muted-foreground">
+                                  ({message.toolName})
+                                </span>
                               </div>
-                              {message.toolParams &&
-                                message.toolParams.length > 0 && (
-                                  <div className="space-y-3 mt-3">
-                                    {/* Group parameters by type for webhook tools */}
-                                    {message.isWebhook ? (
-                                      <>
-                                        {/* Query Parameters */}
-                                        {message.toolParams.filter(
-                                          (p) => p.group === "query",
-                                        ).length > 0 && (
-                                          <div className="bg-background border border-border rounded-xl p-3">
-                                            <h5 className="text-xs font-medium text-muted-foreground mb-3 uppercase tracking-wide">
-                                              Query
-                                            </h5>
-                                            <div className="space-y-3">
-                                              {message.toolParams
-                                                .filter(
-                                                  (p) => p.group === "query",
-                                                )
-                                                .map((param, idx) => {
-                                                  const isEmpty =
-                                                    !param.value.trim();
-                                                  const showError =
-                                                    localValidationAttempted &&
-                                                    isEmpty;
-                                                  return (
-                                                    <div key={idx}>
-                                                      <label className="block text-sm font-medium text-foreground mb-1.5">
-                                                        {param.name}
-                                                      </label>
-                                                      <input
-                                                        type="text"
-                                                        value={param.value}
-                                                        onChange={(e) =>
-                                                          updateToolCallParam(
-                                                            message.id,
-                                                            param.name,
-                                                            e.target.value,
-                                                            param.group,
-                                                          )
-                                                        }
-                                                        placeholder={`Enter ${param.name}`}
-                                                        data-tool-call-id={
-                                                          message.id
-                                                        }
-                                                        className={`w-full h-10 px-3 rounded-lg text-sm bg-muted text-foreground placeholder:text-muted-foreground border focus:outline-none focus:ring-2 focus:ring-accent ${
-                                                          showError
-                                                            ? "border-red-500"
-                                                            : "border-border"
-                                                        }`}
-                                                      />
-                                                      {showError && (
-                                                        <p className="text-xs text-red-500 mt-1">
-                                                          This field cannot be
-                                                          empty
-                                                        </p>
-                                                      )}
-                                                    </div>
-                                                  );
-                                                })}
-                                            </div>
-                                          </div>
-                                        )}
-                                        {/* Body Parameters */}
-                                        {message.toolParams.filter(
-                                          (p) => p.group === "body",
-                                        ).length > 0 && (
-                                          <div className="bg-background border border-border rounded-xl p-3">
-                                            <h5 className="text-xs font-medium text-muted-foreground mb-3 uppercase tracking-wide">
-                                              Body
-                                            </h5>
-                                            <div className="space-y-3">
-                                              {message.toolParams
-                                                .filter(
-                                                  (p) => p.group === "body",
-                                                )
-                                                .map((param, idx) => {
-                                                  const isEmpty =
-                                                    !param.value.trim();
-                                                  const showError =
-                                                    localValidationAttempted &&
-                                                    isEmpty;
-                                                  return (
-                                                    <div key={idx}>
-                                                      <label className="block text-sm font-medium text-foreground mb-1.5">
-                                                        {param.name}
-                                                      </label>
-                                                      <input
-                                                        type="text"
-                                                        value={param.value}
-                                                        onChange={(e) =>
-                                                          updateToolCallParam(
-                                                            message.id,
-                                                            param.name,
-                                                            e.target.value,
-                                                            param.group,
-                                                          )
-                                                        }
-                                                        placeholder={`Enter ${param.name}`}
-                                                        data-tool-call-id={
-                                                          message.id
-                                                        }
-                                                        className={`w-full h-10 px-3 rounded-lg text-sm bg-muted text-foreground placeholder:text-muted-foreground border focus:outline-none focus:ring-2 focus:ring-accent ${
-                                                          showError
-                                                            ? "border-red-500"
-                                                            : "border-border"
-                                                        }`}
-                                                      />
-                                                      {showError && (
-                                                        <p className="text-xs text-red-500 mt-1">
-                                                          This field cannot be
-                                                          empty
-                                                        </p>
-                                                      )}
-                                                    </div>
-                                                  );
-                                                })}
-                                            </div>
-                                          </div>
-                                        )}
-                                      </>
-                                    ) : (
-                                      /* Regular tool parameters */
-                                      <div className="space-y-3">
-                                        {message.toolParams.map(
-                                          (param, idx) => {
-                                            const isEmpty = !param.value.trim();
-                                            const showError =
-                                              localValidationAttempted &&
-                                              isEmpty;
-                                            return (
-                                              <div key={idx}>
-                                                <label className="block text-sm font-medium text-foreground mb-1.5">
-                                                  {param.name}
-                                                </label>
-                                                <input
-                                                  type="text"
-                                                  value={param.value}
-                                                  onChange={(e) =>
-                                                    updateToolCallParam(
-                                                      message.id,
-                                                      param.name,
-                                                      e.target.value,
-                                                      param.group,
-                                                    )
-                                                  }
-                                                  placeholder={`Enter ${param.name}`}
-                                                  className={`w-full h-10 px-4 rounded-lg text-sm bg-background text-foreground placeholder:text-muted-foreground border focus:outline-none focus:ring-2 focus:ring-accent ${
-                                                    showError
-                                                      ? "border-red-500"
-                                                      : "border-border"
-                                                  }`}
-                                                />
-                                                {showError && (
-                                                  <p className="text-xs text-red-500 mt-1">
-                                                    This field cannot be empty
-                                                  </p>
-                                                )}
-                                              </div>
-                                            );
-                                          },
-                                        )}
-                                      </div>
-                                    )}
-                                  </div>
-                                )}
-                            </div>
-                            {turnTimestamp && (
-                              <span className="self-end text-[11px] text-muted-foreground tabular-nums mt-1">
-                                {turnTimestamp}
-                              </span>
-                            )}
-                          </div>
-                        </div>
-                      )}
-
-                      {/* Tool Response Display (for webhook tools) */}
-                      {message.role === "tool_response" && (
-                        <div className="w-1/2">
-                          <div className="bg-muted border border-border rounded-2xl p-4">
-                            <div className="flex items-center gap-2 mb-2">
-                              <svg
-                                className="w-4 h-4 text-muted-foreground"
-                                fill="none"
-                                viewBox="0 0 24 24"
-                                stroke="currentColor"
-                                strokeWidth={1.5}
-                              >
-                                <path
-                                  strokeLinecap="round"
-                                  strokeLinejoin="round"
-                                  d="M9 12.75L11.25 15 15 9.75M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
-                                />
-                              </svg>
-                              <span className="text-sm font-medium text-foreground">
-                                Tool Response
-                              </span>
-                              <span className="text-xs text-muted-foreground">
-                                ({message.toolName})
-                              </span>
-                            </div>
-                            <div className="mt-2">
-                              <label className="block text-xs font-medium text-muted-foreground mb-1.5">
-                                JSON Response{" "}
-                                <span className="text-red-500">*</span>
-                              </label>
-                              <textarea
-                                value={message.content}
-                                onChange={(e) =>
-                                  updateChatMessage(message.id, e.target.value)
-                                }
-                                placeholder='{"status": "success", "response": {}}'
-                                rows={5}
-                                className={`w-full px-3 py-2 rounded-lg text-sm font-mono bg-background text-foreground placeholder:text-muted-foreground border focus:outline-none focus:ring-2 focus:ring-accent ${(() => {
-                                  try {
-                                    JSON.parse(message.content);
-                                    return "border-border";
-                                  } catch {
-                                    return message.content.trim()
-                                      ? "border-red-500"
-                                      : "border-border";
-                                  }
-                                })()}`}
-                              />
-                              {(() => {
-                                try {
-                                  JSON.parse(message.content);
-                                  return null;
-                                } catch {
-                                  return message.content.trim() ? (
-                                    <p className="text-xs text-red-500 mt-1">
-                                      Invalid JSON format
-                                    </p>
-                                  ) : null;
-                                }
-                              })()}
-                            </div>
-                          </div>
-                        </div>
-                      )}
-
-                      {/* Message Actions — Delete + Add on the last non-tool-response message only.
-                           Earlier messages get an inline delete button beside the bubble. */}
-                      <div className="flex items-center gap-2 relative">
-                        {message.role !== "tool_response" &&
-                          isLastNonToolResponse && (
-                            <button
-                              onClick={() => removeChatMessage(message.id)}
-                              className="w-8 h-8 rounded-lg border flex items-center justify-center cursor-pointer transition-colors bg-red-500/10 border-red-500/40 text-red-500 hover:bg-red-500/20 hover:border-red-500/60"
-                              title="Remove message"
-                            >
-                              <svg
-                                className="w-4 h-4"
-                                fill="none"
-                                viewBox="0 0 24 24"
-                                stroke="currentColor"
-                                strokeWidth={2}
-                              >
-                                <path
-                                  strokeLinecap="round"
-                                  strokeLinejoin="round"
-                                  d="M14.74 9l-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 01-2.244 2.077H8.084a2.25 2.25 0 01-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 00-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 013.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 00-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 00-7.5 0"
-                                />
-                              </svg>
-                            </button>
-                          )}
-                        {message.role !== "tool_response" &&
-                          index ===
-                            chatMessages.length -
-                              1 -
-                              (chatMessages[chatMessages.length - 1]?.role ===
-                              "tool_response"
-                                ? 1
-                                : 0) && (
-                            <>
-                              <div className="relative">
-                                <button
-                                  onClick={() =>
-                                    setAddMessageDropdownOpen(
-                                      !addMessageDropdownOpen,
+                              <div className="mt-2">
+                                <label className="block text-xs font-medium text-muted-foreground mb-1.5">
+                                  JSON Response{" "}
+                                  <span className="text-red-500">*</span>
+                                </label>
+                                <textarea
+                                  value={message.content}
+                                  onChange={(e) =>
+                                    updateChatMessage(
+                                      message.id,
+                                      e.target.value,
                                     )
                                   }
-                                  className="w-8 h-8 rounded-lg border flex items-center justify-center cursor-pointer transition-colors bg-emerald-500/12 border-emerald-500/45 text-emerald-700 dark:text-emerald-300 hover:bg-emerald-500/22 dark:hover:bg-emerald-500/18"
-                                  title="Add message"
-                                >
-                                  <svg
-                                    className="w-4 h-4"
-                                    fill="none"
-                                    viewBox="0 0 24 24"
-                                    stroke="currentColor"
-                                    strokeWidth={2}
-                                  >
-                                    <path
-                                      strokeLinecap="round"
-                                      strokeLinejoin="round"
-                                      d="M12 4.5v15m7.5-7.5h-15"
-                                    />
-                                  </svg>
-                                </button>
+                                  placeholder='{"status": "success", "response": {}}'
+                                  rows={5}
+                                  className={`w-full px-3 py-2 rounded-lg text-sm font-mono bg-background text-foreground placeholder:text-muted-foreground border focus:outline-none focus:ring-2 focus:ring-accent ${(() => {
+                                    try {
+                                      JSON.parse(message.content);
+                                      return "border-border";
+                                    } catch {
+                                      return message.content.trim()
+                                        ? "border-red-500"
+                                        : "border-border";
+                                    }
+                                  })()}`}
+                                />
+                                {(() => {
+                                  try {
+                                    JSON.parse(message.content);
+                                    return null;
+                                  } catch {
+                                    return message.content.trim() ? (
+                                      <p className="text-xs text-red-500 mt-1">
+                                        Invalid JSON format
+                                      </p>
+                                    ) : null;
+                                  }
+                                })()}
+                              </div>
+                            </div>
+                          </div>
+                        )}
 
-                                {/* Dropdown Menu */}
-                                {addMessageDropdownOpen && (
-                                  <>
-                                    <div
-                                      className="fixed inset-0 z-[150]"
-                                      onClick={() =>
-                                        setAddMessageDropdownOpen(false)
-                                      }
-                                    />
-                                    <div
-                                      className={`absolute bg-background border border-border rounded-lg shadow-xl z-[200] overflow-hidden whitespace-nowrap ${
-                                        message.role === "user"
-                                          ? chatMessages.length <= 2
-                                            ? "right-0 top-10"
-                                            : "right-0 bottom-full mb-2"
-                                          : chatMessages.length <= 2
-                                            ? "left-0 top-10"
-                                            : "left-0 bottom-full mb-2"
-                                      }`}
+                        {/* Message Actions — Delete + Add on the last non-tool-response message only.
+                           Earlier messages get an inline delete button beside the bubble. */}
+                        <div className="flex items-center gap-2 relative">
+                          {message.role !== "tool_response" &&
+                            isLastNonToolResponse && (
+                              <button
+                                onClick={() => removeChatMessage(message.id)}
+                                className="w-8 h-8 rounded-lg border flex items-center justify-center cursor-pointer transition-colors bg-red-500/10 border-red-500/40 text-red-500 hover:bg-red-500/20 hover:border-red-500/60"
+                                title="Remove message"
+                              >
+                                <svg
+                                  className="w-4 h-4"
+                                  fill="none"
+                                  viewBox="0 0 24 24"
+                                  stroke="currentColor"
+                                  strokeWidth={2}
+                                >
+                                  <path
+                                    strokeLinecap="round"
+                                    strokeLinejoin="round"
+                                    d="M14.74 9l-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 01-2.244 2.077H8.084a2.25 2.25 0 01-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 00-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 013.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 00-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 00-7.5 0"
+                                  />
+                                </svg>
+                              </button>
+                            )}
+                          {message.role !== "tool_response" &&
+                            index ===
+                              chatMessages.length -
+                                1 -
+                                (chatMessages[chatMessages.length - 1]?.role ===
+                                "tool_response"
+                                  ? 1
+                                  : 0) && (
+                              <>
+                                <div className="relative">
+                                  <button
+                                    onClick={() =>
+                                      setAddMessageDropdownOpen(
+                                        !addMessageDropdownOpen,
+                                      )
+                                    }
+                                    className="w-8 h-8 rounded-lg border flex items-center justify-center cursor-pointer transition-colors bg-emerald-500/12 border-emerald-500/45 text-emerald-700 dark:text-emerald-300 hover:bg-emerald-500/22 dark:hover:bg-emerald-500/18"
+                                    title="Add message"
+                                  >
+                                    <svg
+                                      className="w-4 h-4"
+                                      fill="none"
+                                      viewBox="0 0 24 24"
+                                      stroke="currentColor"
+                                      strokeWidth={2}
                                     >
-                                      {/* Three clearly separated hues so
+                                      <path
+                                        strokeLinecap="round"
+                                        strokeLinejoin="round"
+                                        d="M12 4.5v15m7.5-7.5h-15"
+                                      />
+                                    </svg>
+                                  </button>
+
+                                  {/* Dropdown Menu */}
+                                  {addMessageDropdownOpen && (
+                                    <>
+                                      <div
+                                        className="fixed inset-0 z-[150]"
+                                        onClick={() =>
+                                          setAddMessageDropdownOpen(false)
+                                        }
+                                      />
+                                      <div
+                                        className={`absolute bg-background border border-border rounded-lg shadow-xl z-[200] overflow-hidden whitespace-nowrap ${
+                                          message.role === "user"
+                                            ? chatMessages.length <= 2
+                                              ? "right-0 top-10"
+                                              : "right-0 bottom-full mb-2"
+                                            : chatMessages.length <= 2
+                                              ? "left-0 top-10"
+                                              : "left-0 bottom-full mb-2"
+                                        }`}
+                                      >
+                                        {/* Three clearly separated hues so
                                           adjacent rows don't read as the
                                           same family: amber (warm yellow)
                                           for User, sky (cool blue) for
@@ -2918,297 +2933,299 @@ export function AddTestDialog({
                                           for Agent tool call — also
                                           distinct from the violet
                                           "Add evaluator" button above. */}
-                                      <button
-                                        onClick={() => {
-                                          addChatMessage("user");
-                                          setAddMessageDropdownOpen(false);
-                                        }}
-                                        className="w-full px-3 py-1.5 flex items-center gap-2 transition-colors cursor-pointer bg-amber-500/15 text-amber-900 dark:bg-amber-500/20 dark:text-amber-100 hover:bg-amber-500/25 dark:hover:bg-amber-500/30"
-                                      >
-                                        <svg
-                                          className="w-4 h-4"
-                                          fill="none"
-                                          viewBox="0 0 24 24"
-                                          stroke="currentColor"
-                                          strokeWidth={1.5}
+                                        <button
+                                          onClick={() => {
+                                            addChatMessage("user");
+                                            setAddMessageDropdownOpen(false);
+                                          }}
+                                          className="w-full px-3 py-1.5 flex items-center gap-2 transition-colors cursor-pointer bg-amber-500/15 text-amber-900 dark:bg-amber-500/20 dark:text-amber-100 hover:bg-amber-500/25 dark:hover:bg-amber-500/30"
                                         >
-                                          <path
-                                            strokeLinecap="round"
-                                            strokeLinejoin="round"
-                                            d="M15.75 6a3.75 3.75 0 11-7.5 0 3.75 3.75 0 017.5 0zM4.501 20.118a7.5 7.5 0 0114.998 0A17.933 17.933 0 0112 21.75c-2.676 0-5.216-.584-7.499-1.632z"
-                                          />
-                                        </svg>
-                                        <span className="text-sm">
-                                          User message
-                                        </span>
-                                      </button>
-                                      <button
-                                        onClick={() => {
-                                          addChatMessage("agent");
-                                          setAddMessageDropdownOpen(false);
-                                        }}
-                                        className="w-full px-3 py-1.5 flex items-center gap-2 transition-colors cursor-pointer bg-sky-500/15 text-sky-900 dark:bg-sky-500/20 dark:text-sky-100 hover:bg-sky-500/25 dark:hover:bg-sky-500/30"
-                                      >
-                                        <svg
-                                          className="w-4 h-4"
-                                          fill="none"
-                                          viewBox="0 0 24 24"
-                                          stroke="currentColor"
-                                          strokeWidth={1.5}
+                                          <svg
+                                            className="w-4 h-4"
+                                            fill="none"
+                                            viewBox="0 0 24 24"
+                                            stroke="currentColor"
+                                            strokeWidth={1.5}
+                                          >
+                                            <path
+                                              strokeLinecap="round"
+                                              strokeLinejoin="round"
+                                              d="M15.75 6a3.75 3.75 0 11-7.5 0 3.75 3.75 0 017.5 0zM4.501 20.118a7.5 7.5 0 0114.998 0A17.933 17.933 0 0112 21.75c-2.676 0-5.216-.584-7.499-1.632z"
+                                            />
+                                          </svg>
+                                          <span className="text-sm">
+                                            User message
+                                          </span>
+                                        </button>
+                                        <button
+                                          onClick={() => {
+                                            addChatMessage("agent");
+                                            setAddMessageDropdownOpen(false);
+                                          }}
+                                          className="w-full px-3 py-1.5 flex items-center gap-2 transition-colors cursor-pointer bg-sky-500/15 text-sky-900 dark:bg-sky-500/20 dark:text-sky-100 hover:bg-sky-500/25 dark:hover:bg-sky-500/30"
                                         >
-                                          <path
-                                            strokeLinecap="round"
-                                            strokeLinejoin="round"
-                                            d="M8.25 3v1.5M4.5 8.25H3m18 0h-1.5M4.5 12H3m18 0h-1.5m-15 3.75H3m18 0h-1.5M8.25 19.5V21M12 3v1.5m0 15V21m3.75-18v1.5m0 15V21m-9-1.5h10.5a2.25 2.25 0 002.25-2.25V6.75a2.25 2.25 0 00-2.25-2.25H6.75A2.25 2.25 0 004.5 6.75v10.5a2.25 2.25 0 002.25 2.25zm.75-12h9v9h-9v-9z"
-                                          />
-                                        </svg>
-                                        <span className="text-sm">
-                                          Agent message
-                                        </span>
-                                      </button>
-                                      <button
-                                        onClick={() => {
-                                          setAddMessageDropdownOpen(false);
-                                          setToolCallDropdownOpen(true);
-                                        }}
-                                        className="w-full px-3 py-1.5 flex items-center gap-2 transition-colors cursor-pointer bg-fuchsia-500/15 text-fuchsia-900 dark:bg-fuchsia-500/20 dark:text-fuchsia-100 hover:bg-fuchsia-500/25 dark:hover:bg-fuchsia-500/30"
-                                      >
-                                        <svg
-                                          className="w-4 h-4"
-                                          fill="none"
-                                          viewBox="0 0 24 24"
-                                          stroke="currentColor"
-                                          strokeWidth={1.5}
+                                          <svg
+                                            className="w-4 h-4"
+                                            fill="none"
+                                            viewBox="0 0 24 24"
+                                            stroke="currentColor"
+                                            strokeWidth={1.5}
+                                          >
+                                            <path
+                                              strokeLinecap="round"
+                                              strokeLinejoin="round"
+                                              d="M8.25 3v1.5M4.5 8.25H3m18 0h-1.5M4.5 12H3m18 0h-1.5m-15 3.75H3m18 0h-1.5M8.25 19.5V21M12 3v1.5m0 15V21m3.75-18v1.5m0 15V21m-9-1.5h10.5a2.25 2.25 0 002.25-2.25V6.75a2.25 2.25 0 00-2.25-2.25H6.75A2.25 2.25 0 004.5 6.75v10.5a2.25 2.25 0 002.25 2.25zm.75-12h9v9h-9v-9z"
+                                            />
+                                          </svg>
+                                          <span className="text-sm">
+                                            Agent message
+                                          </span>
+                                        </button>
+                                        <button
+                                          onClick={() => {
+                                            setAddMessageDropdownOpen(false);
+                                            setToolCallDropdownOpen(true);
+                                          }}
+                                          className="w-full px-3 py-1.5 flex items-center gap-2 transition-colors cursor-pointer bg-fuchsia-500/15 text-fuchsia-900 dark:bg-fuchsia-500/20 dark:text-fuchsia-100 hover:bg-fuchsia-500/25 dark:hover:bg-fuchsia-500/30"
                                         >
-                                          <path
-                                            strokeLinecap="round"
-                                            strokeLinejoin="round"
-                                            d="M11.42 15.17L17.25 21A2.652 2.652 0 0021 17.25l-5.877-5.877M11.42 15.17l2.496-3.03c.317-.384.74-.626 1.208-.766M11.42 15.17l-4.655 5.653a2.548 2.548 0 11-3.586-3.586l6.837-5.63m5.108-.233c.55-.164 1.163-.188 1.743-.14a4.5 4.5 0 004.486-6.336l-3.276 3.277a3.004 3.004 0 01-2.25-2.25l3.276-3.276a4.5 4.5 0 00-6.336 4.486c.091 1.076-.071 2.264-.904 2.95l-.102.085m-1.745 1.437L5.909 7.5H4.5L2.25 3.75l1.5-1.5L7.5 4.5v1.409l4.26 4.26m-1.745 1.437l1.745-1.437m6.615 8.206L15.75 15.75M4.867 19.125h.008v.008h-.008v-.008z"
-                                          />
-                                        </svg>
-                                        <span className="text-sm">
-                                          Agent tool call
-                                        </span>
-                                      </button>
-                                    </div>
-                                  </>
-                                )}
+                                          <svg
+                                            className="w-4 h-4"
+                                            fill="none"
+                                            viewBox="0 0 24 24"
+                                            stroke="currentColor"
+                                            strokeWidth={1.5}
+                                          >
+                                            <path
+                                              strokeLinecap="round"
+                                              strokeLinejoin="round"
+                                              d="M11.42 15.17L17.25 21A2.652 2.652 0 0021 17.25l-5.877-5.877M11.42 15.17l2.496-3.03c.317-.384.74-.626 1.208-.766M11.42 15.17l-4.655 5.653a2.548 2.548 0 11-3.586-3.586l6.837-5.63m5.108-.233c.55-.164 1.163-.188 1.743-.14a4.5 4.5 0 004.486-6.336l-3.276 3.277a3.004 3.004 0 01-2.25-2.25l3.276-3.276a4.5 4.5 0 00-6.336 4.486c.091 1.076-.071 2.264-.904 2.95l-.102.085m-1.745 1.437L5.909 7.5H4.5L2.25 3.75l1.5-1.5L7.5 4.5v1.409l4.26 4.26m-1.745 1.437l1.745-1.437m6.615 8.206L15.75 15.75M4.867 19.125h.008v.008h-.008v-.008z"
+                                            />
+                                          </svg>
+                                          <span className="text-sm">
+                                            Agent tool call
+                                          </span>
+                                        </button>
+                                      </div>
+                                    </>
+                                  )}
 
-                                {/* Tool Call Selection Dropdown */}
-                                {toolCallDropdownOpen && (
-                                  <>
-                                    <div
-                                      className="fixed inset-0 z-[150]"
-                                      onClick={() => {
-                                        setToolCallDropdownOpen(false);
-                                        setPendingToolCall(null);
-                                      }}
-                                    />
-                                    <div
-                                      className={`absolute bg-background border border-border rounded-xl shadow-xl z-[200] overflow-hidden min-w-[320px] ${
-                                        message.role === "user"
-                                          ? chatMessages.length <= 2
-                                            ? "right-0 top-10"
-                                            : "right-0 bottom-full mb-2"
-                                          : chatMessages.length <= 2
-                                            ? "left-0 top-10"
-                                            : "left-0 bottom-full mb-2"
-                                      }`}
-                                    >
-                                      {!pendingToolCall ? (
-                                        <ToolPicker
-                                          availableTools={availableTools}
-                                          isLoading={availableToolsLoading}
-                                          onSelectInbuiltTool={(
-                                            toolId,
-                                            toolName,
-                                          ) => {
-                                            addToolCallMessage(
+                                  {/* Tool Call Selection Dropdown */}
+                                  {toolCallDropdownOpen && (
+                                    <>
+                                      <div
+                                        className="fixed inset-0 z-[150]"
+                                        onClick={() => {
+                                          setToolCallDropdownOpen(false);
+                                          setPendingToolCall(null);
+                                        }}
+                                      />
+                                      <div
+                                        className={`absolute bg-background border border-border rounded-xl shadow-xl z-[200] overflow-hidden min-w-[320px] ${
+                                          message.role === "user"
+                                            ? chatMessages.length <= 2
+                                              ? "right-0 top-10"
+                                              : "right-0 bottom-full mb-2"
+                                            : chatMessages.length <= 2
+                                              ? "left-0 top-10"
+                                              : "left-0 bottom-full mb-2"
+                                        }`}
+                                      >
+                                        {!pendingToolCall ? (
+                                          <ToolPicker
+                                            availableTools={availableTools}
+                                            isLoading={availableToolsLoading}
+                                            onSelectInbuiltTool={(
                                               toolId,
                                               toolName,
-                                              [],
-                                            );
-                                          }}
-                                          onSelectCustomTool={(tool) => {
-                                            const isWebhook =
-                                              tool.config?.type === "webhook";
-                                            let allParams: Array<{
-                                              name: string;
-                                              value: string;
-                                              group?: string;
-                                            }> = [];
+                                            ) => {
+                                              addToolCallMessage(
+                                                toolId,
+                                                toolName,
+                                                [],
+                                              );
+                                            }}
+                                            onSelectCustomTool={(tool) => {
+                                              const isWebhook =
+                                                tool.config?.type === "webhook";
+                                              let allParams: Array<{
+                                                name: string;
+                                                value: string;
+                                                group?: string;
+                                              }> = [];
 
-                                            if (
-                                              isWebhook &&
-                                              tool.config?.webhook
-                                            ) {
-                                              // Extract webhook-specific parameters
-                                              const webhook =
-                                                tool.config.webhook;
-
-                                              // Query parameters (for GET requests)
                                               if (
-                                                webhook.queryParameters &&
-                                                Array.isArray(
-                                                  webhook.queryParameters,
-                                                )
+                                                isWebhook &&
+                                                tool.config?.webhook
                                               ) {
-                                                webhook.queryParameters.forEach(
-                                                  (p: any) => {
-                                                    allParams.push({
-                                                      name:
-                                                        p.id || p.name || "",
-                                                      value: "",
-                                                      group: "query",
-                                                    });
-                                                  },
-                                                );
-                                              }
+                                                // Extract webhook-specific parameters
+                                                const webhook =
+                                                  tool.config.webhook;
 
-                                              // Body parameters (for POST requests)
-                                              if (
-                                                webhook.body?.parameters &&
-                                                Array.isArray(
-                                                  webhook.body.parameters,
-                                                )
-                                              ) {
-                                                webhook.body.parameters.forEach(
-                                                  (p: any) => {
-                                                    allParams.push({
-                                                      name:
-                                                        p.id || p.name || "",
-                                                      value: "",
-                                                      group: "body",
-                                                    });
-                                                  },
-                                                );
-                                              }
-                                              // Note: Headers are not shown in conversation history UI
-                                            } else {
-                                              // Structured output tool - use regular parameters
-                                              const params =
-                                                tool.config?.parameters;
-                                              if (Array.isArray(params)) {
-                                                allParams = params.map(
-                                                  (p: any) => ({
-                                                    name: p.id || p.name || "",
-                                                    value: "",
-                                                  }),
-                                                );
+                                                // Query parameters (for GET requests)
+                                                if (
+                                                  webhook.queryParameters &&
+                                                  Array.isArray(
+                                                    webhook.queryParameters,
+                                                  )
+                                                ) {
+                                                  webhook.queryParameters.forEach(
+                                                    (p: any) => {
+                                                      allParams.push({
+                                                        name:
+                                                          p.id || p.name || "",
+                                                        value: "",
+                                                        group: "query",
+                                                      });
+                                                    },
+                                                  );
+                                                }
+
+                                                // Body parameters (for POST requests)
+                                                if (
+                                                  webhook.body?.parameters &&
+                                                  Array.isArray(
+                                                    webhook.body.parameters,
+                                                  )
+                                                ) {
+                                                  webhook.body.parameters.forEach(
+                                                    (p: any) => {
+                                                      allParams.push({
+                                                        name:
+                                                          p.id || p.name || "",
+                                                        value: "",
+                                                        group: "body",
+                                                      });
+                                                    },
+                                                  );
+                                                }
+                                                // Note: Headers are not shown in conversation history UI
                                               } else {
-                                                const propsObj =
-                                                  tool.config?.parameters
-                                                    ?.properties ||
-                                                  tool.config?.function
-                                                    ?.parameters?.properties ||
-                                                  tool.config?.properties ||
-                                                  tool.config?.parameters ||
-                                                  {};
-                                                allParams = Object.keys(
-                                                  propsObj,
-                                                ).map((name) => ({
-                                                  name,
-                                                  value: "",
-                                                }));
+                                                // Structured output tool - use regular parameters
+                                                const params =
+                                                  tool.config?.parameters;
+                                                if (Array.isArray(params)) {
+                                                  allParams = params.map(
+                                                    (p: any) => ({
+                                                      name:
+                                                        p.id || p.name || "",
+                                                      value: "",
+                                                    }),
+                                                  );
+                                                } else {
+                                                  const propsObj =
+                                                    tool.config?.parameters
+                                                      ?.properties ||
+                                                    tool.config?.function
+                                                      ?.parameters
+                                                      ?.properties ||
+                                                    tool.config?.properties ||
+                                                    tool.config?.parameters ||
+                                                    {};
+                                                  allParams = Object.keys(
+                                                    propsObj,
+                                                  ).map((name) => ({
+                                                    name,
+                                                    value: "",
+                                                  }));
+                                                }
                                               }
-                                            }
 
-                                            addToolCallMessage(
-                                              tool.uuid,
-                                              tool.name,
-                                              allParams,
-                                              isWebhook,
-                                            );
-                                          }}
-                                        />
-                                      ) : (
-                                        <div className="p-4">
-                                          <div className="flex items-center gap-2 mb-4">
+                                              addToolCallMessage(
+                                                tool.uuid,
+                                                tool.name,
+                                                allParams,
+                                                isWebhook,
+                                              );
+                                            }}
+                                          />
+                                        ) : (
+                                          <div className="p-4">
+                                            <div className="flex items-center gap-2 mb-4">
+                                              <button
+                                                onClick={() =>
+                                                  setPendingToolCall(null)
+                                                }
+                                                className="text-muted-foreground hover:text-foreground transition-colors"
+                                              >
+                                                <svg
+                                                  className="w-4 h-4"
+                                                  fill="none"
+                                                  viewBox="0 0 24 24"
+                                                  stroke="currentColor"
+                                                  strokeWidth={2}
+                                                >
+                                                  <path
+                                                    strokeLinecap="round"
+                                                    strokeLinejoin="round"
+                                                    d="M15.75 19.5L8.25 12l7.5-7.5"
+                                                  />
+                                                </svg>
+                                              </button>
+                                              <h4 className="text-sm font-medium text-foreground">
+                                                {pendingToolCall.toolName}
+                                              </h4>
+                                            </div>
+                                            <p className="text-xs text-muted-foreground mb-3">
+                                              Enter values for parameters:
+                                            </p>
+                                            <div className="space-y-2 max-h-[200px] overflow-y-auto">
+                                              {pendingToolCall.params.map(
+                                                (param, idx) => (
+                                                  <div key={idx}>
+                                                    <label className="block text-xs text-muted-foreground mb-1">
+                                                      {param.name}
+                                                    </label>
+                                                    <input
+                                                      type="text"
+                                                      value={param.value}
+                                                      onChange={(e) => {
+                                                        const newParams = [
+                                                          ...pendingToolCall.params,
+                                                        ];
+                                                        newParams[idx].value =
+                                                          e.target.value;
+                                                        setPendingToolCall({
+                                                          ...pendingToolCall,
+                                                          params: newParams,
+                                                        });
+                                                      }}
+                                                      placeholder={`Enter ${param.name}`}
+                                                      className="w-full h-9 px-3 rounded-lg text-sm bg-background text-foreground placeholder:text-muted-foreground border border-border focus:outline-none focus:ring-1 focus:ring-accent"
+                                                    />
+                                                  </div>
+                                                ),
+                                              )}
+                                            </div>
                                             <button
                                               onClick={() =>
-                                                setPendingToolCall(null)
+                                                addToolCallMessage(
+                                                  pendingToolCall.toolId,
+                                                  pendingToolCall.toolName,
+                                                  pendingToolCall.params,
+                                                )
                                               }
-                                              className="text-muted-foreground hover:text-foreground transition-colors"
+                                              className="w-full mt-4 h-9 px-4 rounded-lg text-sm font-medium bg-foreground text-background hover:opacity-90 transition-opacity cursor-pointer"
                                             >
-                                              <svg
-                                                className="w-4 h-4"
-                                                fill="none"
-                                                viewBox="0 0 24 24"
-                                                stroke="currentColor"
-                                                strokeWidth={2}
-                                              >
-                                                <path
-                                                  strokeLinecap="round"
-                                                  strokeLinejoin="round"
-                                                  d="M15.75 19.5L8.25 12l7.5-7.5"
-                                                />
-                                              </svg>
+                                              Add tool call
                                             </button>
-                                            <h4 className="text-sm font-medium text-foreground">
-                                              {pendingToolCall.toolName}
-                                            </h4>
                                           </div>
-                                          <p className="text-xs text-muted-foreground mb-3">
-                                            Enter values for parameters:
-                                          </p>
-                                          <div className="space-y-2 max-h-[200px] overflow-y-auto">
-                                            {pendingToolCall.params.map(
-                                              (param, idx) => (
-                                                <div key={idx}>
-                                                  <label className="block text-xs text-muted-foreground mb-1">
-                                                    {param.name}
-                                                  </label>
-                                                  <input
-                                                    type="text"
-                                                    value={param.value}
-                                                    onChange={(e) => {
-                                                      const newParams = [
-                                                        ...pendingToolCall.params,
-                                                      ];
-                                                      newParams[idx].value =
-                                                        e.target.value;
-                                                      setPendingToolCall({
-                                                        ...pendingToolCall,
-                                                        params: newParams,
-                                                      });
-                                                    }}
-                                                    placeholder={`Enter ${param.name}`}
-                                                    className="w-full h-9 px-3 rounded-lg text-sm bg-background text-foreground placeholder:text-muted-foreground border border-border focus:outline-none focus:ring-1 focus:ring-accent"
-                                                  />
-                                                </div>
-                                              ),
-                                            )}
-                                          </div>
-                                          <button
-                                            onClick={() =>
-                                              addToolCallMessage(
-                                                pendingToolCall.toolId,
-                                                pendingToolCall.toolName,
-                                                pendingToolCall.params,
-                                              )
-                                            }
-                                            className="w-full mt-4 h-9 px-4 rounded-lg text-sm font-medium bg-foreground text-background hover:opacity-90 transition-opacity cursor-pointer"
-                                          >
-                                            Add tool call
-                                          </button>
-                                        </div>
-                                      )}
-                                    </div>
-                                  </>
-                                )}
-                              </div>
-                            </>
-                          )}
+                                        )}
+                                      </div>
+                                    </>
+                                  )}
+                                </div>
+                              </>
+                            )}
+                        </div>
                       </div>
-                    </div>
-                  );
-                })}
-                <div ref={chatEndRef} />
-              </div>
-            )}
+                    );
+                  })}
+                  <div ref={chatEndRef} />
+                </div>
+              )}
+            </div>
           </div>
         </div>
-      </div>
       )}
     </div>
   );

--- a/src/components/AddTestDialog.tsx
+++ b/src/components/AddTestDialog.tsx
@@ -908,6 +908,33 @@ export function AddTestDialog({
     activeTab,
   ]);
 
+  // Create-mode only: when the user switches between the evaluator-based
+  // tabs (next-reply ↔ conversation), drop every attached evaluator that
+  // doesn't belong to the newly selected type. This removes the auto-seeded
+  // next-reply "Correctness" evaluator (an `llm` evaluator) when moving to
+  // the conversation tab — conversation tests only accept `simulation`
+  // evaluators, and the backend rejects a mismatch — and symmetrically
+  // clears any simulation evaluators when moving back. Editing is left
+  // untouched (the type is immutable there). Only fires on an actual tab
+  // change, so the next-reply default seeded on first load survives.
+  const prevTabRef = useRef(activeTab);
+  useEffect(() => {
+    const prev = prevTabRef.current;
+    prevTabRef.current = activeTab;
+    if (prev === activeTab) return;
+    if (isEditing) return;
+    if (!isEvaluatorTab) return;
+    const wantedType =
+      activeTab === "conversation" ? CONVERSATION_EVALUATOR_TYPE : "llm";
+    setAttachedEvaluators((prevAttached) =>
+      prevAttached.filter(
+        (e) =>
+          availableLLMEvaluators.find((o) => o.uuid === e.evaluator_uuid)
+            ?.evaluator_type === wantedType,
+      ),
+    );
+  }, [activeTab, isEditing, isEvaluatorTab, availableLLMEvaluators]);
+
   const updateEvaluatorVariableValue = (
     evaluatorUuid: string,
     variableName: string,

--- a/src/components/BenchmarkDialog.tsx
+++ b/src/components/BenchmarkDialog.tsx
@@ -24,7 +24,7 @@ type TestData = {
   uuid: string;
   name: string;
   description: string;
-  type: "response" | "tool_call";
+  type: "response" | "tool_call" | "conversation";
   config: Record<string, any>;
   created_at: string;
   updated_at: string;

--- a/src/components/BulkUploadTestsModal.tsx
+++ b/src/components/BulkUploadTestsModal.tsx
@@ -457,7 +457,7 @@ export function BulkUploadTestsModal({
         {
           name: "conversation_history",
           description: isConversationType
-            ? `${CONVERSATION_HISTORY_DESC}\n\nThe full conversation is graded as a whole — it may end on either an assistant or a user turn.`
+            ? `${CONVERSATION_HISTORY_DESC}\n\nThe conversation should end with a user message. On run, the agent generates its reply to that message and the full conversation (history plus the generated reply) is graded as a whole.`
             : CONVERSATION_HISTORY_DESC,
           example: `[
   {"role": "user", "content": "What is your return policy?"},
@@ -1199,7 +1199,7 @@ export function BulkUploadTestsModal({
                     value: "conversation" as const,
                     label: "Conversation",
                     description:
-                      "Evaluate an entire conversation history as a whole",
+                      "Generate the agent's reply, then grade the full conversation as a whole",
                   },
                 ]
               ).map((opt) => {

--- a/src/components/BulkUploadTestsModal.tsx
+++ b/src/components/BulkUploadTestsModal.tsx
@@ -27,7 +27,10 @@ import { parseJsonLenient } from "@/lib/jsonSanitize";
 const HELPER_LINK_CLASS =
   "text-foreground underline decoration-foreground/30 underline-offset-2 hover:decoration-foreground/60 transition-colors";
 
-type TestType = "response" | "tool_call";
+type TestType = "response" | "tool_call" | "conversation";
+
+// evaluator_type filter the Conversation test type uses for its picker.
+const CONVERSATION_EVALUATOR_TYPE = "simulation";
 
 type ParsedTest = {
   name: string;
@@ -167,6 +170,10 @@ export function BulkUploadTestsModal({
 
   const [testType, setTestType] = useState<TestType | null>(null);
   const isResponseType = testType === "response";
+  const isConversationType = testType === "conversation";
+  // Both "Next Reply" (response) and "Conversation" use attached evaluators
+  // rather than tool_calls — they share most of the response code path.
+  const usesEvaluators = isResponseType || isConversationType;
   const [csvFile, setCsvFile] = useState<File | null>(null);
   const [parsedTests, setParsedTests] = useState<ParsedTest[]>([]);
   const [parseError, setParseError] = useState<string | null>(null);
@@ -244,13 +251,13 @@ export function BulkUploadTestsModal({
     }
   }, [isOpen]);
 
-  // Fetch the LLM evaluators list as soon as the user picks "Next Reply" so
-  // we can validate the CSV against it. We only need it for response-type
-  // uploads, so don't preload it on modal open — keeps the round-trip off
-  // the path for users who only ever do tool-call uploads.
+  // Fetch the evaluators list as soon as the user picks "Next Reply" or
+  // "Conversation" so we can validate the CSV against it. We only need it
+  // for evaluator-based uploads, so don't preload it on modal open — keeps
+  // the round-trip off the path for users who only ever do tool-call uploads.
   useEffect(() => {
     if (!isOpen || !backendAccessToken) return;
-    if (testType !== "response") return;
+    if (!usesEvaluators) return;
     if (evaluatorsFetched || evaluatorsLoading) return;
 
     const fetchEvaluators = async () => {
@@ -290,8 +297,12 @@ export function BulkUploadTestsModal({
           live_version?: { variables?: EvaluatorVariableDef[] | null } | null;
         }> = await response.json();
 
+        const wanted =
+          testType === "conversation"
+            ? CONVERSATION_EVALUATOR_TYPE
+            : "llm";
         const llm: LLMEvaluatorOption[] = raw
-          .filter((e) => e.evaluator_type === "llm")
+          .filter((e) => e.evaluator_type === wanted)
           .map((e) => ({
             uuid: e.uuid,
             name: e.name,
@@ -382,7 +393,7 @@ export function BulkUploadTestsModal({
   // user having to re-upload anything.
   useEffect(() => {
     if (!pendingFile) return;
-    if (isResponseType) {
+    if (usesEvaluators) {
       if (!evaluatorsFetched) return;
     } else {
       if (!toolsFetched) return;
@@ -393,7 +404,7 @@ export function BulkUploadTestsModal({
     // handleFileChange is stable for our purposes — re-running on its
     // identity would just thrash; we only care about the gating signals.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [pendingFile, evaluatorsFetched, toolsFetched, isResponseType]);
+  }, [pendingFile, evaluatorsFetched, toolsFetched, usesEvaluators]);
 
   // Lookup set of every tool name the platform recognises for this tenant:
   // the names of all custom tools (from `GET /tools`) plus the ids of every
@@ -440,12 +451,14 @@ export function BulkUploadTestsModal({
   };
 
   const buildGuidelines = (): GuidelineDoc => {
-    if (isResponseType) {
+    if (usesEvaluators) {
       const columns: GuidelineColumn[] = [
         { name: "name", description: "A unique test name." },
         {
           name: "conversation_history",
-          description: CONVERSATION_HISTORY_DESC,
+          description: isConversationType
+            ? `${CONVERSATION_HISTORY_DESC}\n\nThe full conversation is graded as a whole — it may end on either an assistant or a user turn.`
+            : CONVERSATION_HISTORY_DESC,
           example: `[
   {"role": "user", "content": "What is your return policy?"},
   {"role": "assistant", "content": "You can return any item within 30 days."}
@@ -462,7 +475,9 @@ export function BulkUploadTestsModal({
         }
       }
       return {
-        title: "Bulk upload — Next reply tests",
+        title: isConversationType
+          ? "Bulk upload — Conversation tests"
+          : "Bulk upload — Next reply tests",
         intro:
           "Upload a CSV with the following columns. Each row creates one test.",
         columns,
@@ -512,9 +527,11 @@ export function BulkUploadTestsModal({
   const downloadGuidelines = () => {
     if (!testType) return;
     const blob = generateGuidelinesPdf(buildGuidelines());
-    const filename = isResponseType
-      ? "next_reply_tests_csv_guidelines.pdf"
-      : "tool_call_tests_csv_guidelines.pdf";
+    const filename = isConversationType
+      ? "conversation_tests_csv_guidelines.pdf"
+      : isResponseType
+        ? "next_reply_tests_csv_guidelines.pdf"
+        : "tool_call_tests_csv_guidelines.pdf";
     const url = URL.createObjectURL(blob);
     const link = document.createElement("a");
     link.href = url;
@@ -528,14 +545,16 @@ export function BulkUploadTestsModal({
   const downloadSampleCsv = () => {
     if (!testType) return;
 
-    if (isResponseType) {
+    if (usesEvaluators) {
       // Single-CSV download tailored to the user's selected evaluators.
       const csv = buildResponseSampleCsv(committedEvaluators);
       const blob = new Blob([csv], { type: "text/csv" });
       const url = URL.createObjectURL(blob);
       const link = document.createElement("a");
       link.href = url;
-      link.download = "sample_next_reply_tests.csv";
+      link.download = isConversationType
+        ? "sample_conversation_tests.csv"
+        : "sample_next_reply_tests.csv";
       document.body.appendChild(link);
       link.click();
       document.body.removeChild(link);
@@ -568,23 +587,23 @@ export function BulkUploadTestsModal({
     // failure straight away, but if the fetch is still in flight just
     // stash the file and let the deferred-parse effect pick it up once
     // the data lands — no user-facing wait state.
-    if (isResponseType && evaluatorsFetchError) {
+    if (usesEvaluators && evaluatorsFetchError) {
       setParseError(
         `Failed to load evaluators: ${evaluatorsFetchError}. Refresh and try again.`,
       );
       return;
     }
-    if (isResponseType && !evaluatorsFetched) {
+    if (usesEvaluators && !evaluatorsFetched) {
       setPendingFile(file);
       return;
     }
-    if (!isResponseType && toolsFetchError) {
+    if (!usesEvaluators && toolsFetchError) {
       setParseError(
         `Failed to load tools: ${toolsFetchError}. Refresh and try again.`,
       );
       return;
     }
-    if (!isResponseType && !toolsFetched) {
+    if (!usesEvaluators && !toolsFetched) {
       setPendingFile(file);
       return;
     }
@@ -608,7 +627,7 @@ export function BulkUploadTestsModal({
         }
 
         const headers = Object.keys(data[0]);
-        const baseColumns = isResponseType
+        const baseColumns = usesEvaluators
           ? ["name", "conversation_history"]
           : ["name", "conversation_history", "tool_calls"];
         const variableColumns: {
@@ -616,7 +635,7 @@ export function BulkUploadTestsModal({
           varName: string;
           header: string;
         }[] = [];
-        if (isResponseType) {
+        if (usesEvaluators) {
           for (const e of committedEvaluators) {
             for (const v of e.variables) {
               variableColumns.push({
@@ -692,7 +711,7 @@ export function BulkUploadTestsModal({
             return;
           }
 
-          if (isResponseType) {
+          if (usesEvaluators) {
             // Build the EvaluatorRefPayload[] from the user's selected
             // evaluators. Variable values come from the per-variable
             // columns; evaluators with no variables get attached without
@@ -843,7 +862,7 @@ export function BulkUploadTestsModal({
       const tests = parsedTests.map((test) => {
         const conversation_history = parseJsonLenient(test.conversation_history);
 
-        if (isResponseType) {
+        if (usesEvaluators) {
           // Send the resolved EvaluatorRefPayload[] (same shape as the
           // single-test POST /tests `evaluators` field). The legacy
           // `criteria` field is no longer sent — its value lives inside
@@ -1161,69 +1180,73 @@ export function BulkUploadTestsModal({
             <label className="block text-sm font-medium text-foreground mb-3">
               Select the type of test
             </label>
-            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 w-full max-w-2xl">
-              <button
-                type="button"
-                onClick={() => {
-                  setTestType("response");
-                  setCsvFile(null);
-                  setParsedTests([]);
-                  setParseError(null);
-                  setUploadError(null);
-                  setPendingFile(null);
-                  setSelectedEvaluators([]);
-                  setCommittedEvaluators([]);
-                  if (fileInputRef.current) fileInputRef.current.value = "";
-                }}
-                className={`text-left px-4 py-3 rounded-lg border transition-colors cursor-pointer ${
-                  isResponseType
-                    ? "bg-foreground text-background border-foreground"
-                    : "bg-background border-border hover:bg-muted/50"
-                }`}
-              >
-                <div className="text-sm font-medium mb-0.5">Next Reply</div>
-                <div
-                  className={`text-xs leading-snug ${
-                    isResponseType
-                      ? "text-background/80"
-                      : "text-muted-foreground"
-                  }`}
-                >
-                  Evaluate the agent&apos;s response given a conversation
-                  history
-                </div>
-              </button>
-              <button
-                type="button"
-                onClick={() => {
-                  setTestType("tool_call");
-                  setCsvFile(null);
-                  setParsedTests([]);
-                  setParseError(null);
-                  setUploadError(null);
-                  setPendingFile(null);
-                  setSelectedEvaluators([]);
-                  setCommittedEvaluators([]);
-                  if (fileInputRef.current) fileInputRef.current.value = "";
-                }}
-                className={`text-left px-4 py-3 rounded-lg border transition-colors cursor-pointer ${
-                  testType === "tool_call"
-                    ? "bg-foreground text-background border-foreground"
-                    : "bg-background border-border hover:bg-muted/50"
-                }`}
-              >
-                <div className="text-sm font-medium mb-0.5">Tool Call</div>
-                <div
-                  className={`text-xs leading-snug ${
-                    testType === "tool_call"
-                      ? "text-background/80"
-                      : "text-muted-foreground"
-                  }`}
-                >
-                  Check whether the agent invokes the correct tool with the
-                  correct arguments
-                </div>
-              </button>
+            <div className="grid grid-cols-1 sm:grid-cols-3 gap-3 w-full max-w-3xl">
+              {(
+                [
+                  {
+                    value: "response" as const,
+                    label: "Next Reply",
+                    description:
+                      "Evaluate the agent's response given a conversation history",
+                  },
+                  {
+                    value: "tool_call" as const,
+                    label: "Tool Call",
+                    description:
+                      "Check whether the agent invokes the correct tool with the correct arguments",
+                  },
+                  {
+                    value: "conversation" as const,
+                    label: "Conversation",
+                    description:
+                      "Evaluate an entire conversation history as a whole",
+                  },
+                ]
+              ).map((opt) => {
+                const isSelected = testType === opt.value;
+                return (
+                  <button
+                    key={opt.value}
+                    type="button"
+                    onClick={() => {
+                      setTestType(opt.value);
+                      setCsvFile(null);
+                      setParsedTests([]);
+                      setParseError(null);
+                      setUploadError(null);
+                      setPendingFile(null);
+                      setSelectedEvaluators([]);
+                      setCommittedEvaluators([]);
+                      // Reset cached evaluator list so the next-reply ↔
+                      // conversation switch re-fetches with the right
+                      // evaluator_type filter.
+                      setAvailableLLMEvaluators([]);
+                      setEvaluatorsFetched(false);
+                      setEvaluatorsFetchError(null);
+                      if (fileInputRef.current)
+                        fileInputRef.current.value = "";
+                    }}
+                    className={`text-left px-4 py-3 rounded-lg border transition-colors cursor-pointer ${
+                      isSelected
+                        ? "bg-foreground text-background border-foreground"
+                        : "bg-background border-border hover:bg-muted/50"
+                    }`}
+                  >
+                    <div className="text-sm font-medium mb-0.5">
+                      {opt.label}
+                    </div>
+                    <div
+                      className={`text-xs leading-snug ${
+                        isSelected
+                          ? "text-background/80"
+                          : "text-muted-foreground"
+                      }`}
+                    >
+                      {opt.description}
+                    </div>
+                  </button>
+                );
+              })}
             </div>
           </div>
 
@@ -1232,7 +1255,7 @@ export function BulkUploadTestsModal({
               their variables) the user wants to attach, so we ask for
               that up-front and don't show the upload section until at
               least one evaluator is picked. */}
-          {isResponseType && (
+          {usesEvaluators && (
             <div>
               <label className="block text-sm font-medium text-foreground mb-2">
                 Select evaluators to attach
@@ -1290,7 +1313,7 @@ export function BulkUploadTestsModal({
 
           {/* Step 2: CSV Upload (only after type + (for response) at least
               one evaluator are picked) */}
-          {testType && (!isResponseType || committedEvaluators.length > 0) && (
+          {testType && (!usesEvaluators || committedEvaluators.length > 0) && (
             <div>
               {parsedTests.length === 0 && (
                 <div className="mb-3 flex flex-wrap gap-2">
@@ -1321,13 +1344,13 @@ export function BulkUploadTestsModal({
                   surfacing — loading happens silently in the background,
                   and a CSV dropped while in flight is auto-parsed once
                   the fetch lands (see deferred-parse effect). */}
-              {isResponseType && evaluatorsFetchError && (
+              {usesEvaluators && evaluatorsFetchError && (
                 <p className="text-xs text-red-500 mb-3">
                   Failed to load evaluators: {evaluatorsFetchError}. Refresh and
                   try again.
                 </p>
               )}
-              {!isResponseType && toolsFetchError && (
+              {!usesEvaluators && toolsFetchError && (
                 <p className="text-xs text-red-500 mb-3">
                   Failed to load tools: {toolsFetchError}. Refresh and try
                   again.
@@ -1465,7 +1488,7 @@ export function BulkUploadTestsModal({
 
               {/* Parsed Preview */}
               {parsedTests.length > 0 &&
-                isResponseType &&
+                usesEvaluators &&
                 (() => {
                   const variableColumns = committedEvaluators.flatMap((e) =>
                     e.variables.map((v) => ({
@@ -1584,7 +1607,7 @@ export function BulkUploadTestsModal({
 
               {/* Tool-call preview keeps the existing table layout — its
                   per-row `tool_calls` column has its own custom rendering. */}
-              {parsedTests.length > 0 && !isResponseType && (
+              {parsedTests.length > 0 && !usesEvaluators && (
                 <div className="mt-3 rounded-lg bg-muted/50 border border-border overflow-hidden">
                   <div className="px-3 py-2.5 flex items-center gap-2 border-b border-border">
                     <svg

--- a/src/components/TestRunnerDialog.tsx
+++ b/src/components/TestRunnerDialog.tsx
@@ -26,7 +26,7 @@ type TestData = {
   uuid: string;
   name: string;
   description: string;
-  type: "response" | "tool_call";
+  type: "response" | "tool_call" | "conversation";
   config: Record<string, any>;
   created_at: string;
   updated_at: string;

--- a/src/components/agent-tabs/TestsTabContent.tsx
+++ b/src/components/agent-tabs/TestsTabContent.tsx
@@ -1358,7 +1358,10 @@ export function TestsTabContent({
               className="flex flex-col sm:grid sm:grid-cols-[minmax(0,1fr)_5.75rem_5rem_9.25rem] sm:items-start sm:justify-items-stretch gap-2 sm:gap-2 xl:grid-cols-[minmax(0,1fr)_6.25rem_5.75rem_11.5rem] xl:gap-3 px-3 md:px-4 py-2 md:py-2 border-b border-border last:border-b-0 hover:bg-muted/20 transition-colors cursor-pointer"
             >
               <div className="flex items-start justify-between gap-2 sm:block min-w-0">
-                <span className="text-xs md:text-sm font-medium text-foreground block min-w-0 break-words">
+                <span
+                  className="text-xs md:text-sm font-medium text-foreground block min-w-0 truncate"
+                  title={getTestRunDisplayName(run)}
+                >
                   {getTestRunDisplayName(run)}
                 </span>
                 <span className="sm:hidden text-xs text-muted-foreground">

--- a/src/components/agent-tabs/TestsTabContent.tsx
+++ b/src/components/agent-tabs/TestsTabContent.tsx
@@ -18,6 +18,7 @@ import {
 import { BulkUploadTestsModal } from "@/components/BulkUploadTestsModal";
 import { POLLING_INTERVAL_MS } from "@/constants/polling";
 import { showLimitToast } from "@/constants/limits";
+import { testTypeLabel } from "@/lib/testTypes";
 import {
   readBulkNameConflictMessage,
   readNameConflictMessage,
@@ -1298,11 +1299,7 @@ export function TestsTabContent({
                     </p>
                   )}
                   <span className="inline-block mt-1 px-2 py-0.5 text-xs rounded-full bg-muted text-muted-foreground">
-                    {test.type === "tool_call"
-                      ? "Tool Call"
-                      : test.type === "conversation"
-                        ? "Conversation"
-                        : "Next Reply"}
+                    {testTypeLabel(test.type)}
                   </span>
                 </button>
               ))
@@ -1631,11 +1628,7 @@ export function TestsTabContent({
                             </p>
                           )}
                           <span className="inline-block mt-1 px-2 py-0.5 text-xs rounded-full bg-muted text-muted-foreground">
-                            {test.type === "tool_call"
-                              ? "Tool Call"
-                              : test.type === "conversation"
-                                ? "Conversation"
-                                : "Next Reply"}
+                            {testTypeLabel(test.type)}
                           </span>
                         </button>
                       ))
@@ -2073,11 +2066,7 @@ export function TestsTabContent({
                           </svg>
                         )}
                         <span className="text-sm text-muted-foreground">
-                          {test.type === "tool_call"
-                            ? "Tool Call"
-                            : test.type === "conversation"
-                              ? "Conversation"
-                              : "Next Reply"}
+                          {testTypeLabel(test.type)}
                         </span>
                       </div>
                       {/* Run Button */}
@@ -2180,11 +2169,7 @@ export function TestsTabContent({
                               {test.name}
                             </h4>
                             <p className="text-xs text-muted-foreground mt-1">
-                              {test.type === "tool_call"
-                                ? "Tool Call"
-                                : test.type === "conversation"
-                                  ? "Conversation"
-                                  : "Next Reply"}
+                              {testTypeLabel(test.type)}
                             </p>
                           </div>
                         </div>

--- a/src/components/agent-tabs/TestsTabContent.tsx
+++ b/src/components/agent-tabs/TestsTabContent.tsx
@@ -27,7 +27,7 @@ type TestData = {
   uuid: string;
   name: string;
   description: string;
-  type: "response" | "tool_call";
+  type: "response" | "tool_call" | "conversation";
   config: Record<string, any>;
   created_at: string;
   updated_at: string;
@@ -195,7 +195,7 @@ export function TestsTabContent({
   // is Next Reply, "tool_call" is Tool Call. The "select all" checkbox keys
   // off `filteredAgentTests`, so this filter also narrows what gets selected.
   const [typeFilter, setTypeFilter] = useState<
-    "all" | "response" | "tool_call"
+    "all" | "response" | "tool_call" | "conversation"
   >("all");
   const dropdownRef = useRef<HTMLDivElement>(null);
 
@@ -221,7 +221,7 @@ export function TestsTabContent({
   const [editingTestUuid, setEditingTestUuid] = useState<string | null>(null);
   const [isLoadingTest, setIsLoadingTest] = useState(false);
   const [initialTab, setInitialTab] = useState<
-    "next-reply" | "tool-invocation" | undefined
+    "next-reply" | "tool-invocation" | "conversation" | undefined
   >(undefined);
   const [initialConfig, setInitialConfig] = useState<TestConfig | undefined>(
     undefined,
@@ -703,7 +703,9 @@ export function TestsTabContent({
         throw new Error("BACKEND_URL environment variable is not set");
       }
 
-      const isResponse = config.evaluation.type === "response";
+      const evalType = config.evaluation.type;
+      const usesEvaluators =
+        evalType === "response" || evalType === "conversation";
       const testItem: {
         name: string;
         conversation_history: TestConfig["history"];
@@ -713,7 +715,7 @@ export function TestsTabContent({
         name: newTestName.trim(),
         conversation_history: config.history,
       };
-      if (isResponse) {
+      if (usesEvaluators) {
         testItem.evaluators = evaluators;
       } else {
         testItem.tool_calls = config.evaluation.tool_calls ?? [];
@@ -830,7 +832,11 @@ export function TestsTabContent({
 
       setNewTestName(testData.name || "");
       setInitialTab(
-        testData.type === "tool_call" ? "tool-invocation" : "next-reply",
+        testData.type === "tool_call"
+          ? "tool-invocation"
+          : testData.type === "conversation"
+            ? "conversation"
+            : "next-reply",
       );
       if (testData.config) {
         setInitialConfig(testData.config as TestConfig);
@@ -878,11 +884,11 @@ export function TestsTabContent({
       }
 
       // Mirror the standalone tests page: send `evaluators` for next-reply
-      // tests so the pivot set is replaced; omit it for tool-invocation tests
-      // so existing links are left untouched.
+      // and conversation tests so the pivot set is replaced; omit it for
+      // tool-invocation tests so existing links are left untouched.
       const body: {
         name: string;
-        type: "response" | "tool_call";
+        type: "response" | "tool_call" | "conversation";
         config: TestConfig;
         evaluators?: EvaluatorRefPayload[];
       } = {
@@ -890,7 +896,10 @@ export function TestsTabContent({
         type: config.evaluation.type,
         config: config,
       };
-      if (config.evaluation.type === "response") {
+      if (
+        config.evaluation.type === "response" ||
+        config.evaluation.type === "conversation"
+      ) {
         body.evaluators = evaluators;
       }
 
@@ -1289,7 +1298,11 @@ export function TestsTabContent({
                     </p>
                   )}
                   <span className="inline-block mt-1 px-2 py-0.5 text-xs rounded-full bg-muted text-muted-foreground">
-                    {test.type === "tool_call" ? "Tool Call" : "Next Reply"}
+                    {test.type === "tool_call"
+                      ? "Tool Call"
+                      : test.type === "conversation"
+                        ? "Conversation"
+                        : "Next Reply"}
                   </span>
                 </button>
               ))
@@ -1617,7 +1630,9 @@ export function TestsTabContent({
                           <span className="inline-block mt-1 px-2 py-0.5 text-xs rounded-full bg-muted text-muted-foreground">
                             {test.type === "tool_call"
                               ? "Tool Call"
-                              : "Next Reply"}
+                              : test.type === "conversation"
+                                ? "Conversation"
+                                : "Next Reply"}
                           </span>
                         </button>
                       ))
@@ -1800,6 +1815,7 @@ export function TestsTabContent({
                     { value: "all", label: "All" },
                     { value: "response", label: "Next Reply" },
                     { value: "tool_call", label: "Tool Call" },
+                    { value: "conversation", label: "Conversation" },
                   ] as const
                 ).map((opt) => (
                   <button
@@ -2056,7 +2072,9 @@ export function TestsTabContent({
                         <span className="text-sm text-muted-foreground">
                           {test.type === "tool_call"
                             ? "Tool Call"
-                            : "Next Reply"}
+                            : test.type === "conversation"
+                              ? "Conversation"
+                              : "Next Reply"}
                         </span>
                       </div>
                       {/* Run Button */}
@@ -2161,7 +2179,9 @@ export function TestsTabContent({
                             <p className="text-xs text-muted-foreground mt-1">
                               {test.type === "tool_call"
                                 ? "Tool Call"
-                                : "Next Reply"}
+                                : test.type === "conversation"
+                                  ? "Conversation"
+                                  : "Next Reply"}
                             </p>
                           </div>
                         </div>

--- a/src/lib/testTypes.ts
+++ b/src/lib/testTypes.ts
@@ -1,0 +1,32 @@
+/**
+ * Test-type helpers shared across the tests list views.
+ *
+ * A test's `type` is one of these three backend values. Keeping the
+ * human-readable label in one place means a rename only happens here
+ * instead of in every table / card that shows the type.
+ */
+export type TestType = "response" | "tool_call" | "conversation";
+
+/**
+ * Human-readable label for a test type.
+ *
+ * Unknown / missing types fall back to `fallback`. The agent Tests tab
+ * treats anything non-tool_call / non-conversation as "Next Reply" (the
+ * default fallback); the standalone /tests page passes "—" so a truly
+ * unknown type renders as a dash.
+ */
+export function testTypeLabel(
+  type: string | null | undefined,
+  fallback = "Next Reply",
+): string {
+  switch (type) {
+    case "tool_call":
+      return "Tool Call";
+    case "conversation":
+      return "Conversation";
+    case "response":
+      return "Next Reply";
+    default:
+      return fallback;
+  }
+}


### PR DESCRIPTION
Fix https://github.com/ARTPARK-SAHAI-ORG/calibrate-frontend/issues/165

## Summary
Adds a third test type — **Conversation** — alongside the existing **Next reply** and **Tool invocation** types. Conversation tests grade a full conversation transcript as a whole (the last turn may be either role) and only accept evaluators whose `evaluator_type === "simulation"`.

- **AddTestDialog**: third "Conversation test" tab. When active, the evaluator picker filters to `simulation` evaluators, the chat history may end on either role, and submit emits `evaluation.type: "conversation"`. Fetches both `llm` and `simulation` evaluators and toggles the picker source per tab.
- **BulkUploadTestsModal**: third "Conversation" option in the test-type picker. Switching to/from it resets the cached evaluator list so the next fetch uses the right `evaluator_type` filter. Reuses the response CSV pipeline (sample, preview, parser, submit) via a shared `usesEvaluators` flag.
- **TestsTabContent + tests page**: extend `TestData.type`, the type-filter pill set, type-pill rendering, and the create/update bodies so conversation tests round-trip through `POST /tests/bulk` and `PUT /tests/{uuid}` with `evaluators[]`.
- **BenchmarkDialog / TestRunnerDialog**: widen their local `TestData` aliases so conversation tests can flow through without TS errors.

## Backend contract
- New test `type` value sent on `POST /tests`, `POST /tests/bulk`, and `PUT /tests/{uuid}`: `"conversation"`.
- Evaluator filter reuses the existing `evaluator_type === "simulation"` (no new evaluator type added).
- ⚠️ The backend must recognize `type: "conversation"` for these tests to persist/run.

## Test plan
- [ ] Single-test create: open Tests tab → AddTestDialog → "Conversation test" tab; confirm only simulation evaluators are pickable, history can end on an agent turn, and the test saves.
- [ ] Edit an existing conversation test and confirm it opens on the Conversation tab with evaluators hydrated.
- [ ] Bulk upload: pick "Conversation", select simulation evaluators, download sample CSV, upload, confirm preview + submit.
- [ ] Toggle between Next reply ↔ Conversation in bulk modal and confirm the evaluator list refetches with the correct filter.
- [ ] Tests list type-filter pill includes "Conversation" and filters correctly; type labels render in all table/card views.

🤖 Generated with [Claude Code](https://claude.com/claude-code)