### PR TITLE
Send auth token on benchmark run/poll requests

### DIFF
--- a/src/components/BenchmarkResultsDialog.tsx
+++ b/src/components/BenchmarkResultsDialog.tsx
@@ -131,9 +131,13 @@ export function BenchmarkResultsDialog({
     };
   }, [isOpen, backendAccessToken]);
 
-  // Start benchmark when dialog opens
+  // Start benchmark when dialog opens. Gate on `backendAccessToken` too: the
+  // run/poll requests now require a Bearer token, and on a fresh mount the
+  // token resolves a tick after first render (localStorage read for
+  // email/password login). Without this guard the polling closure would
+  // capture a null token and send `Bearer null` on every request.
   useEffect(() => {
-    if (isOpen) {
+    if (isOpen && backendAccessToken) {
       // Clear any existing polling interval first
       if (pollingIntervalRef.current) {
         clearInterval(pollingIntervalRef.current);
@@ -188,7 +192,7 @@ export function BenchmarkResultsDialog({
       }
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isOpen, taskId]);
+  }, [isOpen, taskId, backendAccessToken]);
 
   // Default selection: first test (index 0) of the first model that has
   // `test_results`. When `models` is populated (new run), prefer that order
@@ -244,6 +248,7 @@ export function BenchmarkResultsDialog({
           method: "GET",
           headers: {
             accept: "application/json",
+            Authorization: `Bearer ${backendAccessToken}`,
           },
         },
       );
@@ -345,6 +350,7 @@ export function BenchmarkResultsDialog({
           headers: {
             accept: "application/json",
             "Content-Type": "application/json",
+            Authorization: `Bearer ${backendAccessToken}`,
           },
           body: JSON.stringify({
             models: models,

--- a/src/components/BenchmarkResultsDialog.tsx
+++ b/src/components/BenchmarkResultsDialog.tsx
@@ -106,6 +106,14 @@ export function BenchmarkResultsDialog({
   const pollingIntervalRef = useRef<NodeJS.Timeout | null>(null);
   /** Once per dialog open: select first test of `models[0]` when its row exists. */
   const hasAutoSelectedFirstBenchmarkTestRef = useRef(false);
+  /**
+   * Which "open session" we've already kicked off — keyed by `taskId` (or a
+   * sentinel for a brand-new run). Stays set across auth-token refreshes so a
+   * mid-run token change re-points polling at the SAME run instead of
+   * resetting state or launching a duplicate benchmark. Cleared when the
+   * dialog closes so the next open starts fresh.
+   */
+  const initializedSessionRef = useRef<string | null>(null);
 
   const isDone =
     taskStatus === "completed" ||
@@ -131,58 +139,86 @@ export function BenchmarkResultsDialog({
     };
   }, [isOpen, backendAccessToken]);
 
-  // Start benchmark when dialog opens. Gate on `backendAccessToken` too: the
-  // run/poll requests now require a Bearer token, and on a fresh mount the
-  // token resolves a tick after first render (localStorage read for
-  // email/password login). Without this guard the polling closure would
-  // capture a null token and send `Bearer null` on every request.
+  // Drive the dialog when it opens. This effect also re-fires when
+  // `backendAccessToken` changes, for two reasons:
+  //   1. On a fresh mount the token resolves a tick after first render
+  //      (localStorage read for email/password login); without re-firing we'd
+  //      start polling with a null token and send `Bearer null`.
+  //   2. The auth token can silently refresh while the dialog is open.
+  // `initializedSessionRef` distinguishes the two cases so a token refresh
+  // re-points polling at the in-progress run (with the fresh token) instead of
+  // wiping state or launching a duplicate benchmark.
   useEffect(() => {
-    if (isOpen && backendAccessToken) {
-      // Clear any existing polling interval first
+    const backendUrl = process.env.NEXT_PUBLIC_BACKEND_URL;
+
+    const beginPolling = (id: string) => {
       if (pollingIntervalRef.current) {
         clearInterval(pollingIntervalRef.current);
         pollingIntervalRef.current = null;
       }
+      if (!backendUrl) {
+        setIsInitialLoading(false);
+        setError("BACKEND_URL environment variable is not set");
+        return;
+      }
+      pollingIntervalRef.current = setInterval(() => {
+        pollBenchmarkStatus(id, backendUrl);
+      }, POLLING_INTERVAL_MS);
+      pollBenchmarkStatus(id, backendUrl);
+    };
 
-      setIsInitialLoading(true);
-      setTaskStatus("queued");
-      setModelResults([]);
-      setLeaderboardSummary(undefined);
-      setRunEvaluators([]);
-      setError(null);
-      setExpandedProviders(new Set(models.length > 0 ? [models[0]] : []));
-      setSelectedTest(null);
-      hasAutoSelectedFirstBenchmarkTestRef.current = false;
-      setActiveTab("outputs");
-      setIsPublic(false);
-      setShareToken(null);
-      setCurrentTaskId(taskId ?? null);
+    if (isOpen && backendAccessToken) {
+      // A new run has no taskId yet — give it a stable sentinel key so token
+      // refreshes during the initial run still count as the same session.
+      const sessionKey = taskId ?? "__new__";
 
-      if (taskId) {
-        // View existing benchmark - poll the task immediately
-        const backendUrl = process.env.NEXT_PUBLIC_BACKEND_URL;
-        if (backendUrl) {
-          pollingIntervalRef.current = setInterval(() => {
-            pollBenchmarkStatus(taskId, backendUrl);
-          }, POLLING_INTERVAL_MS);
-          pollBenchmarkStatus(taskId, backendUrl);
+      if (initializedSessionRef.current === sessionKey) {
+        // Same open session, re-firing because the token refreshed. Re-point
+        // polling at the active run with the new token — no reset, no relaunch.
+        const activeId = taskId ?? currentTaskId;
+        if (activeId) beginPolling(activeId);
+      } else {
+        // First open, or switched to a different run: reset and start fresh.
+        initializedSessionRef.current = sessionKey;
+
+        if (pollingIntervalRef.current) {
+          clearInterval(pollingIntervalRef.current);
+          pollingIntervalRef.current = null;
+        }
+
+        setIsInitialLoading(true);
+        setTaskStatus("queued");
+        setModelResults([]);
+        setLeaderboardSummary(undefined);
+        setRunEvaluators([]);
+        setError(null);
+        setExpandedProviders(new Set(models.length > 0 ? [models[0]] : []));
+        setSelectedTest(null);
+        hasAutoSelectedFirstBenchmarkTestRef.current = false;
+        setActiveTab("outputs");
+        setIsPublic(false);
+        setShareToken(null);
+        setCurrentTaskId(taskId ?? null);
+
+        if (taskId) {
+          // View existing benchmark - poll the task immediately
+          beginPolling(taskId);
+        } else if (models.length > 0) {
+          // Start a new benchmark
+          runBenchmark();
         } else {
           setIsInitialLoading(false);
-          setError("BACKEND_URL environment variable is not set");
         }
-      } else if (models.length > 0) {
-        // Start a new benchmark
-        runBenchmark();
-      } else {
-        setIsInitialLoading(false);
       }
-    } else {
-      // Dialog closed - clear polling
+    } else if (!isOpen) {
+      // Dialog closed - clear polling and arm for the next open.
+      initializedSessionRef.current = null;
       if (pollingIntervalRef.current) {
         clearInterval(pollingIntervalRef.current);
         pollingIntervalRef.current = null;
       }
     }
+    // else: open but the token hasn't resolved yet — wait for the re-fire.
 
     // Cleanup on unmount or when dependencies change
     return () => {


### PR DESCRIPTION
## Why

The backend now requires authentication on these endpoints:
- `POST /presigned-url` — require JWT
- `POST /agent/{uuid}/run`, `POST /agent/{uuid}/benchmark`, `GET /run/{task_id}`, `GET /benchmark/{task_id}` — require auth + org-scoping

I audited every frontend call site for these endpoints. All of them already sent `Authorization: Bearer ...` and get `X-Org-UUID` from the `window.fetch` interceptor — **except `BenchmarkResultsDialog.tsx`**, whose run and poll `fetch` calls omitted the `Authorization` header entirely. Those would now 401.

| Endpoint | Call sites | Status |
|---|---|---|
| `POST /presigned-url` | `STTDatasetEditor.tsx` | Already authed ✓ |
| `POST /agent/{uuid}/run` | `TestRunnerDialog.tsx` ×3 | Already authed ✓ |
| `POST /agent/{uuid}/benchmark` | `BenchmarkResultsDialog.tsx` | **Fixed** |
| `GET /run/{task_id}` | `TestRunnerDialog.tsx`, `tests/page.tsx`, `TestsTabContent.tsx` | Already authed ✓ |
| `GET /benchmark/{task_id}` | `BenchmarkResultsDialog.tsx`, `tests/page.tsx`, `TestsTabContent.tsx` | **BenchmarkResultsDialog fixed**; others already OK |

`X-Org-UUID` is supplied automatically to all of these by `fetchInterceptor.ts`, so only the bearer token was the gap.

## What changed

`src/components/BenchmarkResultsDialog.tsx`:
1. Added `Authorization: Bearer ${backendAccessToken}` to both the `POST .../benchmark` (start) and `GET /benchmark/{task_id}` (poll) requests.
2. Gated the run/poll-start effect on `backendAccessToken` being present (and added it to the dependency array). This dialog mounts on demand when viewing an existing benchmark, so on a fresh mount the token resolves a tick after first render (localStorage read for email/password login). Without the guard, the polling closure would capture a `null` token and send `Bearer null` on every poll.

## Testing
- `tsc --noEmit` passes
- `eslint` clean (one pre-existing unrelated `testUuids` unused warning)
- Production build succeeds (ran via pre-commit hook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Manual QA — concrete clicks to make in the UI

Do these while logged in (so a JWT is attached). Each exercises an endpoint that now requires auth. If a flow silently fails or shows "Something went wrong", check the Network tab for a `401`/`403`/`404` on the listed request.

### 1. Run agent tests — `POST /agent-tests/agent/{uuid}/run` + poll `GET /agent-tests/run/{task_id}`
1. Sidebar → **Agents** → click an agent that has at least one test.
2. Open the **Tests** tab.
3. Click **"Run all tests"** (top-right of the tests toolbar).
4. ✅ Expect: the run dialog opens, shows a **Running** spinner, then each test resolves to **Success/Fail**. Confirm it actually finishes (polling works on every poll, not just the first).

### 2. Run a benchmark — `POST /agent-tests/agent/{uuid}/benchmark` + poll `GET /agent-tests/benchmark/{task_id}` *(the main fix)*
1. Same agent → **Tests** tab → click **"Compare models"**.
2. In the "Compare different models" dialog, click **"Select a model"**, pick a model, optionally **"Add model"** for a second one.
3. Click **"Run comparison"**.
4. ✅ Expect: the benchmark dialog opens on the **Outputs** tab showing models running, then auto-switches to the **Leaderboard** tab with pass rates when done. Previously this would have failed auth — confirm it completes.

### 3. Re-open a PAST benchmark — poll `GET /agent-tests/benchmark/{task_id}` on a fresh mount *(the `Bearer null` race fix)*
1. Go to **Tests** (sidebar) → **Runs** tab — **or** an agent's **Tests** tab → **Past runs** panel.
2. Click a completed **benchmark** row (e.g. labelled "N models").
3. ✅ Expect: results load immediately. This is the path that mounts the dialog fresh, so it specifically verifies the token-gating fix — it must NOT get stuck on the loading spinner or error out. (Worth doing once right after a hard refresh / re-login, which is when the token-resolves-late race would bite.)

### 4. STT dataset audio upload — `POST /presigned-url`
1. Sidebar → **STT** (or **Datasets** → open an STT dataset) and open the dataset editor.
2. Drop or select a small audio file (`.wav`, < 25 MB, < 5 min) into the audio upload control on a row.
3. ✅ Expect: the row shows an uploading spinner → success checkmark (the presigned-url request must return 200, then the file PUTs to S3).

### 5. Public sharing still works WITHOUT auth — `/public/...` unchanged
1. After a completed run **or** benchmark, click **"Share"** in the results dialog header → it flips to **"Public"**.
2. Click **"Copy link"** (gives `/public/test-run/{token}` or `/public/benchmark/{token}`).
3. Paste that URL in an **incognito / logged-out** window.
4. ✅ Expect: the shared result page renders with no login required (these routes are intentionally still public).

### Status codes to spot-check in DevTools → Network
- Missing header → **403** · invalid/expired token → **401** (app should send you to re-login) · resource not in your org → **404** (treated as "not found").
