### PR TITLE
Link tool-call tests to tools by tool_uuid

### DIFF
--- a/src/app/tests/page.tsx
+++ b/src/app/tests/page.tsx
@@ -30,6 +30,7 @@ import { useSidebarState } from "@/lib/sidebar";
 import { testTypeLabel } from "@/lib/testTypes";
 import { POLLING_INTERVAL_MS } from "@/constants/polling";
 import {
+  parseBackendErrorResponse,
   readBulkNameConflictMessage,
   readNameConflictMessage,
 } from "@/lib/parseBackendError";
@@ -650,7 +651,12 @@ function LLMPageInner() {
           setIsCreating(false);
           return;
         }
-        throw new Error("Failed to create test");
+        // Surface the backend's verbatim detail for tool-call link failures
+        // (404 "Tool {uuid} not found" when a sent tool_uuid isn't a live tool)
+        // and any other actionable error.
+        throw new Error(
+          await parseBackendErrorResponse(response, "Create test"),
+        );
       }
 
       // Refetch the tests list to get the updated data
@@ -883,7 +889,12 @@ function LLMPageInner() {
           setIsCreating(false);
           return;
         }
-        throw new Error("Failed to update test");
+        // Surface the backend's verbatim detail for tool-call link failures
+        // (404 "Tool {uuid} not found" when a sent tool_uuid isn't a live tool)
+        // and any other actionable error.
+        throw new Error(
+          await parseBackendErrorResponse(response, "Update test"),
+        );
       }
 
       // Refetch the tests list to get the updated data

