### PR TITLE
Route test/benchmark request headers through getDefaultHeaders

### DIFF
--- a/src/app/tests/page.tsx
+++ b/src/app/tests/page.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useRef, useCallback, Suspense } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { signOut } from "next-auth/react";
 import { useAccessToken } from "@/hooks";
+import { getDefaultHeaders } from "@/lib/api";
 import { AppLayout } from "@/components/AppLayout";
 import {
   ToolPicker,
@@ -220,10 +221,7 @@ function LLMPageInner() {
 
       const response = await fetch(`${backendUrl}/tests`, {
         method: "GET",
-        headers: {
-          accept: "application/json",
-          Authorization: `Bearer ${backendAccessToken}`,
-        },
+        headers: getDefaultHeaders(backendAccessToken),
       });
 
       if (response.status === 401) {
@@ -261,10 +259,7 @@ function LLMPageInner() {
         if (!backendUrl) throw new Error("BACKEND_URL not set");
         const response = await fetch(`${backendUrl}/agent-tests/runs`, {
           method: "GET",
-          headers: {
-            accept: "application/json",
-            Authorization: `Bearer ${backendAccessToken}`,
-          },
+          headers: getDefaultHeaders(backendAccessToken),
         });
         if (response.status === 401) { await signOut({ callbackUrl: "/login" }); return; }
         if (!response.ok) throw new Error("Failed to fetch runs");
@@ -344,10 +339,7 @@ function LLMPageInner() {
 
           const response = await fetch(endpoint, {
             method: "GET",
-            headers: {
-              accept: "application/json",
-              Authorization: `Bearer ${backendAccessToken}`,
-            },
+            headers: getDefaultHeaders(backendAccessToken),
           });
 
           if (response.status === 401) {
@@ -510,10 +502,7 @@ function LLMPageInner() {
       for (const uuid of uuidsToDelete) {
         const response = await fetch(`${backendUrl}/tests/${uuid}`, {
           method: "DELETE",
-          headers: {
-            accept: "application/json",
-            Authorization: `Bearer ${backendAccessToken}`,
-          },
+          headers: getDefaultHeaders(backendAccessToken),
         });
 
         if (response.status === 401) {
@@ -562,9 +551,8 @@ function LLMPageInner() {
         const response = await fetch(`${backendUrl}/agent-tests`, {
           method: "POST",
           headers: {
-            accept: "application/json",
+            ...getDefaultHeaders(backendAccessToken),
             "Content-Type": "application/json",
-            Authorization: `Bearer ${backendAccessToken}`,
           },
           body: JSON.stringify({
             agent_uuid: agentUuid,
@@ -635,9 +623,8 @@ function LLMPageInner() {
       const response = await fetch(`${backendUrl}/tests/bulk`, {
         method: "POST",
         headers: {
-          accept: "application/json",
+          ...getDefaultHeaders(backendAccessToken),
           "Content-Type": "application/json",
-          Authorization: `Bearer ${backendAccessToken}`,
         },
         body: JSON.stringify({
           type: config.evaluation.type,
@@ -668,10 +655,7 @@ function LLMPageInner() {
       // Refetch the tests list to get the updated data
       const testsResponse = await fetch(`${backendUrl}/tests`, {
         method: "GET",
-        headers: {
-          accept: "application/json",
-          Authorization: `Bearer ${backendAccessToken}`,
-        },
+        headers: getDefaultHeaders(backendAccessToken),
       });
 
       if (testsResponse.ok) {
@@ -710,10 +694,7 @@ function LLMPageInner() {
 
       const response = await fetch(`${backendUrl}/tests/${uuid}`, {
         method: "GET",
-        headers: {
-          accept: "application/json",
-          Authorization: `Bearer ${backendAccessToken}`,
-        },
+        headers: getDefaultHeaders(backendAccessToken),
       });
 
       if (response.status === 401) {
@@ -788,10 +769,7 @@ function LLMPageInner() {
 
       const response = await fetch(`${backendUrl}/tests/${test.uuid}`, {
         method: "GET",
-        headers: {
-          accept: "application/json",
-          Authorization: `Bearer ${backendAccessToken}`,
-        },
+        headers: getDefaultHeaders(backendAccessToken),
       });
 
       if (response.status === 401) {
@@ -886,9 +864,8 @@ function LLMPageInner() {
       const response = await fetch(`${backendUrl}/tests/${editingTestUuid}`, {
         method: "PUT",
         headers: {
-          accept: "application/json",
+          ...getDefaultHeaders(backendAccessToken),
           "Content-Type": "application/json",
-          Authorization: `Bearer ${backendAccessToken}`,
         },
         body: JSON.stringify(body),
       });
@@ -911,10 +888,7 @@ function LLMPageInner() {
       // Refetch the tests list to get the updated data
       const testsResponse = await fetch(`${backendUrl}/tests`, {
         method: "GET",
-        headers: {
-          accept: "application/json",
-          Authorization: `Bearer ${backendAccessToken}`,
-        },
+        headers: getDefaultHeaders(backendAccessToken),
       });
 
       if (testsResponse.ok) {

--- a/src/components/AddTestDialog.tsx
+++ b/src/components/AddTestDialog.tsx
@@ -10,6 +10,7 @@ import React, {
 import { createPortal } from "react-dom";
 import { signOut } from "next-auth/react";
 import { useAccessToken } from "@/hooks";
+import { getDefaultHeaders } from "@/lib/api";
 import { ToolPicker, AvailableTool } from "@/components/ToolPicker";
 import { INBUILT_TOOLS } from "@/constants/inbuilt-tools";
 import { useHideFloatingButton } from "@/components/AppLayout";
@@ -737,10 +738,7 @@ export function AddTestDialog({
 
         const response = await fetch(`${backendUrl}/tools`, {
           method: "GET",
-          headers: {
-            accept: "application/json",
-            Authorization: `Bearer ${backendAccessToken}`,
-          },
+          headers: getDefaultHeaders(backendAccessToken),
         });
 
         if (response.status === 401) {
@@ -783,10 +781,7 @@ export function AddTestDialog({
           `${backendUrl}/evaluators?include_defaults=true`,
           {
             method: "GET",
-            headers: {
-              accept: "application/json",
-              Authorization: `Bearer ${backendAccessToken}`,
-            },
+            headers: getDefaultHeaders(backendAccessToken),
           },
         );
 

--- a/src/components/BenchmarkDialog.tsx
+++ b/src/components/BenchmarkDialog.tsx
@@ -5,6 +5,7 @@ import { signOut } from "next-auth/react";
 import type { LLMModel } from "./agent-tabs/constants/providers";
 import { LLMSelectorModal } from "./agent-tabs/LLMSelectorModal";
 import { useOpenRouterModels, useAccessToken } from "@/hooks";
+import { getDefaultHeaders } from "@/lib/api";
 import { BenchmarkResultsDialog } from "./BenchmarkResultsDialog";
 import {
   CloseIcon,
@@ -132,9 +133,8 @@ export function BenchmarkDialog({
         {
           method: "POST",
           headers: {
-            accept: "application/json",
+            ...getDefaultHeaders(backendAccessToken),
             "Content-Type": "application/json",
-            Authorization: `Bearer ${backendAccessToken}`,
           },
           body: JSON.stringify({
             model: modelId,

--- a/src/components/BenchmarkResultsDialog.tsx
+++ b/src/components/BenchmarkResultsDialog.tsx
@@ -12,6 +12,7 @@ import {
   type BenchmarkModelResult,
 } from "./eval-details";
 import { StatusBadge } from "@/components/ui";
+import { getDefaultHeaders } from "@/lib/api";
 import { POLLING_INTERVAL_MS } from "@/constants/polling";
 import { useHideFloatingButton } from "@/components/AppLayout";
 import { ShareButton } from "@/components/ShareButton";
@@ -282,10 +283,7 @@ export function BenchmarkResultsDialog({
         `${backendUrl}/agent-tests/benchmark/${taskId}`,
         {
           method: "GET",
-          headers: {
-            accept: "application/json",
-            Authorization: `Bearer ${backendAccessToken}`,
-          },
+          headers: getDefaultHeaders(backendAccessToken),
         },
       );
 
@@ -384,9 +382,8 @@ export function BenchmarkResultsDialog({
         {
           method: "POST",
           headers: {
-            accept: "application/json",
+            ...getDefaultHeaders(backendAccessToken),
             "Content-Type": "application/json",
-            Authorization: `Bearer ${backendAccessToken}`,
           },
           body: JSON.stringify({
             models: models,

--- a/src/components/BulkUploadTestsModal.tsx
+++ b/src/components/BulkUploadTestsModal.tsx
@@ -4,6 +4,7 @@ import React, { useState, useEffect, useRef, useMemo } from "react";
 import Link from "next/link";
 import { signOut } from "next-auth/react";
 import { useAccessToken } from "@/hooks";
+import { getDefaultHeaders } from "@/lib/api";
 import Papa from "papaparse";
 import { MultiAgentPicker } from "@/components/AgentPicker";
 import { MultiSelectPicker } from "@/components/MultiSelectPicker";
@@ -273,10 +274,7 @@ export function BulkUploadTestsModal({
           `${backendUrl}/evaluators?include_defaults=true`,
           {
             method: "GET",
-            headers: {
-              accept: "application/json",
-              Authorization: `Bearer ${backendAccessToken}`,
-            },
+            headers: getDefaultHeaders(backendAccessToken),
           },
         );
 
@@ -352,10 +350,7 @@ export function BulkUploadTestsModal({
 
         const response = await fetch(`${backendUrl}/tools`, {
           method: "GET",
-          headers: {
-            accept: "application/json",
-            Authorization: `Bearer ${backendAccessToken}`,
-          },
+          headers: getDefaultHeaders(backendAccessToken),
         });
 
         if (response.status === 401) {
@@ -897,9 +892,8 @@ export function BulkUploadTestsModal({
       const response = await fetch(`${backendUrl}/tests/bulk`, {
         method: "POST",
         headers: {
-          accept: "application/json",
+          ...getDefaultHeaders(backendAccessToken),
           "Content-Type": "application/json",
-          Authorization: `Bearer ${backendAccessToken}`,
         },
         body: JSON.stringify(body),
       });

--- a/src/components/TestRunnerDialog.tsx
+++ b/src/components/TestRunnerDialog.tsx
@@ -3,6 +3,7 @@
 import React, { useState, useEffect, useRef } from "react";
 import { signOut } from "next-auth/react";
 import { useAccessToken } from "@/hooks";
+import { getDefaultHeaders } from "@/lib/api";
 import {
   TestCaseOutput,
   TestCaseData,
@@ -289,10 +290,7 @@ export function TestRunnerDialog({
     try {
       const response = await fetch(`${backendUrl}/agent-tests/run/${taskId}`, {
         method: "GET",
-        headers: {
-          accept: "application/json",
-          Authorization: `Bearer ${backendAccessToken}`,
-        },
+        headers: getDefaultHeaders(backendAccessToken),
       });
 
       if (response.status === 401) {
@@ -520,9 +518,8 @@ export function TestRunnerDialog({
         {
           method: "POST",
           headers: {
-            accept: "application/json",
+            ...getDefaultHeaders(backendAccessToken),
             "Content-Type": "application/json",
-            Authorization: `Bearer ${backendAccessToken}`,
           },
           body: JSON.stringify(runAllLinked ? {} : { test_uuids: testUuids }),
         },
@@ -603,9 +600,8 @@ export function TestRunnerDialog({
         {
           method: "POST",
           headers: {
-            accept: "application/json",
+            ...getDefaultHeaders(backendAccessToken),
             "Content-Type": "application/json",
-            Authorization: `Bearer ${backendAccessToken}`,
           },
           body: JSON.stringify({
             test_uuids: [testUuid],
@@ -631,10 +627,7 @@ export function TestRunnerDialog({
             `${backendUrl}/agent-tests/run/${result.task_id}`,
             {
               method: "GET",
-              headers: {
-                accept: "application/json",
-                Authorization: `Bearer ${backendAccessToken}`,
-              },
+              headers: getDefaultHeaders(backendAccessToken),
             },
           );
 
@@ -779,9 +772,8 @@ export function TestRunnerDialog({
         {
           method: "POST",
           headers: {
-            accept: "application/json",
+            ...getDefaultHeaders(backendAccessToken),
             "Content-Type": "application/json",
-            Authorization: `Bearer ${backendAccessToken}`,
           },
           body: JSON.stringify({
             test_uuids: testUuids,

--- a/src/components/agent-tabs/TestsTabContent.tsx
+++ b/src/components/agent-tabs/TestsTabContent.tsx
@@ -3,6 +3,7 @@
 import React, { useState, useEffect, useRef, useCallback } from "react";
 import { signOut } from "next-auth/react";
 import { useAccessToken, useMaxRowsPerEval } from "@/hooks";
+import { getDefaultHeaders } from "@/lib/api";
 
 import { DeleteConfirmationDialog } from "@/components/DeleteConfirmationDialog";
 import { TestRunnerDialog } from "@/components/TestRunnerDialog";
@@ -315,10 +316,7 @@ export function TestsTabContent({
         `${backendUrl}/agent-tests/agent/${agentUuid}/tests`,
         {
           method: "GET",
-          headers: {
-            accept: "application/json",
-            Authorization: `Bearer ${backendAccessToken}`,
-          },
+          headers: getDefaultHeaders(backendAccessToken),
         },
       );
 
@@ -364,10 +362,7 @@ export function TestsTabContent({
 
       const response = await fetch(`${backendUrl}/tests`, {
         method: "GET",
-        headers: {
-          accept: "application/json",
-          Authorization: `Bearer ${backendAccessToken}`,
-        },
+        headers: getDefaultHeaders(backendAccessToken),
       });
 
       if (response.status === 401) {
@@ -461,10 +456,7 @@ export function TestsTabContent({
           `${backendUrl}/agent-tests/agent/${agentUuid}/runs`,
           {
             method: "GET",
-            headers: {
-              accept: "application/json",
-              Authorization: `Bearer ${backendAccessToken}`,
-            },
+            headers: getDefaultHeaders(backendAccessToken),
           },
         );
 
@@ -543,10 +535,7 @@ export function TestsTabContent({
 
           const response = await fetch(endpoint, {
             method: "GET",
-            headers: {
-              accept: "application/json",
-              Authorization: `Bearer ${backendAccessToken}`,
-            },
+            headers: getDefaultHeaders(backendAccessToken),
           });
 
           if (!response.ok) continue;
@@ -654,9 +643,8 @@ export function TestsTabContent({
       const response = await fetch(`${backendUrl}/agent-tests`, {
         method: "POST",
         headers: {
-          accept: "application/json",
+          ...getDefaultHeaders(backendAccessToken),
           "Content-Type": "application/json",
-          Authorization: `Bearer ${backendAccessToken}`,
         },
         body: JSON.stringify({
           agent_uuid: agentUuid,
@@ -725,9 +713,8 @@ export function TestsTabContent({
       const response = await fetch(`${backendUrl}/tests/bulk`, {
         method: "POST",
         headers: {
-          accept: "application/json",
+          ...getDefaultHeaders(backendAccessToken),
           "Content-Type": "application/json",
-          Authorization: `Bearer ${backendAccessToken}`,
         },
         body: JSON.stringify({
           type: config.evaluation.type,
@@ -814,10 +801,7 @@ export function TestsTabContent({
 
       const response = await fetch(`${backendUrl}/tests/${uuid}`, {
         method: "GET",
-        headers: {
-          accept: "application/json",
-          Authorization: `Bearer ${backendAccessToken}`,
-        },
+        headers: getDefaultHeaders(backendAccessToken),
       });
 
       if (response.status === 401) {
@@ -885,10 +869,7 @@ export function TestsTabContent({
 
       const response = await fetch(`${backendUrl}/tests/${test.uuid}`, {
         method: "GET",
-        headers: {
-          accept: "application/json",
-          Authorization: `Bearer ${backendAccessToken}`,
-        },
+        headers: getDefaultHeaders(backendAccessToken),
       });
 
       if (response.status === 401) {
@@ -974,9 +955,8 @@ export function TestsTabContent({
       const response = await fetch(`${backendUrl}/tests/${editingTestUuid}`, {
         method: "PUT",
         headers: {
-          accept: "application/json",
+          ...getDefaultHeaders(backendAccessToken),
           "Content-Type": "application/json",
-          Authorization: `Bearer ${backendAccessToken}`,
         },
         body: JSON.stringify(body),
       });
@@ -1170,9 +1150,8 @@ export function TestsTabContent({
           {
             method: "POST",
             headers: {
-              accept: "application/json",
+              ...getDefaultHeaders(backendAccessToken),
               "Content-Type": "application/json",
-              Authorization: `Bearer ${backendAccessToken}`,
             },
             body: JSON.stringify({
               agent_uuid: agentUuid,
@@ -1200,9 +1179,8 @@ export function TestsTabContent({
           const response = await fetch(`${backendUrl}/agent-tests`, {
             method: "DELETE",
             headers: {
-              accept: "application/json",
+              ...getDefaultHeaders(backendAccessToken),
               "Content-Type": "application/json",
-              Authorization: `Bearer ${backendAccessToken}`,
             },
             body: JSON.stringify({
               agent_uuid: agentUuid,

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -22,7 +22,7 @@ export function getBackendUrl(): string {
 /**
  * Default headers for API requests
  */
-export function getDefaultHeaders(accessToken?: string): Record<string, string> {
+export function getDefaultHeaders(accessToken?: string | null): Record<string, string> {
   const headers: Record<string, string> = {
     accept: "application/json",
   };


### PR DESCRIPTION
## What

The test and benchmark screens each hand-copied the same "attach login token" header literal — `{ accept, Authorization: Bearer <token> }` — into every backend `fetch` call. This was duplicated across **35 sites in 7 files**, and bypassed the existing shared `getDefaultHeaders()` helper in `src/lib/api.ts`, which already produces those headers plus `X-Org-UUID` workspace scoping.

## Changes

- Replaced every inline header literal with `getDefaultHeaders(backendAccessToken)` — a plain call for GET/DELETE requests, and a spread (`...getDefaultHeaders(...)` + `Content-Type`) for body requests — across:
  - `BenchmarkResultsDialog.tsx`, `BenchmarkDialog.tsx`
  - `TestRunnerDialog.tsx`, `AddTestDialog.tsx`, `BulkUploadTestsModal.tsx`
  - `tests/page.tsx`, `agent-tabs/TestsTabContent.tsx`
- Widened the helper's parameter to `string | null` so it accepts `useAccessToken()`'s return type directly (its internal guard already handles null).

## Impact

- **−113 / +43 lines** (70 fewer).
- Behavior-preserving, with one upside: these requests now send `X-Org-UUID` directly via the helper instead of relying solely on the fetch-interceptor monkeypatch.
- `tsc --noEmit` clean (0 errors, same as baseline); the pre-commit production build passes.
- Pre-existing `no-explicit-any` / unused-var lint warnings in these files are untouched.

## Scope note

The same copy-paste pattern exists on ~28 other (non-test) screens (~95 more sites). This PR is intentionally scoped to the test/benchmark screens; the rest can follow as a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)