### PR TITLE
Fix test-duplicate flow and tooltip behavior

### DIFF
--- a/src/app/tests/page.tsx
+++ b/src/app/tests/page.tsx
@@ -25,6 +25,7 @@ import {
 import { BulkUploadTestsModal } from "@/components/BulkUploadTestsModal";
 import { DeleteIconButton } from "@/components/ui/DeleteIconButton";
 import { DuplicateIconButton } from "@/components/ui/DuplicateIconButton";
+import { Tooltip } from "@/components/Tooltip";
 import { useSidebarState } from "@/lib/sidebar";
 import { testTypeLabel } from "@/lib/testTypes";
 import { POLLING_INTERVAL_MS } from "@/constants/polling";
@@ -1219,29 +1220,24 @@ function LLMPageInner() {
                   </p>
                   <div className="flex items-center gap-1">
                     {/* Play Button */}
-                    <button
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        openRunTestDialog(test);
-                      }}
-                      className="group relative w-8 h-8 flex items-center justify-center rounded-lg bg-foreground/90 text-background hover:bg-foreground transition-colors cursor-pointer"
-                    >
-                      <svg
-                        className="w-3.5 h-3.5"
-                        fill="currentColor"
-                        viewBox="0 0 24 24"
+                    <Tooltip content="Run this test">
+                      <button
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          openRunTestDialog(test);
+                        }}
+                        aria-label="Run this test"
+                        className="w-8 h-8 flex items-center justify-center rounded-lg bg-foreground/90 text-background hover:bg-foreground transition-colors cursor-pointer"
                       >
-                        <path d="M8 5v14l11-7z" />
-                      </svg>
-                      {/* Tooltip */}
-                      <div className="absolute bottom-full mb-3 left-1/2 -translate-x-1/2 opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none">
-                        <span className="px-3 py-1.5 text-sm font-medium text-gray-900 bg-white rounded-full whitespace-nowrap shadow-lg">
-                          Run this test
-                        </span>
-                        {/* Arrow */}
-                        <div className="absolute top-full left-1/2 -translate-x-1/2 -mt-1 w-0 h-0 border-l-[6px] border-l-transparent border-r-[6px] border-r-transparent border-t-[6px] border-t-white"></div>
-                      </div>
-                    </button>
+                        <svg
+                          className="w-3.5 h-3.5"
+                          fill="currentColor"
+                          viewBox="0 0 24 24"
+                        >
+                          <path d="M8 5v14l11-7z" />
+                        </svg>
+                      </button>
+                    </Tooltip>
                     {/* Duplicate Button — opens the create dialog pre-filled
                         from this test; nothing is saved until submit. */}
                     <DuplicateIconButton

--- a/src/components/AddTestDialog.tsx
+++ b/src/components/AddTestDialog.tsx
@@ -538,10 +538,11 @@ export function AddTestDialog({
 
   // Two-phase create flow: when creating a brand-new test we first show a
   // centred type picker (the same three boxes as the bulk-upload modal),
-  // then animate into the full editor. Editing (type is immutable) and
-  // labelItem mode skip the intro entirely. `typeChosen` gates which phase
-  // renders; `editorEntered` drives the entrance transition once chosen.
-  const showTypeIntroFlow = !isLabelItem && !isEditing;
+  // then animate into the full editor. Editing (type is immutable),
+  // labelItem mode, and duplicating (the type is inherited via `initialTab`)
+  // all skip the intro entirely. `typeChosen` gates which phase renders;
+  // `editorEntered` drives the entrance transition once chosen.
+  const showTypeIntroFlow = !isLabelItem && !isEditing && !initialTab;
   const [typeChosen, setTypeChosen] = useState<boolean>(!showTypeIntroFlow);
   const [editorEntered, setEditorEntered] =
     useState<boolean>(!showTypeIntroFlow);
@@ -550,10 +551,10 @@ export function AddTestDialog({
   // starts on the picker and an edit always lands straight in the editor.
   useEffect(() => {
     if (!isOpen) return;
-    const skipIntro = isLabelItem || isEditing;
+    const skipIntro = isLabelItem || isEditing || !!initialTab;
     setTypeChosen(skipIntro);
     setEditorEntered(skipIntro);
-  }, [isOpen, isLabelItem, isEditing]);
+  }, [isOpen, isLabelItem, isEditing, initialTab]);
 
   // Drive the editor's scale/opacity entrance on the frame after the type is
   // chosen, so the swap from the intro picker reads as an animation.

--- a/src/components/Tooltip.tsx
+++ b/src/components/Tooltip.tsx
@@ -132,8 +132,10 @@ export function Tooltip({
         onMouseLeave={() => setIsVisible(false)}
         // Hide on click too: clicking the trigger often opens a dialog/overlay
         // on top of it, so the pointer never physically leaves and no
-        // mouseleave fires — leaving the tooltip stuck on screen.
-        onClick={() => setIsVisible(false)}
+        // mouseleave fires — leaving the tooltip stuck on screen. Use the
+        // capture phase so it still fires when the child button calls
+        // stopPropagation() in its own (bubble-phase) onClick.
+        onClickCapture={() => setIsVisible(false)}
       >
         {children}
       </div>

--- a/src/components/Tooltip.tsx
+++ b/src/components/Tooltip.tsx
@@ -130,6 +130,10 @@ export function Tooltip({
         className={`relative ${className}`}
         onMouseEnter={() => setIsVisible(true)}
         onMouseLeave={() => setIsVisible(false)}
+        // Hide on click too: clicking the trigger often opens a dialog/overlay
+        // on top of it, so the pointer never physically leaves and no
+        // mouseleave fires — leaving the tooltip stuck on screen.
+        onClick={() => setIsVisible(false)}
       >
         {children}
       </div>


### PR DESCRIPTION
Small UX fixes around the tests UI.

## Changes
- **Duplicate test skips the type picker.** Duplicating a test already knows the original's type (passed via `initialTab`), but the dialog still showed the "Next reply / Tool call / Conversation" picker first. It now opens straight into the editor on the correct tab. Fresh creates pass no `initialTab`, so they still see the picker.
- **Tooltips no longer linger.** Clicking a tooltip trigger opens a dialog overlay on top of it, so no `mouseleave` fires and the tooltip got stuck on screen. The shared `Tooltip` now hides on click — via the capture phase, so it still works for buttons (like Duplicate) that call `stopPropagation()` in their own handler.
- **Consistent run-test tooltip.** The play button used a hand-rolled tooltip (pill shape, `text-sm`) that looked different from every other tooltip. Swapped it for the shared `Tooltip` component so it matches and inherits viewport clamping + click-to-hide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)