--- a/src/components/AddTestDialog.tsx
+++ b/src/components/AddTestDialog.tsx
@@ -155,6 +155,12 @@ const expectedValueTypeError = (value: string, dataType: string): boolean => {
 
 type SelectedToolConfig = {
   id: string;
+  // The tool's permanent uuid, set only for library tools resolved from
+  // GET /tools. Undefined for inbuilt tools and for name-only entries whose
+  // tool isn't a live library tool (agent-owned, CSV-imported, or deleted).
+  // Drives whether `tool_uuid` is sent on save — never derive it from `id`,
+  // which for those name-only cases holds the name, not a uuid.
+  toolUuid?: string;
   name: string;
   expectation: "should-call" | "should-not-call";
   acceptAnyParameterValues: boolean;
@@ -574,7 +580,15 @@ export type TestConfig = {
   evaluation: {
     type: "tool_call" | "response" | "conversation";
     tool_calls?: Array<{
+      // Display name. On write this can be anything — the backend overwrites
+      // it with the live name resolved from `tool_uuid`. On read it's always
+      // the tool's current name (or last-known name if the tool was deleted).
       tool: string;
+      // Optional permanent link to the tool. Sent for library tools (those in
+      // GET /tools) to get rename-tracking; omitted for inbuilt/agent-owned
+      // tools, which are stored by name. A sent uuid is validated by the
+      // backend (404 if it isn't a live tool in the org).
+      tool_uuid?: string;
       arguments: Record<string, any>;
       is_called?: boolean;
       accept_any_arguments?: boolean;
@@ -971,12 +985,19 @@ export function AddTestDialog({
                   : "should-call";
               const acceptAny = toolCall.accept_any_arguments === true;
 
-              // Check if this is an inbuilt tool by matching tool id or name
+              // Check if this is an inbuilt tool by matching tool id or name.
+              // Inbuilt system tools (e.g. end_call) carry no tool_uuid.
               const inbuiltTool = INBUILT_TOOLS.find(
                 (t) => t.id === toolCall.tool || t.name === toolCall.tool,
               );
+              // Custom tools now link by their permanent `tool_uuid`. Match on
+              // that first; fall back to name for any pre-link/edge data. A
+              // tool that was deleted won't be found here — we keep the saved
+              // uuid + last-known name so the row still renders.
               const matchedTool = availableTools.find(
-                (t) => t.uuid === toolCall.tool || t.name === toolCall.tool,
+                (t) =>
+                  (toolCall.tool_uuid && t.uuid === toolCall.tool_uuid) ||
+                  t.name === toolCall.tool,
               );
               const savedArgs =
                 toolCall.arguments &&
@@ -1004,7 +1025,16 @@ export function AddTestDialog({
               }
 
               return {
-                id: inbuiltTool ? inbuiltTool.id : toolCall.tool,
+                // `id` is just the row key/dedup handle. Prefer a stable uuid
+                // (the saved link or a live match), falling back to the name.
+                id: inbuiltTool
+                  ? inbuiltTool.id
+                  : (toolCall.tool_uuid ?? matchedTool?.uuid ?? toolCall.tool),
+                // Only carry a uuid forward to the next save when it resolves
+                // to a LIVE library tool. A saved uuid whose tool was deleted
+                // (or belongs to another org) is intentionally dropped so the
+                // re-save falls back to name-only rather than 404-ing.
+                toolUuid: inbuiltTool ? undefined : matchedTool?.uuid,
                 name: inbuiltTool ? inbuiltTool.name : toolCall.tool,
                 expectation,
                 acceptAnyParameterValues: acceptAny,
@@ -1593,6 +1623,7 @@ export function AddTestDialog({
 
     const newTool: SelectedToolConfig = {
       id: tool.uuid,
+      toolUuid: tool.uuid,
       name: tool.name,
       expectation: "should-call",
       acceptAnyParameterValues: isWebhook,
@@ -2418,11 +2449,21 @@ export function AddTestDialog({
             ? {}
             : buildArgsFromExpectedParams(tool.expectedParameters);
 
-          return {
+          const entry: NonNullable<
+            TestConfig["evaluation"]["tool_calls"]
+          >[number] = {
             tool: toolIdentifier,
             arguments: expectedArgs,
             accept_any_arguments: tool.acceptAnyParameterValues,
           };
+          // Link library tools by their permanent uuid so renames track; the
+          // backend resolves the live name from it. `toolUuid` is set only for
+          // live library tools — inbuilt, agent-owned and deleted tools leave
+          // it undefined and are stored by name (a sent uuid would 404).
+          if (tool.toolUuid) {
+            entry.tool_uuid = tool.toolUuid;
+          }
+          return entry;
         });
 
         evaluation = {

--- a/src/components/BulkUploadTestsModal.tsx
+++ b/src/components/BulkUploadTestsModal.tsx
@@ -411,6 +411,22 @@ export function BulkUploadTestsModal({
     return names;
   }, [availableTools]);
 
+  // Map a live library-tool name to its uuid, used to stamp `tool_uuid` onto
+  // imported tool-call entries so they get rename-tracking. Names shared by
+  // more than one live tool are excluded so we never guess the wrong link —
+  // those entries fall back to name-only. Inbuilt tools (e.g. `end_call`)
+  // aren't in GET /tools, so they're never stamped and stay name-only.
+  const toolUuidByName = useMemo(() => {
+    const byName = new Map<string, string>();
+    const ambiguous = new Set<string>();
+    for (const t of availableTools) {
+      if (byName.has(t.name)) ambiguous.add(t.name);
+      else byName.set(t.name, t.uuid);
+    }
+    for (const name of ambiguous) byName.delete(name);
+    return byName;
+  }, [availableTools]);
+
   // Evaluators to render in the preview's pill row and per-variable
   // column headers. Sourced directly from the user's up-front pick — the
   // CSV doesn't carry an evaluator list anymore.
@@ -869,7 +885,24 @@ export function BulkUploadTestsModal({
             evaluators: test.evaluators ?? [],
           };
         } else {
-          const tool_calls = parseJsonLenient(test.tool_calls!);
+          const parsed = parseJsonLenient(test.tool_calls!);
+          // Stamp `tool_uuid` onto each entry whose `tool` name resolves to a
+          // live library tool, so renames track. Entries that already carry a
+          // tool_uuid keep it (the author-supplied id wins); inbuilt and
+          // unknown tool names are left name-only. Non-array / malformed input
+          // is passed through untouched for the backend to reject.
+          const tool_calls = Array.isArray(parsed)
+            ? parsed.map((entry) => {
+                if (!entry || typeof entry !== "object") return entry;
+                const e = entry as Record<string, unknown>;
+                if (typeof e.tool_uuid === "string" && e.tool_uuid) return e;
+                const uuid =
+                  typeof e.tool === "string"
+                    ? toolUuidByName.get(e.tool)
+                    : undefined;
+                return uuid ? { ...e, tool_uuid: uuid } : e;
+              })
+            : parsed;
           return {
             name: test.name,
             conversation_history,

--- a/src/components/agent-tabs/TestsTabContent.tsx
+++ b/src/components/agent-tabs/TestsTabContent.tsx
@@ -21,6 +21,7 @@ import { POLLING_INTERVAL_MS } from "@/constants/polling";
 import { showLimitToast } from "@/constants/limits";
 import { testTypeLabel } from "@/lib/testTypes";
 import {
+  parseBackendErrorResponse,
   readBulkNameConflictMessage,
   readNameConflictMessage,
 } from "@/lib/parseBackendError";
@@ -738,7 +739,12 @@ export function TestsTabContent({
           setIsCreating(false);
           return;
         }
-        throw new Error("Failed to create test");
+        // Surface the backend's verbatim detail for tool-call link failures
+        // (404 "Tool {uuid} not found" when a sent tool_uuid isn't a live tool)
+        // and any other actionable error.
+        throw new Error(
+          await parseBackendErrorResponse(response, "Create test"),
+        );
       }
 
       // Bulk endpoint creates the test atomically but links it best-effort.
@@ -975,7 +981,12 @@ export function TestsTabContent({
           setIsCreating(false);
           return;
         }
-        throw new Error("Failed to update test");
+        // Surface the backend's verbatim detail for tool-call link failures
+        // (404 "Tool {uuid} not found" when a sent tool_uuid isn't a live tool)
+        // and any other actionable error.
+        throw new Error(
+          await parseBackendErrorResponse(response, "Update test"),
+        );
       }
 
       await fetchAgentTests();


### PR DESCRIPTION
## What
- Tool-call tests now link to a tool by its permanent `tool_uuid` (sent on create/edit for live library tools), so renaming a tool no longer breaks or shows stale names — the live name is resolved from the id.
- Built-in (`end_call`), agent-owned, and deleted tools save name-only with no `tool_uuid`; a uuid is only sent when it resolves to a live tool, so re-saving never 404s on a dead/foreign id.
- Bulk CSV import resolves entry tool names to library-tool uuids at submit time (ambiguous/inbuilt/unknown names stay name-only).
- Create/update handlers surface the backend's 404 detail ("Tool {uuid} not found") instead of a generic failure.

## Notes
- Pairs with backend PR ARTPARK-SAHAI-ORG/calibrate-backend#73 (`tool_uuid` optional, validated on POST/PUT, name-only still accepted).
- Not done: a visual "tool deleted" badge in the edit dialog (graceful save is handled; no UI indicator).