### PR TITLE
Tool dialog: UI ⇆ JSON editor toggle

### DIFF
--- a/src/components/AddToolDialog.tsx
+++ b/src/components/AddToolDialog.tsx
@@ -687,16 +687,17 @@ export function AddToolDialog({
 
   // Convert a list of parameters into an OpenAI-style object schema
   // ({ type: "object", properties: { name: {...} }, required: [...] }).
-  // Empty-named (in-progress) params are dropped, matching buildParametersConfig.
+  // In-progress params with no name yet are kept under an empty-string ("") key
+  // so their description / nested props survive a JSON round-trip instead of
+  // silently vanishing. The backend payload (buildParametersConfig) still drops
+  // nameless params, and validation blocks saving until they're named.
   const paramsToObjectSchema = (params: Parameter[]): Record<string, any> => {
     const properties: Record<string, any> = {};
     const required: string[] = [];
-    params
-      .filter((param) => param.name)
-      .forEach((param) => {
-        properties[param.name] = parameterToJsonSchema(param);
-        if (param.required) required.push(param.name);
-      });
+    params.forEach((param) => {
+      properties[param.name] = parameterToJsonSchema(param);
+      if (param.required) required.push(param.name);
+    });
     const schema: Record<string, any> = { type: "object", properties };
     if (required.length > 0) schema.required = required;
     return schema;

--- a/src/components/AddToolDialog.tsx
+++ b/src/components/AddToolDialog.tsx
@@ -74,7 +74,12 @@ export function AddToolDialog({
   // of truth), so the existing create/update paths keep working unchanged.
   const [viewMode, setViewMode] = useState<"ui" | "json">("ui");
   const [jsonText, setJsonText] = useState("");
+  // JSON syntax / structural parse error (the "JSON mistake").
   const [jsonError, setJsonError] = useState<string | null>(null);
+  // Field-completeness errors from a failed submit (valid JSON, but missing
+  // names/descriptions/properties). Surfaced as the form's inline red errors,
+  // and shown at the top of the JSON editor when toggled back.
+  const [submitError, setSubmitError] = useState<string | null>(null);
 
   // Webhook-specific state
   const [webhookMethod, setWebhookMethod] = useState<
@@ -110,6 +115,7 @@ export function AddToolDialog({
       setViewMode("ui");
       setJsonText("");
       setJsonError(null);
+      setSubmitError(null);
       if (editingToolUuid) {
         // Load existing tool data
         loadToolData(editingToolUuid);
@@ -150,6 +156,7 @@ export function AddToolDialog({
     setViewMode("ui");
     setJsonText("");
     setJsonError(null);
+    setSubmitError(null);
   };
 
   const handleClose = () => {
@@ -930,9 +937,11 @@ export function AddToolDialog({
   };
 
   // Live-sync: valid JSON flows into form state on every keystroke; invalid JSON
-  // surfaces an inline error and leaves the last-good state untouched.
+  // surfaces an inline error and leaves the last-good state untouched. Editing the
+  // JSON also clears any stale field-completeness message from a prior submit.
   const handleJsonChange = (text: string) => {
     setJsonText(text);
+    setSubmitError(null);
     const result = parseToolJson(text);
     if (result.error) {
       setJsonError(result.error);
@@ -944,7 +953,11 @@ export function AddToolDialog({
 
   const switchToJson = () => {
     setJsonText(buildToolJson());
+    // Rebuilt JSON is always syntactically valid, so no parse error. Recompute the
+    // field-completeness message (only after a submit was attempted) so it stays
+    // accurate and visible at the top of the editor when toggling back.
     setJsonError(null);
+    setSubmitError(validationAttempted ? collectIncompleteFields() : null);
     setViewMode("json");
   };
 
@@ -952,39 +965,98 @@ export function AddToolDialog({
     setViewMode("ui");
   };
 
-  // Mirrors the inline validation inside createTool/updateTool so JSON-mode Save
-  // can surface a single readable message instead of silently no-op'ing.
-  const validateForSubmit = (): string | null => {
-    if (!toolName.trim()) return "Name is required.";
-    if (!toolDescription.trim()) return "Description is required.";
-    if (toolType === "webhook") {
-      if (!isValidUrl(webhookUrl)) return "A valid webhook URL is required.";
-      if (webhookHeaders.length > 0 && hasInvalidHeaders(webhookHeaders)) {
-        return "Each header needs both a name and a value.";
+  // Build a specific, field-by-field list of what is missing. Mirrors the rules in
+  // hasInvalidParameters / hasInvalidSingleParameter exactly, but reports each
+  // offending field by name/path instead of a single boolean.
+  const collectItemIssues = (item: Parameter, label: string): string[] => {
+    const issues: string[] = [];
+    if (!item.description.trim()) {
+      issues.push(`${label}: item description is required`);
+    }
+    if (item.dataType === "object") {
+      if (!item.properties || item.properties.length === 0) {
+        issues.push(`${label}: object items need at least one property`);
+      } else {
+        issues.push(...collectParamIssues(item.properties, `${label} › `));
       }
-      if (queryParameters.length > 0 && hasInvalidParameters(queryParameters)) {
-        return "One or more query parameters are incomplete.";
+    }
+    if (item.dataType === "array" && item.items) {
+      issues.push(...collectItemIssues(item.items, `${label}[]`));
+    }
+    return issues;
+  };
+
+  const collectParamIssues = (
+    params: Parameter[],
+    prefix: string,
+  ): string[] => {
+    const issues: string[] = [];
+    const counts = new Map<string, number>();
+    params.forEach((p) => {
+      const key = p.name.trim().toLowerCase();
+      if (key) counts.set(key, (counts.get(key) || 0) + 1);
+    });
+    const reportedDup = new Set<string>();
+    params.forEach((p) => {
+      const name = p.name.trim();
+      const label = `${prefix}${name || "(unnamed)"}`;
+      if (!name) issues.push(`${label}: name is required`);
+      if (!p.description.trim()) issues.push(`${label}: description is required`);
+      const dupKey = name.toLowerCase();
+      if (name && (counts.get(dupKey) || 0) > 1 && !reportedDup.has(dupKey)) {
+        reportedDup.add(dupKey);
+        issues.push(`${prefix}${name}: duplicate name`);
       }
-      if (["POST", "PUT", "PATCH"].includes(webhookMethod)) {
-        if (!bodyDescription.trim()) return "Body description is required.";
-        if (bodyParameters.length > 0 && hasInvalidParameters(bodyParameters)) {
-          return "One or more body parameters are incomplete.";
+      if (p.dataType === "object") {
+        if (!p.properties || p.properties.length === 0) {
+          issues.push(`${label}: object needs at least one property`);
+        } else {
+          issues.push(...collectParamIssues(p.properties, `${label} › `));
         }
       }
-    } else if (hasInvalidParameters(parameters)) {
-      return "One or more parameters are incomplete (each needs a name and description; objects need at least one property).";
+      if (p.dataType === "array" && p.items) {
+        issues.push(...collectItemIssues(p.items, `${label}[]`));
+      }
+    });
+    return issues;
+  };
+
+  // Returns a multi-line message naming every incomplete field, or null if valid.
+  const collectIncompleteFields = (): string | null => {
+    const issues: string[] = [];
+    if (!toolName.trim()) issues.push("Name is required");
+    if (!toolDescription.trim()) issues.push("Description is required");
+    if (toolType === "webhook") {
+      if (!isValidUrl(webhookUrl)) issues.push("A valid webhook URL is required");
+      if (webhookHeaders.length > 0 && hasInvalidHeaders(webhookHeaders)) {
+        issues.push("Each header needs both a name and a value");
+      }
+      issues.push(...collectParamIssues(queryParameters, "Query param "));
+      if (["POST", "PUT", "PATCH"].includes(webhookMethod)) {
+        if (!bodyDescription.trim()) issues.push("Body description is required");
+        issues.push(...collectParamIssues(bodyParameters, "Body param "));
+      }
+    } else {
+      issues.push(...collectParamIssues(parameters, "Parameter "));
     }
-    return null;
+    if (issues.length === 0) return null;
+    return `Please fix:\n${issues.map((i) => `• ${i}`).join("\n")}`;
   };
 
   const handleSubmit = () => {
     if (viewMode === "json") {
+      // Can't submit (or validate fields on) unparseable JSON.
       if (jsonError) return;
-      const err = validateForSubmit();
-      if (err) {
-        setJsonError(err);
+      setValidationAttempted(true);
+      const message = collectIncompleteFields();
+      if (message) {
+        // Switch to the form so the user sees the inline red errors in context,
+        // and keep the message so it's still visible if they toggle back to JSON.
+        setSubmitError(message);
+        setViewMode("ui");
         return;
       }
+      setSubmitError(null);
     }
     if (editingToolUuid) {
       updateTool();
@@ -1437,8 +1509,7 @@ export function AddToolDialog({
                   <button
                     type="button"
                     onClick={switchToUi}
-                    disabled={viewMode === "json" && !!jsonError}
-                    className={`h-7 px-3 rounded-full text-xs font-medium transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed ${
+                    className={`h-7 px-3 rounded-full text-xs font-medium transition-colors cursor-pointer ${
                       viewMode === "ui"
                         ? "bg-background text-foreground shadow-sm"
                         : "text-muted-foreground hover:text-foreground"
@@ -1462,18 +1533,24 @@ export function AddToolDialog({
 
               {viewMode === "json" ? (
                 <div className="space-y-2">
+                  {(jsonError || submitError) && (
+                    <div className="rounded-md border border-red-500 bg-red-500/10 px-4 py-3">
+                      <p className="text-sm text-red-500 whitespace-pre-line">
+                        {jsonError || submitError}
+                      </p>
+                    </div>
+                  )}
                   <textarea
                     value={jsonText}
                     onChange={(e) => handleJsonChange(e.target.value)}
                     spellCheck={false}
                     placeholder='{ "name": "", "description": "", "parameters": { "type": "object", "properties": {} } }'
                     className={`w-full min-h-[480px] px-4 py-3 rounded-md text-sm font-mono bg-background text-foreground placeholder:text-muted-foreground border focus:outline-none focus:ring-2 focus:ring-accent focus:border-transparent resize-y ${
-                      jsonError ? "border-red-500" : "border-border"
+                      jsonError || submitError
+                        ? "border-red-500"
+                        : "border-border"
                     }`}
                   />
-                  {jsonError && (
-                    <p className="text-sm text-red-500">{jsonError}</p>
-                  )}
                 </div>
               ) : (
                 <>

--- a/src/components/AddToolDialog.tsx
+++ b/src/components/AddToolDialog.tsx
@@ -201,7 +201,7 @@ export function AddToolDialog({
   const updateParameterAtPath = (
     params: Parameter[],
     path: string[],
-    updates: Partial<Parameter>
+    updates: Partial<Parameter>,
   ): Parameter[] => {
     if (path.length === 0) return params;
     const [currentId, ...restPath] = path;
@@ -225,7 +225,7 @@ export function AddToolDialog({
         const updatedItems = updateSingleParameterAtPath(
           currentItems,
           deeperPath,
-          updates
+          updates,
         );
         return { ...p, items: updatedItems };
       }
@@ -234,7 +234,7 @@ export function AddToolDialog({
         properties: updateParameterAtPath(
           p.properties || [],
           restPath,
-          updates
+          updates,
         ),
       };
     });
@@ -243,7 +243,7 @@ export function AddToolDialog({
   const updateSingleParameterAtPath = (
     param: Parameter,
     path: string[],
-    updates: Partial<Parameter>
+    updates: Partial<Parameter>,
   ): Parameter => {
     if (path.length === 0) {
       return { ...param, ...updates };
@@ -273,7 +273,7 @@ export function AddToolDialog({
 
   const addPropertyAtPath = (
     params: Parameter[],
-    path: string[]
+    path: string[],
   ): Parameter[] => {
     if (path.length === 0) return params;
     const [currentId, ...restPath] = path;
@@ -309,7 +309,7 @@ export function AddToolDialog({
 
   const addPropertyToSingleParam = (
     param: Parameter,
-    path: string[]
+    path: string[],
   ): Parameter => {
     if (path.length === 0) {
       return {
@@ -341,7 +341,7 @@ export function AddToolDialog({
   const removePropertyAtPath = (
     params: Parameter[],
     path: string[],
-    idToRemove: string
+    idToRemove: string,
   ): Parameter[] => {
     if (path.length === 0) {
       return params.filter((p) => p.id !== idToRemove);
@@ -355,7 +355,7 @@ export function AddToolDialog({
           items: removePropertyFromSingleParam(
             p.items,
             restPath.slice(1),
-            idToRemove
+            idToRemove,
           ),
         };
       }
@@ -363,7 +363,7 @@ export function AddToolDialog({
         return {
           ...p,
           properties: (p.properties || []).filter(
-            (prop) => prop.id !== idToRemove
+            (prop) => prop.id !== idToRemove,
           ),
         };
       }
@@ -372,7 +372,7 @@ export function AddToolDialog({
         properties: removePropertyAtPath(
           p.properties || [],
           restPath,
-          idToRemove
+          idToRemove,
         ),
       };
     });
@@ -381,7 +381,7 @@ export function AddToolDialog({
   const removePropertyFromSingleParam = (
     param: Parameter,
     path: string[],
-    idToRemove: string
+    idToRemove: string,
   ): Parameter => {
     if (path.length === 0) {
       return {
@@ -395,7 +395,7 @@ export function AddToolDialog({
         items: removePropertyFromSingleParam(
           param.items,
           path.slice(1),
-          idToRemove
+          idToRemove,
         ),
       };
     }
@@ -404,7 +404,7 @@ export function AddToolDialog({
       properties: removePropertyAtPath(
         param.properties || [],
         path,
-        idToRemove
+        idToRemove,
       ),
     };
   };
@@ -412,7 +412,7 @@ export function AddToolDialog({
   const setItemsAtPath = (
     params: Parameter[],
     path: string[],
-    items: Parameter | undefined
+    items: Parameter | undefined,
   ): Parameter[] => {
     if (path.length === 0) return params;
     const [currentId, ...restPath] = path;
@@ -437,7 +437,7 @@ export function AddToolDialog({
   const setItemsOnSingleParam = (
     param: Parameter,
     path: string[],
-    items: Parameter | undefined
+    items: Parameter | undefined,
   ): Parameter => {
     if (path.length === 0) {
       return { ...param, items };
@@ -471,7 +471,7 @@ export function AddToolDialog({
 
   const handleSetItemsAtPath = (
     path: string[],
-    items: Parameter | undefined
+    items: Parameter | undefined,
   ) => {
     setValidationAttempted(false);
     setParameters((prev) => setItemsAtPath(prev, path, items));
@@ -480,7 +480,7 @@ export function AddToolDialog({
   // Query parameter handlers (same logic, different state)
   const handleQueryUpdateAtPath = (
     path: string[],
-    updates: Partial<Parameter>
+    updates: Partial<Parameter>,
   ) => {
     setQueryParameters((prev) => updateParameterAtPath(prev, path, updates));
   };
@@ -497,7 +497,7 @@ export function AddToolDialog({
 
   const handleQuerySetItemsAtPath = (
     path: string[],
-    items: Parameter | undefined
+    items: Parameter | undefined,
   ) => {
     setValidationAttempted(false);
     setQueryParameters((prev) => setItemsAtPath(prev, path, items));
@@ -522,7 +522,7 @@ export function AddToolDialog({
   // Body parameter handlers (same logic, different state)
   const handleBodyUpdateAtPath = (
     path: string[],
-    updates: Partial<Parameter>
+    updates: Partial<Parameter>,
   ) => {
     setBodyParameters((prev) => updateParameterAtPath(prev, path, updates));
   };
@@ -539,7 +539,7 @@ export function AddToolDialog({
 
   const handleBodySetItemsAtPath = (
     path: string[],
-    items: Parameter | undefined
+    items: Parameter | undefined,
   ) => {
     setValidationAttempted(false);
     setBodyParameters((prev) => setItemsAtPath(prev, path, items));
@@ -674,7 +674,7 @@ export function AddToolDialog({
   };
 
   const buildParametersConfig = (
-    params: Parameter[]
+    params: Parameter[],
   ): Array<Record<string, any>> => {
     return params
       .filter((param) => param.name)
@@ -716,21 +716,42 @@ export function AddToolDialog({
         parseParameterSchema(
           propName,
           propConfig,
-          requiredProps.includes(propName)
-        )
+          requiredProps.includes(propName),
+        ),
     );
   };
 
+  // Normalize a JSON-schema "type" that may be a nullable union
+  // (e.g. ["integer", "null"]) into a single dataType plus a nullable flag.
+  // The first non-"null" member wins; nullable fields are treated as optional.
+  const normalizeSchemaType = (
+    rawType: any,
+  ): { dataType: string; nullable: boolean } => {
+    if (Array.isArray(rawType)) {
+      const nullable = rawType.includes("null");
+      const nonNull = rawType.find((t) => t !== "null");
+      return {
+        dataType: typeof nonNull === "string" ? nonNull : "string",
+        nullable,
+      };
+    }
+    return {
+      dataType: typeof rawType === "string" ? rawType : "string",
+      nullable: false,
+    };
+  };
+
   const parseItemsSchema = (itemsConfig: any): Parameter => {
+    const { dataType } = normalizeSchemaType(itemsConfig.type);
     const itemParam: Parameter = {
       id: crypto.randomUUID(),
       name: "",
-      dataType: itemsConfig.type || "string",
+      dataType,
       required: true,
       description: itemsConfig.description || "",
     };
 
-    if (itemsConfig.type === "object" && itemsConfig.properties) {
+    if (dataType === "object" && itemsConfig.properties) {
       itemParam.properties = [];
       const requiredProps = itemsConfig.required || [];
       Object.entries(itemsConfig.properties).forEach(
@@ -739,14 +760,14 @@ export function AddToolDialog({
             parseParameterSchema(
               propName,
               propConfig,
-              requiredProps.includes(propName)
-            )
+              requiredProps.includes(propName),
+            ),
           );
-        }
+        },
       );
     }
 
-    if (itemsConfig.type === "array" && itemsConfig.items) {
+    if (dataType === "array" && itemsConfig.items) {
       itemParam.items = parseItemsSchema(itemsConfig.items);
     }
 
@@ -756,21 +777,23 @@ export function AddToolDialog({
   const parseParameterSchema = (
     paramName: string,
     paramConfig: any,
-    isRequired: boolean = true
+    isRequired: boolean = true,
   ): Parameter => {
+    const { dataType, nullable } = normalizeSchemaType(paramConfig.type);
     const param: Parameter = {
       id: crypto.randomUUID(),
       name: paramName,
-      dataType: paramConfig.type || "string",
-      required: paramConfig.required ?? isRequired,
+      dataType,
+      // A nullable union (e.g. ["integer", "null"]) marks the field optional.
+      required: nullable ? false : (paramConfig.required ?? isRequired),
       description: paramConfig.description || "",
     };
 
-    if (paramConfig.type === "array" && paramConfig.items) {
+    if (dataType === "array" && paramConfig.items) {
       param.items = parseItemsSchema(paramConfig.items);
     }
 
-    if (paramConfig.type === "object" && paramConfig.properties) {
+    if (dataType === "object" && paramConfig.properties) {
       param.properties = [];
       const requiredProps = paramConfig.required || [];
       Object.entries(paramConfig.properties).forEach(
@@ -779,10 +802,10 @@ export function AddToolDialog({
             parseParameterSchema(
               propName,
               propConfig,
-              requiredProps.includes(propName)
-            )
+              requiredProps.includes(propName),
+            ),
           );
-        }
+        },
       );
     }
 
@@ -824,9 +847,7 @@ export function AddToolDialog({
 
   // Validate the structural shape of pasted/edited JSON. Returns a single
   // human-readable error string, or the parsed object when it is acceptable.
-  const parseToolJson = (
-    text: string
-  ): { value?: any; error?: string } => {
+  const parseToolJson = (text: string): { value?: any; error?: string } => {
     let obj: any;
     try {
       obj = JSON.parse(text);
@@ -873,19 +894,19 @@ export function AddToolDialog({
   const applyToolJson = (obj: any) => {
     setToolName(typeof obj.name === "string" ? obj.name : "");
     setToolDescription(
-      typeof obj.description === "string" ? obj.description : ""
+      typeof obj.description === "string" ? obj.description : "",
     );
     if (toolType === "webhook") {
       const webhook = obj.webhook || {};
       const method = ["GET", "POST", "PUT", "PATCH", "DELETE"].includes(
-        webhook.method
+        webhook.method,
       )
         ? webhook.method
         : "POST";
       setWebhookMethod(method);
       setWebhookUrl(typeof webhook.url === "string" ? webhook.url : "");
       setResponseTimeout(
-        typeof webhook.timeout === "number" ? webhook.timeout : 20
+        typeof webhook.timeout === "number" ? webhook.timeout : 20,
       );
       setWebhookHeaders(
         (Array.isArray(webhook.headers) ? webhook.headers : []).map(
@@ -893,14 +914,14 @@ export function AddToolDialog({
             id: crypto.randomUUID(),
             name: typeof h?.name === "string" ? h.name : "",
             value: typeof h?.value === "string" ? h.value : "",
-          })
-        )
+          }),
+        ),
       );
       setQueryParameters(objectSchemaToParams(webhook.queryParameters));
       setBodyDescription(
         typeof webhook.body?.description === "string"
           ? webhook.body.description
-          : ""
+          : "",
       );
       setBodyParameters(objectSchemaToParams(webhook.body?.parameters));
     } else {
@@ -1004,7 +1025,7 @@ export function AddToolDialog({
 
       setToolName(toolData.name || "");
       setToolDescription(
-        toolData.description || toolData.config?.description || ""
+        toolData.description || toolData.config?.description || "",
       );
 
       const toolParams: Parameter[] = [];
@@ -1018,7 +1039,7 @@ export function AddToolDialog({
           Object.entries(toolData.config.parameters).forEach(
             ([paramName, paramConfig]: [string, any]) => {
               toolParams.push(parseParameterSchema(paramName, paramConfig));
-            }
+            },
           );
         }
       }
@@ -1036,7 +1057,7 @@ export function AddToolDialog({
               id: crypto.randomUUID(),
               name: h.name || "",
               value: h.value || "",
-            }))
+            })),
           );
         }
         // Load query parameters (same format as parameters)
@@ -1047,7 +1068,7 @@ export function AddToolDialog({
               (paramConfig: any) => {
                 const paramName = paramConfig.id || paramConfig.name || "";
                 queryParams.push(parseParameterSchema(paramName, paramConfig));
-              }
+              },
             );
           }
           setQueryParameters(queryParams);
@@ -1062,7 +1083,7 @@ export function AddToolDialog({
                 (paramConfig: any) => {
                   const paramName = paramConfig.id || paramConfig.name || "";
                   bodyParams.push(parseParameterSchema(paramName, paramConfig));
-                }
+                },
               );
             }
             setBodyParameters(bodyParams);
@@ -1072,7 +1093,7 @@ export function AddToolDialog({
     } catch (err) {
       console.error("Error fetching tool:", err);
       setCreateError(
-        err instanceof Error ? err.message : "Failed to load tool"
+        err instanceof Error ? err.message : "Failed to load tool",
       );
     } finally {
       setIsLoadingTool(false);
@@ -1196,7 +1217,7 @@ export function AddToolDialog({
     } catch (err) {
       console.error("Error creating tool:", err);
       setCreateError(
-        err instanceof Error ? err.message : "Failed to create tool"
+        err instanceof Error ? err.message : "Failed to create tool",
       );
     } finally {
       setIsCreating(false);
@@ -1301,7 +1322,7 @@ export function AddToolDialog({
     } catch (err) {
       console.error("Error updating tool:", err);
       setCreateError(
-        err instanceof Error ? err.message : "Failed to update tool"
+        err instanceof Error ? err.message : "Failed to update tool",
       );
     } finally {
       setIsCreating(false);
@@ -1313,7 +1334,10 @@ export function AddToolDialog({
   return (
     <div className="fixed inset-0 z-50 flex justify-end">
       {/* Backdrop */}
-      <div className="absolute inset-0 bg-black/50 backdrop-blur-sm" onClick={handleClose} />
+      <div
+        className="absolute inset-0 bg-black/50 backdrop-blur-sm"
+        onClick={handleClose}
+      />
       {/* Sidebar */}
       <div className="relative w-full md:w-[40%] md:min-w-[500px] bg-background md:border-l border-border flex flex-col h-full shadow-2xl">
         {/* Header */}
@@ -1387,6 +1411,26 @@ export function AddToolDialog({
             </div>
           ) : (
             <>
+              {/* Helper Callout — shown at the top in both Form and JSON views */}
+              <div className="flex gap-3 p-4 rounded-xl bg-blue-500/10 border border-blue-500/20">
+                <svg
+                  className="w-5 h-5 text-blue-500 flex-shrink-0 mt-0.5"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                  strokeWidth={1.5}
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    d="M11.25 11.25l.041-.02a.75.75 0 011.063.852l-.708 2.836a.75.75 0 001.063.853l.041-.021M21 12a9 9 0 11-18 0 9 9 0 0118 0zm-9-3.75h.008v.008H12V8.25z"
+                  />
+                </svg>
+                <p className="text-sm text-blue-700 dark:text-blue-200">
+                  {TOOL_TYPE_CONFIG[toolType].description}
+                </p>
+              </div>
+
               {/* View mode toggle: Form ⇆ JSON */}
               <div className="flex items-center justify-end">
                 <div className="flex items-center gap-0.5 rounded-full bg-muted/60 p-0.5">
@@ -1418,11 +1462,6 @@ export function AddToolDialog({
 
               {viewMode === "json" ? (
                 <div className="space-y-2">
-                  <p className="text-sm text-muted-foreground">
-                    Edit the full tool definition as JSON. The parameters use the
-                    OpenAI function-call schema. Valid edits sync back to the form
-                    when you switch views.
-                  </p>
                   <textarea
                     value={jsonText}
                     onChange={(e) => handleJsonChange(e.target.value)}
@@ -1438,468 +1477,465 @@ export function AddToolDialog({
                 </div>
               ) : (
                 <>
-              {/* Helper Callout */}
-              <div className="flex gap-3 p-4 rounded-xl bg-blue-500/10 border border-blue-500/20">
-                <svg
-                  className="w-5 h-5 text-blue-500 flex-shrink-0 mt-0.5"
-                  fill="none"
-                  viewBox="0 0 24 24"
-                  stroke="currentColor"
-                  strokeWidth={1.5}
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    d="M11.25 11.25l.041-.02a.75.75 0 011.063.852l-.708 2.836a.75.75 0 001.063.853l.041-.021M21 12a9 9 0 11-18 0 9 9 0 0118 0zm-9-3.75h.008v.008H12V8.25z"
-                  />
-                </svg>
-                <p className="text-sm text-blue-700 dark:text-blue-200">
-                  {TOOL_TYPE_CONFIG[toolType].description}
-                </p>
-              </div>
-
-              {/* Configuration Section */}
-              <div className="border border-border rounded-xl p-5 space-y-5 bg-muted/100">
-                <div>
-                  <h3 className="text-base font-medium mb-1">Configuration</h3>
-                </div>
-
-                {/* Name */}
-                <div>
-                  <label className="block text-sm font-medium mb-2">
-                    Name <span className="text-red-500">*</span>
-                  </label>
-                  <input
-                    type="text"
-                    value={toolName}
-                    onChange={(e) => {
-                      setToolName(e.target.value);
-                      if (nameConflictError) setNameConflictError(null);
-                    }}
-                    placeholder="An informative name for the tool that reflects its purpose"
-                    className={`w-full h-10 px-4 rounded-md text-base border bg-background text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-accent focus:border-transparent ${
-                      nameConflictError ||
-                      (validationAttempted && !toolName.trim())
-                        ? "border-red-500"
-                        : "border-border"
-                    }`}
-                  />
-                  {nameConflictError && (
-                    <p className="mt-1 text-sm text-red-500">
-                      {nameConflictError}
-                    </p>
-                  )}
-                </div>
-
-                {/* Description */}
-                <div>
-                  <label className="block text-sm font-medium mb-2">
-                    Description <span className="text-red-500">*</span>
-                  </label>
-                  <textarea
-                    value={toolDescription}
-                    onChange={(e) => setToolDescription(e.target.value)}
-                    placeholder="Describe to the LLM how and when to use the tool along with what should be passed to the tool"
-                    rows={3}
-                    className={`w-full px-4 py-3 rounded-md text-base border bg-background text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-accent focus:border-transparent resize-none ${
-                      validationAttempted && !toolDescription.trim()
-                        ? "border-red-500"
-                        : "border-border"
-                    }`}
-                  />
-                </div>
-
-                {/* Webhook-specific fields */}
-                {toolType === "webhook" && (
-                  <>
-                    {/* Method and URL */}
-                    <div className="flex gap-4">
-                      <div className="w-36">
-                        <label className="block text-sm font-medium mb-2">
-                          Method
-                        </label>
-                        <div className="relative">
-                          <select
-                            value={webhookMethod}
-                            onChange={(e) =>
-                              setWebhookMethod(
-                                e.target.value as
-                                  | "GET"
-                                  | "POST"
-                                  | "PUT"
-                                  | "PATCH"
-                                  | "DELETE"
-                              )
-                            }
-                            className="w-full h-10 px-4 pr-10 rounded-md text-base border border-border bg-background text-foreground focus:outline-none focus:ring-2 focus:ring-accent focus:border-transparent appearance-none cursor-pointer"
-                          >
-                            <option value="GET">GET</option>
-                            <option value="POST">POST</option>
-                            <option value="PUT">PUT</option>
-                            <option value="PATCH">PATCH</option>
-                            <option value="DELETE">DELETE</option>
-                          </select>
-                          <svg
-                            className="absolute right-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground pointer-events-none"
-                            fill="none"
-                            viewBox="0 0 24 24"
-                            stroke="currentColor"
-                            strokeWidth={2}
-                          >
-                            <path
-                              strokeLinecap="round"
-                              strokeLinejoin="round"
-                              d="M19 9l-7 7-7-7"
-                            />
-                          </svg>
-                        </div>
-                      </div>
-                      <div className="flex-1">
-                        <label className="block text-sm font-medium mb-2">
-                          URL <span className="text-red-500">*</span>
-                        </label>
-                        <input
-                          type="text"
-                          value={webhookUrl}
-                          onChange={(e) => setWebhookUrl(e.target.value)}
-                          placeholder="https://example.com/{hi}/webhook"
-                          className={`w-full h-10 px-4 rounded-md text-base border bg-background text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-accent focus:border-transparent ${
-                            validationAttempted &&
-                            toolType === "webhook" &&
-                            !isValidUrl(webhookUrl)
-                              ? "border-red-500"
-                              : "border-border"
-                          }`}
-                        />
-                        {validationAttempted &&
-                          toolType === "webhook" &&
-                          !isValidUrl(webhookUrl) && (
-                            <p className="text-xs text-red-500 mt-1">
-                              {webhookUrl.trim()
-                                ? "Please enter a valid URL"
-                                : "URL is required"}
-                            </p>
-                          )}
-                      </div>
-                    </div>
-
-                    {/* Response Timeout */}
-                    <div>
-                      <label className="block text-sm font-medium mb-1">
-                        Response timeout (seconds)
-                      </label>
-                      <p className="text-sm text-muted-foreground mb-3">
-                        How long to wait for the webhook tool to respond before
-                        timing out. Default is 20 seconds.
-                      </p>
-                      <div className="relative pt-6">
-                        {/* Tooltip */}
-                        {showTimeoutTooltip && (
-                          <div
-                            className="absolute -top-1 transform -translate-x-1/2 pointer-events-none z-10"
-                            style={{
-                              left: `calc(${
-                                ((responseTimeout - 1) / 119) * 100
-                              }% + ${
-                                8 - ((responseTimeout - 1) / 119) * 16
-                              }px)`,
-                            }}
-                          >
-                            <div className="bg-foreground text-background text-xs font-medium px-2 py-1 rounded-md whitespace-nowrap">
-                              {responseTimeout} secs
-                            </div>
-                            <div className="w-2 h-2 bg-foreground transform rotate-45 absolute left-1/2 -translate-x-1/2 -bottom-1" />
-                          </div>
-                        )}
-                        {/* Track background */}
-                        <div className="relative h-2">
-                          {/* Unfilled track */}
-                          <div className="absolute inset-0 bg-muted rounded-full" />
-                          {/* Filled track */}
-                          <div
-                            className="absolute top-0 left-0 h-full bg-foreground rounded-full"
-                            style={{
-                              width: `${((responseTimeout - 1) / 119) * 100}%`,
-                            }}
-                          />
-                          {/* Input */}
-                          <input
-                            type="range"
-                            min={1}
-                            max={120}
-                            value={responseTimeout}
-                            onChange={(e) =>
-                              setResponseTimeout(parseInt(e.target.value, 10))
-                            }
-                            onMouseEnter={() => setShowTimeoutTooltip(true)}
-                            onMouseLeave={() => setShowTimeoutTooltip(false)}
-                            onFocus={() => setShowTimeoutTooltip(true)}
-                            onBlur={() => setShowTimeoutTooltip(false)}
-                            className="absolute inset-0 w-full h-full appearance-none bg-transparent cursor-pointer [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:w-4 [&::-webkit-slider-thumb]:h-4 [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:bg-foreground [&::-webkit-slider-thumb]:cursor-pointer [&::-webkit-slider-thumb]:shadow-md [&::-moz-range-thumb]:w-4 [&::-moz-range-thumb]:h-4 [&::-moz-range-thumb]:rounded-full [&::-moz-range-thumb]:bg-foreground [&::-moz-range-thumb]:border-0 [&::-moz-range-thumb]:cursor-pointer [&::-moz-range-thumb]:shadow-md"
-                          />
-                        </div>
-                      </div>
-                    </div>
-                  </>
-                )}
-              </div>
-
-              {/* Headers Section - Webhook only */}
-              {toolType === "webhook" && (
-                <div className="border border-border rounded-xl p-5 space-y-5 bg-muted/100">
-                  <div className="flex items-start justify-between">
-                    <div>
-                      <h3 className="text-base font-medium mb-1">Headers</h3>
-                      <p className="text-sm text-muted-foreground">
-                        Define headers that will be sent with the request
-                      </p>
-                    </div>
-                    <button
-                      onClick={() => {
-                        setWebhookHeaders([
-                          ...webhookHeaders,
-                          {
-                            id: crypto.randomUUID(),
-                            name: "",
-                            value: "",
-                          },
-                        ]);
-                      }}
-                      className="h-9 px-4 rounded-md text-sm font-medium border border-border bg-background hover:bg-muted/50 transition-colors cursor-pointer whitespace-nowrap flex-shrink-0"
-                    >
-                      Add header
-                    </button>
-                  </div>
-
-                  {/* Header Cards */}
-                  {webhookHeaders.map((header) => (
-                    <div
-                      key={header.id}
-                      className="border border-border rounded-xl p-4 space-y-4 bg-background"
-                    >
-                      {/* Name */}
-                      <div>
-                        <label className="block text-sm font-medium mb-2">
-                          Name <span className="text-red-500">*</span>
-                        </label>
-                        <input
-                          type="text"
-                          value={header.name}
-                          onChange={(e) => {
-                            setWebhookHeaders(
-                              webhookHeaders.map((h) =>
-                                h.id === header.id
-                                  ? { ...h, name: e.target.value }
-                                  : h
-                              )
-                            );
-                          }}
-                          placeholder="e.g. Authorization"
-                          className={`w-full h-10 px-4 rounded-md text-base border bg-background text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-accent focus:border-transparent ${
-                            validationAttempted && !header.name.trim()
-                              ? "border-red-500"
-                              : "border-border"
-                          }`}
-                        />
-                      </div>
-
-                      {/* Value */}
-                      <div>
-                        <label className="block text-sm font-medium mb-2">
-                          Value <span className="text-red-500">*</span>
-                        </label>
-                        <input
-                          type="text"
-                          value={header.value}
-                          onChange={(e) => {
-                            setWebhookHeaders(
-                              webhookHeaders.map((h) =>
-                                h.id === header.id
-                                  ? { ...h, value: e.target.value }
-                                  : h
-                              )
-                            );
-                          }}
-                          placeholder="Header value"
-                          className={`w-full h-10 px-4 rounded-md text-base border bg-background text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-accent focus:border-transparent ${
-                            validationAttempted && !header.value.trim()
-                              ? "border-red-500"
-                              : "border-border"
-                          }`}
-                        />
-                      </div>
-
-                      {/* Delete button */}
-                      <div className="flex justify-end">
-                        <button
-                          onClick={() => {
-                            setWebhookHeaders(
-                              webhookHeaders.filter((h) => h.id !== header.id)
-                            );
-                          }}
-                          className="h-9 px-4 rounded-md text-sm font-medium text-red-500 bg-red-500/10 hover:text-red-600 hover:bg-red-500/20 transition-colors cursor-pointer"
-                        >
-                          Delete
-                        </button>
-                      </div>
-                    </div>
-                  ))}
-                </div>
-              )}
-
-              {/* Parameters Section - Structured Output Tools Only */}
-              {toolType === "structured_output" && (
-                <div className="border border-border rounded-xl p-5 space-y-5 bg-muted/100">
-                  <div className="flex items-start justify-between">
-                    <div>
-                      <h3 className="text-base font-medium mb-1">Parameters</h3>
-                      <p className="text-sm text-muted-foreground">
-                        Define the structure of the output that the agent should
-                        produce
-                      </p>
-                    </div>
-                    <button
-                      onClick={addParameter}
-                      className="h-9 px-4 rounded-md text-sm font-medium border border-border bg-background hover:bg-muted/50 transition-colors cursor-pointer whitespace-nowrap flex-shrink-0"
-                    >
-                      Add param
-                    </button>
-                  </div>
-
-                  {/* Parameter Cards */}
-                  {parameters.map((param) => (
-                    <ParameterCard
-                      key={param.id}
-                      param={param}
-                      path={[]}
-                      onUpdate={handleUpdateAtPath}
-                      onRemove={handleRemoveAtPath}
-                      onAddProperty={handleAddPropertyAtPath}
-                      onSetItems={handleSetItemsAtPath}
-                      validationAttempted={validationAttempted}
-                      siblingNames={parameters
-                        .filter((p) => p.id !== param.id)
-                        .map((p) => p.name)}
-                    />
-                  ))}
-                </div>
-              )}
-
-              {/* Query Parameters Section - Webhook Tools Only */}
-              {toolType === "webhook" && (
-                <div className="border border-border rounded-xl p-5 space-y-5 bg-muted/100">
-                  <div className="flex items-start justify-between">
+                  {/* Configuration Section */}
+                  <div className="border border-border rounded-xl p-5 space-y-5 bg-muted/100">
                     <div>
                       <h3 className="text-base font-medium mb-1">
-                        Query parameters
+                        Configuration
                       </h3>
-                      <p className="text-sm text-muted-foreground">
-                        Define parameters that will be collected by the LLM and
-                        sent as the query of the request.
-                      </p>
                     </div>
-                    <button
-                      onClick={addQueryParameter}
-                      className="h-9 px-4 rounded-md text-sm font-medium border border-border bg-background hover:bg-muted/50 transition-colors cursor-pointer whitespace-nowrap flex-shrink-0"
-                    >
-                      Add param
-                    </button>
-                  </div>
 
-                  {/* Query Parameter Cards */}
-                  {queryParameters.map((param) => (
-                    <div
-                      key={param.id}
-                      ref={(el) => {
-                        if (el) {
-                          queryParamRefs.current.set(param.id, el);
-                        } else {
-                          queryParamRefs.current.delete(param.id);
-                        }
-                      }}
-                    >
-                      <ParameterCard
-                        param={param}
-                        path={[]}
-                        onUpdate={handleQueryUpdateAtPath}
-                        onRemove={handleQueryRemoveAtPath}
-                        onAddProperty={handleQueryAddPropertyAtPath}
-                        onSetItems={handleQuerySetItemsAtPath}
-                        validationAttempted={validationAttempted}
-                        siblingNames={queryParameters
-                          .filter((p) => p.id !== param.id)
-                          .map((p) => p.name)}
+                    {/* Name */}
+                    <div>
+                      <label className="block text-sm font-medium mb-2">
+                        Name <span className="text-red-500">*</span>
+                      </label>
+                      <input
+                        type="text"
+                        value={toolName}
+                        onChange={(e) => {
+                          setToolName(e.target.value);
+                          if (nameConflictError) setNameConflictError(null);
+                        }}
+                        placeholder="An informative name for the tool that reflects its purpose"
+                        className={`w-full h-10 px-4 rounded-md text-base border bg-background text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-accent focus:border-transparent ${
+                          nameConflictError ||
+                          (validationAttempted && !toolName.trim())
+                            ? "border-red-500"
+                            : "border-border"
+                        }`}
+                      />
+                      {nameConflictError && (
+                        <p className="mt-1 text-sm text-red-500">
+                          {nameConflictError}
+                        </p>
+                      )}
+                    </div>
+
+                    {/* Description */}
+                    <div>
+                      <label className="block text-sm font-medium mb-2">
+                        Description <span className="text-red-500">*</span>
+                      </label>
+                      <textarea
+                        value={toolDescription}
+                        onChange={(e) => setToolDescription(e.target.value)}
+                        placeholder="Describe to the LLM how and when to use the tool along with what should be passed to the tool"
+                        rows={3}
+                        className={`w-full px-4 py-3 rounded-md text-base border bg-background text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-accent focus:border-transparent resize-none ${
+                          validationAttempted && !toolDescription.trim()
+                            ? "border-red-500"
+                            : "border-border"
+                        }`}
                       />
                     </div>
-                  ))}
-                </div>
-              )}
 
-              {/* Body Parameters Section - Webhook Tools with POST, PUT, PATCH Only */}
-              {toolType === "webhook" &&
-                ["POST", "PUT", "PATCH"].includes(webhookMethod) && (
-                  <div className="border border-border rounded-xl p-5 space-y-5 bg-muted/50">
-                    <div>
-                      <h3 className="text-base font-medium mb-1">
-                        Body parameters
-                      </h3>
-                      <p className="text-sm text-muted-foreground">
-                        Define parameters that will be collected by the LLM and
-                        sent as the body of the request.
-                      </p>
-                    </div>
-
-                    {/* Inner container for body content */}
-                    <div className="border border-border rounded-xl p-4 space-y-4 bg-background">
-                      {/* Body Description */}
-                      <div>
-                        <label className="block text-sm font-medium mb-2">
-                          Description <span className="text-red-500">*</span>
-                        </label>
-                        <textarea
-                          value={bodyDescription}
-                          onChange={(e) => setBodyDescription(e.target.value)}
-                          placeholder="Describe the body structure"
-                          rows={3}
-                          className={`w-full px-4 py-3 rounded-md text-base border bg-background text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-accent focus:border-transparent resize-none ${
-                            validationAttempted && !bodyDescription.trim()
-                              ? "border-red-500"
-                              : "border-border"
-                          }`}
-                        />
-                      </div>
-
-                      {/* Properties - same UI as object type properties */}
-                      <div>
-                        <label className="block text-sm font-medium mb-2">
-                          Properties
-                        </label>
-                        <NestedContainer onAddProperty={addBodyParameter}>
-                          {/* Body Parameter Cards */}
-                          {bodyParameters.length > 0 && (
-                            <div className="space-y-4">
-                              {bodyParameters.map((param) => (
-                                <ParameterCard
-                                  key={param.id}
-                                  param={param}
-                                  path={[]}
-                                  onUpdate={handleBodyUpdateAtPath}
-                                  onRemove={handleBodyRemoveAtPath}
-                                  onAddProperty={handleBodyAddPropertyAtPath}
-                                  onSetItems={handleBodySetItemsAtPath}
-                                  validationAttempted={validationAttempted}
-                                  siblingNames={bodyParameters
-                                    .filter((p) => p.id !== param.id)
-                                    .map((p) => p.name)}
+                    {/* Webhook-specific fields */}
+                    {toolType === "webhook" && (
+                      <>
+                        {/* Method and URL */}
+                        <div className="flex gap-4">
+                          <div className="w-36">
+                            <label className="block text-sm font-medium mb-2">
+                              Method
+                            </label>
+                            <div className="relative">
+                              <select
+                                value={webhookMethod}
+                                onChange={(e) =>
+                                  setWebhookMethod(
+                                    e.target.value as
+                                      | "GET"
+                                      | "POST"
+                                      | "PUT"
+                                      | "PATCH"
+                                      | "DELETE",
+                                  )
+                                }
+                                className="w-full h-10 px-4 pr-10 rounded-md text-base border border-border bg-background text-foreground focus:outline-none focus:ring-2 focus:ring-accent focus:border-transparent appearance-none cursor-pointer"
+                              >
+                                <option value="GET">GET</option>
+                                <option value="POST">POST</option>
+                                <option value="PUT">PUT</option>
+                                <option value="PATCH">PATCH</option>
+                                <option value="DELETE">DELETE</option>
+                              </select>
+                              <svg
+                                className="absolute right-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground pointer-events-none"
+                                fill="none"
+                                viewBox="0 0 24 24"
+                                stroke="currentColor"
+                                strokeWidth={2}
+                              >
+                                <path
+                                  strokeLinecap="round"
+                                  strokeLinejoin="round"
+                                  d="M19 9l-7 7-7-7"
                                 />
-                              ))}
+                              </svg>
                             </div>
-                          )}
-                        </NestedContainer>
-                      </div>
-                    </div>
+                          </div>
+                          <div className="flex-1">
+                            <label className="block text-sm font-medium mb-2">
+                              URL <span className="text-red-500">*</span>
+                            </label>
+                            <input
+                              type="text"
+                              value={webhookUrl}
+                              onChange={(e) => setWebhookUrl(e.target.value)}
+                              placeholder="https://example.com/{hi}/webhook"
+                              className={`w-full h-10 px-4 rounded-md text-base border bg-background text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-accent focus:border-transparent ${
+                                validationAttempted &&
+                                toolType === "webhook" &&
+                                !isValidUrl(webhookUrl)
+                                  ? "border-red-500"
+                                  : "border-border"
+                              }`}
+                            />
+                            {validationAttempted &&
+                              toolType === "webhook" &&
+                              !isValidUrl(webhookUrl) && (
+                                <p className="text-xs text-red-500 mt-1">
+                                  {webhookUrl.trim()
+                                    ? "Please enter a valid URL"
+                                    : "URL is required"}
+                                </p>
+                              )}
+                          </div>
+                        </div>
+
+                        {/* Response Timeout */}
+                        <div>
+                          <label className="block text-sm font-medium mb-1">
+                            Response timeout (seconds)
+                          </label>
+                          <p className="text-sm text-muted-foreground mb-3">
+                            How long to wait for the webhook tool to respond
+                            before timing out. Default is 20 seconds.
+                          </p>
+                          <div className="relative pt-6">
+                            {/* Tooltip */}
+                            {showTimeoutTooltip && (
+                              <div
+                                className="absolute -top-1 transform -translate-x-1/2 pointer-events-none z-10"
+                                style={{
+                                  left: `calc(${
+                                    ((responseTimeout - 1) / 119) * 100
+                                  }% + ${
+                                    8 - ((responseTimeout - 1) / 119) * 16
+                                  }px)`,
+                                }}
+                              >
+                                <div className="bg-foreground text-background text-xs font-medium px-2 py-1 rounded-md whitespace-nowrap">
+                                  {responseTimeout} secs
+                                </div>
+                                <div className="w-2 h-2 bg-foreground transform rotate-45 absolute left-1/2 -translate-x-1/2 -bottom-1" />
+                              </div>
+                            )}
+                            {/* Track background */}
+                            <div className="relative h-2">
+                              {/* Unfilled track */}
+                              <div className="absolute inset-0 bg-muted rounded-full" />
+                              {/* Filled track */}
+                              <div
+                                className="absolute top-0 left-0 h-full bg-foreground rounded-full"
+                                style={{
+                                  width: `${((responseTimeout - 1) / 119) * 100}%`,
+                                }}
+                              />
+                              {/* Input */}
+                              <input
+                                type="range"
+                                min={1}
+                                max={120}
+                                value={responseTimeout}
+                                onChange={(e) =>
+                                  setResponseTimeout(
+                                    parseInt(e.target.value, 10),
+                                  )
+                                }
+                                onMouseEnter={() => setShowTimeoutTooltip(true)}
+                                onMouseLeave={() =>
+                                  setShowTimeoutTooltip(false)
+                                }
+                                onFocus={() => setShowTimeoutTooltip(true)}
+                                onBlur={() => setShowTimeoutTooltip(false)}
+                                className="absolute inset-0 w-full h-full appearance-none bg-transparent cursor-pointer [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:w-4 [&::-webkit-slider-thumb]:h-4 [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:bg-foreground [&::-webkit-slider-thumb]:cursor-pointer [&::-webkit-slider-thumb]:shadow-md [&::-moz-range-thumb]:w-4 [&::-moz-range-thumb]:h-4 [&::-moz-range-thumb]:rounded-full [&::-moz-range-thumb]:bg-foreground [&::-moz-range-thumb]:border-0 [&::-moz-range-thumb]:cursor-pointer [&::-moz-range-thumb]:shadow-md"
+                              />
+                            </div>
+                          </div>
+                        </div>
+                      </>
+                    )}
                   </div>
-                )}
+
+                  {/* Headers Section - Webhook only */}
+                  {toolType === "webhook" && (
+                    <div className="border border-border rounded-xl p-5 space-y-5 bg-muted/100">
+                      <div className="flex items-start justify-between">
+                        <div>
+                          <h3 className="text-base font-medium mb-1">
+                            Headers
+                          </h3>
+                          <p className="text-sm text-muted-foreground">
+                            Define headers that will be sent with the request
+                          </p>
+                        </div>
+                        <button
+                          onClick={() => {
+                            setWebhookHeaders([
+                              ...webhookHeaders,
+                              {
+                                id: crypto.randomUUID(),
+                                name: "",
+                                value: "",
+                              },
+                            ]);
+                          }}
+                          className="h-9 px-4 rounded-md text-sm font-medium border border-border bg-background hover:bg-muted/50 transition-colors cursor-pointer whitespace-nowrap flex-shrink-0"
+                        >
+                          Add header
+                        </button>
+                      </div>
+
+                      {/* Header Cards */}
+                      {webhookHeaders.map((header) => (
+                        <div
+                          key={header.id}
+                          className="border border-border rounded-xl p-4 space-y-4 bg-background"
+                        >
+                          {/* Name */}
+                          <div>
+                            <label className="block text-sm font-medium mb-2">
+                              Name <span className="text-red-500">*</span>
+                            </label>
+                            <input
+                              type="text"
+                              value={header.name}
+                              onChange={(e) => {
+                                setWebhookHeaders(
+                                  webhookHeaders.map((h) =>
+                                    h.id === header.id
+                                      ? { ...h, name: e.target.value }
+                                      : h,
+                                  ),
+                                );
+                              }}
+                              placeholder="e.g. Authorization"
+                              className={`w-full h-10 px-4 rounded-md text-base border bg-background text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-accent focus:border-transparent ${
+                                validationAttempted && !header.name.trim()
+                                  ? "border-red-500"
+                                  : "border-border"
+                              }`}
+                            />
+                          </div>
+
+                          {/* Value */}
+                          <div>
+                            <label className="block text-sm font-medium mb-2">
+                              Value <span className="text-red-500">*</span>
+                            </label>
+                            <input
+                              type="text"
+                              value={header.value}
+                              onChange={(e) => {
+                                setWebhookHeaders(
+                                  webhookHeaders.map((h) =>
+                                    h.id === header.id
+                                      ? { ...h, value: e.target.value }
+                                      : h,
+                                  ),
+                                );
+                              }}
+                              placeholder="Header value"
+                              className={`w-full h-10 px-4 rounded-md text-base border bg-background text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-accent focus:border-transparent ${
+                                validationAttempted && !header.value.trim()
+                                  ? "border-red-500"
+                                  : "border-border"
+                              }`}
+                            />
+                          </div>
+
+                          {/* Delete button */}
+                          <div className="flex justify-end">
+                            <button
+                              onClick={() => {
+                                setWebhookHeaders(
+                                  webhookHeaders.filter(
+                                    (h) => h.id !== header.id,
+                                  ),
+                                );
+                              }}
+                              className="h-9 px-4 rounded-md text-sm font-medium text-red-500 bg-red-500/10 hover:text-red-600 hover:bg-red-500/20 transition-colors cursor-pointer"
+                            >
+                              Delete
+                            </button>
+                          </div>
+                        </div>
+                      ))}
+                    </div>
+                  )}
+
+                  {/* Parameters Section - Structured Output Tools Only */}
+                  {toolType === "structured_output" && (
+                    <div className="border border-border rounded-xl p-5 space-y-5 bg-muted/100">
+                      <div className="flex items-start justify-between">
+                        <div>
+                          <h3 className="text-base font-medium mb-1">
+                            Parameters
+                          </h3>
+                          <p className="text-sm text-muted-foreground">
+                            Define the structure of the output that the agent
+                            should produce
+                          </p>
+                        </div>
+                        <button
+                          onClick={addParameter}
+                          className="h-9 px-4 rounded-md text-sm font-medium border border-border bg-background hover:bg-muted/50 transition-colors cursor-pointer whitespace-nowrap flex-shrink-0"
+                        >
+                          Add param
+                        </button>
+                      </div>
+
+                      {/* Parameter Cards */}
+                      {parameters.map((param) => (
+                        <ParameterCard
+                          key={param.id}
+                          param={param}
+                          path={[]}
+                          onUpdate={handleUpdateAtPath}
+                          onRemove={handleRemoveAtPath}
+                          onAddProperty={handleAddPropertyAtPath}
+                          onSetItems={handleSetItemsAtPath}
+                          validationAttempted={validationAttempted}
+                          siblingNames={parameters
+                            .filter((p) => p.id !== param.id)
+                            .map((p) => p.name)}
+                        />
+                      ))}
+                    </div>
+                  )}
+
+                  {/* Query Parameters Section - Webhook Tools Only */}
+                  {toolType === "webhook" && (
+                    <div className="border border-border rounded-xl p-5 space-y-5 bg-muted/100">
+                      <div className="flex items-start justify-between">
+                        <div>
+                          <h3 className="text-base font-medium mb-1">
+                            Query parameters
+                          </h3>
+                          <p className="text-sm text-muted-foreground">
+                            Define parameters that will be collected by the LLM
+                            and sent as the query of the request.
+                          </p>
+                        </div>
+                        <button
+                          onClick={addQueryParameter}
+                          className="h-9 px-4 rounded-md text-sm font-medium border border-border bg-background hover:bg-muted/50 transition-colors cursor-pointer whitespace-nowrap flex-shrink-0"
+                        >
+                          Add param
+                        </button>
+                      </div>
+
+                      {/* Query Parameter Cards */}
+                      {queryParameters.map((param) => (
+                        <div
+                          key={param.id}
+                          ref={(el) => {
+                            if (el) {
+                              queryParamRefs.current.set(param.id, el);
+                            } else {
+                              queryParamRefs.current.delete(param.id);
+                            }
+                          }}
+                        >
+                          <ParameterCard
+                            param={param}
+                            path={[]}
+                            onUpdate={handleQueryUpdateAtPath}
+                            onRemove={handleQueryRemoveAtPath}
+                            onAddProperty={handleQueryAddPropertyAtPath}
+                            onSetItems={handleQuerySetItemsAtPath}
+                            validationAttempted={validationAttempted}
+                            siblingNames={queryParameters
+                              .filter((p) => p.id !== param.id)
+                              .map((p) => p.name)}
+                          />
+                        </div>
+                      ))}
+                    </div>
+                  )}
+
+                  {/* Body Parameters Section - Webhook Tools with POST, PUT, PATCH Only */}
+                  {toolType === "webhook" &&
+                    ["POST", "PUT", "PATCH"].includes(webhookMethod) && (
+                      <div className="border border-border rounded-xl p-5 space-y-5 bg-muted/50">
+                        <div>
+                          <h3 className="text-base font-medium mb-1">
+                            Body parameters
+                          </h3>
+                          <p className="text-sm text-muted-foreground">
+                            Define parameters that will be collected by the LLM
+                            and sent as the body of the request.
+                          </p>
+                        </div>
+
+                        {/* Inner container for body content */}
+                        <div className="border border-border rounded-xl p-4 space-y-4 bg-background">
+                          {/* Body Description */}
+                          <div>
+                            <label className="block text-sm font-medium mb-2">
+                              Description{" "}
+                              <span className="text-red-500">*</span>
+                            </label>
+                            <textarea
+                              value={bodyDescription}
+                              onChange={(e) =>
+                                setBodyDescription(e.target.value)
+                              }
+                              placeholder="Describe the body structure"
+                              rows={3}
+                              className={`w-full px-4 py-3 rounded-md text-base border bg-background text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-accent focus:border-transparent resize-none ${
+                                validationAttempted && !bodyDescription.trim()
+                                  ? "border-red-500"
+                                  : "border-border"
+                              }`}
+                            />
+                          </div>
+
+                          {/* Properties - same UI as object type properties */}
+                          <div>
+                            <label className="block text-sm font-medium mb-2">
+                              Properties
+                            </label>
+                            <NestedContainer onAddProperty={addBodyParameter}>
+                              {/* Body Parameter Cards */}
+                              {bodyParameters.length > 0 && (
+                                <div className="space-y-4">
+                                  {bodyParameters.map((param) => (
+                                    <ParameterCard
+                                      key={param.id}
+                                      param={param}
+                                      path={[]}
+                                      onUpdate={handleBodyUpdateAtPath}
+                                      onRemove={handleBodyRemoveAtPath}
+                                      onAddProperty={
+                                        handleBodyAddPropertyAtPath
+                                      }
+                                      onSetItems={handleBodySetItemsAtPath}
+                                      validationAttempted={validationAttempted}
+                                      siblingNames={bodyParameters
+                                        .filter((p) => p.id !== param.id)
+                                        .map((p) => p.name)}
+                                    />
+                                  ))}
+                                </div>
+                              )}
+                            </NestedContainer>
+                          </div>
+                        </div>
+                      </div>
+                    )}
                 </>
               )}
             </>

--- a/src/components/AddToolDialog.tsx
+++ b/src/components/AddToolDialog.tsx
@@ -80,6 +80,8 @@ export function AddToolDialog({
   // names/descriptions/properties). Surfaced as the form's inline red errors,
   // and shown at the top of the JSON editor when toggled back.
   const [submitError, setSubmitError] = useState<string | null>(null);
+  // Bumped on each failed submit to scroll the first invalid field into view.
+  const [errorScrollTick, setErrorScrollTick] = useState(0);
 
   // Webhook-specific state
   const [webhookMethod, setWebhookMethod] = useState<
@@ -163,6 +165,20 @@ export function AddToolDialog({
     resetForm();
     onClose();
   };
+
+  // After a failed submit, scroll the first invalid field into view. The timeout
+  // lets React paint the red borders (and any json→form view switch) first.
+  // Every invalid field shares the `border-red-500` class, so the first match in
+  // document order is the topmost error.
+  useEffect(() => {
+    if (errorScrollTick === 0) return;
+    const timer = setTimeout(() => {
+      const firstError =
+        sidebarContentRef.current?.querySelector(".border-red-500");
+      firstError?.scrollIntoView({ behavior: "smooth", block: "center" });
+    }, 60);
+    return () => clearTimeout(timer);
+  }, [errorScrollTick]);
 
   // Scroll to newly added query parameter
   useEffect(() => {
@@ -1044,20 +1060,22 @@ export function AddToolDialog({
   };
 
   const handleSubmit = () => {
-    if (viewMode === "json") {
-      // Can't submit (or validate fields on) unparseable JSON.
-      if (jsonError) return;
-      setValidationAttempted(true);
-      const message = collectIncompleteFields();
-      if (message) {
-        // Switch to the form so the user sees the inline red errors in context,
-        // and keep the message so it's still visible if they toggle back to JSON.
-        setSubmitError(message);
-        setViewMode("ui");
-        return;
-      }
-      setSubmitError(null);
+    // Can't submit (or validate fields on) unparseable JSON.
+    if (viewMode === "json" && jsonError) return;
+
+    setValidationAttempted(true);
+    const message = collectIncompleteFields();
+    if (message) {
+      setSubmitError(message);
+      // From JSON mode, switch to the form so the inline red errors show in
+      // context (the message stays visible at the top if they toggle back).
+      if (viewMode === "json") setViewMode("ui");
+      // Scroll the first invalid field into view (after the switch + repaint).
+      setErrorScrollTick((t) => t + 1);
+      return;
     }
+
+    setSubmitError(null);
     if (editingToolUuid) {
       updateTool();
     } else {

--- a/src/components/AddToolDialog.tsx
+++ b/src/components/AddToolDialog.tsx
@@ -610,29 +610,38 @@ export function AddToolDialog({
     return new Set(names).size !== names.length;
   };
 
-  const hasInvalidParameters = (params: Parameter[]): boolean => {
+  const hasInvalidParameters = (
+    params: Parameter[],
+    requireDescription = true,
+  ): boolean => {
     if (hasDuplicateNames(params)) return true;
     for (const p of params) {
-      if (!p.name.trim() || !p.description.trim()) return true;
+      if (!p.name.trim()) return true;
+      if (requireDescription && !p.description.trim()) return true;
       if (p.dataType === "object") {
         if (!p.properties || p.properties.length === 0) return true;
-        if (hasInvalidParameters(p.properties)) return true;
+        if (hasInvalidParameters(p.properties, requireDescription)) return true;
       }
       if (p.dataType === "array" && p.items) {
-        if (hasInvalidSingleParameter(p.items)) return true;
+        if (hasInvalidSingleParameter(p.items, requireDescription)) return true;
       }
     }
     return false;
   };
 
-  const hasInvalidSingleParameter = (param: Parameter): boolean => {
-    if (!param.description.trim()) return true;
+  const hasInvalidSingleParameter = (
+    param: Parameter,
+    requireDescription = true,
+  ): boolean => {
+    if (requireDescription && !param.description.trim()) return true;
     if (param.dataType === "object") {
       if (!param.properties || param.properties.length === 0) return true;
-      if (hasInvalidParameters(param.properties)) return true;
+      if (hasInvalidParameters(param.properties, requireDescription))
+        return true;
     }
     if (param.dataType === "array" && param.items) {
-      if (hasInvalidSingleParameter(param.items)) return true;
+      if (hasInvalidSingleParameter(param.items, requireDescription))
+        return true;
     }
     return false;
   };
@@ -984,20 +993,26 @@ export function AddToolDialog({
   // Build a specific, field-by-field list of what is missing. Mirrors the rules in
   // hasInvalidParameters / hasInvalidSingleParameter exactly, but reports each
   // offending field by name/path instead of a single boolean.
-  const collectItemIssues = (item: Parameter, label: string): string[] => {
+  const collectItemIssues = (
+    item: Parameter,
+    label: string,
+    requireDescription: boolean,
+  ): string[] => {
     const issues: string[] = [];
-    if (!item.description.trim()) {
-      issues.push(`${label}: item description is required`);
+    if (requireDescription && !item.description.trim()) {
+      issues.push(`${label}: item description cannot be empty`);
     }
     if (item.dataType === "object") {
       if (!item.properties || item.properties.length === 0) {
         issues.push(`${label}: object items need at least one property`);
       } else {
-        issues.push(...collectParamIssues(item.properties, `${label} › `));
+        issues.push(
+          ...collectParamIssues(item.properties, `${label} › `, requireDescription),
+        );
       }
     }
     if (item.dataType === "array" && item.items) {
-      issues.push(...collectItemIssues(item.items, `${label}[]`));
+      issues.push(...collectItemIssues(item.items, `${label}[]`, requireDescription));
     }
     return issues;
   };
@@ -1005,6 +1020,7 @@ export function AddToolDialog({
   const collectParamIssues = (
     params: Parameter[],
     prefix: string,
+    requireDescription: boolean,
   ): string[] => {
     const issues: string[] = [];
     const counts = new Map<string, number>();
@@ -1016,8 +1032,10 @@ export function AddToolDialog({
     params.forEach((p) => {
       const name = p.name.trim();
       const label = `${prefix}${name || "(unnamed)"}`;
-      if (!name) issues.push(`${label}: name is required`);
-      if (!p.description.trim()) issues.push(`${label}: description is required`);
+      if (!name) issues.push(`${label}: name cannot be empty`);
+      if (requireDescription && !p.description.trim()) {
+        issues.push(`${label}: description cannot be empty`);
+      }
       const dupKey = name.toLowerCase();
       if (name && (counts.get(dupKey) || 0) > 1 && !reportedDup.has(dupKey)) {
         reportedDup.add(dupKey);
@@ -1027,33 +1045,36 @@ export function AddToolDialog({
         if (!p.properties || p.properties.length === 0) {
           issues.push(`${label}: object needs at least one property`);
         } else {
-          issues.push(...collectParamIssues(p.properties, `${label} › `));
+          issues.push(
+            ...collectParamIssues(p.properties, `${label} › `, requireDescription),
+          );
         }
       }
       if (p.dataType === "array" && p.items) {
-        issues.push(...collectItemIssues(p.items, `${label}[]`));
+        issues.push(...collectItemIssues(p.items, `${label}[]`, requireDescription));
       }
     });
     return issues;
   };
 
   // Returns a multi-line message naming every incomplete field, or null if valid.
+  // Tool/param descriptions are optional for structured-output tools.
   const collectIncompleteFields = (): string | null => {
     const issues: string[] = [];
-    if (!toolName.trim()) issues.push("Name is required");
-    if (!toolDescription.trim()) issues.push("Description is required");
+    if (!toolName.trim()) issues.push("Name cannot be empty");
     if (toolType === "webhook") {
+      if (!toolDescription.trim()) issues.push("Description cannot be empty");
       if (!isValidUrl(webhookUrl)) issues.push("A valid webhook URL is required");
       if (webhookHeaders.length > 0 && hasInvalidHeaders(webhookHeaders)) {
         issues.push("Each header needs both a name and a value");
       }
-      issues.push(...collectParamIssues(queryParameters, "Query param "));
+      issues.push(...collectParamIssues(queryParameters, "Query param ", true));
       if (["POST", "PUT", "PATCH"].includes(webhookMethod)) {
-        if (!bodyDescription.trim()) issues.push("Body description is required");
-        issues.push(...collectParamIssues(bodyParameters, "Body param "));
+        if (!bodyDescription.trim()) issues.push("Body description cannot be empty");
+        issues.push(...collectParamIssues(bodyParameters, "Body param ", true));
       }
     } else {
-      issues.push(...collectParamIssues(parameters, "Parameter "));
+      issues.push(...collectParamIssues(parameters, "Parameter ", false));
     }
     if (issues.length === 0) return null;
     return `Please fix:\n${issues.map((i) => `• ${i}`).join("\n")}`;
@@ -1212,9 +1233,11 @@ export function AddToolDialog({
   // Create tool
   const createTool = async () => {
     setValidationAttempted(true);
-    if (!toolName.trim() || !toolDescription.trim()) return;
+    if (!toolName.trim()) return;
 
     if (toolType === "webhook") {
+      // Description is required for webhook tools (optional for structured output)
+      if (!toolDescription.trim()) return;
       // Validate webhook URL
       if (!isValidUrl(webhookUrl)) return;
       // Validate headers - if any header exists, both name and value are required
@@ -1230,8 +1253,8 @@ export function AddToolDialog({
           return;
       }
     } else {
-      // Validate structured output parameters
-      if (hasInvalidParameters(parameters)) return;
+      // Validate structured output parameters (descriptions optional)
+      if (hasInvalidParameters(parameters, false)) return;
     }
 
     try {
@@ -1317,9 +1340,11 @@ export function AddToolDialog({
   // Update tool
   const updateTool = async () => {
     setValidationAttempted(true);
-    if (!toolName.trim() || !toolDescription.trim() || !editingToolUuid) return;
+    if (!toolName.trim() || !editingToolUuid) return;
 
     if (toolType === "webhook") {
+      // Description is required for webhook tools (optional for structured output)
+      if (!toolDescription.trim()) return;
       // Validate webhook URL
       if (!isValidUrl(webhookUrl)) return;
       // Validate headers - if any header exists, both name and value are required
@@ -1335,8 +1360,8 @@ export function AddToolDialog({
           return;
       }
     } else {
-      // Validate structured output parameters
-      if (hasInvalidParameters(parameters)) return;
+      // Validate structured output parameters (descriptions optional)
+      if (hasInvalidParameters(parameters, false)) return;
     }
 
     try {
@@ -1605,12 +1630,22 @@ export function AddToolDialog({
                           {nameConflictError}
                         </p>
                       )}
+                      {!nameConflictError &&
+                        validationAttempted &&
+                        !toolName.trim() && (
+                          <p className="mt-1 text-sm text-red-500">
+                            Name cannot be empty
+                          </p>
+                        )}
                     </div>
 
-                    {/* Description */}
+                    {/* Description (required only for webhook tools) */}
                     <div>
                       <label className="block text-sm font-medium mb-2">
-                        Description <span className="text-red-500">*</span>
+                        Description{" "}
+                        {toolType === "webhook" && (
+                          <span className="text-red-500">*</span>
+                        )}
                       </label>
                       <textarea
                         value={toolDescription}
@@ -1618,11 +1653,20 @@ export function AddToolDialog({
                         placeholder="Describe to the LLM how and when to use the tool along with what should be passed to the tool"
                         rows={3}
                         className={`w-full px-4 py-3 rounded-md text-base border bg-background text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-accent focus:border-transparent resize-none ${
-                          validationAttempted && !toolDescription.trim()
+                          validationAttempted &&
+                          toolType === "webhook" &&
+                          !toolDescription.trim()
                             ? "border-red-500"
                             : "border-border"
                         }`}
                       />
+                      {validationAttempted &&
+                        toolType === "webhook" &&
+                        !toolDescription.trim() && (
+                          <p className="mt-1 text-sm text-red-500">
+                            Description cannot be empty
+                          </p>
+                        )}
                     </div>
 
                     {/* Webhook-specific fields */}
@@ -1823,6 +1867,11 @@ export function AddToolDialog({
                                   : "border-border"
                               }`}
                             />
+                            {validationAttempted && !header.name.trim() && (
+                              <p className="mt-1 text-sm text-red-500">
+                                Name cannot be empty
+                              </p>
+                            )}
                           </div>
 
                           {/* Value */}
@@ -1849,6 +1898,11 @@ export function AddToolDialog({
                                   : "border-border"
                               }`}
                             />
+                            {validationAttempted && !header.value.trim() && (
+                              <p className="mt-1 text-sm text-red-500">
+                                Value cannot be empty
+                              </p>
+                            )}
                           </div>
 
                           {/* Delete button */}
@@ -1903,6 +1957,7 @@ export function AddToolDialog({
                           onAddProperty={handleAddPropertyAtPath}
                           onSetItems={handleSetItemsAtPath}
                           validationAttempted={validationAttempted}
+                          requireDescription={false}
                           siblingNames={parameters
                             .filter((p) => p.id !== param.id)
                             .map((p) => p.name)}
@@ -1996,6 +2051,11 @@ export function AddToolDialog({
                                   : "border-border"
                               }`}
                             />
+                            {validationAttempted && !bodyDescription.trim() && (
+                              <p className="mt-1 text-sm text-red-500">
+                                Description cannot be empty
+                              </p>
+                            )}
                           </div>
 
                           {/* Properties - same UI as object type properties */}

--- a/src/components/AddToolDialog.tsx
+++ b/src/components/AddToolDialog.tsx
@@ -69,6 +69,13 @@ export function AddToolDialog({
   const [validationAttempted, setValidationAttempted] = useState(false);
   const sidebarContentRef = useRef<HTMLDivElement>(null);
 
+  // UI ⇆ JSON view toggle. In JSON mode the whole tool definition is edited as
+  // raw text; valid JSON syncs live into the form state below (the single source
+  // of truth), so the existing create/update paths keep working unchanged.
+  const [viewMode, setViewMode] = useState<"ui" | "json">("ui");
+  const [jsonText, setJsonText] = useState("");
+  const [jsonError, setJsonError] = useState<string | null>(null);
+
   // Webhook-specific state
   const [webhookMethod, setWebhookMethod] = useState<
     "GET" | "POST" | "PUT" | "PATCH" | "DELETE"
@@ -99,6 +106,10 @@ export function AddToolDialog({
   // Reset form when dialog opens/closes or editingToolUuid changes
   useEffect(() => {
     if (isOpen) {
+      // Always open in Form view, with a clean JSON editor buffer.
+      setViewMode("ui");
+      setJsonText("");
+      setJsonError(null);
       if (editingToolUuid) {
         // Load existing tool data
         loadToolData(editingToolUuid);
@@ -136,6 +147,9 @@ export function AddToolDialog({
     setQueryParameters([]);
     setBodyDescription("");
     setBodyParameters([]);
+    setViewMode("ui");
+    setJsonText("");
+    setJsonError(null);
   };
 
   const handleClose = () => {
@@ -674,6 +688,39 @@ export function AddToolDialog({
       });
   };
 
+  // Convert a list of parameters into an OpenAI-style object schema
+  // ({ type: "object", properties: { name: {...} }, required: [...] }).
+  // Empty-named (in-progress) params are dropped, matching buildParametersConfig.
+  const paramsToObjectSchema = (params: Parameter[]): Record<string, any> => {
+    const properties: Record<string, any> = {};
+    const required: string[] = [];
+    params
+      .filter((param) => param.name)
+      .forEach((param) => {
+        properties[param.name] = parameterToJsonSchema(param);
+        if (param.required) required.push(param.name);
+      });
+    const schema: Record<string, any> = { type: "object", properties };
+    if (required.length > 0) schema.required = required;
+    return schema;
+  };
+
+  // Inverse of paramsToObjectSchema: turn an object schema back into Parameter[].
+  const objectSchemaToParams = (schema: any): Parameter[] => {
+    if (!schema || typeof schema !== "object" || !schema.properties) return [];
+    const requiredProps: string[] = Array.isArray(schema.required)
+      ? schema.required
+      : [];
+    return Object.entries(schema.properties).map(
+      ([propName, propConfig]: [string, any]) =>
+        parseParameterSchema(
+          propName,
+          propConfig,
+          requiredProps.includes(propName)
+        )
+    );
+  };
+
   const parseItemsSchema = (itemsConfig: any): Parameter => {
     const itemParam: Parameter = {
       id: crypto.randomUUID(),
@@ -740,6 +787,189 @@ export function AddToolDialog({
     }
 
     return param;
+  };
+
+  // ----- JSON view (serialize / parse / apply) -----
+
+  // Serialize the current form state into the canonical tool JSON (OpenAI
+  // function-call schema for parameters, plus the webhook block for webhooks).
+  const buildToolJson = (): string => {
+    const base: Record<string, any> = {
+      name: toolName,
+      description: toolDescription,
+    };
+    if (toolType === "webhook") {
+      const webhook: Record<string, any> = {
+        method: webhookMethod,
+        url: webhookUrl,
+        timeout: responseTimeout,
+        headers: webhookHeaders.map((h) => ({ name: h.name, value: h.value })),
+        queryParameters: paramsToObjectSchema(queryParameters),
+      };
+      if (["POST", "PUT", "PATCH"].includes(webhookMethod)) {
+        webhook.body = {
+          description: bodyDescription,
+          parameters: paramsToObjectSchema(bodyParameters),
+        };
+      }
+      base.webhook = webhook;
+    } else {
+      base.parameters = paramsToObjectSchema(parameters);
+    }
+    return JSON.stringify(base, null, 2);
+  };
+
+  const isObjectSchema = (value: any): boolean =>
+    typeof value === "object" && value !== null && !Array.isArray(value);
+
+  // Validate the structural shape of pasted/edited JSON. Returns a single
+  // human-readable error string, or the parsed object when it is acceptable.
+  const parseToolJson = (
+    text: string
+  ): { value?: any; error?: string } => {
+    let obj: any;
+    try {
+      obj = JSON.parse(text);
+    } catch (e) {
+      return { error: `Invalid JSON: ${(e as Error).message}` };
+    }
+    if (!isObjectSchema(obj)) {
+      return { error: "The top-level value must be a JSON object." };
+    }
+    if (obj.name != null && typeof obj.name !== "string") {
+      return { error: '"name" must be a string.' };
+    }
+    if (obj.description != null && typeof obj.description !== "string") {
+      return { error: '"description" must be a string.' };
+    }
+    if (toolType === "webhook") {
+      if (obj.webhook != null && !isObjectSchema(obj.webhook)) {
+        return { error: '"webhook" must be an object.' };
+      }
+      const qp = obj.webhook?.queryParameters;
+      if (qp != null && !isObjectSchema(qp)) {
+        return {
+          error:
+            '"webhook.queryParameters" must be an object schema (with "properties").',
+        };
+      }
+      const bp = obj.webhook?.body?.parameters;
+      if (bp != null && !isObjectSchema(bp)) {
+        return {
+          error:
+            '"webhook.body.parameters" must be an object schema (with "properties").',
+        };
+      }
+    } else if (obj.parameters != null && !isObjectSchema(obj.parameters)) {
+      return {
+        error:
+          '"parameters" must be an object schema (type "object" with "properties").',
+      };
+    }
+    return { value: obj };
+  };
+
+  // Push a parsed JSON object into the form state.
+  const applyToolJson = (obj: any) => {
+    setToolName(typeof obj.name === "string" ? obj.name : "");
+    setToolDescription(
+      typeof obj.description === "string" ? obj.description : ""
+    );
+    if (toolType === "webhook") {
+      const webhook = obj.webhook || {};
+      const method = ["GET", "POST", "PUT", "PATCH", "DELETE"].includes(
+        webhook.method
+      )
+        ? webhook.method
+        : "POST";
+      setWebhookMethod(method);
+      setWebhookUrl(typeof webhook.url === "string" ? webhook.url : "");
+      setResponseTimeout(
+        typeof webhook.timeout === "number" ? webhook.timeout : 20
+      );
+      setWebhookHeaders(
+        (Array.isArray(webhook.headers) ? webhook.headers : []).map(
+          (h: any) => ({
+            id: crypto.randomUUID(),
+            name: typeof h?.name === "string" ? h.name : "",
+            value: typeof h?.value === "string" ? h.value : "",
+          })
+        )
+      );
+      setQueryParameters(objectSchemaToParams(webhook.queryParameters));
+      setBodyDescription(
+        typeof webhook.body?.description === "string"
+          ? webhook.body.description
+          : ""
+      );
+      setBodyParameters(objectSchemaToParams(webhook.body?.parameters));
+    } else {
+      setParameters(objectSchemaToParams(obj.parameters));
+    }
+  };
+
+  // Live-sync: valid JSON flows into form state on every keystroke; invalid JSON
+  // surfaces an inline error and leaves the last-good state untouched.
+  const handleJsonChange = (text: string) => {
+    setJsonText(text);
+    const result = parseToolJson(text);
+    if (result.error) {
+      setJsonError(result.error);
+      return;
+    }
+    setJsonError(null);
+    applyToolJson(result.value);
+  };
+
+  const switchToJson = () => {
+    setJsonText(buildToolJson());
+    setJsonError(null);
+    setViewMode("json");
+  };
+
+  const switchToUi = () => {
+    setViewMode("ui");
+  };
+
+  // Mirrors the inline validation inside createTool/updateTool so JSON-mode Save
+  // can surface a single readable message instead of silently no-op'ing.
+  const validateForSubmit = (): string | null => {
+    if (!toolName.trim()) return "Name is required.";
+    if (!toolDescription.trim()) return "Description is required.";
+    if (toolType === "webhook") {
+      if (!isValidUrl(webhookUrl)) return "A valid webhook URL is required.";
+      if (webhookHeaders.length > 0 && hasInvalidHeaders(webhookHeaders)) {
+        return "Each header needs both a name and a value.";
+      }
+      if (queryParameters.length > 0 && hasInvalidParameters(queryParameters)) {
+        return "One or more query parameters are incomplete.";
+      }
+      if (["POST", "PUT", "PATCH"].includes(webhookMethod)) {
+        if (!bodyDescription.trim()) return "Body description is required.";
+        if (bodyParameters.length > 0 && hasInvalidParameters(bodyParameters)) {
+          return "One or more body parameters are incomplete.";
+        }
+      }
+    } else if (hasInvalidParameters(parameters)) {
+      return "One or more parameters are incomplete (each needs a name and description; objects need at least one property).";
+    }
+    return null;
+  };
+
+  const handleSubmit = () => {
+    if (viewMode === "json") {
+      if (jsonError) return;
+      const err = validateForSubmit();
+      if (err) {
+        setJsonError(err);
+        return;
+      }
+    }
+    if (editingToolUuid) {
+      updateTool();
+    } else {
+      createTool();
+    }
   };
 
   // Load tool data for editing
@@ -1157,6 +1387,57 @@ export function AddToolDialog({
             </div>
           ) : (
             <>
+              {/* View mode toggle: Form ⇆ JSON */}
+              <div className="flex items-center justify-end">
+                <div className="flex items-center gap-0.5 rounded-full bg-muted/60 p-0.5">
+                  <button
+                    type="button"
+                    onClick={switchToUi}
+                    disabled={viewMode === "json" && !!jsonError}
+                    className={`h-7 px-3 rounded-full text-xs font-medium transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed ${
+                      viewMode === "ui"
+                        ? "bg-background text-foreground shadow-sm"
+                        : "text-muted-foreground hover:text-foreground"
+                    }`}
+                  >
+                    Form
+                  </button>
+                  <button
+                    type="button"
+                    onClick={switchToJson}
+                    className={`h-7 px-3 rounded-full text-xs font-medium transition-colors cursor-pointer ${
+                      viewMode === "json"
+                        ? "bg-background text-foreground shadow-sm"
+                        : "text-muted-foreground hover:text-foreground"
+                    }`}
+                  >
+                    JSON
+                  </button>
+                </div>
+              </div>
+
+              {viewMode === "json" ? (
+                <div className="space-y-2">
+                  <p className="text-sm text-muted-foreground">
+                    Edit the full tool definition as JSON. The parameters use the
+                    OpenAI function-call schema. Valid edits sync back to the form
+                    when you switch views.
+                  </p>
+                  <textarea
+                    value={jsonText}
+                    onChange={(e) => handleJsonChange(e.target.value)}
+                    spellCheck={false}
+                    placeholder='{ "name": "", "description": "", "parameters": { "type": "object", "properties": {} } }'
+                    className={`w-full min-h-[480px] px-4 py-3 rounded-md text-sm font-mono bg-background text-foreground placeholder:text-muted-foreground border focus:outline-none focus:ring-2 focus:ring-accent focus:border-transparent resize-y ${
+                      jsonError ? "border-red-500" : "border-border"
+                    }`}
+                  />
+                  {jsonError && (
+                    <p className="text-sm text-red-500">{jsonError}</p>
+                  )}
+                </div>
+              ) : (
+                <>
               {/* Helper Callout */}
               <div className="flex gap-3 p-4 rounded-xl bg-blue-500/10 border border-blue-500/20">
                 <svg
@@ -1619,6 +1900,8 @@ export function AddToolDialog({
                     </div>
                   </div>
                 )}
+                </>
+              )}
             </>
           )}
         </div>
@@ -1635,8 +1918,12 @@ export function AddToolDialog({
               Cancel
             </button>
             <button
-              onClick={editingToolUuid ? updateTool : createTool}
-              disabled={isCreating || isLoadingTool}
+              onClick={handleSubmit}
+              disabled={
+                isCreating ||
+                isLoadingTool ||
+                (viewMode === "json" && !!jsonError)
+              }
               className="h-10 px-4 rounded-md text-base font-medium bg-foreground text-background hover:opacity-90 transition-opacity cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2"
             >
               {isCreating ? (

--- a/src/components/AddToolDialog.tsx
+++ b/src/components/AddToolDialog.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useRef } from "react";
 import { signOut } from "next-auth/react";
 import { ParameterCard, Parameter } from "@/components/ParameterCard";
 import { NestedContainer } from "@/components/ui/NestedContainer";
+import { FieldError } from "@/components/ui/FieldError";
 import { useHideFloatingButton } from "@/components/AppLayout";
 import { readNameConflictMessage } from "@/lib/parseBackendError";
 
@@ -603,48 +604,12 @@ export function AddToolDialog({
     }
   };
 
-  const hasDuplicateNames = (params: Parameter[]): boolean => {
-    const names = params
-      .map((p) => p.name.trim().toLowerCase())
-      .filter(Boolean);
-    return new Set(names).size !== names.length;
-  };
-
+  // Single source of truth for parameter validity is collectParamIssues (below);
+  // this boolean gate just asks whether it found anything to fix.
   const hasInvalidParameters = (
     params: Parameter[],
     requireDescription = true,
-  ): boolean => {
-    if (hasDuplicateNames(params)) return true;
-    for (const p of params) {
-      if (!p.name.trim()) return true;
-      if (requireDescription && !p.description.trim()) return true;
-      if (p.dataType === "object") {
-        if (!p.properties || p.properties.length === 0) return true;
-        if (hasInvalidParameters(p.properties, requireDescription)) return true;
-      }
-      if (p.dataType === "array" && p.items) {
-        if (hasInvalidSingleParameter(p.items, requireDescription)) return true;
-      }
-    }
-    return false;
-  };
-
-  const hasInvalidSingleParameter = (
-    param: Parameter,
-    requireDescription = true,
-  ): boolean => {
-    if (requireDescription && !param.description.trim()) return true;
-    if (param.dataType === "object") {
-      if (!param.properties || param.properties.length === 0) return true;
-      if (hasInvalidParameters(param.properties, requireDescription))
-        return true;
-    }
-    if (param.dataType === "array" && param.items) {
-      if (hasInvalidSingleParameter(param.items, requireDescription))
-        return true;
-    }
-    return false;
-  };
+  ): boolean => collectParamIssues(params, "", requireDescription).length > 0;
 
   const hasInvalidHeaders = (headers: WebhookHeader[]): boolean => {
     for (const header of headers) {
@@ -990,9 +955,9 @@ export function AddToolDialog({
     setViewMode("ui");
   };
 
-  // Build a specific, field-by-field list of what is missing. Mirrors the rules in
-  // hasInvalidParameters / hasInvalidSingleParameter exactly, but reports each
-  // offending field by name/path instead of a single boolean.
+  // Single source of truth for parameter validation: returns a field-by-field
+  // list of what is missing (name/description/properties/duplicates), keyed by
+  // path. hasInvalidParameters above is the boolean view of the same rules.
   const collectItemIssues = (
     item: Parameter,
     label: string,
@@ -1625,18 +1590,18 @@ export function AddToolDialog({
                             : "border-border"
                         }`}
                       />
-                      {nameConflictError && (
-                        <p className="mt-1 text-sm text-red-500">
-                          {nameConflictError}
-                        </p>
-                      )}
-                      {!nameConflictError &&
-                        validationAttempted &&
-                        !toolName.trim() && (
-                          <p className="mt-1 text-sm text-red-500">
-                            Name cannot be empty
-                          </p>
-                        )}
+                      <FieldError show={!!nameConflictError}>
+                        {nameConflictError}
+                      </FieldError>
+                      <FieldError
+                        show={
+                          !nameConflictError &&
+                          validationAttempted &&
+                          !toolName.trim()
+                        }
+                      >
+                        Name cannot be empty
+                      </FieldError>
                     </div>
 
                     {/* Description (required only for webhook tools) */}
@@ -1660,13 +1625,15 @@ export function AddToolDialog({
                             : "border-border"
                         }`}
                       />
-                      {validationAttempted &&
-                        toolType === "webhook" &&
-                        !toolDescription.trim() && (
-                          <p className="mt-1 text-sm text-red-500">
-                            Description cannot be empty
-                          </p>
-                        )}
+                      <FieldError
+                        show={
+                          validationAttempted &&
+                          toolType === "webhook" &&
+                          !toolDescription.trim()
+                        }
+                      >
+                        Description cannot be empty
+                      </FieldError>
                     </div>
 
                     {/* Webhook-specific fields */}
@@ -1867,11 +1834,11 @@ export function AddToolDialog({
                                   : "border-border"
                               }`}
                             />
-                            {validationAttempted && !header.name.trim() && (
-                              <p className="mt-1 text-sm text-red-500">
-                                Name cannot be empty
-                              </p>
-                            )}
+                            <FieldError
+                              show={validationAttempted && !header.name.trim()}
+                            >
+                              Name cannot be empty
+                            </FieldError>
                           </div>
 
                           {/* Value */}
@@ -1898,11 +1865,11 @@ export function AddToolDialog({
                                   : "border-border"
                               }`}
                             />
-                            {validationAttempted && !header.value.trim() && (
-                              <p className="mt-1 text-sm text-red-500">
-                                Value cannot be empty
-                              </p>
-                            )}
+                            <FieldError
+                              show={validationAttempted && !header.value.trim()}
+                            >
+                              Value cannot be empty
+                            </FieldError>
                           </div>
 
                           {/* Delete button */}
@@ -2051,11 +2018,13 @@ export function AddToolDialog({
                                   : "border-border"
                               }`}
                             />
-                            {validationAttempted && !bodyDescription.trim() && (
-                              <p className="mt-1 text-sm text-red-500">
-                                Description cannot be empty
-                              </p>
-                            )}
+                            <FieldError
+                              show={
+                                validationAttempted && !bodyDescription.trim()
+                              }
+                            >
+                              Description cannot be empty
+                            </FieldError>
                           </div>
 
                           {/* Properties - same UI as object type properties */}

--- a/src/components/ParameterCard.tsx
+++ b/src/components/ParameterCard.tsx
@@ -23,6 +23,7 @@ type ParameterCardProps = {
   siblingNames?: string[]; // Names of sibling parameters (excluding this one)
   hideDelete?: boolean; // Hide delete button (e.g., when only one parameter exists)
   showRequired?: boolean; // Show required checkbox (default: true)
+  requireDescription?: boolean; // Whether the description is mandatory (default: true)
 };
 
 // Recursive component for rendering parameter/property cards
@@ -40,6 +41,7 @@ export const ParameterCard = ({
   siblingNames = [],
   hideDelete = false,
   showRequired = true,
+  requireDescription = true,
 }: ParameterCardProps) => {
   const currentPath = [...path, param.id];
   const parentPath = path;
@@ -111,11 +113,16 @@ export const ParameterCard = ({
                   : "border-border"
               }`}
             />
-            {validationAttempted && isDuplicateName && (
-              <p className="text-sm text-red-500 mt-1">
-                A parameter with this name already exists
-              </p>
+            {validationAttempted && !param.name.trim() && (
+              <p className="text-sm text-red-500 mt-1">Name cannot be empty</p>
             )}
+            {validationAttempted &&
+              param.name.trim() !== "" &&
+              isDuplicateName && (
+                <p className="text-sm text-red-500 mt-1">
+                  A parameter with this name already exists
+                </p>
+              )}
           </div>
         )}
       </div>
@@ -154,7 +161,8 @@ export const ParameterCard = ({
       {/* Description */}
       <div>
         <label className="block text-sm font-medium mb-2">
-          Description <span className="text-red-500">*</span>
+          Description{" "}
+          {requireDescription && <span className="text-red-500">*</span>}
         </label>
         <textarea
           value={param.description}
@@ -168,11 +176,16 @@ export const ParameterCard = ({
           rows={3}
           placeholder="This field will be passed to the LLM and should describe in detail what the parameter is for and how it should be populated"
           className={`w-full px-4 py-3 rounded-md text-base border bg-background text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-accent focus:border-transparent resize-none ${
-            validationAttempted && !param.description.trim()
+            validationAttempted && requireDescription && !param.description.trim()
               ? "border-red-500"
               : "border-border"
           }`}
         />
+        {validationAttempted && requireDescription && !param.description.trim() && (
+          <p className="text-sm text-red-500 mt-1">
+            Description cannot be empty
+          </p>
+        )}
       </div>
 
       {/* Properties section for object type */}
@@ -210,11 +223,18 @@ export const ParameterCard = ({
                         .map((p) => p.name) ?? []
                     }
                     showRequired={showRequired}
+                    requireDescription={requireDescription}
                   />
                 ))}
               </div>
             )}
           </NestedContainer>
+          {validationAttempted &&
+            (!param.properties || param.properties.length === 0) && (
+              <p className="text-sm text-red-500 mt-1">
+                Add at least one property
+              </p>
+            )}
         </div>
       )}
 
@@ -245,6 +265,7 @@ export const ParameterCard = ({
               validationAttempted={validationAttempted}
               isArrayItem={true}
               showRequired={showRequired}
+              requireDescription={requireDescription}
             />
           </NestedContainer>
         </div>

--- a/src/components/ParameterCard.tsx
+++ b/src/components/ParameterCard.tsx
@@ -1,4 +1,5 @@
 import { NestedContainer } from "@/components/ui/NestedContainer";
+import { FieldError } from "@/components/ui/FieldError";
 
 export type Parameter = {
   id: string;
@@ -113,16 +114,18 @@ export const ParameterCard = ({
                   : "border-border"
               }`}
             />
-            {validationAttempted && !param.name.trim() && (
-              <p className="text-sm text-red-500 mt-1">Name cannot be empty</p>
-            )}
-            {validationAttempted &&
-              param.name.trim() !== "" &&
-              isDuplicateName && (
-                <p className="text-sm text-red-500 mt-1">
-                  A parameter with this name already exists
-                </p>
-              )}
+            <FieldError show={validationAttempted && !param.name.trim()}>
+              Name cannot be empty
+            </FieldError>
+            <FieldError
+              show={
+                validationAttempted &&
+                param.name.trim() !== "" &&
+                isDuplicateName
+              }
+            >
+              A parameter with this name already exists
+            </FieldError>
           </div>
         )}
       </div>
@@ -181,11 +184,13 @@ export const ParameterCard = ({
               : "border-border"
           }`}
         />
-        {validationAttempted && requireDescription && !param.description.trim() && (
-          <p className="text-sm text-red-500 mt-1">
-            Description cannot be empty
-          </p>
-        )}
+        <FieldError
+          show={
+            validationAttempted && requireDescription && !param.description.trim()
+          }
+        >
+          Description cannot be empty
+        </FieldError>
       </div>
 
       {/* Properties section for object type */}
@@ -229,12 +234,14 @@ export const ParameterCard = ({
               </div>
             )}
           </NestedContainer>
-          {validationAttempted &&
-            (!param.properties || param.properties.length === 0) && (
-              <p className="text-sm text-red-500 mt-1">
-                Add at least one property
-              </p>
-            )}
+          <FieldError
+            show={
+              validationAttempted &&
+              (!param.properties || param.properties.length === 0)
+            }
+          >
+            Add at least one property
+          </FieldError>
         </div>
       )}
 

--- a/src/components/ui/FieldError.tsx
+++ b/src/components/ui/FieldError.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+
+/**
+ * Inline validation message shown beneath a form field, in the standard red
+ * style used across the tool/parameter forms. Renders nothing when `show` is
+ * false so call sites stay a single line.
+ */
+export const FieldError = ({
+  show,
+  children,
+}: {
+  show: boolean;
+  children: React.ReactNode;
+}) => {
+  if (!show) return null;
+  return <p className="mt-1 text-sm text-red-500">{children}</p>;
+};


### PR DESCRIPTION
## Summary

Adds a **Form ⇆ JSON** toggle to the New/Edit tool dialog so you can read, paste, and bulk-edit the whole tool as JSON (OpenAI function-call schema) and round-trip it back to the form. Also sharpens validation feedback and makes descriptions optional for structured-output tools.

## Changes

- **JSON mode** — edit the full tool as JSON; valid edits live-sync into the form. Pasted nullable unions (`["integer","null"]`) normalize to a single type (optional).
- **Errors** — syntax errors show at the top of the editor; incomplete-field errors name the exact fields, auto-switch to the form, and scroll to the first error. Every required field shows a "… cannot be empty" message.
- **Structured tools** — tool and parameter descriptions are now optional (webhook tools unchanged).

## Files
- `src/components/AddToolDialog.tsx`, `src/components/ParameterCard.tsx`

## Verification
`tsc` and `npm run build` pass. Manual browser testing still pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)