### PR TITLE
Show tool execution output in tool-call test results

### DIFF
--- a/src/components/AgentDetail.tsx
+++ b/src/components/AgentDetail.tsx
@@ -1073,8 +1073,10 @@ export function AgentDetail({
         )}
       </div>
 
-      {/* Tab Content Container */}
-      <div className="pt-2 md:pt-4">
+      {/* Tab Content Container — pb clears the fixed "Talk to us" FAB so it
+          never overlaps the end of the page content (e.g. the connection
+          format docs). */}
+      <div className="pt-2 md:pt-4 pb-24">
         {/* Connection Tab Content */}
         {activeTab === "connection" && agent.type === "connection" && (
           <AgentConnectionTabContent

--- a/src/components/agent-tabs/AgentConnectionTabContent.tsx
+++ b/src/components/agent-tabs/AgentConnectionTabContent.tsx
@@ -662,21 +662,29 @@ export function AgentConnectionTabContent({
                 Your agent must respond with:
               </p>
               <pre className="text-xs bg-muted rounded-lg p-3 overflow-x-auto text-foreground">
-                {showToolCalls
-                  ? `{
+                {showToolCalls ? (
+                  <>
+                    {`{
   "response": "Aapki beti ka agla vaccination 14 weeks pe hai — OPV aur DPT ke liye.",
   "tool_calls": [
     {
       "tool": "get_schedule",
       "arguments": { "child_age_weeks": 14 },
-      // optional
+      `}
+                    <span className="italic text-muted-foreground">
+                      {`// optional`}
+                    </span>
+                    {`
       "output": { "next_vaccines": ["OPV", "DPT"], "due_in_weeks": 14 }
     }
   ]
-}`
-                  : `{
-  "response": "Aapki beti ka agla vaccination 14 weeks pe hai — OPV aur DPT ke liye."
 }`}
+                  </>
+                ) : (
+                  `{
+  "response": "Aapki beti ka agla vaccination 14 weeks pe hai — OPV aur DPT ke liye."
+}`
+                )}
               </pre>
               {showToolCalls && (
                 <p className="text-xs text-muted-foreground">

--- a/src/components/agent-tabs/AgentConnectionTabContent.tsx
+++ b/src/components/agent-tabs/AgentConnectionTabContent.tsx
@@ -665,13 +665,28 @@ export function AgentConnectionTabContent({
                   ? `{
   "response": "Aapki beti ka agla vaccination 14 weeks pe hai — OPV aur DPT ke liye.",
   "tool_calls": [
-    { "tool": "get_schedule", "arguments": { "child_age_weeks": 14 } }
+    {
+      "tool": "get_schedule",
+      "arguments": { "child_age_weeks": 14 },
+      "output": { "next_vaccines": ["OPV", "DPT"], "due_in_weeks": 14 }
+    }
   ]
 }`
                   : `{
   "response": "Aapki beti ka agla vaccination 14 weeks pe hai — OPV aur DPT ke liye."
 }`}
               </pre>
+              {showToolCalls && (
+                <p className="text-xs text-muted-foreground">
+                  <code className="text-[11px] bg-muted px-1 py-0.5 rounded">
+                    output
+                  </code>{" "}
+                  is optional — include the tool&apos;s execution result (any
+                  JSON value) and it will be shown alongside the tool call in
+                  tool-call test results. Omit it if your agent doesn&apos;t run
+                  the tool.
+                </p>
+              )}
             </div>
           </div>
         </div>

--- a/src/components/agent-tabs/AgentConnectionTabContent.tsx
+++ b/src/components/agent-tabs/AgentConnectionTabContent.tsx
@@ -182,7 +182,11 @@ export function AgentConnectionTabContent({
       }
     }
 
-    const success = await verify.verifyAdHoc(agentUrl, currentHeadersObj, messages);
+    const success = await verify.verifyAdHoc(
+      agentUrl,
+      currentHeadersObj,
+      messages,
+    );
 
     const newStatus: VerificationStatus = success ? "verified" : "failed";
     const now = success ? new Date().toISOString() : null;
@@ -440,9 +444,7 @@ export function AgentConnectionTabContent({
                   onChange={(e) => handleProviderChange(e.target.value)}
                   className="w-full h-9 md:h-10 px-3 md:px-4 pr-10 rounded-md text-sm md:text-base border border-border bg-background text-foreground focus:outline-none focus:ring-2 focus:ring-accent focus:border-transparent cursor-pointer appearance-none"
                 >
-                  <option value="openrouter">
-                    OpenRouter (all providers)
-                  </option>
+                  <option value="openrouter">OpenRouter (all providers)</option>
                   <option value="openai">OpenAI</option>
                   <option value="anthropic">Anthropic</option>
                   <option value="google">Google</option>
@@ -523,9 +525,7 @@ export function AgentConnectionTabContent({
             <button
               type="button"
               onClick={handleVerifyClick}
-              disabled={
-                verify.isVerifying || !agentUrl.trim() || isSaving
-              }
+              disabled={verify.isVerifying || !agentUrl.trim() || isSaving}
               className="h-8 md:h-9 px-3 md:px-4 rounded-md text-xs md:text-sm font-medium bg-yellow-500 text-black hover:bg-yellow-400 transition-colors cursor-pointer disabled:opacity-70 disabled:cursor-not-allowed flex-shrink-0 flex items-center gap-1.5"
             >
               {verifyStatus === "verifying" ? (
@@ -541,23 +541,24 @@ export function AgentConnectionTabContent({
             </button>
           </div>
 
-          {verifyStatus === "failed" && (verifyError || verify.verifySampleResponse) && (
-            <div className="space-y-2 rounded-lg border border-red-500/20 bg-red-500/5 p-3">
-              {verifyError && (
-                <p className="text-xs text-red-400">{verifyError}</p>
-              )}
-              {verify.verifySampleResponse && (
-                <div className="space-y-1">
-                  <p className="text-xs font-medium text-muted-foreground">
-                    Your agent responded with:
-                  </p>
-                  <pre className="text-xs bg-muted rounded-lg p-3 overflow-x-auto text-foreground max-h-48 overflow-y-auto">
-                    {JSON.stringify(verify.verifySampleResponse, null, 2)}
-                  </pre>
-                </div>
-              )}
-            </div>
-          )}
+          {verifyStatus === "failed" &&
+            (verifyError || verify.verifySampleResponse) && (
+              <div className="space-y-2 rounded-lg border border-red-500/20 bg-red-500/5 p-3">
+                {verifyError && (
+                  <p className="text-xs text-red-400">{verifyError}</p>
+                )}
+                {verify.verifySampleResponse && (
+                  <div className="space-y-1">
+                    <p className="text-xs font-medium text-muted-foreground">
+                      Your agent responded with:
+                    </p>
+                    <pre className="text-xs bg-muted rounded-lg p-3 overflow-x-auto text-foreground max-h-48 overflow-y-auto">
+                      {JSON.stringify(verify.verifySampleResponse, null, 2)}
+                    </pre>
+                  </div>
+                )}
+              </div>
+            )}
         </div>
 
         {/* Expected Format */}
@@ -668,6 +669,7 @@ export function AgentConnectionTabContent({
     {
       "tool": "get_schedule",
       "arguments": { "child_age_weeks": 14 },
+      // optional
       "output": { "next_vaccines": ["OPV", "DPT"], "due_in_weeks": 14 }
     }
   ]
@@ -681,10 +683,10 @@ export function AgentConnectionTabContent({
                   <code className="text-[11px] bg-muted px-1 py-0.5 rounded">
                     output
                   </code>{" "}
-                  is optional — include the tool&apos;s execution result (any
+                  is optional. Include the tool&apos;s execution result (any
                   JSON value) and it will be shown alongside the tool call in
-                  tool-call test results. Omit it if your agent doesn&apos;t run
-                  the tool.
+                  the test results. Omit it if your agent doesn&apos;t run the
+                  tool.
                 </p>
               )}
             </div>

--- a/src/components/test-results/shared.tsx
+++ b/src/components/test-results/shared.tsx
@@ -54,6 +54,12 @@ export { CheckIcon, XIcon, SpinnerIcon, ToolIcon, CloseIcon, DocumentIcon };
 export type ToolCallOutput = {
   tool: string;
   arguments: Record<string, any>;
+  /** The tool's execution result, echoed back by the external agent.
+   * Any JSON value. Only populated for agent-connection tests where the
+   * agent actually runs the tool; `null`/absent for managed
+   * calibrate-agent tests (which declare tool calls but never execute
+   * them). Render only when present. */
+  output?: unknown;
 };
 
 export type TestCaseOutput = {
@@ -274,6 +280,7 @@ function formatParamValue(value: any): string {
 export function normalizeToolCall(tc: any): {
   toolName: string;
   args: Record<string, any>;
+  output?: unknown;
 } {
   if (!tc || typeof tc !== "object") {
     return { toolName: "Unknown tool", args: {} };
@@ -321,17 +328,27 @@ export function normalizeToolCall(tc: any): {
     }
   }
 
-  return { toolName, args };
+  const output =
+    tc.output === undefined || tc.output === null ? undefined : tc.output;
+
+  return { toolName, args, output };
 }
 
 // Shared Tool Call Card Component
 export function ToolCallCard({
   toolName,
   args,
+  output,
 }: {
   toolName: string;
   args: Record<string, any>;
+  /** The tool's execution result (agent-connection tests only). Rendered
+   * only when present — `undefined`/`null` hides the result section. */
+  output?: unknown;
 }) {
+  const hasOutput = output !== undefined && output !== null;
+  const outputValue = hasOutput ? formatParamValue(output) : "";
+  const outputIsMultiLine = outputValue.includes("\n");
   return (
     <div className="bg-muted border border-border rounded-2xl p-4">
       <div className="flex items-center gap-2 mb-2">
@@ -360,6 +377,20 @@ export function ToolCallCard({
                 </div>
               );
             })}
+        </div>
+      )}
+      {hasOutput && (
+        <div className="mt-3 pt-3 border-t border-border">
+          <label className="block text-sm font-medium text-muted-foreground mb-1.5">
+            Output
+          </label>
+          <div
+            className={`px-3 py-2 rounded-lg text-sm bg-background border border-border text-foreground whitespace-pre-wrap break-all ${
+              outputIsMultiLine ? "font-mono text-xs" : ""
+            }`}
+          >
+            {outputValue}
+          </div>
         </div>
       )}
     </div>
@@ -758,10 +789,18 @@ export function TestDetailView({
               </div>
               <div className="space-y-3">
                 {output.tool_calls.map((toolCall, index) => {
-                  const { toolName, args } = normalizeToolCall(toolCall);
+                  const {
+                    toolName,
+                    args,
+                    output: toolOutput,
+                  } = normalizeToolCall(toolCall);
                   return (
                     <div key={index} className="w-[88%] md:w-3/4">
-                      <ToolCallCard toolName={toolName} args={args} />
+                      <ToolCallCard
+                        toolName={toolName}
+                        args={args}
+                        output={toolOutput}
+                      />
                     </div>
                   );
                 })}


### PR DESCRIPTION
## Summary
- Surface each tool call's execution `output` in tool-call test results. The backend now echoes the tool's result via an optional `output` field on each `output.tool_calls[]` entry.
- Rendered in the shared test-result renderer (`src/components/test-results/shared.tsx`), so it appears everywhere tool calls already render: the test runner dialog, past runs, and the public test-run/benchmark pages (including nested benchmark `model_results[].test_results[]`).
- **Render-on-presence** keeps it scoped to agent-connection tests automatically — managed calibrate-agent tests send `null`/absent and show nothing, so no `agentType` prop threading is needed.
- Document the new optional `output` field in the connection agent config page's "Expected request & response format" helper, so connection-agent authors know they can echo the tool's result back.

## Changes
- `ToolCallOutput` type gains `output?: unknown`.
- `normalizeToolCall` extracts `output` (treats `null`/`undefined` as absent).
- `ToolCallCard` renders an "Output" section (reusing `formatParamValue`, mono styling for multi-line) only when output is present.
- `AgentConnectionTabContent` — the "Does your agent return tool calls?" example now includes `output`, plus a note that it's optional and shown in tool-call test results.

Purely additive — no breaking changes; existing fields untouched.

## Test plan
- [x] `tsc --noEmit` passes
- [x] Production build passes (pre-commit hook)
- [ ] Run a tool-call test against an agent-connection agent and confirm the tool's result renders under "Output"
- [ ] Confirm managed calibrate-agent tool-call tests show no Output section
- [ ] Spot-check public test-run and benchmark result pages
- [ ] On a connection agent's config page, toggle "Does your agent return tool calls?" and confirm the example shows the `output` field + helper note

🤖 Generated with [Claude Code](https://claude.com/claude-code)