### PR TITLE
Use "conversation" as labelling task type & lead picker with Speech to Text

### DIFF
--- a/src/app/evaluators/page.tsx
+++ b/src/app/evaluators/page.tsx
@@ -168,13 +168,13 @@ function MetricsPageInner() {
   // page reloads and is restored when the user clicks back from a detail page.
   const [activeTab, setActiveTab] = useState<EvaluatorTab>(() => {
     const t = searchParams.get("tab");
-    return t === "mine" ? "mine" : "default";
+    return t === "default" ? "default" : "mine";
   });
 
   // Keep state in sync if the URL changes (e.g. back/forward navigation).
   useEffect(() => {
     const t = searchParams.get("tab");
-    const next: EvaluatorTab = t === "mine" ? "mine" : "default";
+    const next: EvaluatorTab = t === "default" ? "default" : "mine";
     setActiveTab((prev) => (prev === next ? prev : next));
   }, [searchParams]);
 
@@ -733,16 +733,6 @@ function MetricsPageInner() {
         {/* Tabs */}
         <div className="flex items-center gap-4 md:gap-6 border-b border-border">
           <button
-            onClick={() => changeActiveTab("default")}
-            className={`pb-2 text-sm md:text-base font-medium transition-colors cursor-pointer whitespace-nowrap border-b-2 -mb-px ${
-              activeTab === "default"
-                ? "border-foreground text-foreground"
-                : "border-transparent text-muted-foreground hover:text-foreground"
-            }`}
-          >
-            Default ({defaultEvaluators.length})
-          </button>
-          <button
             onClick={() => changeActiveTab("mine")}
             className={`pb-2 text-sm md:text-base font-medium transition-colors cursor-pointer whitespace-nowrap border-b-2 -mb-px ${
               activeTab === "mine"
@@ -751,6 +741,16 @@ function MetricsPageInner() {
             }`}
           >
             My evaluators ({myEvaluators.length})
+          </button>
+          <button
+            onClick={() => changeActiveTab("default")}
+            className={`pb-2 text-sm md:text-base font-medium transition-colors cursor-pointer whitespace-nowrap border-b-2 -mb-px ${
+              activeTab === "default"
+                ? "border-foreground text-foreground"
+                : "border-transparent text-muted-foreground hover:text-foreground"
+            }`}
+          >
+            Default ({defaultEvaluators.length})
           </button>
         </div>
 

--- a/src/app/evaluators/page.tsx
+++ b/src/app/evaluators/page.tsx
@@ -26,6 +26,7 @@ import {
 } from "@/components/evaluators/BinaryScaleEditor";
 import { defaultBinaryLabel } from "@/lib/binaryLabels";
 import { UseCasePickerDialog } from "@/components/evaluators/UseCasePickerDialog";
+import { Select } from "@/components/ui/Select";
 import { extractVariableNames } from "@/lib/evaluatorVariables";
 import { useSidebarState } from "@/lib/sidebar";
 
@@ -781,65 +782,35 @@ function MetricsPageInner() {
             />
           </div>
           <div className="flex items-center gap-2 md:gap-3">
-            <div className="relative">
-              <select
-                value={purposeFilter}
-                onChange={(e) =>
-                  setPurposeFilter(e.target.value as EvaluatorType | "all")
-                }
-                className="appearance-none h-9 md:h-10 pl-3 pr-9 rounded-md text-sm md:text-base border border-border bg-background dark:bg-muted text-foreground focus:outline-none focus:ring-2 focus:ring-accent focus:border-transparent cursor-pointer"
-                aria-label="Filter by purpose"
-              >
-                <option value="all">All purposes</option>
-                {EVALUATOR_TYPE_OPTIONS.map((opt) => (
-                  <option key={opt.value} value={opt.value}>
-                    {EVALUATOR_TYPE_LABELS[opt.value]}
-                  </option>
-                ))}
-              </select>
-              <svg
-                className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground"
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke="currentColor"
-                strokeWidth={2}
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  d="M19.5 8.25l-7.5 7.5-7.5-7.5"
-                />
-              </svg>
-            </div>
-            <div className="relative">
-              <select
-                value={outputTypeFilter}
-                onChange={(e) =>
-                  setOutputTypeFilter(
-                    e.target.value as "binary" | "rating" | "all",
-                  )
-                }
-                className="appearance-none h-9 md:h-10 pl-3 pr-9 rounded-md text-sm md:text-base border border-border bg-background dark:bg-muted text-foreground focus:outline-none focus:ring-2 focus:ring-accent focus:border-transparent cursor-pointer"
-                aria-label="Filter by output type"
-              >
-                <option value="all">All outputs</option>
-                <option value="binary">Binary</option>
-                <option value="rating">Rating</option>
-              </select>
-              <svg
-                className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground"
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke="currentColor"
-                strokeWidth={2}
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  d="M19.5 8.25l-7.5 7.5-7.5-7.5"
-                />
-              </svg>
-            </div>
+            <Select
+              value={purposeFilter}
+              onChange={(e) =>
+                setPurposeFilter(e.target.value as EvaluatorType | "all")
+              }
+              className="h-9 md:h-10 text-sm md:text-base dark:bg-muted cursor-pointer"
+              aria-label="Filter by purpose"
+            >
+              <option value="all">All purposes</option>
+              {EVALUATOR_TYPE_OPTIONS.map((opt) => (
+                <option key={opt.value} value={opt.value}>
+                  {EVALUATOR_TYPE_LABELS[opt.value]}
+                </option>
+              ))}
+            </Select>
+            <Select
+              value={outputTypeFilter}
+              onChange={(e) =>
+                setOutputTypeFilter(
+                  e.target.value as "binary" | "rating" | "all",
+                )
+              }
+              className="h-9 md:h-10 text-sm md:text-base dark:bg-muted cursor-pointer"
+              aria-label="Filter by output type"
+            >
+              <option value="all">All outputs</option>
+              <option value="binary">Binary</option>
+              <option value="rating">Rating</option>
+            </Select>
           </div>
         </div>
 

--- a/src/app/evaluators/page.tsx
+++ b/src/app/evaluators/page.tsx
@@ -75,7 +75,7 @@ const EVALUATOR_TYPE_TO_DATA_TYPE: Record<EvaluatorType, "text" | "audio"> = {
   tts: "audio",
   stt: "audio",
   llm: "text",
-  simulation: "text",
+  conversation: "text",
 };
 
 const EVALUATOR_TYPE_OPTIONS: {
@@ -101,7 +101,7 @@ const EVALUATOR_TYPE_OPTIONS: {
       "Given a conversation history, evaluate the agent's next response",
   },
   {
-    value: "simulation",
+    value: "conversation",
     title: "Full conversation",
     description:
       "Evaluate the agent's performance during a complete conversation",
@@ -358,7 +358,7 @@ function MetricsPageInner() {
         } | null;
       } = await response.json();
 
-      // `name` is null for `purpose === "simulation"` (no seeded evaluator
+      // `name` is null for `purpose === "conversation"` (no seeded evaluator
       // name); the user must type their own. For all other purposes the
       // server returns a suggested slug-style name we drop straight in.
       setEvaluatorName(data.name ?? "");

--- a/src/app/human-alignment/page.tsx
+++ b/src/app/human-alignment/page.tsx
@@ -58,7 +58,7 @@ type LabellingTaskSummary = {
 type LabellingTaskEvaluator = {
   uuid: string;
   name: string;
-  evaluator_type?: "llm" | "stt" | "tts" | "simulation";
+  evaluator_type?: "llm" | "stt" | "tts" | "conversation";
   output_type?: "binary" | "rating";
   owner_user_id?: string | null;
 };
@@ -73,14 +73,6 @@ type LabellingTask = {
   item_count?: number;
   evaluators?: LabellingTaskEvaluator[];
 };
-
-// Annotation tasks carry type "conversation"; the matching evaluator type
-// is "simulation". Map task type → evaluator type for display/grouping.
-function taskTypeToEvaluatorType(
-  t: "llm" | "stt" | "tts" | "conversation" | undefined,
-): "llm" | "stt" | "tts" | "simulation" | undefined {
-  return t === "conversation" ? "simulation" : t;
-}
 
 type SortDirection = "asc" | "desc";
 
@@ -627,8 +619,7 @@ function HumanLabellingPageInner() {
                 {sortedTasks.map((task) => {
                   const evaluators = task.evaluators ?? [];
                   const evaluatorType =
-                    taskTypeToEvaluatorType(task.type) ??
-                    evaluators[0]?.evaluator_type;
+                    task.type ?? evaluators[0]?.evaluator_type;
                   return (
                     <div
                       key={task.uuid}
@@ -704,8 +695,7 @@ function HumanLabellingPageInner() {
                 {sortedTasks.map((task) => {
                   const evaluators = task.evaluators ?? [];
                   const evaluatorType =
-                    taskTypeToEvaluatorType(task.type) ??
-                    evaluators[0]?.evaluator_type;
+                    task.type ?? evaluators[0]?.evaluator_type;
                   return (
                     <div
                       key={task.uuid}
@@ -1265,7 +1255,7 @@ type SeriesRow = {
   current: number | null;
   pairCount: number;
   series: AgreementSeriesPoint[];
-  evaluatorType?: "llm" | "stt" | "tts" | "simulation";
+  evaluatorType?: "llm" | "stt" | "tts" | "conversation";
   emptyTitle: string;
   emptyDescription: string;
 };
@@ -1302,10 +1292,10 @@ function AgreementOverview({
   tasks: LabellingTask[];
 }) {
   const evaluatorTypeMap = (() => {
-    const m = new Map<string, "llm" | "stt" | "tts" | "simulation">();
+    const m = new Map<string, "llm" | "stt" | "tts" | "conversation">();
     for (const t of tasks) {
       for (const ev of t.evaluators ?? []) {
-        const type = ev.evaluator_type ?? taskTypeToEvaluatorType(t.type);
+        const type = ev.evaluator_type ?? t.type;
         if (type && !m.has(ev.uuid)) m.set(ev.uuid, type);
       }
     }

--- a/src/app/human-alignment/page.tsx
+++ b/src/app/human-alignment/page.tsx
@@ -66,13 +66,21 @@ type LabellingTaskEvaluator = {
 type LabellingTask = {
   uuid: string;
   name: string;
-  type?: "llm" | "stt" | "tts" | "simulation";
+  type?: "llm" | "stt" | "tts" | "conversation";
   description?: string;
   created_at?: string;
   updated_at?: string;
   item_count?: number;
   evaluators?: LabellingTaskEvaluator[];
 };
+
+// Annotation tasks carry type "conversation"; the matching evaluator type
+// is "simulation". Map task type → evaluator type for display/grouping.
+function taskTypeToEvaluatorType(
+  t: "llm" | "stt" | "tts" | "conversation" | undefined,
+): "llm" | "stt" | "tts" | "simulation" | undefined {
+  return t === "conversation" ? "simulation" : t;
+}
 
 type SortDirection = "asc" | "desc";
 
@@ -619,7 +627,8 @@ function HumanLabellingPageInner() {
                 {sortedTasks.map((task) => {
                   const evaluators = task.evaluators ?? [];
                   const evaluatorType =
-                    task.type ?? evaluators[0]?.evaluator_type;
+                    taskTypeToEvaluatorType(task.type) ??
+                    evaluators[0]?.evaluator_type;
                   return (
                     <div
                       key={task.uuid}
@@ -695,7 +704,8 @@ function HumanLabellingPageInner() {
                 {sortedTasks.map((task) => {
                   const evaluators = task.evaluators ?? [];
                   const evaluatorType =
-                    task.type ?? evaluators[0]?.evaluator_type;
+                    taskTypeToEvaluatorType(task.type) ??
+                    evaluators[0]?.evaluator_type;
                   return (
                     <div
                       key={task.uuid}
@@ -1295,7 +1305,7 @@ function AgreementOverview({
     const m = new Map<string, "llm" | "stt" | "tts" | "simulation">();
     for (const t of tasks) {
       for (const ev of t.evaluators ?? []) {
-        const type = ev.evaluator_type ?? t.type;
+        const type = ev.evaluator_type ?? taskTypeToEvaluatorType(t.type);
         if (type && !m.has(ev.uuid)) m.set(ev.uuid, type);
       }
     }

--- a/src/app/human-alignment/tasks/[uuid]/evaluator-runs/[runUuid]/page.tsx
+++ b/src/app/human-alignment/tasks/[uuid]/evaluator-runs/[runUuid]/page.tsx
@@ -527,7 +527,7 @@ export default function EvaluatorRunDetailPage() {
         task &&
         (task.type === "stt" ||
           task.type === "llm" ||
-          task.type === "simulation") ? (
+          task.type === "conversation") ? (
           <EvaluatorRunDetailView
             job={job}
             task={task}

--- a/src/app/human-alignment/tasks/[uuid]/page.tsx
+++ b/src/app/human-alignment/tasks/[uuid]/page.tsx
@@ -21,10 +21,7 @@ import {
   type TestConfig,
 } from "@/components/AddTestDialog";
 import { AppLayout } from "@/components/AppLayout";
-import {
-  EvaluatorTypePill,
-  type EvaluatorType,
-} from "@/components/EvaluatorPills";
+import { EvaluatorTypePill } from "@/components/EvaluatorPills";
 import {
   ExportResultsButton,
   type ExportColumn,
@@ -240,7 +237,7 @@ type LabellingTask = {
     name: string;
     description?: string | null;
     slug?: string | null;
-    evaluator_type?: "llm" | "stt" | "tts" | "simulation";
+    evaluator_type?: "llm" | "stt" | "tts" | "conversation";
     output_type?: "binary" | "rating" | null;
     scale_min?: number | boolean | null;
     scale_max?: number | boolean | null;
@@ -262,18 +259,6 @@ type LabellingTask = {
 };
 
 type TaskKind = "llm" | "stt" | "tts" | "conversation" | undefined;
-
-// Annotation tasks use "conversation"; evaluators use "simulation". These
-// two helpers bridge the divergence so task-level code stays in the
-// "conversation" vocabulary and only converts at the evaluator boundary
-// (EvaluatorTypePill, evaluator filtering).
-function evaluatorTypeToTaskKind(t: EvaluatorType | undefined): TaskKind {
-  return t === "simulation" ? "conversation" : t;
-}
-
-function taskKindToEvaluatorType(t: TaskKind): EvaluatorType | undefined {
-  return t === "conversation" ? "simulation" : t;
-}
 
 function previewItemPayload(payload: unknown, kind: TaskKind): string {
   if (payload == null || typeof payload !== "object") {
@@ -1627,8 +1612,7 @@ function LabellingTaskPageInner() {
     (itemsSearch ? false : items.length > 0);
   const jobsCount = jobs.length;
   const taskType =
-    task?.type ??
-    evaluatorTypeToTaskKind(task?.evaluators?.[0]?.evaluator_type);
+    task?.type ?? task?.evaluators?.[0]?.evaluator_type;
   const canAddItem =
     taskType === "llm" || taskType === "conversation" || taskType === "stt";
 
@@ -2329,11 +2313,7 @@ function LabellingTaskPageInner() {
                   (task?.name ?? "—")
                 )}
               </h1>
-              {taskType && (
-                <EvaluatorTypePill
-                  evaluatorType={taskKindToEvaluatorType(taskType)!}
-                />
-              )}
+              {taskType && <EvaluatorTypePill evaluatorType={taskType} />}
             </div>
             {task?.description && (
               <p className="text-muted-foreground text-sm md:text-base leading-relaxed mt-1 max-w-3xl">
@@ -4142,10 +4122,7 @@ function LabellingTaskPageInner() {
         <ManageEvaluatorsDialog
           accessToken={accessToken}
           taskUuid={task.uuid}
-          taskType={
-            taskKindToEvaluatorType(task.type) ??
-            task.evaluators?.[0]?.evaluator_type
-          }
+          taskType={task.type ?? task.evaluators?.[0]?.evaluator_type}
           currentEvaluatorIds={(task.evaluators ?? []).map((e) => e.uuid)}
           onClose={() => setManageOpen(false)}
           onSaved={() => {

--- a/src/app/human-alignment/tasks/[uuid]/page.tsx
+++ b/src/app/human-alignment/tasks/[uuid]/page.tsx
@@ -124,7 +124,7 @@ type SummaryRow = {
 };
 type TaskSummaryResponse = {
   task_id: string;
-  task_type: "stt" | "llm" | "simulation";
+  task_type: "stt" | "llm" | "conversation";
   evaluators: SummaryEvaluator[];
   annotators: SummaryAnnotator[];
   rows: SummaryRow[];
@@ -228,7 +228,7 @@ type LabellingJob = {
 type LabellingTask = {
   uuid: string;
   name: string;
-  type?: "llm" | "stt" | "tts" | "simulation";
+  type?: "llm" | "stt" | "tts" | "conversation";
   description?: string;
   created_at?: string;
   updated_at?: string;
@@ -259,6 +259,15 @@ type LabellingTask = {
 };
 
 type TaskKind = "llm" | "stt" | "tts" | "simulation" | undefined;
+
+// Backend annotation tasks carry type "conversation" where evaluators
+// carry "simulation". Normalize to the evaluator-side value so all
+// downstream branching and the shared EvaluatorTypePill keep working.
+function normalizeTaskType(
+  t: "llm" | "stt" | "tts" | "conversation" | undefined,
+): TaskKind {
+  return t === "conversation" ? "simulation" : t;
+}
 
 function previewItemPayload(payload: unknown, kind: TaskKind): string {
   if (payload == null || typeof payload !== "object") {
@@ -1611,7 +1620,8 @@ function LabellingTaskPageInner() {
     (taskSummary?.pagination?.total ?? 0) > 0 ||
     (itemsSearch ? false : items.length > 0);
   const jobsCount = jobs.length;
-  const taskType = task?.type ?? task?.evaluators?.[0]?.evaluator_type;
+  const taskType =
+    normalizeTaskType(task?.type) ?? task?.evaluators?.[0]?.evaluator_type;
   const canAddItem =
     taskType === "llm" || taskType === "simulation" || taskType === "stt";
 
@@ -4121,7 +4131,9 @@ function LabellingTaskPageInner() {
         <ManageEvaluatorsDialog
           accessToken={accessToken}
           taskUuid={task.uuid}
-          taskType={task.type ?? task.evaluators?.[0]?.evaluator_type}
+          taskType={
+            normalizeTaskType(task.type) ?? task.evaluators?.[0]?.evaluator_type
+          }
           currentEvaluatorIds={(task.evaluators ?? []).map((e) => e.uuid)}
           onClose={() => setManageOpen(false)}
           onSaved={() => {
@@ -4135,7 +4147,10 @@ function LabellingTaskPageInner() {
         isOpen={!!itemDetailUuid}
         onClose={() => setItemDetailUuid(null)}
         task={
-          task && (task.type === "llm" || task.type === "stt" || task.type === "simulation")
+          task &&
+          (task.type === "llm" ||
+            task.type === "stt" ||
+            task.type === "conversation")
             ? {
                 uuid: task.uuid,
                 name: task.name,

--- a/src/app/human-alignment/tasks/[uuid]/page.tsx
+++ b/src/app/human-alignment/tasks/[uuid]/page.tsx
@@ -1603,6 +1603,11 @@ function LabellingTaskPageInner() {
     itemsLimit > 0 ? Math.floor(itemsOffset / itemsLimit) + 1 : 1;
   const itemsRangeStart = itemsTotal === 0 ? 0 : itemsOffset + 1;
   const itemsRangeEnd = Math.min(itemsOffset + items.length, itemsTotal);
+  // Hide the whole pagination footer when pagination can never apply — i.e.
+  // even the smallest page size fits every item on one page. Above that
+  // threshold we keep the footer (so the Per-page selector stays reachable)
+  // but hide the prev/next page nav whenever there's only a single page.
+  const showItemsPagination = itemsTotal > ITEMS_PAGE_SIZE_OPTIONS[0];
   /** True when the task itself has any items (regardless of the
    * current search). Used to distinguish the "no items yet" empty state
    * from the "no search matches" state. */
@@ -3379,6 +3384,8 @@ function LabellingTaskPageInner() {
                   (bottom-6 right-6) so the prev/next controls stay
                   visible when the user scrolls to the bottom. */}
               <div className="flex flex-wrap items-center justify-between gap-3 pt-1 pb-20 text-sm text-muted-foreground">
+                {showItemsPagination && (
+                  <>
                 <div>
                   {itemsTotal === 0 ? (
                     "0 items"
@@ -3441,6 +3448,7 @@ function LabellingTaskPageInner() {
                       </svg>
                     </div>
                   </label>
+                  {itemsPageCount > 1 && (
                   <div className="flex items-center gap-1">
                     <button
                       type="button"
@@ -3504,7 +3512,10 @@ function LabellingTaskPageInner() {
                       </svg>
                     </button>
                   </div>
+                  )}
                 </div>
+                  </>
+                )}
               </div>
             </div>
           ))}

--- a/src/app/human-alignment/tasks/[uuid]/page.tsx
+++ b/src/app/human-alignment/tasks/[uuid]/page.tsx
@@ -21,7 +21,10 @@ import {
   type TestConfig,
 } from "@/components/AddTestDialog";
 import { AppLayout } from "@/components/AppLayout";
-import { EvaluatorTypePill } from "@/components/EvaluatorPills";
+import {
+  EvaluatorTypePill,
+  type EvaluatorType,
+} from "@/components/EvaluatorPills";
 import {
   ExportResultsButton,
   type ExportColumn,
@@ -31,7 +34,7 @@ import { Tooltip } from "@/components/Tooltip";
 import { DeleteConfirmationDialog } from "@/components/DeleteConfirmationDialog";
 import { AddSttItemsDialog } from "@/components/human-labelling/AddSttItemsDialog";
 import { BulkUploadSttItemsDialog } from "@/components/human-labelling/BulkUploadSttItemsDialog";
-import { BulkUploadSimulationItemsDialog } from "@/components/human-labelling/BulkUploadSimulationItemsDialog";
+import { BulkUploadConversationItemsDialog } from "@/components/human-labelling/BulkUploadConversationItemsDialog";
 import { BulkUploadLlmItemsDialog } from "@/components/human-labelling/BulkUploadLlmItemsDialog";
 import { AssignAnnotatorsDialog } from "@/components/human-labelling/AssignAnnotatorsDialog";
 import { EditTaskDialog } from "@/components/human-labelling/EditTaskDialog";
@@ -258,14 +261,17 @@ type LabellingTask = {
   item_count?: number;
 };
 
-type TaskKind = "llm" | "stt" | "tts" | "simulation" | undefined;
+type TaskKind = "llm" | "stt" | "tts" | "conversation" | undefined;
 
-// Backend annotation tasks carry type "conversation" where evaluators
-// carry "simulation". Normalize to the evaluator-side value so all
-// downstream branching and the shared EvaluatorTypePill keep working.
-function normalizeTaskType(
-  t: "llm" | "stt" | "tts" | "conversation" | undefined,
-): TaskKind {
+// Annotation tasks use "conversation"; evaluators use "simulation". These
+// two helpers bridge the divergence so task-level code stays in the
+// "conversation" vocabulary and only converts at the evaluator boundary
+// (EvaluatorTypePill, evaluator filtering).
+function evaluatorTypeToTaskKind(t: EvaluatorType | undefined): TaskKind {
+  return t === "simulation" ? "conversation" : t;
+}
+
+function taskKindToEvaluatorType(t: TaskKind): EvaluatorType | undefined {
   return t === "conversation" ? "simulation" : t;
 }
 
@@ -293,7 +299,7 @@ function previewItemPayload(payload: unknown, kind: TaskKind): string {
       if (typeof last?.content === "string") return last.content;
     }
   }
-  if (kind === "simulation") {
+  if (kind === "conversation") {
     if (Array.isArray(p.transcript) && p.transcript.length > 0) {
       const first = p.transcript[0] as { content?: unknown };
       if (typeof first?.content === "string") return first.content;
@@ -360,7 +366,7 @@ function buildItemsCsv(
   if (taskType !== "stt") {
     columns.push({ key: "description", header: "description" });
   }
-  if (taskType === "simulation") {
+  if (taskType === "conversation") {
     columns.push({
       key: "conversation_history",
       header: "conversation_history",
@@ -434,7 +440,7 @@ function buildItemsCsv(
     if (taskType !== "stt") {
       out.description = typeof p.description === "string" ? p.description : "";
     }
-    if (taskType === "simulation") {
+    if (taskType === "conversation") {
       out.conversation_history = Array.isArray(p.transcript)
         ? JSON.stringify(p.transcript)
         : "";
@@ -1621,9 +1627,10 @@ function LabellingTaskPageInner() {
     (itemsSearch ? false : items.length > 0);
   const jobsCount = jobs.length;
   const taskType =
-    normalizeTaskType(task?.type) ?? task?.evaluators?.[0]?.evaluator_type;
+    task?.type ??
+    evaluatorTypeToTaskKind(task?.evaluators?.[0]?.evaluator_type);
   const canAddItem =
-    taskType === "llm" || taskType === "simulation" || taskType === "stt";
+    taskType === "llm" || taskType === "conversation" || taskType === "stt";
 
   /**
    * Anchor for shift+click range selection — the uuid of the most
@@ -2143,7 +2150,7 @@ function LabellingTaskPageInner() {
     };
 
     let history: HistoryItem[];
-    if (taskType === "simulation") {
+    if (taskType === "conversation") {
       history = parseHistory(payload.transcript);
     } else {
       // LLM: chat_history (may include tool calls + tool responses) +
@@ -2223,7 +2230,7 @@ function LabellingTaskPageInner() {
   const [addItemOpen, setAddItemOpen] = useState(false);
   const [addSttItemsOpen, setAddSttItemsOpen] = useState(false);
   const [bulkUploadSttOpen, setBulkUploadSttOpen] = useState(false);
-  const [bulkUploadSimulationOpen, setBulkUploadSimulationOpen] =
+  const [bulkUploadConversationOpen, setBulkUploadConversationOpen] =
     useState(false);
   const [bulkUploadLlmOpen, setBulkUploadLlmOpen] = useState(false);
   const [newItemName, setNewItemName] = useState("");
@@ -2322,7 +2329,11 @@ function LabellingTaskPageInner() {
                   (task?.name ?? "—")
                 )}
               </h1>
-              {taskType && <EvaluatorTypePill evaluatorType={taskType} />}
+              {taskType && (
+                <EvaluatorTypePill
+                  evaluatorType={taskKindToEvaluatorType(taskType)!}
+                />
+              )}
             </div>
             {task?.description && (
               <p className="text-muted-foreground text-sm md:text-base leading-relaxed mt-1 max-w-3xl">
@@ -2448,7 +2459,7 @@ function LabellingTaskPageInner() {
               </button>
               <button
                 onClick={() => {
-                  if (taskType === "llm" || taskType === "simulation") {
+                  if (taskType === "llm" || taskType === "conversation") {
                     setNewItemName("");
                     setNewItemDescription("");
                     setCreateItemError(null);
@@ -2495,8 +2506,8 @@ function LabellingTaskPageInner() {
                       if (llmNoEvaluators) return;
                       if (taskType === "stt") {
                         setBulkUploadSttOpen(true);
-                      } else if (taskType === "simulation") {
-                        setBulkUploadSimulationOpen(true);
+                      } else if (taskType === "conversation") {
+                        setBulkUploadConversationOpen(true);
                       } else if (taskType === "llm") {
                         setBulkUploadLlmOpen(true);
                       } else {
@@ -3654,7 +3665,7 @@ function LabellingTaskPageInner() {
           setItemDescription={setNewItemDescription}
           validationAttempted={validationAttempted}
           mode="labelItem"
-          allowAgentLastMessage={taskType === "simulation"}
+          allowAgentLastMessage={taskType === "conversation"}
           requireAssistantLastMessage={taskType === "llm"}
           initialConfig={addItemInitialConfig}
           initialEvaluators={newItemInitialEvaluators}
@@ -3705,7 +3716,7 @@ function LabellingTaskPageInner() {
               : {};
 
             let payload: Record<string, unknown>;
-            if (taskType === "simulation") {
+            if (taskType === "conversation") {
               payload = {
                 name: newItemName.trim(),
                 ...descriptionField,
@@ -3776,7 +3787,7 @@ function LabellingTaskPageInner() {
           setItemDescription={setEditLlmItemDescription}
           validationAttempted={false}
           mode="labelItem"
-          allowAgentLastMessage={taskType === "simulation"}
+          allowAgentLastMessage={taskType === "conversation"}
           requireAssistantLastMessage={taskType === "llm"}
           initialConfig={editingInitialConfig}
           initialEvaluators={editingInitialEvaluators}
@@ -3815,7 +3826,7 @@ function LabellingTaskPageInner() {
             const descriptionField = { description: trimmedDescription };
 
             let payload: Record<string, unknown>;
-            if (taskType === "simulation") {
+            if (taskType === "conversation") {
               payload = {
                 name: editLlmItemName.trim(),
                 ...descriptionField,
@@ -3907,8 +3918,8 @@ function LabellingTaskPageInner() {
       )}
 
       {accessToken && (
-        <BulkUploadSimulationItemsDialog
-          isOpen={bulkUploadSimulationOpen}
+        <BulkUploadConversationItemsDialog
+          isOpen={bulkUploadConversationOpen}
           accessToken={accessToken}
           taskUuid={uuid}
           linkedEvaluators={(task?.evaluators ?? []).map((e) => ({
@@ -3918,9 +3929,9 @@ function LabellingTaskPageInner() {
             scale_min: typeof e.scale_min === "number" ? e.scale_min : null,
             scale_max: typeof e.scale_max === "number" ? e.scale_max : null,
           }))}
-          onClose={() => setBulkUploadSimulationOpen(false)}
+          onClose={() => setBulkUploadConversationOpen(false)}
           onSuccess={async (count) => {
-            setBulkUploadSimulationOpen(false);
+            setBulkUploadConversationOpen(false);
             handleTabChange("items");
             await Promise.all([fetchTask(), fetchTaskSummary()]);
             toast.success(`Added ${count} ${count === 1 ? "item" : "items"}`);
@@ -4132,7 +4143,8 @@ function LabellingTaskPageInner() {
           accessToken={accessToken}
           taskUuid={task.uuid}
           taskType={
-            normalizeTaskType(task.type) ?? task.evaluators?.[0]?.evaluator_type
+            taskKindToEvaluatorType(task.type) ??
+            task.evaluators?.[0]?.evaluator_type
           }
           currentEvaluatorIds={(task.evaluators ?? []).map((e) => e.uuid)}
           onClose={() => setManageOpen(false)}

--- a/src/app/simulations/[uuid]/page.tsx
+++ b/src/app/simulations/[uuid]/page.tsx
@@ -471,7 +471,7 @@ export default function SimulationDetailPage() {
     fetchScenarios();
   }, [backendAccessToken]);
 
-  // Fetch evaluators — only `evaluator_type === "simulation"` is offered as a
+  // Fetch evaluators — only `evaluator_type === "conversation"` is offered as a
   // metric for simulations. Other use cases (LLM, TTS, STT) are filtered out
   // here so the picker doesn't expose evaluators that can't run on a full
   // conversation.
@@ -509,7 +509,7 @@ export default function SimulationDetailPage() {
           ? data
               .filter(
                 (m: { evaluator_type?: string }) =>
-                  m.evaluator_type === "simulation",
+                  m.evaluator_type === "conversation",
               )
               .map(
                 (m: {

--- a/src/components/AddTestDialog.tsx
+++ b/src/components/AddTestDialog.tsx
@@ -59,7 +59,7 @@ export type TestConfig = {
 };
 
 // Evaluator type for the conversation tab — picker is filtered to this.
-const CONVERSATION_EVALUATOR_TYPE = "simulation";
+const CONVERSATION_EVALUATOR_TYPE = "conversation";
 
 type TestTab = "next-reply" | "tool-invocation" | "conversation";
 
@@ -136,7 +136,7 @@ type LLMEvaluatorOption = {
   slug: string | null;
   owner_user_id: string | null;
   variables: EvaluatorVariableDef[];
-  /** "llm" for next-reply tab, "simulation" for conversation tab. */
+  /** "llm" for next-reply tab, "conversation" for conversation tab. */
   evaluator_type?: string;
 };
 

--- a/src/components/BulkUploadTestsModal.tsx
+++ b/src/components/BulkUploadTestsModal.tsx
@@ -30,7 +30,7 @@ const HELPER_LINK_CLASS =
 type TestType = "response" | "tool_call" | "conversation";
 
 // evaluator_type filter the Conversation test type uses for its picker.
-const CONVERSATION_EVALUATOR_TYPE = "simulation";
+const CONVERSATION_EVALUATOR_TYPE = "conversation";
 
 type ParsedTest = {
   name: string;

--- a/src/components/EvaluatorPills.tsx
+++ b/src/components/EvaluatorPills.tsx
@@ -5,7 +5,7 @@ import { Tooltip } from "@/components/Tooltip";
 
 type Kind = "single" | "side_by_side";
 type OutputType = "binary" | "rating";
-export type EvaluatorType = "tts" | "stt" | "llm" | "simulation";
+export type EvaluatorType = "tts" | "stt" | "llm" | "conversation";
 
 const baseClasses =
   "inline-flex items-center px-2 py-0.5 rounded-md text-[10px] md:text-[11px] font-medium uppercase tracking-wide";
@@ -22,21 +22,21 @@ export const EVALUATOR_TYPE_LABELS: Record<EvaluatorType, string> = {
   tts: "Text to Speech",
   stt: "Speech to Text",
   llm: "Single LLM response",
-  simulation: "Full conversation",
+  conversation: "Full conversation",
 };
 
 export const EVALUATOR_TYPE_TOOLTIPS: Record<EvaluatorType, string> = {
   tts: "Evaluate the quality of generated audio.",
   stt: "Evaluate the output of transcription of an audio.",
   llm: "Given a conversation history, evaluate the agent's next response.",
-  simulation: "Evaluate an entire conversation history from a simulation.",
+  conversation: "Evaluate an entire conversation history.",
 };
 
 const EVALUATOR_TYPE_COLORS: Record<EvaluatorType, string> = {
   tts: "bg-purple-500/10 text-purple-600 dark:text-purple-400",
   stt: "bg-blue-500/10 text-blue-600 dark:text-blue-400",
   llm: "bg-orange-500/10 text-orange-600 dark:text-orange-400",
-  simulation: "bg-pink-500/10 text-pink-600 dark:text-pink-400",
+  conversation: "bg-pink-500/10 text-pink-600 dark:text-pink-400",
 };
 
 export function EvaluatorTypePill({

--- a/src/components/evaluators/UseCasePickerDialog.tsx
+++ b/src/components/evaluators/UseCasePickerDialog.tsx
@@ -14,7 +14,7 @@ const TYPE_INACTIVE_CLASSES: Record<EvaluatorType, string> = {
   tts: "border-purple-500/20 bg-purple-500/[0.04] hover:bg-purple-500/10 hover:border-purple-500/40",
   stt: "border-blue-500/20 bg-blue-500/[0.04] hover:bg-blue-500/10 hover:border-blue-500/40",
   llm: "border-orange-500/20 bg-orange-500/[0.04] hover:bg-orange-500/10 hover:border-orange-500/40",
-  simulation:
+  conversation:
     "border-pink-500/20 bg-pink-500/[0.04] hover:bg-pink-500/10 hover:border-pink-500/40",
 };
 
@@ -22,14 +22,14 @@ const TYPE_ACTIVE_CLASSES: Record<EvaluatorType, string> = {
   tts: "border-purple-500/60 bg-purple-500/15 ring-1 ring-purple-500/40",
   stt: "border-blue-500/60 bg-blue-500/15 ring-1 ring-blue-500/40",
   llm: "border-orange-500/60 bg-orange-500/15 ring-1 ring-orange-500/40",
-  simulation: "border-pink-500/60 bg-pink-500/15 ring-1 ring-pink-500/40",
+  conversation: "border-pink-500/60 bg-pink-500/15 ring-1 ring-pink-500/40",
 };
 
 const TYPE_TITLE_CLASSES: Record<EvaluatorType, string> = {
   tts: "text-purple-700 dark:text-purple-300",
   stt: "text-blue-700 dark:text-blue-300",
   llm: "text-orange-700 dark:text-orange-300",
-  simulation: "text-pink-700 dark:text-pink-300",
+  conversation: "text-pink-700 dark:text-pink-300",
 };
 
 type UseCasePickerDialogProps = {

--- a/src/components/evaluators/UseCasePickerDialog.tsx
+++ b/src/components/evaluators/UseCasePickerDialog.tsx
@@ -63,8 +63,8 @@ export function UseCasePickerDialog({
               What is this evaluator for?
             </h2>
             <p className="text-xs md:text-sm text-muted-foreground mt-1">
-              Pick the use case so we can configure the right judge model and
-              inputs.
+              Pick the use case so we can set a good default LLM judge model and
+              prompt for you
             </p>
           </div>
           <button

--- a/src/components/human-labelling/AnnotationJobView.tsx
+++ b/src/components/human-labelling/AnnotationJobView.tsx
@@ -7,7 +7,7 @@ import { EvaluatorVerdictCard } from "@/components/EvaluatorVerdictCard";
 import { getBinaryLabel, toRatingScale } from "@/lib/binaryLabels";
 import { LlmItemPane } from "./item-panes/LlmItemPane";
 import { Section } from "./item-panes/shared";
-import { SimulationItemPane } from "./item-panes/SimulationItemPane";
+import { ConversationItemPane } from "./item-panes/ConversationItemPane";
 import { SttItemPane } from "./item-panes/SttItemPane";
 
 function fireConfetti() {
@@ -826,7 +826,7 @@ function AnnotateView({
               />
             </div>
           ) : (
-            // LLM / simulation: long conversation on the left, evaluators
+            // LLM / conversation: long conversation on the left, evaluators
             // on the right. Each panel scrolls independently so the
             // evaluator controls stay visible while the annotator scrolls
             // through history.
@@ -878,7 +878,7 @@ export function ItemPane({
   if (taskType === "stt") return <SttItemPane payload={payload} />;
   if (taskType === "llm") return <LlmItemPane payload={payload} />;
   if (taskType === "conversation")
-    return <SimulationItemPane payload={payload} />;
+    return <ConversationItemPane payload={payload} />;
   return (
     <div className="space-y-2">
       <Section title="Item payload">

--- a/src/components/human-labelling/AnnotationJobView.tsx
+++ b/src/components/human-labelling/AnnotationJobView.tsx
@@ -42,7 +42,7 @@ type Annotator = { uuid: string; name: string };
 export type Task = {
   uuid: string;
   name: string;
-  type: "llm" | "stt" | "tts" | "simulation";
+  type: "llm" | "stt" | "tts" | "conversation";
   description: string | null;
 };
 
@@ -877,7 +877,7 @@ export function ItemPane({
   const payload = (item.payload ?? {}) as Record<string, unknown>;
   if (taskType === "stt") return <SttItemPane payload={payload} />;
   if (taskType === "llm") return <LlmItemPane payload={payload} />;
-  if (taskType === "simulation")
+  if (taskType === "conversation")
     return <SimulationItemPane payload={payload} />;
   return (
     <div className="space-y-2">

--- a/src/components/human-labelling/BulkUploadConversationItemsDialog.tsx
+++ b/src/components/human-labelling/BulkUploadConversationItemsDialog.tsx
@@ -35,14 +35,14 @@ const TRANSCRIPT_HEADERS = [
   "conversation",
   "conversation_history",
 ];
-const NAME_HEADERS = ["name", "title", "simulation_name"];
+const NAME_HEADERS = ["name", "title", "conversation_name"];
 const DESCRIPTION_HEADERS = ["description", "desc", "notes"];
 
 function csvEscape(s: string): string {
   return `"${s.replace(/"/g, '""')}"`;
 }
 
-const SAMPLE_SIMULATION_BASE_ROWS: Array<{
+const SAMPLE_CONVERSATION_BASE_ROWS: Array<{
   name: string;
   description: string;
   transcript: string;
@@ -78,7 +78,7 @@ const SAMPLE_SIMULATION_BASE_ROWS: Array<{
   },
 ];
 
-function buildSampleSimulationCsv(
+function buildSampleConversationCsv(
   evaluators: EvaluatorMeta[],
   includeAnnotations: boolean,
 ): string {
@@ -93,7 +93,7 @@ function buildSampleSimulationCsv(
         ])
       : []),
   ];
-  const lines = SAMPLE_SIMULATION_BASE_ROWS.map((r) =>
+  const lines = SAMPLE_CONVERSATION_BASE_ROWS.map((r) =>
     [
       csvEscape(r.name),
       csvEscape(r.description),
@@ -116,7 +116,7 @@ type ParsedItem = {
   annotations: ParsedAnnotation[];
 };
 
-export type SimulationLinkedEvaluator = {
+export type ConversationLinkedEvaluator = {
   uuid: string;
   name: string;
   output_type: "binary" | "rating" | null;
@@ -124,11 +124,11 @@ export type SimulationLinkedEvaluator = {
   scale_max: number | null;
 };
 
-type BulkUploadSimulationItemsDialogProps = {
+type BulkUploadConversationItemsDialogProps = {
   isOpen: boolean;
   accessToken: string;
   taskUuid: string;
-  linkedEvaluators?: SimulationLinkedEvaluator[];
+  linkedEvaluators?: ConversationLinkedEvaluator[];
   onClose: () => void;
   onSuccess: (count: number, withAnnotations: boolean) => void;
 };
@@ -160,14 +160,14 @@ function TranscriptPreview({ turns }: { turns: TurnObject[] }) {
   );
 }
 
-export function BulkUploadSimulationItemsDialog({
+export function BulkUploadConversationItemsDialog({
   isOpen,
   accessToken,
   taskUuid,
   linkedEvaluators = [],
   onClose,
   onSuccess,
-}: BulkUploadSimulationItemsDialogProps) {
+}: BulkUploadConversationItemsDialogProps) {
   const [csvFile, setCsvFile] = useState<File | null>(null);
   const [parsedItems, setParsedItems] = useState<ParsedItem[]>([]);
   const [parseError, setParseError] = useState<string | null>(null);
@@ -458,9 +458,9 @@ export function BulkUploadSimulationItemsDialog({
     });
 
     return {
-      title: "Bulk upload — Simulation labelling items",
+      title: "Bulk upload — Conversation labelling items",
       intro:
-        "Upload a CSV with the following columns. Each row creates one simulation annotation item.",
+        "Upload a CSV with the following columns. Each row creates one conversation annotation item.",
       columns,
     };
   };
@@ -628,18 +628,18 @@ export function BulkUploadSimulationItemsDialog({
       isOpen={isOpen}
       title="Bulk upload items"
       buildSampleCsv={() =>
-        buildSampleSimulationCsv(annotationEvaluatorsMeta, uploadAnnotations)
+        buildSampleConversationCsv(annotationEvaluatorsMeta, uploadAnnotations)
       }
       sampleFilename={() =>
         uploadAnnotations
-          ? "sample_simulation_items_with_annotations.csv"
-          : "sample_simulation_items.csv"
+          ? "sample_conversation_items_with_annotations.csv"
+          : "sample_conversation_items.csv"
       }
       buildGuidelines={buildGuidelines}
       guidelinesFilename={() =>
         uploadAnnotations
-          ? "simulation_items_csv_guidelines_with_annotations.pdf"
-          : "simulation_items_csv_guidelines.pdf"
+          ? "conversation_items_csv_guidelines_with_annotations.pdf"
+          : "conversation_items_csv_guidelines.pdf"
       }
       csvFile={csvFile}
       onFile={handleFile}

--- a/src/components/human-labelling/CreateLabellingTaskDialog.tsx
+++ b/src/components/human-labelling/CreateLabellingTaskDialog.tsx
@@ -49,7 +49,7 @@ const TASK_TYPE_OPTIONS: {
 ];
 
 // Per-type tints, mirroring EvaluatorTypePill's palette
-// (llm=orange, stt=blue, simulation=pink) so the picker reads as the
+// (llm=orange, stt=blue, conversation=pink) so the picker reads as the
 // same "type" affordance the user sees on evaluator cards. We use a
 // subtle tint by default (so the cards announce their type at rest)
 // and a stronger tint + bordered ring when active.

--- a/src/components/human-labelling/CreateLabellingTaskDialog.tsx
+++ b/src/components/human-labelling/CreateLabellingTaskDialog.tsx
@@ -4,7 +4,6 @@ import { useEffect, useMemo, useState } from "react";
 import { useHideFloatingButton } from "@/components/AppLayout";
 import {
   EVALUATOR_TYPE_LABELS,
-  EvaluatorTypePill,
   type EvaluatorType,
 } from "@/components/EvaluatorPills";
 import { apiClient } from "@/lib/api";
@@ -253,214 +252,195 @@ export function CreateLabellingTaskDialog({
               aligns with the bottom of the type-picker cards (left
               column's last child) — never extending past it. */}
           <div className={taskType ? "md:relative" : ""}>
-          <div
-            className={`min-w-0 space-y-5 ${
-              taskType ? "md:max-w-[42rem]" : ""
-            }`}
-          >
-          {/* Name */}
-          <div>
-            <label className="block text-sm font-medium mb-2">
-              Name <span className="text-red-500">*</span>
-            </label>
-            <input
-              autoFocus
-              value={name}
-              onChange={(e) => {
-                setName(e.target.value);
-                if (nameConflictError) setNameConflictError(null);
-              }}
-              placeholder="e.g., Helpfulness review — Q2 batch"
-              className={`w-full h-10 px-3 rounded-md text-sm border bg-background text-foreground focus:outline-none focus:ring-2 focus:ring-accent ${
-                nameConflictError ? "border-red-500" : "border-border"
+            <div
+              className={`min-w-0 space-y-5 ${
+                taskType ? "md:max-w-[42rem]" : ""
               }`}
-            />
-            {nameConflictError && (
-              <p className="mt-1 text-sm text-red-500">{nameConflictError}</p>
-            )}
-          </div>
-
-          {/* Description */}
-          <div>
-            <label className="block text-sm font-medium mb-2">
-              Description
-            </label>
-            <textarea
-              value={description}
-              onChange={(e) => setDescription(e.target.value)}
-              placeholder="Short description of the labelling task"
-              rows={3}
-              className="w-full px-3 py-2 rounded-md text-sm border border-border bg-background text-foreground focus:outline-none focus:ring-2 focus:ring-accent resize-y"
-            />
-          </div>
-
-          {/* Type picker */}
-          <div>
-            <label className="block text-sm font-medium mb-1">
-              Type <span className="text-red-500">*</span>
-            </label>
-            <p className="text-xs text-muted-foreground mb-2">
-              Type can&apos;t be changed after the task is created.
-            </p>
-            <div className="mb-2 flex items-start gap-2.5 p-3 rounded-lg bg-yellow-500/10 border border-yellow-500/20">
-              <svg
-                className="w-4 h-4 flex-shrink-0 mt-0.5 text-yellow-500"
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke="currentColor"
-                strokeWidth={2}
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126zM12 15.75h.007v.008H12v-.008z"
+            >
+              {/* Name */}
+              <div>
+                <label className="block text-sm font-medium mb-2">
+                  Name <span className="text-red-500">*</span>
+                </label>
+                <input
+                  autoFocus
+                  value={name}
+                  onChange={(e) => {
+                    setName(e.target.value);
+                    if (nameConflictError) setNameConflictError(null);
+                  }}
+                  placeholder="e.g., Helpfulness review — Q2 batch"
+                  className={`w-full h-10 px-3 rounded-md text-sm border bg-background text-foreground focus:outline-none focus:ring-2 focus:ring-accent ${
+                    nameConflictError ? "border-red-500" : "border-border"
+                  }`}
                 />
-              </svg>
-              <span className="text-xs md:text-sm text-foreground inline-flex items-center gap-1.5 flex-wrap">
-                Human alignment for
-                <EvaluatorTypePill evaluatorType="tts" />
-                evaluators is not supported yet
-              </span>
-            </div>
-            <div className="grid grid-cols-1 sm:grid-cols-3 gap-2">
-              {TASK_TYPE_OPTIONS.map((opt) => {
-                const active = taskType === opt.value;
-                return (
-                  <button
-                    key={opt.value}
-                    type="button"
-                    onClick={() => setTaskType(opt.value)}
-                    className={`flex flex-col items-start text-left p-3 rounded-md border transition-colors cursor-pointer ${
-                      active
-                        ? TASK_TYPE_ACTIVE_CLASSES[opt.value]
-                        : TASK_TYPE_INACTIVE_CLASSES[opt.value]
-                    }`}
-                  >
-                    <div
-                      className={`text-sm font-medium ${TASK_TYPE_TITLE_CLASSES[opt.value]}`}
-                    >
-                      {opt.title}
-                    </div>
-                    <div className="text-xs text-muted-foreground mt-1 leading-relaxed">
-                      {opt.description}
-                    </div>
-                  </button>
-                );
-              })}
-            </div>
-          </div>
-          </div>
+                {nameConflictError && (
+                  <p className="mt-1 text-sm text-red-500">
+                    {nameConflictError}
+                  </p>
+                )}
+              </div>
 
-          {/* Evaluator picker — only shown once a type is chosen.
+              {/* Description */}
+              <div>
+                <label className="block text-sm font-medium mb-2">
+                  Description
+                </label>
+                <textarea
+                  value={description}
+                  onChange={(e) => setDescription(e.target.value)}
+                  placeholder="Short description of the labelling task"
+                  rows={3}
+                  className="w-full px-3 py-2 rounded-md text-sm border border-border bg-background text-foreground focus:outline-none focus:ring-2 focus:ring-accent resize-y"
+                />
+              </div>
+
+              {/* Type picker */}
+              <div>
+                <label className="block text-sm font-medium mb-1">
+                  Task type <span className="text-red-500">*</span>
+                </label>
+                <p className="text-xs text-muted-foreground mb-2">
+                  The task type cannot be changed after the task is created
+                </p>
+                <div className="grid grid-cols-1 sm:grid-cols-3 gap-2">
+                  {TASK_TYPE_OPTIONS.map((opt) => {
+                    const active = taskType === opt.value;
+                    return (
+                      <button
+                        key={opt.value}
+                        type="button"
+                        onClick={() => setTaskType(opt.value)}
+                        className={`flex flex-col items-start text-left p-3 rounded-md border transition-colors cursor-pointer ${
+                          active
+                            ? TASK_TYPE_ACTIVE_CLASSES[opt.value]
+                            : TASK_TYPE_INACTIVE_CLASSES[opt.value]
+                        }`}
+                      >
+                        <div
+                          className={`text-sm font-medium ${TASK_TYPE_TITLE_CLASSES[opt.value]}`}
+                        >
+                          {opt.title}
+                        </div>
+                        <div className="text-xs text-muted-foreground mt-1 leading-relaxed">
+                          {opt.description}
+                        </div>
+                      </button>
+                    );
+                  })}
+                </div>
+              </div>
+            </div>
+
+            {/* Evaluator picker — only shown once a type is chosen.
               On md+ this is positioned absolutely so its top/bottom
               align with the left column's content (bottom = bottom of
               the type-picker cards). On mobile it falls back to the
               normal flow underneath. The list inside flexes to fill
               the remaining vertical space. */}
-          {taskType && (
-            <div
-              className="mt-5 md:mt-0 md:absolute md:top-0 md:bottom-0 md:left-[calc(42rem+1.5rem)] md:right-0 flex flex-col md:overflow-hidden"
-            >
-              <label className="block text-sm font-medium mb-2">
-                Evaluators <span className="text-red-500">*</span>
-                <span className="ml-2 text-xs font-normal text-muted-foreground">
-                  ({selectedEvaluatorIds.size} selected)
-                </span>
-              </label>
-              <p className="text-xs text-muted-foreground mb-2">
-                Pick at least one evaluator that annotators will grade against.
-              </p>
+            {taskType && (
+              <div className="mt-5 md:mt-0 md:absolute md:top-0 md:bottom-0 md:left-[calc(42rem+1.5rem)] md:right-0 flex flex-col md:overflow-hidden">
+                <label className="block text-sm font-medium mb-2">
+                  Evaluators <span className="text-red-500">*</span>
+                  <span className="ml-2 text-xs font-normal text-muted-foreground">
+                    ({selectedEvaluatorIds.size} selected)
+                  </span>
+                </label>
+                <p className="text-xs text-muted-foreground mb-2">
+                  Pick at least one evaluator that annotators will grade
+                  against.
+                </p>
 
-              <div className="relative mb-2">
-                <div className="absolute inset-y-0 left-0 flex items-center pl-3 pointer-events-none">
-                  <svg
-                    className="w-4 h-4 text-muted-foreground"
-                    fill="none"
-                    viewBox="0 0 24 24"
-                    stroke="currentColor"
-                    strokeWidth={2}
-                  >
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      d="M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 5.196a7.5 7.5 0 0010.607 10.607z"
-                    />
-                  </svg>
-                </div>
-                <input
-                  type="text"
-                  value={evaluatorSearch}
-                  onChange={(e) => setEvaluatorSearch(e.target.value)}
-                  placeholder={`Search evaluators`}
-                  className="w-full h-9 pl-9 pr-3 rounded-md text-sm border border-border bg-background text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-accent"
-                />
-              </div>
-
-              <div className="border border-border rounded-md min-h-0 overflow-y-auto divide-y divide-border">
-                {evaluatorsLoading ? (
-                  <div className="p-4 flex items-center gap-2 text-sm text-muted-foreground">
+                <div className="relative mb-2">
+                  <div className="absolute inset-y-0 left-0 flex items-center pl-3 pointer-events-none">
                     <svg
-                      className="w-4 h-4 animate-spin"
+                      className="w-4 h-4 text-muted-foreground"
                       fill="none"
                       viewBox="0 0 24 24"
+                      stroke="currentColor"
+                      strokeWidth={2}
                     >
-                      <circle
-                        className="opacity-25"
-                        cx="12"
-                        cy="12"
-                        r="10"
-                        stroke="currentColor"
-                        strokeWidth="4"
-                      />
                       <path
-                        className="opacity-75"
-                        fill="currentColor"
-                        d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        d="M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 5.196a7.5 7.5 0 0010.607 10.607z"
                       />
                     </svg>
-                    Loading evaluators
                   </div>
-                ) : evaluatorsError ? (
-                  <div className="p-4 text-sm text-red-500">
-                    {evaluatorsError}
-                  </div>
-                ) : filteredEvaluators.length === 0 ? (
-                  <div className="p-4 text-sm text-muted-foreground">
-                    {evaluatorSearch.trim()
-                      ? "No matching evaluators."
-                      : `No ${EVALUATOR_TYPE_LABELS[taskType]} evaluators yet.`}
-                  </div>
-                ) : (
-                  filteredEvaluators.map((ev) => {
-                    const checked = selectedEvaluatorIds.has(ev.uuid);
-                    return (
-                      <label
-                        key={ev.uuid}
-                        className="flex items-start gap-3 px-3 py-2.5 hover:bg-muted/30 transition-colors cursor-pointer"
+                  <input
+                    type="text"
+                    value={evaluatorSearch}
+                    onChange={(e) => setEvaluatorSearch(e.target.value)}
+                    placeholder={`Search evaluators`}
+                    className="w-full h-9 pl-9 pr-3 rounded-md text-sm border border-border bg-background text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-accent"
+                  />
+                </div>
+
+                <div className="border border-border rounded-md min-h-0 overflow-y-auto divide-y divide-border">
+                  {evaluatorsLoading ? (
+                    <div className="p-4 flex items-center gap-2 text-sm text-muted-foreground">
+                      <svg
+                        className="w-4 h-4 animate-spin"
+                        fill="none"
+                        viewBox="0 0 24 24"
                       >
-                        <input
-                          type="checkbox"
-                          checked={checked}
-                          onChange={() => toggleEvaluator(ev.uuid)}
-                          className="mt-0.5 w-4 h-4 cursor-pointer accent-foreground"
+                        <circle
+                          className="opacity-25"
+                          cx="12"
+                          cy="12"
+                          r="10"
+                          stroke="currentColor"
+                          strokeWidth="4"
                         />
-                        <div className="min-w-0 flex-1">
-                          <div className="text-sm font-medium truncate">
-                            {ev.name}
-                          </div>
-                          {ev.description && (
-                            <div className="text-xs text-muted-foreground line-clamp-2 mt-0.5">
-                              {ev.description}
+                        <path
+                          className="opacity-75"
+                          fill="currentColor"
+                          d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+                        />
+                      </svg>
+                      Loading evaluators
+                    </div>
+                  ) : evaluatorsError ? (
+                    <div className="p-4 text-sm text-red-500">
+                      {evaluatorsError}
+                    </div>
+                  ) : filteredEvaluators.length === 0 ? (
+                    <div className="p-4 text-sm text-muted-foreground">
+                      {evaluatorSearch.trim()
+                        ? "No matching evaluators."
+                        : `No ${EVALUATOR_TYPE_LABELS[taskType]} evaluators yet.`}
+                    </div>
+                  ) : (
+                    filteredEvaluators.map((ev) => {
+                      const checked = selectedEvaluatorIds.has(ev.uuid);
+                      return (
+                        <label
+                          key={ev.uuid}
+                          className="flex items-start gap-3 px-3 py-2.5 hover:bg-muted/30 transition-colors cursor-pointer"
+                        >
+                          <input
+                            type="checkbox"
+                            checked={checked}
+                            onChange={() => toggleEvaluator(ev.uuid)}
+                            className="mt-0.5 w-4 h-4 cursor-pointer accent-foreground"
+                          />
+                          <div className="min-w-0 flex-1">
+                            <div className="text-sm font-medium truncate">
+                              {ev.name}
                             </div>
-                          )}
-                        </div>
-                      </label>
-                    );
-                  })
-                )}
+                            {ev.description && (
+                              <div className="text-xs text-muted-foreground line-clamp-2 mt-0.5">
+                                {ev.description}
+                              </div>
+                            )}
+                          </div>
+                        </label>
+                      );
+                    })
+                  )}
+                </div>
               </div>
-            </div>
-          )}
+            )}
           </div>
 
           {submitError && (

--- a/src/components/human-labelling/CreateLabellingTaskDialog.tsx
+++ b/src/components/human-labelling/CreateLabellingTaskDialog.tsx
@@ -10,19 +10,9 @@ import {
 import { apiClient } from "@/lib/api";
 import { readNameConflictFromError } from "@/lib/parseBackendError";
 
-// Only these three task types are allowed for labelling tasks.
-// Note: the "conversation" task type maps to the "simulation" evaluator
-// type — annotation tasks use "conversation" but evaluators are still
-// typed "simulation" (see TASK_TO_EVALUATOR_TYPE).
-type TaskType = "llm" | "stt" | "conversation";
-
-// A labelling task's type and its evaluators' type diverge for full
-// conversations: the task is "conversation", the evaluators are "simulation".
-const TASK_TO_EVALUATOR_TYPE: Record<TaskType, EvaluatorType> = {
-  llm: "llm",
-  stt: "stt",
-  conversation: "simulation",
-};
+// Only these three task types are allowed for labelling tasks. A task's
+// type matches its evaluators' evaluator_type one-to-one.
+type TaskType = Extract<EvaluatorType, "llm" | "stt" | "conversation">;
 
 const TASK_TYPE_OPTIONS: {
   value: TaskType;
@@ -155,11 +145,10 @@ export function CreateLabellingTaskDialog({
   // When the type changes, drop selections that don't belong to the new type.
   useEffect(() => {
     if (!taskType) return;
-    const evaluatorType = TASK_TO_EVALUATOR_TYPE[taskType];
     setSelectedEvaluatorIds((prev) => {
       const next = new Set<string>();
       for (const ev of evaluators) {
-        if (ev.evaluator_type === evaluatorType && prev.has(ev.uuid)) {
+        if (ev.evaluator_type === taskType && prev.has(ev.uuid)) {
           next.add(ev.uuid);
         }
       }
@@ -169,10 +158,9 @@ export function CreateLabellingTaskDialog({
 
   const filteredEvaluators = useMemo(() => {
     if (!taskType) return [];
-    const evaluatorType = TASK_TO_EVALUATOR_TYPE[taskType];
     const q = evaluatorSearch.trim().toLowerCase();
     return evaluators
-      .filter((ev) => ev.evaluator_type === evaluatorType)
+      .filter((ev) => ev.evaluator_type === taskType)
       .filter((ev) => (q ? ev.name.toLowerCase().includes(q) : true));
   }, [evaluators, taskType, evaluatorSearch]);
 
@@ -440,7 +428,7 @@ export function CreateLabellingTaskDialog({
                   <div className="p-4 text-sm text-muted-foreground">
                     {evaluatorSearch.trim()
                       ? "No matching evaluators."
-                      : `No ${EVALUATOR_TYPE_LABELS[TASK_TO_EVALUATOR_TYPE[taskType]]} evaluators yet.`}
+                      : `No ${EVALUATOR_TYPE_LABELS[taskType]} evaluators yet.`}
                   </div>
                 ) : (
                   filteredEvaluators.map((ev) => {

--- a/src/components/human-labelling/CreateLabellingTaskDialog.tsx
+++ b/src/components/human-labelling/CreateLabellingTaskDialog.tsx
@@ -19,15 +19,15 @@ const TASK_TYPE_OPTIONS: {
   description: string;
 }[] = [
   {
+    value: "stt",
+    title: "Speech to Text",
+    description: "Evaluate the transcription quality against a reference text.",
+  },
+  {
     value: "llm",
     title: "Single LLM response",
     description:
       "Given a conversation history, evaluate the agent's next response.",
-  },
-  {
-    value: "stt",
-    title: "Speech to Text",
-    description: "Evaluate the transcription quality against a reference text.",
   },
   {
     value: "simulation",

--- a/src/components/human-labelling/CreateLabellingTaskDialog.tsx
+++ b/src/components/human-labelling/CreateLabellingTaskDialog.tsx
@@ -10,8 +10,19 @@ import {
 import { apiClient } from "@/lib/api";
 import { readNameConflictFromError } from "@/lib/parseBackendError";
 
-// Only these three task types are allowed for labelling tasks
-type TaskType = Extract<EvaluatorType, "llm" | "stt" | "simulation">;
+// Only these three task types are allowed for labelling tasks.
+// Note: the "conversation" task type maps to the "simulation" evaluator
+// type — annotation tasks use "conversation" but evaluators are still
+// typed "simulation" (see TASK_TO_EVALUATOR_TYPE).
+type TaskType = "llm" | "stt" | "conversation";
+
+// A labelling task's type and its evaluators' type diverge for full
+// conversations: the task is "conversation", the evaluators are "simulation".
+const TASK_TO_EVALUATOR_TYPE: Record<TaskType, EvaluatorType> = {
+  llm: "llm",
+  stt: "stt",
+  conversation: "simulation",
+};
 
 const TASK_TYPE_OPTIONS: {
   value: TaskType;
@@ -30,7 +41,7 @@ const TASK_TYPE_OPTIONS: {
       "Given a conversation history, evaluate the agent's next response.",
   },
   {
-    value: "simulation",
+    value: "conversation",
     title: "Full conversation",
     description:
       "Evaluate the agent's performance during a complete conversation.",
@@ -45,20 +56,20 @@ const TASK_TYPE_OPTIONS: {
 const TASK_TYPE_INACTIVE_CLASSES: Record<TaskType, string> = {
   llm: "border-orange-500/20 bg-orange-500/[0.04] hover:bg-orange-500/10 hover:border-orange-500/40",
   stt: "border-blue-500/20 bg-blue-500/[0.04] hover:bg-blue-500/10 hover:border-blue-500/40",
-  simulation:
+  conversation:
     "border-pink-500/20 bg-pink-500/[0.04] hover:bg-pink-500/10 hover:border-pink-500/40",
 };
 
 const TASK_TYPE_ACTIVE_CLASSES: Record<TaskType, string> = {
   llm: "border-orange-500/60 bg-orange-500/15 ring-1 ring-orange-500/40",
   stt: "border-blue-500/60 bg-blue-500/15 ring-1 ring-blue-500/40",
-  simulation: "border-pink-500/60 bg-pink-500/15 ring-1 ring-pink-500/40",
+  conversation: "border-pink-500/60 bg-pink-500/15 ring-1 ring-pink-500/40",
 };
 
 const TASK_TYPE_TITLE_CLASSES: Record<TaskType, string> = {
   llm: "text-orange-700 dark:text-orange-300",
   stt: "text-blue-700 dark:text-blue-300",
-  simulation: "text-pink-700 dark:text-pink-300",
+  conversation: "text-pink-700 dark:text-pink-300",
 };
 
 type EvaluatorListItem = {
@@ -144,10 +155,11 @@ export function CreateLabellingTaskDialog({
   // When the type changes, drop selections that don't belong to the new type.
   useEffect(() => {
     if (!taskType) return;
+    const evaluatorType = TASK_TO_EVALUATOR_TYPE[taskType];
     setSelectedEvaluatorIds((prev) => {
       const next = new Set<string>();
       for (const ev of evaluators) {
-        if (ev.evaluator_type === taskType && prev.has(ev.uuid)) {
+        if (ev.evaluator_type === evaluatorType && prev.has(ev.uuid)) {
           next.add(ev.uuid);
         }
       }
@@ -157,9 +169,10 @@ export function CreateLabellingTaskDialog({
 
   const filteredEvaluators = useMemo(() => {
     if (!taskType) return [];
+    const evaluatorType = TASK_TO_EVALUATOR_TYPE[taskType];
     const q = evaluatorSearch.trim().toLowerCase();
     return evaluators
-      .filter((ev) => ev.evaluator_type === taskType)
+      .filter((ev) => ev.evaluator_type === evaluatorType)
       .filter((ev) => (q ? ev.name.toLowerCase().includes(q) : true));
   }, [evaluators, taskType, evaluatorSearch]);
 
@@ -427,7 +440,7 @@ export function CreateLabellingTaskDialog({
                   <div className="p-4 text-sm text-muted-foreground">
                     {evaluatorSearch.trim()
                       ? "No matching evaluators."
-                      : `No ${EVALUATOR_TYPE_LABELS[taskType]} evaluators yet.`}
+                      : `No ${EVALUATOR_TYPE_LABELS[TASK_TO_EVALUATOR_TYPE[taskType]]} evaluators yet.`}
                   </div>
                 ) : (
                   filteredEvaluators.map((ev) => {

--- a/src/components/human-labelling/EvaluatorRunDetailView.tsx
+++ b/src/components/human-labelling/EvaluatorRunDetailView.tsx
@@ -142,7 +142,7 @@ export type EvaluatorRunJob = {
 export type LabellingTaskFull = {
   uuid: string;
   name: string;
-  type: "llm" | "stt" | "tts" | "simulation";
+  type: "llm" | "stt" | "tts" | "conversation";
   description?: string | null;
   evaluators?: { uuid: string; name: string }[];
   items?: Item[];
@@ -1705,7 +1705,7 @@ export function EvaluatorRunDetailView({
   };
 
   if (
-    !(task.type === "stt" || task.type === "llm" || task.type === "simulation")
+    !(task.type === "stt" || task.type === "llm" || task.type === "conversation")
   ) {
     return null;
   }

--- a/src/components/human-labelling/ItemDetailDialog.tsx
+++ b/src/components/human-labelling/ItemDetailDialog.tsx
@@ -111,7 +111,7 @@ function itemTitle(item: Item | null): string {
 export type ItemDetailDialogTask = {
   uuid: string;
   name: string;
-  type: "llm" | "stt" | "simulation";
+  type: "llm" | "stt" | "conversation";
   evaluators?: TaskEvaluatorDef[];
 };
 

--- a/src/components/human-labelling/bulk-upload-shared.tsx
+++ b/src/components/human-labelling/bulk-upload-shared.tsx
@@ -152,7 +152,7 @@ export function parseAnnotationCell(
   return { error: `unsupported evaluator type for "${e.name}"` };
 }
 
-// ─── Parsed-items preview + annotated-check (LLM / STT / Simulation) ───────
+// ─── Parsed-items preview + annotated-check (LLM / STT / Conversation) ─────
 
 /** POST `annotated-check` when bulk-uploading with pre-filled annotations. */
 export function useAnnotatedItemsCheck(args: {
@@ -991,7 +991,7 @@ function downloadBlob(blob: Blob, filename: string): void {
   URL.revokeObjectURL(url);
 }
 
-// Shared shell for the three bulk-upload dialogs (LLM / STT / Simulation).
+// Shared shell for the three bulk-upload dialogs (LLM / STT / Conversation).
 // Owns the modal chrome, header, footer, dropzone, format-help toggle, tip
 // callout, and sample-CSV download wiring. Each dialog supplies its own
 // help body, parsing/upload logic, and items preview.

--- a/src/components/human-labelling/item-panes/ConversationItemPane.tsx
+++ b/src/components/human-labelling/item-panes/ConversationItemPane.tsx
@@ -3,7 +3,7 @@ import {
   type TestCaseHistory,
 } from "@/components/test-results/shared";
 
-export function SimulationItemPane({
+export function ConversationItemPane({
   payload,
 }: {
   payload: Record<string, unknown>;

--- a/src/lib/publicEvaluators.ts
+++ b/src/lib/publicEvaluators.ts
@@ -2,7 +2,7 @@ export type PublicDefaultEvaluator = {
   uuid: string;
   name: string;
   description?: string | null;
-  evaluator_type: "stt" | "tts" | "llm" | "simulation" | string;
+  evaluator_type: "stt" | "tts" | "llm" | "conversation" | string;
   output_type: "binary" | "rating";
   live_version?: {
     output_config?: {
@@ -14,7 +14,7 @@ export type PublicDefaultEvaluator = {
 export async function getPublicDefaultEvaluator(
   backendUrl: string,
   shareToken: string,
-  type: "stt" | "tts" | "llm" | "simulation",
+  type: "stt" | "tts" | "llm" | "conversation",
 ): Promise<PublicDefaultEvaluator | null> {
   const response = await fetch(
     `${backendUrl}/public/evaluators/defaults?share_token=${encodeURIComponent(


### PR DESCRIPTION
Fix #174 

## Summary
- Reorder the **Create labelling task** type picker so **Speech to Text** appears first (before Single LLM response and Full conversation).
- Switch the labelling/annotation task type wire value from `"simulation"` to `"conversation"` to match the backend change. Evaluators still carry `evaluator_type: "simulation"`, so the two now diverge.
- Bridge the divergence:
  - Create dialog sends `type: "conversation"` and maps task type → evaluator type (`conversation → simulation`) for evaluator filtering/labels.
  - Read-back paths that feed the shared `EvaluatorTypePill` or evaluator filtering (task detail page, human-alignment list page) normalize `conversation → simulation` at the boundary; else-fallback panes (job view, run detail) just switch the literal.

## Notes
- Backend must return/accept `"conversation"` for the annotation task `type` for this to render correctly at runtime.
- Typecheck (`tsc --noEmit`) and production build both pass; no new lint errors in changed files.

## Test plan
- [ ] Open **Create labelling task** — Speech to Text card is first; selecting each type shows the matching evaluators.
- [ ] Create a Full conversation task and confirm `type: "conversation"` is POSTed and the task saves.
- [ ] Open a conversation task detail page — type pill renders "Full conversation", items/evaluators load, add-item flow works.
- [ ] Open the human-alignment list and agreement overview — conversation tasks show the correct type pill.
- [ ] Open an annotation job view and an evaluator-run detail page for a conversation task — panes render correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)