### PR TITLE
Add duplicate button to test and labelling item rows

### DIFF
--- a/src/app/human-alignment/tasks/[uuid]/page.tsx
+++ b/src/app/human-alignment/tasks/[uuid]/page.tsx
@@ -48,6 +48,7 @@ import {
 } from "@/components/human-labelling/AgreementStatCard";
 import { EmptyState } from "@/components/ui/LoadingState";
 import { DeleteIconButton } from "@/components/ui/DeleteIconButton";
+import { DuplicateIconButton } from "@/components/ui/DuplicateIconButton";
 import { useAccessToken } from "@/hooks";
 import { apiClient } from "@/lib/api";
 import { useSidebarState } from "@/lib/sidebar";
@@ -837,27 +838,10 @@ function ItemRowActions({
         </button>
       )}
       {onDuplicate && (
-        <button
-          type="button"
+        <DuplicateIconButton
           onClick={() => onDuplicate(itemUuid)}
-          aria-label="Duplicate item"
-          title="Duplicate item"
-          className="w-8 h-8 flex items-center justify-center rounded-md text-muted-foreground hover:text-foreground hover:bg-muted transition-colors cursor-pointer"
-        >
-          <svg
-            className="w-4 h-4"
-            fill="none"
-            viewBox="0 0 24 24"
-            stroke="currentColor"
-            strokeWidth={1.5}
-          >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              d="M15.75 17.25v3.375c0 .621-.504 1.125-1.125 1.125h-9.75a1.125 1.125 0 01-1.125-1.125V7.875c0-.621.504-1.125 1.125-1.125H6.75a9.06 9.06 0 011.5.124m7.5 10.376h3.375c.621 0 1.125-.504 1.125-1.125V11.25c0-4.46-3.243-8.161-7.5-8.876a9.06 9.06 0 00-1.5-.124H9.375c-.621 0-1.125.504-1.125 1.125v3.5m7.5 10.375H9.375a1.125 1.125 0 01-1.125-1.125v-9.25m12 6.625v-1.875a3.375 3.375 0 00-3.375-3.375h-1.5a1.125 1.125 0 01-1.125-1.125v-1.5a3.375 3.375 0 00-3.375-3.375H9.75"
-            />
-          </svg>
-        </button>
+          tooltip="Duplicate item"
+        />
       )}
       {/* Delete Button */}
       <DeleteIconButton

--- a/src/app/human-alignment/tasks/[uuid]/page.tsx
+++ b/src/app/human-alignment/tasks/[uuid]/page.tsx
@@ -791,12 +791,14 @@ function ItemRowActions({
   onLabel,
   onEdit,
   onEvaluate,
+  onDuplicate,
 }: {
   itemUuid: string;
   onDelete: (uuid: string) => void | Promise<void>;
   onLabel?: (uuid: string) => void;
   onEdit?: (uuid: string) => void;
   onEvaluate?: (uuid: string) => void;
+  onDuplicate?: (uuid: string) => void;
 }) {
   return (
     <div
@@ -831,6 +833,29 @@ function ItemRowActions({
           className="h-8 px-3 rounded-md text-sm font-medium border border-border bg-background hover:bg-muted/50 transition-colors cursor-pointer"
         >
           Edit
+        </button>
+      )}
+      {onDuplicate && (
+        <button
+          type="button"
+          onClick={() => onDuplicate(itemUuid)}
+          aria-label="Duplicate item"
+          title="Duplicate item"
+          className="w-8 h-8 flex items-center justify-center rounded-md text-muted-foreground hover:text-foreground hover:bg-muted transition-colors cursor-pointer"
+        >
+          <svg
+            className="w-4 h-4"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            strokeWidth={1.5}
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              d="M15.75 17.25v3.375c0 .621-.504 1.125-1.125 1.125h-9.75a1.125 1.125 0 01-1.125-1.125V7.875c0-.621.504-1.125 1.125-1.125H6.75a9.06 9.06 0 011.5.124m7.5 10.376h3.375c.621 0 1.125-.504 1.125-1.125V11.25c0-4.46-3.243-8.161-7.5-8.876a9.06 9.06 0 00-1.5-.124H9.375c-.621 0-1.125.504-1.125 1.125v3.5m7.5 10.375H9.375a1.125 1.125 0 01-1.125-1.125v-9.25m12 6.625v-1.875a3.375 3.375 0 00-3.375-3.375h-1.5a1.125 1.125 0 01-1.125-1.125v-1.5a3.375 3.375 0 00-3.375-3.375H9.75"
+            />
+          </svg>
         </button>
       )}
       {/* Delete Button */}
@@ -1229,6 +1254,16 @@ function LabellingTaskPageInner() {
   const [editLlmItemDescription, setEditLlmItemDescription] = useState("");
   const [savingLlmItem, setSavingLlmItem] = useState(false);
   const [editLlmError, setEditLlmError] = useState<string | null>(null);
+  // When duplicating an item, the create dialog opens pre-filled from this
+  // payload. Cleared whenever the create dialog opens fresh or closes.
+  const [duplicateSourcePayload, setDuplicateSourcePayload] = useState<Record<
+    string,
+    unknown
+  > | null>(null);
+  // STT items use a separate dialog; this holds the row to seed it with.
+  const [duplicateSttRows, setDuplicateSttRows] = useState<
+    { uuid: string; name: string; actual: string; predicted: string }[] | null
+  >(null);
 
   // Sort direction for the items table's Updated at column. Always
   // applied to `updated_at` on the backend; defaults to desc (newest
@@ -2077,10 +2112,16 @@ function LabellingTaskPageInner() {
   const editingInitialEvaluators = buildInitialEvaluators(
     readEvaluatorVariables(editingPayload),
   );
-  const newItemInitialEvaluators = buildInitialEvaluators({});
+  // When duplicating, seed the create dialog's evaluators from the source
+  // item; otherwise start with the task's linked evaluators (empty values).
+  const newItemInitialEvaluators = duplicateSourcePayload
+    ? buildInitialEvaluators(readEvaluatorVariables(duplicateSourcePayload))
+    : buildInitialEvaluators({});
 
-  const editingInitialConfig = (() => {
-    if (!editingPayload) return undefined;
+  const buildInitialConfig = (
+    payload: Record<string, unknown> | null,
+  ): TestConfig | undefined => {
+    if (!payload) return undefined;
     type HistoryItem = TestConfig["history"][number];
     const parseHistory = (raw: unknown): HistoryItem[] => {
       if (!Array.isArray(raw)) return [];
@@ -2124,13 +2165,13 @@ function LabellingTaskPageInner() {
 
     let history: HistoryItem[];
     if (taskType === "simulation") {
-      history = parseHistory(editingPayload.transcript);
+      history = parseHistory(payload.transcript);
     } else {
       // LLM: chat_history (may include tool calls + tool responses) +
       // optional trailing agent_response (the regular text reply being
       // graded).
-      history = parseHistory(editingPayload.chat_history);
-      const ar = editingPayload.agent_response;
+      history = parseHistory(payload.chat_history);
+      const ar = payload.agent_response;
       if (typeof ar === "string" && ar.length > 0) {
         history.push({ role: "assistant", content: ar });
       }
@@ -2139,7 +2180,10 @@ function LabellingTaskPageInner() {
       history,
       evaluation: { type: "response" as const, criteria: "" },
     };
-  })();
+  };
+
+  const editingInitialConfig = buildInitialConfig(editingPayload);
+  const addItemInitialConfig = buildInitialConfig(duplicateSourcePayload);
 
   // Sync the name field whenever a different item is opened for edit.
   useEffect(() => {
@@ -2430,8 +2474,10 @@ function LabellingTaskPageInner() {
                     setNewItemDescription("");
                     setCreateItemError(null);
                     setValidationAttempted(false);
+                    setDuplicateSourcePayload(null);
                     setAddItemOpen(true);
                   } else if (taskType === "stt") {
+                    setDuplicateSttRows(null);
                     setAddSttItemsOpen(true);
                   }
                 }}
@@ -3148,6 +3194,33 @@ function LabellingTaskPageInner() {
                               setEditSttSingleItemUuid(uuid);
                               setEditSttItemsOpen(true);
                             }}
+                            onDuplicate={(uuid) => {
+                              const item = items.find((i) => i.uuid === uuid);
+                              if (!item) return;
+                              const p = (item.payload ?? {}) as Record<
+                                string,
+                                unknown
+                              >;
+                              const nm =
+                                typeof p.name === "string"
+                                  ? (p.name as string)
+                                  : `Item ${item.id}`;
+                              setDuplicateSttRows([
+                                {
+                                  uuid: item.uuid,
+                                  name: `Copy of ${nm}`,
+                                  actual:
+                                    typeof p.reference_transcript === "string"
+                                      ? (p.reference_transcript as string)
+                                      : "",
+                                  predicted:
+                                    typeof p.predicted_transcript === "string"
+                                      ? (p.predicted_transcript as string)
+                                      : "",
+                                },
+                              ]);
+                              setAddSttItemsOpen(true);
+                            }}
                             onEvaluate={
                               selectedItemIds.size === 0 && !selectAllTotal
                                 ? (uuid) => {
@@ -3291,6 +3364,28 @@ function LabellingTaskPageInner() {
                                 : undefined
                             }
                             onEdit={(uuid) => setEditLlmItemUuid(uuid)}
+                            onDuplicate={(uuid) => {
+                              const item = items.find((i) => i.uuid === uuid);
+                              if (!item) return;
+                              const p = (item.payload ?? null) as Record<
+                                string,
+                                unknown
+                              > | null;
+                              const name =
+                                typeof p?.name === "string"
+                                  ? (p.name as string)
+                                  : `Item ${item.id}`;
+                              const desc =
+                                typeof p?.description === "string"
+                                  ? (p.description as string)
+                                  : "";
+                              setNewItemName(`Copy of ${name}`);
+                              setNewItemDescription(desc);
+                              setDuplicateSourcePayload(p);
+                              setCreateItemError(null);
+                              setValidationAttempted(false);
+                              setAddItemOpen(true);
+                            }}
                             onEvaluate={
                               selectedItemIds.size === 0 && !selectAllTotal
                                 ? (uuid) => {
@@ -3565,7 +3660,10 @@ function LabellingTaskPageInner() {
         <AddTestDialog
           isOpen={addItemOpen}
           onClose={() => {
-            if (!creatingItem) setAddItemOpen(false);
+            if (!creatingItem) {
+              setAddItemOpen(false);
+              setDuplicateSourcePayload(null);
+            }
           }}
           isEditing={false}
           isLoading={false}
@@ -3579,6 +3677,7 @@ function LabellingTaskPageInner() {
           mode="labelItem"
           allowAgentLastMessage={taskType === "simulation"}
           requireAssistantLastMessage={taskType === "llm"}
+          initialConfig={addItemInitialConfig}
           initialEvaluators={newItemInitialEvaluators}
           onSubmit={async (
             config: TestConfig,
@@ -3669,6 +3768,7 @@ function LabellingTaskPageInner() {
                 body: { items: [{ payload }] },
               });
               setAddItemOpen(false);
+              setDuplicateSourcePayload(null);
               handleTabChange("items");
               await Promise.all([fetchTask(), fetchTaskSummary()]);
             } catch (err) {
@@ -3875,7 +3975,11 @@ function LabellingTaskPageInner() {
 
       <AddSttItemsDialog
         isOpen={addSttItemsOpen}
-        onClose={() => setAddSttItemsOpen(false)}
+        initialRows={duplicateSttRows ?? undefined}
+        onClose={() => {
+          setAddSttItemsOpen(false);
+          setDuplicateSttRows(null);
+        }}
         onSubmit={async (rows) => {
           if (!accessToken) return;
           await apiClient(`/annotation-tasks/${uuid}/items`, accessToken, {
@@ -3893,6 +3997,7 @@ function LabellingTaskPageInner() {
           handleTabChange("items");
           await Promise.all([fetchTask(), fetchTaskSummary()]);
           setAddSttItemsOpen(false);
+          setDuplicateSttRows(null);
         }}
       />
 

--- a/src/app/human-alignment/tasks/[uuid]/page.tsx
+++ b/src/app/human-alignment/tasks/[uuid]/page.tsx
@@ -47,6 +47,7 @@ import {
   agreementColor,
 } from "@/components/human-labelling/AgreementStatCard";
 import { EmptyState } from "@/components/ui/LoadingState";
+import { DeleteIconButton } from "@/components/ui/DeleteIconButton";
 import { useAccessToken } from "@/hooks";
 import { apiClient } from "@/lib/api";
 import { useSidebarState } from "@/lib/sidebar";
@@ -859,26 +860,10 @@ function ItemRowActions({
         </button>
       )}
       {/* Delete Button */}
-      <button
-        type="button"
+      <DeleteIconButton
         onClick={() => onDelete(itemUuid)}
-        aria-label="Delete item"
-        className="w-8 h-8 flex items-center justify-center rounded-md text-muted-foreground hover:text-foreground hover:bg-muted transition-colors cursor-pointer"
-      >
-        <svg
-          className="w-4 h-4"
-          fill="none"
-          viewBox="0 0 24 24"
-          stroke="currentColor"
-          strokeWidth={2}
-        >
-          <path
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            d="M14.74 9l-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 01-2.244 2.077H8.084a2.25 2.25 0 01-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 00-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 013.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 00-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 00-7.5 0"
-          />
-        </svg>
-      </button>
+        title="Delete item"
+      />
     </div>
   );
 }

--- a/src/app/tests/page.tsx
+++ b/src/app/tests/page.tsx
@@ -23,6 +23,7 @@ import {
 } from "@/components/AddTestDialog";
 import { BulkUploadTestsModal } from "@/components/BulkUploadTestsModal";
 import { DeleteIconButton } from "@/components/ui/DeleteIconButton";
+import { DuplicateIconButton } from "@/components/ui/DuplicateIconButton";
 import { useSidebarState } from "@/lib/sidebar";
 import { POLLING_INTERVAL_MS } from "@/constants/polling";
 import {
@@ -1255,28 +1256,10 @@ function LLMPageInner() {
                     </button>
                     {/* Duplicate Button — opens the create dialog pre-filled
                         from this test; nothing is saved until submit. */}
-                    <button
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        openDuplicateTest(test);
-                      }}
-                      className="w-8 h-8 flex items-center justify-center rounded-md text-muted-foreground hover:text-foreground hover:bg-muted transition-colors cursor-pointer"
-                      title="Duplicate test"
-                    >
-                      <svg
-                        className="w-4 h-4"
-                        fill="none"
-                        viewBox="0 0 24 24"
-                        stroke="currentColor"
-                        strokeWidth={1.5}
-                      >
-                        <path
-                          strokeLinecap="round"
-                          strokeLinejoin="round"
-                          d="M15.75 17.25v3.375c0 .621-.504 1.125-1.125 1.125h-9.75a1.125 1.125 0 01-1.125-1.125V7.875c0-.621.504-1.125 1.125-1.125H6.75a9.06 9.06 0 011.5.124m7.5 10.376h3.375c.621 0 1.125-.504 1.125-1.125V11.25c0-4.46-3.243-8.161-7.5-8.876a9.06 9.06 0 00-1.5-.124H9.375c-.621 0-1.125.504-1.125 1.125v3.5m7.5 10.375H9.375a1.125 1.125 0 01-1.125-1.125v-9.25m12 6.625v-1.875a3.375 3.375 0 00-3.375-3.375h-1.5a1.125 1.125 0 01-1.125-1.125v-1.5a3.375 3.375 0 00-3.375-3.375H9.75"
-                        />
-                      </svg>
-                    </button>
+                    <DuplicateIconButton
+                      onClick={() => openDuplicateTest(test)}
+                      tooltip="Duplicate test"
+                    />
                     {/* Delete Button */}
                     <DeleteIconButton
                       onClick={() => openDeleteDialog(test)}

--- a/src/app/tests/page.tsx
+++ b/src/app/tests/page.tsx
@@ -169,6 +169,9 @@ function LLMPageInner() {
   );
   const [editingTestUuid, setEditingTestUuid] = useState<string | null>(null);
   const [isLoadingTest, setIsLoadingTest] = useState(false);
+  // UUID of the test whose details are being fetched for duplication. Drives
+  // the per-row spinner; the dialog only opens once the fetch resolves.
+  const [duplicatingUuid, setDuplicatingUuid] = useState<string | null>(null);
   const [validationAttempted, setValidationAttempted] = useState(false);
   const [initialTab, setInitialTab] = useState<
     "next-reply" | "tool-invocation" | undefined
@@ -761,17 +764,15 @@ function LLMPageInner() {
     }
   };
 
-  // Open the create dialog pre-filled from an existing test. editingTestUuid
-  // stays null so submitting creates a brand-new test — nothing is persisted
-  // until the user submits.
+  // Duplicate a test: fetch its details first (showing a spinner on the row's
+  // duplicate button), then open the create dialog pre-filled. The dialog is
+  // mounted only after the fresh data is in state, so it can't briefly show a
+  // previous duplicate's leftover config/evaluators. editingTestUuid stays
+  // null so submitting creates a brand-new test — nothing is persisted until
+  // the user submits.
   const openDuplicateTest = async (test: TestData) => {
     try {
-      setIsLoadingTest(true);
-      setEditingTestUuid(null);
-      setAddTestSidebarOpen(true);
-      setCreateError(null);
-      setNameConflictError(null);
-      setValidationAttempted(false);
+      setDuplicatingUuid(test.uuid);
 
       const backendUrl = process.env.NEXT_PUBLIC_BACKEND_URL;
       if (!backendUrl) {
@@ -797,6 +798,11 @@ function LLMPageInner() {
 
       const testData: TestData = await response.json();
 
+      // Populate all dialog inputs before opening it.
+      setEditingTestUuid(null);
+      setCreateError(null);
+      setNameConflictError(null);
+      setValidationAttempted(false);
       setNewTestName(`Copy of ${testData.name || test.name}`);
       setNewTestDescription(
         testData.config?.description || testData.description || ""
@@ -804,9 +810,7 @@ function LLMPageInner() {
       setInitialTab(
         testData.type === "tool_call" ? "tool-invocation" : "next-reply"
       );
-      if (testData.config) {
-        setInitialConfig(testData.config as TestConfig);
-      }
+      setInitialConfig(testData.config ? (testData.config as TestConfig) : undefined);
       if (Array.isArray(testData.evaluators)) {
         setInitialEvaluators(
           testData.evaluators.map((e) => ({
@@ -821,13 +825,16 @@ function LLMPageInner() {
       } else {
         setInitialEvaluators([]);
       }
+
+      // Open the dialog only now that the fresh data is in state.
+      setAddTestSidebarOpen(true);
     } catch (err) {
       console.error("Error duplicating test:", err);
       setCreateError(
         err instanceof Error ? err.message : "Failed to load test"
       );
     } finally {
-      setIsLoadingTest(false);
+      setDuplicatingUuid(null);
     }
   };
 
@@ -1259,6 +1266,7 @@ function LLMPageInner() {
                     <DuplicateIconButton
                       onClick={() => openDuplicateTest(test)}
                       tooltip="Duplicate test"
+                      loading={duplicatingUuid === test.uuid}
                     />
                     {/* Delete Button */}
                     <DeleteIconButton

--- a/src/app/tests/page.tsx
+++ b/src/app/tests/page.tsx
@@ -1282,7 +1282,7 @@ function LLMPageInner() {
                         e.stopPropagation();
                         openDeleteDialog(test);
                       }}
-                      className="w-8 h-8 flex items-center justify-center rounded-md text-muted-foreground hover:text-foreground hover:bg-muted transition-colors cursor-pointer"
+                      className="w-8 h-8 flex items-center justify-center rounded-md text-muted-foreground hover:text-red-500 hover:bg-red-500/10 transition-colors cursor-pointer"
                     >
                       <svg
                         className="w-4 h-4"

--- a/src/app/tests/page.tsx
+++ b/src/app/tests/page.tsx
@@ -759,6 +759,76 @@ function LLMPageInner() {
     }
   };
 
+  // Open the create dialog pre-filled from an existing test. editingTestUuid
+  // stays null so submitting creates a brand-new test — nothing is persisted
+  // until the user submits.
+  const openDuplicateTest = async (test: TestData) => {
+    try {
+      setIsLoadingTest(true);
+      setEditingTestUuid(null);
+      setAddTestSidebarOpen(true);
+      setCreateError(null);
+      setNameConflictError(null);
+      setValidationAttempted(false);
+
+      const backendUrl = process.env.NEXT_PUBLIC_BACKEND_URL;
+      if (!backendUrl) {
+        throw new Error("BACKEND_URL environment variable is not set");
+      }
+
+      const response = await fetch(`${backendUrl}/tests/${test.uuid}`, {
+        method: "GET",
+        headers: {
+          accept: "application/json",
+          Authorization: `Bearer ${backendAccessToken}`,
+        },
+      });
+
+      if (response.status === 401) {
+        await signOut({ callbackUrl: "/login" });
+        return;
+      }
+
+      if (!response.ok) {
+        throw new Error("Failed to fetch test details");
+      }
+
+      const testData: TestData = await response.json();
+
+      setNewTestName(`Copy of ${testData.name || test.name}`);
+      setNewTestDescription(
+        testData.config?.description || testData.description || ""
+      );
+      setInitialTab(
+        testData.type === "tool_call" ? "tool-invocation" : "next-reply"
+      );
+      if (testData.config) {
+        setInitialConfig(testData.config as TestConfig);
+      }
+      if (Array.isArray(testData.evaluators)) {
+        setInitialEvaluators(
+          testData.evaluators.map((e) => ({
+            evaluator_uuid: e.uuid,
+            name: e.name,
+            description: e.description ?? null,
+            slug: e.slug,
+            variables: Array.isArray(e.variables) ? e.variables : [],
+            variable_values: e.variable_values ?? null,
+          }))
+        );
+      } else {
+        setInitialEvaluators([]);
+      }
+    } catch (err) {
+      console.error("Error duplicating test:", err);
+      setCreateError(
+        err instanceof Error ? err.message : "Failed to load test"
+      );
+    } finally {
+      setIsLoadingTest(false);
+    }
+  };
+
   // Update existing test via PUT API
   const updateTest = async (
     config: TestConfig,
@@ -1182,6 +1252,30 @@ function LLMPageInner() {
                         <div className="absolute top-full left-1/2 -translate-x-1/2 -mt-1 w-0 h-0 border-l-[6px] border-l-transparent border-r-[6px] border-r-transparent border-t-[6px] border-t-white"></div>
                       </div>
                     </button>
+                    {/* Duplicate Button — opens the create dialog pre-filled
+                        from this test; nothing is saved until submit. */}
+                    <button
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        openDuplicateTest(test);
+                      }}
+                      className="w-8 h-8 flex items-center justify-center rounded-md text-muted-foreground hover:text-foreground hover:bg-muted transition-colors cursor-pointer"
+                      title="Duplicate test"
+                    >
+                      <svg
+                        className="w-4 h-4"
+                        fill="none"
+                        viewBox="0 0 24 24"
+                        stroke="currentColor"
+                        strokeWidth={1.5}
+                      >
+                        <path
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          d="M15.75 17.25v3.375c0 .621-.504 1.125-1.125 1.125h-9.75a1.125 1.125 0 01-1.125-1.125V7.875c0-.621.504-1.125 1.125-1.125H6.75a9.06 9.06 0 011.5.124m7.5 10.376h3.375c.621 0 1.125-.504 1.125-1.125V11.25c0-4.46-3.243-8.161-7.5-8.876a9.06 9.06 0 00-1.5-.124H9.375c-.621 0-1.125.504-1.125 1.125v3.5m7.5 10.375H9.375a1.125 1.125 0 01-1.125-1.125v-9.25m12 6.625v-1.875a3.375 3.375 0 00-3.375-3.375h-1.5a1.125 1.125 0 01-1.125-1.125v-1.5a3.375 3.375 0 00-3.375-3.375H9.75"
+                        />
+                      </svg>
+                    </button>
                     {/* Delete Button */}
                     <button
                       onClick={(e) => {
@@ -1280,6 +1374,28 @@ function LLMPageInner() {
                         <path d="M8 5v14l11-7z" />
                       </svg>
                       Run test
+                    </button>
+                    <button
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        openDuplicateTest(test);
+                      }}
+                      className="flex-1 h-8 flex items-center justify-center gap-2 rounded-md text-xs font-medium text-foreground bg-muted hover:bg-muted/70 transition-colors"
+                    >
+                      <svg
+                        className="w-4 h-4"
+                        fill="none"
+                        viewBox="0 0 24 24"
+                        stroke="currentColor"
+                        strokeWidth={1.5}
+                      >
+                        <path
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          d="M15.75 17.25v3.375c0 .621-.504 1.125-1.125 1.125h-9.75a1.125 1.125 0 01-1.125-1.125V7.875c0-.621.504-1.125 1.125-1.125H6.75a9.06 9.06 0 011.5.124m7.5 10.376h3.375c.621 0 1.125-.504 1.125-1.125V11.25c0-4.46-3.243-8.161-7.5-8.876a9.06 9.06 0 00-1.5-.124H9.375c-.621 0-1.125.504-1.125 1.125v3.5m7.5 10.375H9.375a1.125 1.125 0 01-1.125-1.125v-9.25m12 6.625v-1.875a3.375 3.375 0 00-3.375-3.375h-1.5a1.125 1.125 0 01-1.125-1.125v-1.5a3.375 3.375 0 00-3.375-3.375H9.75"
+                        />
+                      </svg>
+                      Duplicate
                     </button>
                     <button
                       onClick={(e) => {

--- a/src/app/tests/page.tsx
+++ b/src/app/tests/page.tsx
@@ -22,6 +22,7 @@ import {
   EvaluatorVariableDef,
 } from "@/components/AddTestDialog";
 import { BulkUploadTestsModal } from "@/components/BulkUploadTestsModal";
+import { DeleteIconButton } from "@/components/ui/DeleteIconButton";
 import { useSidebarState } from "@/lib/sidebar";
 import { POLLING_INTERVAL_MS } from "@/constants/polling";
 import {
@@ -1277,27 +1278,10 @@ function LLMPageInner() {
                       </svg>
                     </button>
                     {/* Delete Button */}
-                    <button
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        openDeleteDialog(test);
-                      }}
-                      className="w-8 h-8 flex items-center justify-center rounded-md text-muted-foreground hover:text-red-500 hover:bg-red-500/10 transition-colors cursor-pointer"
-                    >
-                      <svg
-                        className="w-4 h-4"
-                        fill="none"
-                        viewBox="0 0 24 24"
-                        stroke="currentColor"
-                        strokeWidth={2}
-                      >
-                        <path
-                          strokeLinecap="round"
-                          strokeLinejoin="round"
-                          d="M14.74 9l-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 01-2.244 2.077H8.084a2.25 2.25 0 01-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 00-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 013.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 00-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 00-7.5 0"
-                        />
-                      </svg>
-                    </button>
+                    <DeleteIconButton
+                      onClick={() => openDeleteDialog(test)}
+                      title="Delete test"
+                    />
                   </div>
                 </div>
               ))}

--- a/src/components/AddTestDialog.tsx
+++ b/src/components/AddTestDialog.tsx
@@ -765,9 +765,10 @@ export function AddTestDialog({
       (e) => e.slug === DEFAULT_NEXT_REPLY_EVALUATOR_SLUG,
     );
 
-    // Legacy edit: pre-fill criteria from the old free-text field.
+    // Legacy edit/duplicate: pre-fill criteria from the old free-text field.
+    // Guarded by the presence of criteria text, so it only fires for tests
+    // that actually carry it (never for a from-scratch create).
     if (
-      isEditing &&
       initialConfig?.evaluation?.type === "response" &&
       typeof initialConfig.evaluation.criteria === "string" &&
       initialConfig.evaluation.criteria.length > 0 &&

--- a/src/components/agent-tabs/TestsTabContent.tsx
+++ b/src/components/agent-tabs/TestsTabContent.tsx
@@ -859,6 +859,73 @@ export function TestsTabContent({
     }
   };
 
+  // Open the create dialog pre-filled from an existing test. Editing is left
+  // off (editingTestUuid stays null) so submitting creates a brand-new test
+  // via POST /tests/bulk — nothing is persisted until the user submits.
+  const openDuplicateTest = async (test: TestData) => {
+    try {
+      setIsLoadingTest(true);
+      setEditingTestUuid(null);
+      setCreateDialogOpen(true);
+      setCreateError(null);
+      setNameConflictError(null);
+      setValidationAttempted(false);
+
+      const backendUrl = process.env.NEXT_PUBLIC_BACKEND_URL;
+      if (!backendUrl) {
+        throw new Error("BACKEND_URL environment variable is not set");
+      }
+
+      const response = await fetch(`${backendUrl}/tests/${test.uuid}`, {
+        method: "GET",
+        headers: {
+          accept: "application/json",
+          Authorization: `Bearer ${backendAccessToken}`,
+        },
+      });
+
+      if (response.status === 401) {
+        await signOut({ callbackUrl: "/login" });
+        return;
+      }
+
+      if (!response.ok) {
+        throw new Error("Failed to fetch test details");
+      }
+
+      const testData: TestDetail = await response.json();
+
+      setNewTestName(`Copy of ${testData.name || test.name}`);
+      setInitialTab(
+        testData.type === "tool_call" ? "tool-invocation" : "next-reply",
+      );
+      if (testData.config) {
+        setInitialConfig(testData.config as TestConfig);
+      }
+      if (Array.isArray(testData.evaluators)) {
+        setInitialEvaluators(
+          testData.evaluators.map((e) => ({
+            evaluator_uuid: e.uuid,
+            name: e.name,
+            description: e.description ?? null,
+            slug: e.slug,
+            variables: Array.isArray(e.variables) ? e.variables : [],
+            variable_values: e.variable_values ?? null,
+          })),
+        );
+      } else {
+        setInitialEvaluators([]);
+      }
+    } catch (err) {
+      console.error("Error duplicating test:", err);
+      setCreateError(
+        err instanceof Error ? err.message : "Failed to load test",
+      );
+    } finally {
+      setIsLoadingTest(false);
+    }
+  };
+
   // Update an existing test via PUT /tests/{uuid}. The test's agent links
   // are not touched here — this only edits the test itself.
   const updateTest = async (
@@ -1936,7 +2003,7 @@ export function TestsTabContent({
                 {/* Desktop Table */}
                 <div className="hidden md:block border border-border rounded-xl overflow-hidden">
                   {/* Table Header */}
-                  <div className="grid grid-cols-[40px_minmax(0,1fr)_120px_auto_auto] gap-4 px-4 py-2 border-b border-border bg-muted/30">
+                  <div className="grid grid-cols-[40px_minmax(0,1fr)_120px_auto_auto_auto] gap-4 px-4 py-2 border-b border-border bg-muted/30">
                     <div className="flex items-center">
                       <button
                         type="button"
@@ -1976,13 +2043,14 @@ export function TestsTabContent({
                     </div>
                     <div className="w-8"></div>
                     <div className="w-8"></div>
+                    <div className="w-8"></div>
                   </div>
                   {/* Table Body */}
                   {filteredAgentTests.map((test) => (
                     <div
                       key={test.uuid}
                       onClick={() => openEditTest(test.uuid)}
-                      className="grid grid-cols-[40px_minmax(0,1fr)_120px_auto_auto] gap-4 px-4 py-2 border-b border-border last:border-b-0 hover:bg-muted/20 transition-colors cursor-pointer items-center"
+                      className="grid grid-cols-[40px_minmax(0,1fr)_120px_auto_auto_auto] gap-4 px-4 py-2 border-b border-border last:border-b-0 hover:bg-muted/20 transition-colors cursor-pointer items-center"
                     >
                       {/* Checkbox */}
                       <div className="flex items-center">
@@ -2082,6 +2150,32 @@ export function TestsTabContent({
                               strokeLinecap="round"
                               strokeLinejoin="round"
                               d="M5.25 5.653c0-.856.917-1.398 1.667-.986l11.54 6.348a1.125 1.125 0 010 1.971l-11.54 6.347a1.125 1.125 0 01-1.667-.986V5.653z"
+                            />
+                          </svg>
+                        </button>
+                      </div>
+                      {/* Duplicate Button — opens the create dialog pre-filled
+                          from this test; nothing is saved until submit. */}
+                      <div className="flex items-center">
+                        <button
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            openDuplicateTest(test);
+                          }}
+                          className="w-8 h-8 flex items-center justify-center rounded-md text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-colors cursor-pointer"
+                          title="Duplicate test"
+                        >
+                          <svg
+                            className="w-4 h-4"
+                            fill="none"
+                            viewBox="0 0 24 24"
+                            stroke="currentColor"
+                            strokeWidth={1.5}
+                          >
+                            <path
+                              strokeLinecap="round"
+                              strokeLinejoin="round"
+                              d="M15.75 17.25v3.375c0 .621-.504 1.125-1.125 1.125h-9.75a1.125 1.125 0 01-1.125-1.125V7.875c0-.621.504-1.125 1.125-1.125H6.75a9.06 9.06 0 011.5.124m7.5 10.376h3.375c.621 0 1.125-.504 1.125-1.125V11.25c0-4.46-3.243-8.161-7.5-8.876a9.06 9.06 0 00-1.5-.124H9.375c-.621 0-1.125.504-1.125 1.125v3.5m7.5 10.375H9.375a1.125 1.125 0 01-1.125-1.125v-9.25m12 6.625v-1.875a3.375 3.375 0 00-3.375-3.375h-1.5a1.125 1.125 0 01-1.125-1.125v-1.5a3.375 3.375 0 00-3.375-3.375H9.75"
                             />
                           </svg>
                         </button>
@@ -2187,6 +2281,28 @@ export function TestsTabContent({
                                 strokeLinecap="round"
                                 strokeLinejoin="round"
                                 d="M5.25 5.653c0-.856.917-1.398 1.667-.986l11.54 6.348a1.125 1.125 0 010 1.971l-11.54 6.347a1.125 1.125 0 01-1.667-.986V5.653z"
+                              />
+                            </svg>
+                          </button>
+                          <button
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              openDuplicateTest(test);
+                            }}
+                            className="w-8 h-8 flex items-center justify-center rounded-md text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-colors cursor-pointer"
+                            title="Duplicate test"
+                          >
+                            <svg
+                              className="w-4 h-4"
+                              fill="none"
+                              viewBox="0 0 24 24"
+                              stroke="currentColor"
+                              strokeWidth={1.5}
+                            >
+                              <path
+                                strokeLinecap="round"
+                                strokeLinejoin="round"
+                                d="M15.75 17.25v3.375c0 .621-.504 1.125-1.125 1.125h-9.75a1.125 1.125 0 01-1.125-1.125V7.875c0-.621.504-1.125 1.125-1.125H6.75a9.06 9.06 0 011.5.124m7.5 10.376h3.375c.621 0 1.125-.504 1.125-1.125V11.25c0-4.46-3.243-8.161-7.5-8.876a9.06 9.06 0 00-1.5-.124H9.375c-.621 0-1.125.504-1.125 1.125v3.5m7.5 10.375H9.375a1.125 1.125 0 01-1.125-1.125v-9.25m12 6.625v-1.875a3.375 3.375 0 00-3.375-3.375h-1.5a1.125 1.125 0 01-1.125-1.125v-1.5a3.375 3.375 0 00-3.375-3.375H9.75"
                               />
                             </svg>
                           </button>

--- a/src/components/ui/DeleteIconButton.tsx
+++ b/src/components/ui/DeleteIconButton.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import React from "react";
+
+type DeleteIconButtonProps = {
+  /** Invoked when the button is clicked. Click propagation is stopped first,
+   *  so this is safe to use inside clickable rows. */
+  onClick: () => void;
+  /** Tooltip text. */
+  title?: string;
+  /** Accessible label. Defaults to the title. */
+  ariaLabel?: string;
+  /** Extra classes appended to the base styling. */
+  className?: string;
+};
+
+/**
+ * Shared icon button for destructive delete actions. Renders a trash icon
+ * that turns red on hover. Used across resource rows (tests, labelling items,
+ * etc.) so the delete affordance stays consistent.
+ */
+export function DeleteIconButton({
+  onClick,
+  title = "Delete",
+  ariaLabel,
+  className = "",
+}: DeleteIconButtonProps) {
+  return (
+    <button
+      type="button"
+      onClick={(e) => {
+        e.stopPropagation();
+        onClick();
+      }}
+      title={title}
+      aria-label={ariaLabel ?? title}
+      className={`w-8 h-8 flex items-center justify-center rounded-md text-muted-foreground hover:text-red-500 hover:bg-red-500/10 transition-colors cursor-pointer ${className}`}
+    >
+      <svg
+        className="w-4 h-4"
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke="currentColor"
+        strokeWidth={2}
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          d="M14.74 9l-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 01-2.244 2.077H8.084a2.25 2.25 0 01-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 00-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 013.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 00-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 00-7.5 0"
+        />
+      </svg>
+    </button>
+  );
+}

--- a/src/components/ui/DuplicateIconButton.tsx
+++ b/src/components/ui/DuplicateIconButton.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import React from "react";
+import { Tooltip } from "@/components/Tooltip";
+
+type DuplicateIconButtonProps = {
+  /** Invoked when the button is clicked. Click propagation is stopped first,
+   *  so this is safe to use inside clickable rows. */
+  onClick: () => void;
+  /** Tooltip text shown on hover. Also used as the accessible label. */
+  tooltip?: string;
+  /** Extra classes appended to the base styling. */
+  className?: string;
+};
+
+/**
+ * Shared icon button for duplicate actions. Renders a copy icon with a
+ * hover tooltip (via the Tooltip component). Used across resource rows
+ * (tests, labelling items, etc.) so the duplicate affordance stays
+ * consistent.
+ */
+export function DuplicateIconButton({
+  onClick,
+  tooltip = "Duplicate",
+  className = "",
+}: DuplicateIconButtonProps) {
+  return (
+    <Tooltip content={tooltip}>
+      <button
+        type="button"
+        onClick={(e) => {
+          e.stopPropagation();
+          onClick();
+        }}
+        aria-label={tooltip}
+        className={`w-8 h-8 flex items-center justify-center rounded-md text-muted-foreground hover:text-foreground hover:bg-muted transition-colors cursor-pointer ${className}`}
+      >
+        <svg
+          className="w-4 h-4"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+          strokeWidth={1.5}
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M15.75 17.25v3.375c0 .621-.504 1.125-1.125 1.125h-9.75a1.125 1.125 0 01-1.125-1.125V7.875c0-.621.504-1.125 1.125-1.125H6.75a9.06 9.06 0 011.5.124m7.5 10.376h3.375c.621 0 1.125-.504 1.125-1.125V11.25c0-4.46-3.243-8.161-7.5-8.876a9.06 9.06 0 00-1.5-.124H9.375c-.621 0-1.125.504-1.125 1.125v3.5m7.5 10.375H9.375a1.125 1.125 0 01-1.125-1.125v-9.25m12 6.625v-1.875a3.375 3.375 0 00-3.375-3.375h-1.5a1.125 1.125 0 01-1.125-1.125v-1.5a3.375 3.375 0 00-3.375-3.375H9.75"
+          />
+        </svg>
+      </button>
+    </Tooltip>
+  );
+}

--- a/src/components/ui/DuplicateIconButton.tsx
+++ b/src/components/ui/DuplicateIconButton.tsx
@@ -2,6 +2,7 @@
 
 import React from "react";
 import { Tooltip } from "@/components/Tooltip";
+import { SpinnerIcon } from "@/components/icons";
 
 type DuplicateIconButtonProps = {
   /** Invoked when the button is clicked. Click propagation is stopped first,
@@ -9,6 +10,8 @@ type DuplicateIconButtonProps = {
   onClick: () => void;
   /** Tooltip text shown on hover. Also used as the accessible label. */
   tooltip?: string;
+  /** Shows a spinner and disables the button while the source data loads. */
+  loading?: boolean;
   /** Extra classes appended to the base styling. */
   className?: string;
 };
@@ -17,37 +20,48 @@ type DuplicateIconButtonProps = {
  * Shared icon button for duplicate actions. Renders a copy icon with a
  * hover tooltip (via the Tooltip component). Used across resource rows
  * (tests, labelling items, etc.) so the duplicate affordance stays
- * consistent.
+ * consistent. While `loading` is true it shows a spinner and is disabled —
+ * callers use this to fetch the source item before opening the dialog.
  */
 export function DuplicateIconButton({
   onClick,
   tooltip = "Duplicate",
+  loading = false,
   className = "",
 }: DuplicateIconButtonProps) {
   return (
     <Tooltip content={tooltip}>
       <button
         type="button"
+        disabled={loading}
         onClick={(e) => {
           e.stopPropagation();
+          if (loading) return;
           onClick();
         }}
         aria-label={tooltip}
-        className={`w-8 h-8 flex items-center justify-center rounded-md text-muted-foreground hover:text-foreground hover:bg-muted transition-colors cursor-pointer ${className}`}
+        aria-busy={loading}
+        className={`w-8 h-8 flex items-center justify-center rounded-md text-muted-foreground hover:text-foreground hover:bg-muted transition-colors disabled:opacity-50 disabled:cursor-not-allowed ${
+          loading ? "cursor-not-allowed" : "cursor-pointer"
+        } ${className}`}
       >
-        <svg
-          className="w-4 h-4"
-          fill="none"
-          viewBox="0 0 24 24"
-          stroke="currentColor"
-          strokeWidth={1.5}
-        >
-          <path
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            d="M15.75 17.25v3.375c0 .621-.504 1.125-1.125 1.125h-9.75a1.125 1.125 0 01-1.125-1.125V7.875c0-.621.504-1.125 1.125-1.125H6.75a9.06 9.06 0 011.5.124m7.5 10.376h3.375c.621 0 1.125-.504 1.125-1.125V11.25c0-4.46-3.243-8.161-7.5-8.876a9.06 9.06 0 00-1.5-.124H9.375c-.621 0-1.125.504-1.125 1.125v3.5m7.5 10.375H9.375a1.125 1.125 0 01-1.125-1.125v-9.25m12 6.625v-1.875a3.375 3.375 0 00-3.375-3.375h-1.5a1.125 1.125 0 01-1.125-1.125v-1.5a3.375 3.375 0 00-3.375-3.375H9.75"
-          />
-        </svg>
+        {loading ? (
+          <SpinnerIcon className="w-4 h-4 animate-spin" />
+        ) : (
+          <svg
+            className="w-4 h-4"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            strokeWidth={1.5}
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              d="M15.75 17.25v3.375c0 .621-.504 1.125-1.125 1.125h-9.75a1.125 1.125 0 01-1.125-1.125V7.875c0-.621.504-1.125 1.125-1.125H6.75a9.06 9.06 0 011.5.124m7.5 10.376h3.375c.621 0 1.125-.504 1.125-1.125V11.25c0-4.46-3.243-8.161-7.5-8.876a9.06 9.06 0 00-1.5-.124H9.375c-.621 0-1.125.504-1.125 1.125v3.5m7.5 10.375H9.375a1.125 1.125 0 01-1.125-1.125v-9.25m12 6.625v-1.875a3.375 3.375 0 00-3.375-3.375h-1.5a1.125 1.125 0 01-1.125-1.125v-1.5a3.375 3.375 0 00-3.375-3.375H9.75"
+            />
+          </svg>
+        )}
       </button>
     </Tooltip>
   );

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -13,3 +13,4 @@ export { StatusBadge } from "./StatusBadge";
 export { NestedContainer } from "./NestedContainer";
 export { RetryIcon } from "./RetryIcon";
 export { DeleteIconButton } from "./DeleteIconButton";
+export { DuplicateIconButton } from "./DuplicateIconButton";

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -12,3 +12,4 @@ export { BackHeader } from "./BackHeader";
 export { StatusBadge } from "./StatusBadge";
 export { NestedContainer } from "./NestedContainer";
 export { RetryIcon } from "./RetryIcon";
+export { DeleteIconButton } from "./DeleteIconButton";


### PR DESCRIPTION
## Summary
- Adds a **duplicate** action to the left of the delete button on test rows (agent Tests tab and the standalone `/tests` page) and on labelling item rows (STT, LLM, and simulation tasks).
- Clicking it opens the existing create dialog pre-filled with `Copy of {name}` and the source item's details. Nothing is persisted until the user submits — no backend call on click.
- Tests duplicate opens the dialog in *create* mode (submit → `POST /tests/bulk`); labelling LLM/sim items seed the create dialog's `initialConfig` + evaluators, STT items seed the STT add dialog's `initialRows`.
- Relaxed `AddTestDialog`'s legacy free-text-criteria pre-fill so a duplicated legacy test keeps its criteria (still guarded by criteria being present, so from-scratch creates are unaffected).

## Test plan
- [ ] Agent Tests tab: duplicate a test → dialog opens prefilled as "Copy of …", submit creates a new test
- [ ] `/tests` page: duplicate on desktop row and mobile card
- [ ] Labelling task (LLM): duplicate an item → create dialog prefilled with history + evaluators
- [ ] Labelling task (simulation): duplicate an item
- [ ] Labelling task (STT): duplicate an item → STT add dialog prefilled with transcripts
- [ ] Confirm no backend write happens until the dialog is submitted

🤖 Generated with [Claude Code](https://claude.com/claude-code)