### PR TITLE
Improve agent test management: multi-select attach, required agent linkage, smarter discard

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,7 +85,7 @@ Use `useSidebarState()` from `src/lib/sidebar.ts` for the open/closed state — 
 
 **Agent types**: there are two — `type: "agent"` (Build, platform-configured STT/TTS/LLM) and `type: "connection"` (Connect, external `agent_url`). Never use `"calibrate"` as the type value. Tabs and settings differ between the two.
 
-**Monitoring**: Sentry is wired through `sentry.edge.config.ts`, `sentry.server.config.ts`, `src/instrumentation.ts`, and `src/instrumentation-client.ts`. `@vercel/analytics` is also enabled.
+**Monitoring**: Sentry is wired through `sentry.edge.config.ts`, `sentry.server.config.ts`, `src/instrumentation.ts`, and `src/instrumentation-client.ts`. `@vercel/analytics` is also enabled. In catch blocks use `reportError(message, error)` from `src/lib/reportError.ts` instead of `console.error` — it captures the failure in Sentry (and still logs to the console in development). Don't add bare `console.error`/`console.log` calls.
 
 ## Conventions worth knowing
 

--- a/src/app/datasets/[id]/page.tsx
+++ b/src/app/datasets/[id]/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { reportError } from "@/lib/reportError";
 
 import { useState, useEffect, useCallback, useRef } from "react";
 import { useRouter, useParams } from "next/navigation";
@@ -83,7 +84,7 @@ export default function DatasetDetailPage() {
         };
       });
     } catch (err) {
-      console.error("Failed to delete item:", err);
+      reportError("Failed to delete item:", err);
       toast.error("Failed to delete item. Please try again.");
       throw err;
     }
@@ -130,7 +131,7 @@ export default function DatasetDetailPage() {
         );
       toast.success(parts.join(", ") + ".");
     } catch (err) {
-      console.error("Failed to save:", err);
+      reportError("Failed to save:", err);
       toast.error("Failed to save. Please try again.");
     } finally {
       setIsSaving(false);

--- a/src/app/evaluators/[uuid]/page.tsx
+++ b/src/app/evaluators/[uuid]/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { reportError } from "@/lib/reportError";
 
 import { Suspense, useCallback, useEffect, useMemo, useState } from "react";
 import { useParams, useRouter, useSearchParams } from "next/navigation";
@@ -259,7 +260,7 @@ function EvaluatorDetailPageInner() {
         const data: EvaluatorDetail = await res.json();
         setEvaluator(data);
       } catch (err) {
-        console.error("Error fetching evaluator:", err);
+        reportError("Error fetching evaluator:", err);
         setError(
           err instanceof Error ? err.message : "Failed to load evaluator",
         );
@@ -324,7 +325,7 @@ function EvaluatorDetailPageInner() {
         setEvaluator(data);
       }
     } catch (err) {
-      console.error("Error setting live version:", err);
+      reportError("Error setting live version:", err);
     } finally {
       setSettingLiveUuid(null);
     }
@@ -385,7 +386,7 @@ function EvaluatorDetailPageInner() {
       );
       setEditOpen(false);
     } catch (err) {
-      console.error("Error saving evaluator:", err);
+      reportError("Error saving evaluator:", err);
       setEditError(
         err instanceof Error ? err.message : "Failed to save evaluator",
       );
@@ -582,7 +583,7 @@ function EvaluatorDetailPageInner() {
         window.scrollTo({ top: 0, behavior: "smooth" });
       }
     } catch (err) {
-      console.error("Error creating version:", err);
+      reportError("Error creating version:", err);
       setNewVersionError(
         err instanceof Error ? err.message : "Failed to create version",
       );

--- a/src/app/evaluators/page.tsx
+++ b/src/app/evaluators/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { reportError } from "@/lib/reportError";
 
 import React, { Suspense, useState, useEffect } from "react";
 import Link from "next/link";
@@ -282,7 +283,7 @@ function MetricsPageInner() {
         const data: EvaluatorData[] = await response.json();
         setEvaluators(data);
       } catch (err) {
-        console.error("Error fetching evaluators:", err);
+        reportError("Error fetching evaluators:", err);
         setEvaluatorsError(
           err instanceof Error ? err.message : "Failed to load evaluators",
         );
@@ -336,7 +337,7 @@ function MetricsPageInner() {
       // On any other failure, leave the form blank — prefill is best-effort
       // and shouldn't block the create flow.
       if (!response.ok) {
-        console.error(
+        reportError(
           "Failed to fetch default prompt for purpose:",
           purpose,
           response.status,
@@ -399,7 +400,7 @@ function MetricsPageInner() {
       // them so the user can override either and we only send a
       // scale payload when they do.
     } catch (err) {
-      console.error("Error prefilling default prompt:", err);
+      reportError("Error prefilling default prompt:", err);
     }
   };
 
@@ -454,7 +455,7 @@ function MetricsPageInner() {
       );
       closeDeleteDialog();
     } catch (err) {
-      console.error("Error deleting evaluator:", err);
+      reportError("Error deleting evaluator:", err);
     } finally {
       setIsEvaluatorDeleting(false);
     }
@@ -500,7 +501,7 @@ function MetricsPageInner() {
           setEvaluators(updatedEvaluators);
         }
       } catch (err) {
-        console.error("Error refetching evaluators:", err);
+        reportError("Error refetching evaluators:", err);
       }
     }
     // Navigate to the new evaluator's detail page
@@ -656,7 +657,7 @@ function MetricsPageInner() {
       setAddEvaluatorSidebarOpen(false);
       changeActiveTab("mine");
     } catch (err) {
-      console.error("Error creating evaluator:", err);
+      reportError("Error creating evaluator:", err);
       setCreateError(
         err instanceof Error ? err.message : "Failed to create evaluator",
       );
@@ -1176,7 +1177,7 @@ function DuplicateEvaluatorDialog({
       onDuplicated(newEvaluator);
       onClose();
     } catch (err) {
-      console.error("Error duplicating evaluator:", err);
+      reportError("Error duplicating evaluator:", err);
       setError(
         err instanceof Error ? err.message : "Failed to duplicate evaluator",
       );

--- a/src/app/personas/page.tsx
+++ b/src/app/personas/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { reportError } from "@/lib/reportError";
 
 import React, { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
@@ -108,7 +109,7 @@ export default function PersonasPage() {
         const data: PersonaData[] = await response.json();
         setPersonas(data);
       } catch (err) {
-        console.error("Error fetching personas:", err);
+        reportError("Error fetching personas:", err);
         setPersonasError(
           err instanceof Error ? err.message : "Failed to load personas"
         );
@@ -171,7 +172,7 @@ export default function PersonasPage() {
       );
       closeDeleteDialog();
     } catch (err) {
-      console.error("Error deleting persona:", err);
+      reportError("Error deleting persona:", err);
     } finally {
       setIsPersonaDeleting(false);
     }
@@ -256,7 +257,7 @@ export default function PersonasPage() {
       resetForm();
       setAddPersonaSidebarOpen(false);
     } catch (err) {
-      console.error("Error creating persona:", err);
+      reportError("Error creating persona:", err);
       setCreateError(
         err instanceof Error ? err.message : "Failed to create persona"
       );
@@ -308,7 +309,7 @@ export default function PersonasPage() {
       );
       setPersonaLanguage(personaData.config?.language || "english");
     } catch (err) {
-      console.error("Error fetching persona:", err);
+      reportError("Error fetching persona:", err);
       setCreateError(
         err instanceof Error ? err.message : "Failed to load persona"
       );
@@ -389,7 +390,7 @@ export default function PersonasPage() {
       resetForm();
       setAddPersonaSidebarOpen(false);
     } catch (err) {
-      console.error("Error updating persona:", err);
+      reportError("Error updating persona:", err);
       setCreateError(
         err instanceof Error ? err.message : "Failed to update persona"
       );

--- a/src/app/scenarios/page.tsx
+++ b/src/app/scenarios/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { reportError } from "@/lib/reportError";
 
 import React, { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
@@ -94,7 +95,7 @@ export default function ScenariosPage() {
         const data: ScenarioData[] = await response.json();
         setScenarios(data);
       } catch (err) {
-        console.error("Error fetching scenarios:", err);
+        reportError("Error fetching scenarios:", err);
         setScenariosError(
           err instanceof Error ? err.message : "Failed to load scenarios"
         );
@@ -157,7 +158,7 @@ export default function ScenariosPage() {
       );
       closeDeleteDialog();
     } catch (err) {
-      console.error("Error deleting scenario:", err);
+      reportError("Error deleting scenario:", err);
     } finally {
       setIsScenarioDeleting(false);
     }
@@ -232,7 +233,7 @@ export default function ScenariosPage() {
       resetForm();
       setAddScenarioSidebarOpen(false);
     } catch (err) {
-      console.error("Error creating scenario:", err);
+      reportError("Error creating scenario:", err);
       setCreateError(
         err instanceof Error ? err.message : "Failed to create scenario"
       );
@@ -277,7 +278,7 @@ export default function ScenariosPage() {
       setScenarioLabel(scenarioData.name || "");
       setScenarioDescription(scenarioData.description || DEFAULT_DESCRIPTION);
     } catch (err) {
-      console.error("Error fetching scenario:", err);
+      reportError("Error fetching scenario:", err);
       setCreateError(
         err instanceof Error ? err.message : "Failed to load scenario"
       );
@@ -353,7 +354,7 @@ export default function ScenariosPage() {
       resetForm();
       setAddScenarioSidebarOpen(false);
     } catch (err) {
-      console.error("Error updating scenario:", err);
+      reportError("Error updating scenario:", err);
       setCreateError(
         err instanceof Error ? err.message : "Failed to update scenario"
       );

--- a/src/app/simulations/[uuid]/page.tsx
+++ b/src/app/simulations/[uuid]/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { reportError } from "@/lib/reportError";
 
 import React, { useState, useEffect, useRef } from "react";
 import { useParams, useRouter, useSearchParams } from "next/navigation";
@@ -225,7 +226,7 @@ export default function SimulationDetailPage() {
 
       router.push(`/simulations/${uuid}/runs/${runId}`);
     } catch (err) {
-      console.error("Error launching simulation:", err);
+      reportError("Error launching simulation:", err);
       alert(err instanceof Error ? err.message : "Failed to launch simulation");
     } finally {
       setIsLaunching(false);
@@ -276,7 +277,7 @@ export default function SimulationDetailPage() {
 
       setIsConfigured(true);
     } catch (err) {
-      console.error("Error updating simulation:", err);
+      reportError("Error updating simulation:", err);
       alert(err instanceof Error ? err.message : "Failed to update simulation");
     } finally {
       setIsCreating(false);
@@ -366,7 +367,7 @@ export default function SimulationDetailPage() {
           }
         }
       } catch (err) {
-        console.error("Error fetching simulation:", err);
+        reportError("Error fetching simulation:", err);
         setError(
           err instanceof Error ? err.message : "Failed to load simulation"
         );
@@ -417,7 +418,7 @@ export default function SimulationDetailPage() {
           : [];
         setPersonas(formattedPersonas);
       } catch (err) {
-        console.error("Error fetching personas:", err);
+        reportError("Error fetching personas:", err);
       } finally {
         setPersonasLoading(false);
       }
@@ -463,7 +464,7 @@ export default function SimulationDetailPage() {
           : [];
         setScenarios(formattedScenarios);
       } catch (err) {
-        console.error("Error fetching scenarios:", err);
+        reportError("Error fetching scenarios:", err);
       } finally {
         setScenariosLoading(false);
       }
@@ -526,7 +527,7 @@ export default function SimulationDetailPage() {
           : [];
         setMetrics(formattedMetrics);
       } catch (err) {
-        console.error("Error fetching evaluators:", err);
+        reportError("Error fetching evaluators:", err);
       } finally {
         setMetricsLoading(false);
       }
@@ -587,7 +588,7 @@ export default function SimulationDetailPage() {
       setIsEditNameDialogOpen(false);
       toast.success("Simulation name updated");
     } catch (err) {
-      console.error("Error saving simulation name:", err);
+      reportError("Error saving simulation name:", err);
       toast.error(err instanceof Error ? err.message : "Failed to save name");
     } finally {
       setIsSavingName(false);

--- a/src/app/simulations/[uuid]/runs/[runId]/page.tsx
+++ b/src/app/simulations/[uuid]/runs/[runId]/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { reportError } from "@/lib/reportError";
 
 import React, {
   useState,
@@ -162,7 +163,7 @@ export default function SimulationRunPage() {
       frozenSimulationRef.current = null;
       setRunData(data);
     } catch (err) {
-      console.error("Error refreshing run data for audio URLs:", err);
+      reportError("Error refreshing run data for audio URLs:", err);
     }
   }, [runId, backendAccessToken]);
 
@@ -266,7 +267,7 @@ export default function SimulationRunPage() {
           }
         }
       } catch (err) {
-        console.error("Error fetching simulation name:", err);
+        reportError("Error fetching simulation name:", err);
       }
     };
 
@@ -323,7 +324,7 @@ export default function SimulationRunPage() {
           pollInterval = null;
         }
       } catch (err) {
-        console.error("Error fetching run data:", err);
+        reportError("Error fetching run data:", err);
         if (isInitialLoad) {
           setError(err instanceof Error ? err.message : "Failed to load run");
         } else {
@@ -605,14 +606,14 @@ export default function SimulationRunPage() {
       }
 
       if (!response.ok) {
-        console.error("Failed to abort simulation");
+        reportError("Failed to abort simulation");
         return;
       }
 
       const data: RunData = await response.json();
       setRunData(data);
     } catch (err) {
-      console.error("Error aborting simulation:", err);
+      reportError("Error aborting simulation:", err);
     } finally {
       setIsAborting(false);
     }

--- a/src/app/simulations/page.tsx
+++ b/src/app/simulations/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { reportError } from "@/lib/reportError";
 
 import React, { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
@@ -79,7 +80,7 @@ export default function SimulationsPage() {
         const data: SimulationData[] = await response.json();
         setSimulations(data);
       } catch (err) {
-        console.error("Error fetching simulations:", err);
+        reportError("Error fetching simulations:", err);
         setSimulationsError(
           err instanceof Error ? err.message : "Failed to load simulations"
         );
@@ -144,7 +145,7 @@ export default function SimulationsPage() {
       );
       closeDeleteDialog();
     } catch (err) {
-      console.error("Error deleting simulation:", err);
+      reportError("Error deleting simulation:", err);
     } finally {
       setIsSimulationDeleting(false);
     }

--- a/src/app/stt/[uuid]/page.tsx
+++ b/src/app/stt/[uuid]/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { reportError } from "@/lib/reportError";
 
 import React, { useState, useEffect, useMemo, useRef } from "react";
 import { useParams, useRouter, useSearchParams } from "next/navigation";
@@ -297,7 +298,7 @@ export default function STTEvaluationDetailPage() {
           : [];
         setSttEvaluators(items);
       } catch (err) {
-        console.error("Error fetching evaluators:", err);
+        reportError("Error fetching evaluators:", err);
       }
     };
 
@@ -408,7 +409,7 @@ export default function STTEvaluationDetailPage() {
           }, POLLING_INTERVAL_MS);
         }
       } catch (err) {
-        console.error("Error fetching evaluation result:", err);
+        reportError("Error fetching evaluation result:", err);
         setError(
           err instanceof Error ? err.message : "Failed to load evaluation",
         );
@@ -467,7 +468,7 @@ export default function STTEvaluationDetailPage() {
         }
       }
     } catch (error) {
-      console.error("Error polling task status:", error);
+      reportError("Error polling task status:", error);
       // Set status to failed so the UI shows the error state
       setEvaluationResult((prev) =>
         prev ? { ...prev, status: "failed" } : prev,

--- a/src/app/stt/page.tsx
+++ b/src/app/stt/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { reportError } from "@/lib/reportError";
 
 import React, { useState, useEffect, Suspense } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
@@ -145,7 +146,7 @@ function STTPageInner() {
 
         setJobs(validatedJobs);
       } catch (err) {
-        console.error("Error fetching STT jobs:", err);
+        reportError("Error fetching STT jobs:", err);
         setError(
           err instanceof Error ? err.message : "Failed to load STT jobs",
         );

--- a/src/app/tests/page.tsx
+++ b/src/app/tests/page.tsx
@@ -1045,7 +1045,8 @@ function LLMPageInner() {
 
         {tests.length > 0 && (
           <p className="text-sm text-muted-foreground">
-            {tests.length} {tests.length === 1 ? "test" : "tests"}
+            {filteredTests.length}{" "}
+            {filteredTests.length === 1 ? "test" : "tests"}
           </p>
         )}
 

--- a/src/app/tests/page.tsx
+++ b/src/app/tests/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { reportError } from "@/lib/reportError";
 
 import { useState, useEffect, useRef, useCallback, Suspense } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
@@ -237,7 +238,7 @@ function LLMPageInner() {
       const data: TestData[] = await response.json();
       setTests(data);
     } catch (err) {
-      console.error("Error fetching tests:", err);
+      reportError("Error fetching tests:", err);
       setTestsError(
         err instanceof Error ? err.message : "Failed to load tests"
       );
@@ -267,7 +268,7 @@ function LLMPageInner() {
         const data = await response.json();
         setAllRuns(data.runs || []);
       } catch (err) {
-        console.error("Error fetching all runs:", err);
+        reportError("Error fetching all runs:", err);
       } finally {
         setAllRunsLoading(false);
       }
@@ -375,7 +376,7 @@ function LLMPageInner() {
             }),
           );
         } catch (err) {
-          console.error(`Error polling run ${run.uuid}:`, err);
+          reportError(`Error polling run ${run.uuid}:`, err);
         }
       }
     };
@@ -521,7 +522,7 @@ function LLMPageInner() {
       setSelectedTestUuids(new Set());
       closeDeleteDialog();
     } catch (err) {
-      console.error("Error deleting test(s):", err);
+      reportError("Error deleting test(s):", err);
     } finally {
       setIsTestDeleting(false);
     }
@@ -567,7 +568,7 @@ function LLMPageInner() {
         }
 
         if (!response.ok) {
-          console.error("Failed to attach test to agent");
+          reportError("Failed to attach test to agent");
         }
       }
 
@@ -579,7 +580,7 @@ function LLMPageInner() {
       setTestRunnerAgentName(agentName);
       setTestRunnerOpen(true);
     } catch (err) {
-      console.error("Error running test:", err);
+      reportError("Error running test:", err);
       setRunTestDialogOpen(false);
       setTestToRun(null);
     }
@@ -671,7 +672,7 @@ function LLMPageInner() {
       // Close the sidebar
       setAddTestSidebarOpen(false);
     } catch (err) {
-      console.error("Error creating test:", err);
+      reportError("Error creating test:", err);
       setCreateError(
         err instanceof Error ? err.message : "Failed to create test"
       );
@@ -744,7 +745,7 @@ function LLMPageInner() {
         setInitialEvaluators([]);
       }
     } catch (err) {
-      console.error("Error fetching test:", err);
+      reportError("Error fetching test:", err);
       setCreateError(
         err instanceof Error ? err.message : "Failed to load test"
       );
@@ -815,7 +816,7 @@ function LLMPageInner() {
       // Open the dialog only now that the fresh data is in state.
       setAddTestSidebarOpen(true);
     } catch (err) {
-      console.error("Error duplicating test:", err);
+      reportError("Error duplicating test:", err);
       setCreateError(
         err instanceof Error ? err.message : "Failed to load test"
       );
@@ -901,7 +902,7 @@ function LLMPageInner() {
       resetForm();
       setAddTestSidebarOpen(false);
     } catch (err) {
-      console.error("Error updating test:", err);
+      reportError("Error updating test:", err);
       setCreateError(
         err instanceof Error ? err.message : "Failed to update test"
       );

--- a/src/app/tools/page.tsx
+++ b/src/app/tools/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { reportError } from "@/lib/reportError";
 
 import { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
@@ -76,7 +77,7 @@ export default function ToolsPage() {
         const data: ToolData[] = await response.json();
         setTools(data);
       } catch (err) {
-        console.error("Error fetching tools:", err);
+        reportError("Error fetching tools:", err);
         setToolsError(
           err instanceof Error ? err.message : "Failed to load tools"
         );
@@ -134,7 +135,7 @@ export default function ToolsPage() {
       setTools(tools.filter((tool) => tool.uuid !== toolToDelete.uuid));
       closeDeleteDialog();
     } catch (err) {
-      console.error("Error deleting tool:", err);
+      reportError("Error deleting tool:", err);
     } finally {
       setIsToolDeleting(false);
     }

--- a/src/app/tts/[uuid]/page.tsx
+++ b/src/app/tts/[uuid]/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { reportError } from "@/lib/reportError";
 
 import React, { useState, useEffect, useMemo, useRef } from "react";
 import { useParams, useRouter, useSearchParams } from "next/navigation";
@@ -297,7 +298,7 @@ export default function TTSEvaluationDetailPage() {
           : [];
         setTtsEvaluators(items);
       } catch (err) {
-        console.error("Error fetching evaluators:", err);
+        reportError("Error fetching evaluators:", err);
       }
     };
 
@@ -410,7 +411,7 @@ export default function TTSEvaluationDetailPage() {
           }, POLLING_INTERVAL_MS);
         }
       } catch (err) {
-        console.error("Error fetching evaluation result:", err);
+        reportError("Error fetching evaluation result:", err);
         setError(
           err instanceof Error ? err.message : "Failed to load evaluation",
         );
@@ -469,7 +470,7 @@ export default function TTSEvaluationDetailPage() {
         }
       }
     } catch (error) {
-      console.error("Error polling task status:", error);
+      reportError("Error polling task status:", error);
       // Set status to failed so the UI shows the error state
       setEvaluationResult((prev) =>
         prev ? { ...prev, status: "failed" } : prev,

--- a/src/app/tts/page.tsx
+++ b/src/app/tts/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { reportError } from "@/lib/reportError";
 
 import React, { useState, useEffect, Suspense } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
@@ -144,7 +145,7 @@ function TTSPageInner() {
 
         setJobs(validatedJobs);
       } catch (err) {
-        console.error("Error fetching TTS jobs:", err);
+        reportError("Error fetching TTS jobs:", err);
         setError(
           err instanceof Error ? err.message : "Failed to load TTS jobs",
         );

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,3 +1,4 @@
+import { reportError } from "@/lib/reportError";
 import NextAuth from "next-auth";
 import Google from "next-auth/providers/google";
 
@@ -44,7 +45,7 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
             }
           }
         } catch (error) {
-          console.error("Failed to sync user with backend:", error);
+          reportError("Failed to sync user with backend:", error);
         }
       }
       return token;

--- a/src/components/AddTestDialog.tsx
+++ b/src/components/AddTestDialog.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { reportError } from "@/lib/reportError";
 
 import React, {
   useState,
@@ -1387,7 +1388,7 @@ export function AddTestDialog({
         const data: AvailableTool[] = await response.json();
         setAvailableTools(data);
       } catch (err) {
-        console.error("Error fetching tools:", err);
+        reportError("Error fetching tools:", err);
       } finally {
         setAvailableToolsLoading(false);
         setToolsFetched(true);
@@ -1457,7 +1458,7 @@ export function AddTestDialog({
           }));
         setAvailableLLMEvaluators(llm);
       } catch (err) {
-        console.error("Error fetching evaluators:", err);
+        reportError("Error fetching evaluators:", err);
       } finally {
         setEvaluatorsLoading(false);
         setEvaluatorsFetched(true);

--- a/src/components/AddTestDialog.tsx
+++ b/src/components/AddTestDialog.tsx
@@ -1266,6 +1266,16 @@ export function AddTestDialog({
   } | null>(null);
   const [showCloseConfirmation, setShowCloseConfirmation] = useState(false);
 
+  // Discard-guard baseline. `baselineRef` holds a serialized snapshot of the
+  // form's canonical (would-be-saved) content, captured once the dialog has
+  // finished its async initialization. A backdrop click only raises the
+  // "Discard changes?" prompt when the current form differs from this
+  // baseline — so clicking outside a pristine (just-opened, unedited) dialog
+  // closes immediately. `baselineArmed` defers the capture by one render so
+  // the populate effects' state updates are reflected first.
+  const baselineRef = useRef<string | null>(null);
+  const [baselineArmed, setBaselineArmed] = useState(false);
+
   const chatEndRef = useRef<HTMLDivElement>(null);
 
   // The tool-call dropdown is anchored to the "Add message" button but its
@@ -1568,6 +1578,46 @@ export function AddTestDialog({
     isLoading,
     activeTab,
   ]);
+
+  // Discard-guard baseline capture (paired with `baselineRef`).
+  //
+  // Reset on close so the next open re-captures from scratch.
+  useEffect(() => {
+    if (!isOpen) {
+      baselineRef.current = null;
+      setBaselineArmed(false);
+    }
+  }, [isOpen]);
+
+  // Phase 1 — arm once the editor is shown and async init has settled:
+  // a type is chosen, evaluators are initialized, and (when editing/
+  // duplicating) the initialConfig-driven history/tools have populated.
+  useEffect(() => {
+    if (!isOpen || baselineArmed || baselineRef.current !== null) return;
+    const initSettled =
+      typeChosen &&
+      attachedEvaluatorsInitialized &&
+      (!initialConfig || toolsFetched);
+    if (initSettled) setBaselineArmed(true);
+  }, [
+    isOpen,
+    baselineArmed,
+    typeChosen,
+    attachedEvaluatorsInitialized,
+    initialConfig,
+    toolsFetched,
+  ]);
+
+  // Phase 2 — capture one render after arming, by which point the populate
+  // effects' state updates are reflected in the form.
+  useEffect(() => {
+    if (baselineArmed && baselineRef.current === null) {
+      baselineRef.current = serializeFormState();
+    }
+    // serializeFormState is intentionally omitted: the baseline must be taken
+    // exactly once, at the moment of arming, not re-derived on every edit.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [baselineArmed]);
 
   // Create-mode only: when the user switches between the evaluator-based
   // tabs (next-reply ↔ conversation), drop every attached evaluator that
@@ -2522,6 +2572,32 @@ export function AddTestDialog({
     });
   };
 
+  // Serialize the form's canonical (would-be-saved) content for the discard
+  // guard. Built from the same buildConfig()/buildEvaluatorsPayload() output
+  // that submission uses, so it's dirty iff what would be saved differs from
+  // the captured baseline. buildConfig() mints fresh UUIDs for tool_call ids
+  // on every call, so those volatile ids are stripped before comparing.
+  const serializeFormState = (): string => {
+    const config = buildConfig();
+    const history = config.history.map((item) => {
+      const next: Record<string, unknown> = { ...item };
+      if (Array.isArray(next.tool_calls)) {
+        next.tool_calls = (
+          next.tool_calls as Array<{ function: unknown; type: unknown }>
+        ).map((tc) => ({ function: tc.function, type: tc.type }));
+      }
+      delete next.tool_call_id;
+      return next;
+    });
+    return JSON.stringify({
+      name: testName,
+      description: itemDescription ?? "",
+      history,
+      evaluation: config.evaluation,
+      evaluators: buildEvaluatorsPayload(),
+    });
+  };
+
   // Returns true if any attached evaluator has at least one variable whose
   // value is empty (after trim). Used to gate the Save button.
   const hasUnfilledEvaluatorVariables = () => {
@@ -2626,6 +2702,17 @@ export function AddTestDialog({
   };
 
   const handleBackdropClick = () => {
+    // Skip the discard prompt when the form is unchanged from the baseline
+    // captured after load (pristine open, or edits reverted). When the
+    // baseline hasn't been captured yet — e.g. an existing test is still
+    // loading — keep the prompt to err on the side of not losing edits.
+    if (
+      baselineRef.current !== null &&
+      serializeFormState() === baselineRef.current
+    ) {
+      onClose();
+      return;
+    }
     setShowCloseConfirmation(true);
   };
 

--- a/src/components/AddToolDialog.tsx
+++ b/src/components/AddToolDialog.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { reportError } from "@/lib/reportError";
 
 import { useState, useEffect, useRef } from "react";
 import { signOut } from "next-auth/react";
@@ -1105,7 +1106,7 @@ export function AddToolDialog({
         }
       }
     } catch (err) {
-      console.error("Error fetching tool:", err);
+      reportError("Error fetching tool:", err);
       setCreateError(
         err instanceof Error ? err.message : "Failed to load tool",
       );
@@ -1231,7 +1232,7 @@ export function AddToolDialog({
       await refetchTools();
       handleClose();
     } catch (err) {
-      console.error("Error creating tool:", err);
+      reportError("Error creating tool:", err);
       setCreateError(
         err instanceof Error ? err.message : "Failed to create tool",
       );
@@ -1338,7 +1339,7 @@ export function AddToolDialog({
       await refetchTools();
       handleClose();
     } catch (err) {
-      console.error("Error updating tool:", err);
+      reportError("Error updating tool:", err);
       setCreateError(
         err instanceof Error ? err.message : "Failed to update tool",
       );

--- a/src/components/AgentDetail.tsx
+++ b/src/components/AgentDetail.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { reportError } from "@/lib/reportError";
 
 import React, { useState, useEffect, useRef } from "react";
 import Link from "next/link";
@@ -446,7 +447,7 @@ export function AgentDetail({
           }
         }
       } catch (err) {
-        console.error("Error fetching agent:", err);
+        reportError("Error fetching agent:", err);
         setError(err instanceof Error ? err.message : "Failed to load agent");
       } finally {
         setIsLoading(false);
@@ -503,7 +504,7 @@ export function AgentDetail({
         const data: ToolData[] = await response.json();
         setAgentTools(data);
       } catch (err) {
-        console.error("Error fetching agent tools:", err);
+        reportError("Error fetching agent tools:", err);
         setAgentToolsError(
           err instanceof Error ? err.message : "Failed to load agent tools",
         );
@@ -548,7 +549,7 @@ export function AgentDetail({
         const data: ToolData[] = await response.json();
         setAllTools(data);
       } catch (err) {
-        console.error("Error fetching tools:", err);
+        reportError("Error fetching tools:", err);
         setAllToolsError(
           err instanceof Error ? err.message : "Failed to load tools",
         );
@@ -668,7 +669,7 @@ export function AgentDetail({
           setShowSaveToast(true);
         }
       } catch (err) {
-        console.error("Error saving agent:", err);
+        reportError("Error saving agent:", err);
         if (!silent) {
           alert(err instanceof Error ? err.message : "Failed to save agent");
         }
@@ -857,7 +858,7 @@ export function AgentDetail({
       setIsEditNameDialogOpen(false);
       setShowSaveToast(true);
     } catch (err) {
-      console.error("Error saving agent name:", err);
+      reportError("Error saving agent name:", err);
       alert(err instanceof Error ? err.message : "Failed to save agent name");
     } finally {
       setIsSaving(false);

--- a/src/components/AgentPicker.tsx
+++ b/src/components/AgentPicker.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { reportError } from "@/lib/reportError";
 
 import React, { useState, useEffect, useRef } from "react";
 import { signOut } from "next-auth/react";
@@ -128,7 +129,7 @@ export function AgentPicker({
           : [];
         setAgents(formattedAgents);
       } catch (err) {
-        console.error("Error fetching agents:", err);
+        reportError("Error fetching agents:", err);
       } finally {
         setAgentsLoading(false);
       }
@@ -227,7 +228,7 @@ export function MultiAgentPicker({
           : [];
         setAgents(formattedAgents);
       } catch (err) {
-        console.error("Error fetching agents:", err);
+        reportError("Error fetching agents:", err);
       } finally {
         setAgentsLoading(false);
       }

--- a/src/components/AgentPicker.tsx
+++ b/src/components/AgentPicker.tsx
@@ -175,6 +175,13 @@ type MultiAgentPickerProps = {
   onToggleAgent: (uuid: string) => void;
   placeholder?: string;
   className?: string;
+  /**
+   * Fired once the agent list has successfully loaded, with the resolved
+   * agents. Lets callers react to an empty workspace (e.g. hide the picker
+   * entirely). Not called on fetch failure, so callers can't mistake an
+   * errored load for a genuinely empty workspace.
+   */
+  onAgentsLoaded?: (agents: Agent[]) => void;
 };
 
 export function MultiAgentPicker({
@@ -182,6 +189,7 @@ export function MultiAgentPicker({
   onToggleAgent,
   placeholder = "Select agents",
   className = "",
+  onAgentsLoaded,
 }: MultiAgentPickerProps) {
   const backendAccessToken = useAccessToken();
   const triggerRef = useRef<HTMLDivElement>(null);
@@ -189,6 +197,13 @@ export function MultiAgentPicker({
   const [agentsLoading, setAgentsLoading] = useState(false);
   const [dropdownOpen, setDropdownOpen] = useState(false);
   const [searchQuery, setSearchQuery] = useState("");
+
+  // Keep the latest callback in a ref so the fetch effect doesn't depend on
+  // its identity (which would re-run the fetch on every parent render).
+  const onAgentsLoadedRef = useRef(onAgentsLoaded);
+  useEffect(() => {
+    onAgentsLoadedRef.current = onAgentsLoaded;
+  }, [onAgentsLoaded]);
 
   useEffect(() => {
     const fetchAgents = async () => {
@@ -227,6 +242,7 @@ export function MultiAgentPicker({
             }))
           : [];
         setAgents(formattedAgents);
+        onAgentsLoadedRef.current?.(formattedAgents);
       } catch (err) {
         reportError("Error fetching agents:", err);
       } finally {

--- a/src/components/Agents.tsx
+++ b/src/components/Agents.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { reportError } from "@/lib/reportError";
 
 import { useState, useEffect } from "react";
 import Link from "next/link";
@@ -107,7 +108,7 @@ export function Agents({ onNavigateToAgent }: AgentsProps) {
           : [];
         setAgents(formattedAgents);
       } catch (err) {
-        console.error("Error fetching agents:", err);
+        reportError("Error fetching agents:", err);
         setError(err instanceof Error ? err.message : "Failed to load agents");
       } finally {
         setIsLoading(false);
@@ -202,7 +203,7 @@ export function Agents({ onNavigateToAgent }: AgentsProps) {
       );
       closeDeleteDialog();
     } catch (err) {
-      console.error("Error deleting agent:", err);
+      reportError("Error deleting agent:", err);
     } finally {
       setDeletingAgentUuid(null);
     }
@@ -746,7 +747,7 @@ function NewAgentDialog({
         onCreateAgent(agentUuid);
       }
     } catch (err) {
-      console.error("Error creating agent:", err);
+      reportError("Error creating agent:", err);
       setError(err instanceof Error ? err.message : "Failed to create agent");
     } finally {
       setIsCreating(false);
@@ -1021,7 +1022,7 @@ function DuplicateAgentDialog({
         onNavigateToAgent(data.uuid);
       }
     } catch (err) {
-      console.error("Error duplicating agent:", err);
+      reportError("Error duplicating agent:", err);
       setError(
         err instanceof Error ? err.message : "Failed to duplicate agent",
       );

--- a/src/components/BenchmarkResultsDialog.tsx
+++ b/src/components/BenchmarkResultsDialog.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { reportError } from "@/lib/reportError";
 
 import React, { useState, useEffect, useRef } from "react";
 import {
@@ -342,7 +343,7 @@ export function BenchmarkResultsDialog({
         }
 
         if (result.error) {
-          console.error("Benchmark error:", result.error);
+          reportError("Benchmark error:", result.error);
           setError(result.error);
         } else {
           setLeaderboardSummary(result.leaderboard_summary);
@@ -351,7 +352,7 @@ export function BenchmarkResultsDialog({
         }
       }
     } catch (err) {
-      console.error("Error polling benchmark status:", err);
+      reportError("Error polling benchmark status:", err);
       setIsInitialLoading(false);
       setTaskStatus("failed");
       setError(err instanceof Error ? err.message : "Failed to poll status");
@@ -412,7 +413,7 @@ export function BenchmarkResultsDialog({
       // Also poll immediately
       pollBenchmarkStatus(newTaskId, backendUrl);
     } catch (err) {
-      console.error("Error starting benchmark:", err);
+      reportError("Error starting benchmark:", err);
       setIsInitialLoading(false);
       setError(
         err instanceof Error ? err.message : "Failed to start benchmark",

--- a/src/components/BulkUploadTestsModal.tsx
+++ b/src/components/BulkUploadTestsModal.tsx
@@ -216,7 +216,6 @@ export function BulkUploadTestsModal({
   // parse effect once `evaluatorsFetched` flips to true. Lets us validate
   // the upload as soon as data is available without forcing a re-upload.
   const [pendingFile, setPendingFile] = useState<File | null>(null);
-  const [assignToAgents, setAssignToAgents] = useState(false);
   const [selectedAgentUuids, setSelectedAgentUuids] = useState<string[]>([]);
   const [isUploading, setIsUploading] = useState(false);
   const [uploadError, setUploadError] = useState<string | null>(null);
@@ -267,7 +266,6 @@ export function BulkUploadTestsModal({
       setParsedTests([]);
       setParseError(null);
       setPendingFile(null);
-      setAssignToAgents(false);
       setSelectedAgentUuids([]);
       setIsUploading(false);
       setUploadError(null);
@@ -926,7 +924,9 @@ export function BulkUploadTestsModal({
       } = { type: testType, tests };
       if (lockedAgentUuid) {
         body.agent_uuids = [lockedAgentUuid];
-      } else if (assignToAgents && selectedAgentUuids.length > 0) {
+      } else {
+        // Unlocked (global /tests) uploads must link to at least one agent;
+        // the submit button stays disabled until one is picked.
         body.agent_uuids = selectedAgentUuids;
       }
 
@@ -1707,59 +1707,25 @@ export function BulkUploadTestsModal({
             </div>
           )}
 
-          {/* Step 3: Assign to Agents (optional, hidden when modal is
-              locked to a specific agent — see lockedAgentUuid prop). */}
+          {/* Step 3: Assign to Agents (required, hidden when modal is
+              locked to a specific agent — see lockedAgentUuid prop). Bulk
+              uploads must link to at least one agent so the new tests are
+              never orphaned in the library. */}
           {testType && parsedTests.length > 0 && !lockedAgentUuid && (
             <div ref={assignAgentsSectionRef}>
-              <div className="flex items-center gap-3 mb-3">
-                <button
-                  onClick={() => {
-                    const next = !assignToAgents;
-                    setAssignToAgents(next);
-                    if (!next) {
-                      setSelectedAgentUuids([]);
-                    } else {
-                      setTimeout(() => {
-                        assignAgentsSectionRef.current?.scrollIntoView({
-                          behavior: "smooth",
-                          block: "end",
-                        });
-                      }, 50);
-                    }
-                  }}
-                  className={`w-5 h-5 rounded border-2 flex-shrink-0 flex items-center justify-center transition-colors cursor-pointer ${
-                    assignToAgents
-                      ? "bg-foreground border-foreground"
-                      : "bg-background border-muted-foreground hover:border-foreground"
-                  }`}
-                >
-                  {assignToAgents && (
-                    <svg
-                      className="w-3 h-3 text-background"
-                      fill="none"
-                      viewBox="0 0 24 24"
-                      stroke="currentColor"
-                      strokeWidth={3}
-                    >
-                      <path
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        d="M4.5 12.75l6 6 9-13.5"
-                      />
-                    </svg>
-                  )}
-                </button>
+              <div className="flex items-center gap-2 mb-1">
                 <span className="text-sm font-medium text-foreground">
                   Assign tests to agents
                 </span>
+                <span className="text-red-500">*</span>
               </div>
-
-              {assignToAgents && (
-                <MultiAgentPicker
-                  selectedAgentUuids={selectedAgentUuids}
-                  onToggleAgent={toggleAgentSelection}
-                />
-              )}
+              <p className="text-xs text-muted-foreground mb-3">
+                Select one or more agents to link these tests to.
+              </p>
+              <MultiAgentPicker
+                selectedAgentUuids={selectedAgentUuids}
+                onToggleAgent={toggleAgentSelection}
+              />
             </div>
           )}
         </div>
@@ -1803,9 +1769,7 @@ export function BulkUploadTestsModal({
                   disabled={
                     isUploading ||
                     parsedTests.length === 0 ||
-                    (!lockedAgentUuid &&
-                      assignToAgents &&
-                      selectedAgentUuids.length === 0)
+                    (!lockedAgentUuid && selectedAgentUuids.length === 0)
                   }
                   className="h-10 px-5 rounded-lg text-sm font-medium bg-foreground text-background hover:opacity-90 transition-opacity cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2"
                 >

--- a/src/components/BulkUploadTestsModal.tsx
+++ b/src/components/BulkUploadTestsModal.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { reportError } from "@/lib/reportError";
 
 import React, { useState, useEffect, useRef, useMemo } from "react";
 import Link from "next/link";
@@ -340,7 +341,7 @@ export function BulkUploadTestsModal({
           }));
         setAvailableLLMEvaluators(llm);
       } catch (err) {
-        console.error("Error fetching evaluators:", err);
+        reportError("Error fetching evaluators:", err);
         setEvaluatorsFetchError(
           err instanceof Error ? err.message : "Failed to load evaluators",
         );
@@ -396,7 +397,7 @@ export function BulkUploadTestsModal({
         const data: AvailableTool[] = await response.json();
         setAvailableTools(data);
       } catch (err) {
-        console.error("Error fetching tools:", err);
+        reportError("Error fetching tools:", err);
         setToolsFetchError(
           err instanceof Error ? err.message : "Failed to load tools",
         );
@@ -983,7 +984,7 @@ export function BulkUploadTestsModal({
         onClose();
       }
     } catch (err) {
-      console.error("Error bulk uploading tests:", err);
+      reportError("Error bulk uploading tests:", err);
       setUploadError(
         err instanceof Error ? err.message : "Failed to upload tests",
       );

--- a/src/components/BulkUploadTestsModal.tsx
+++ b/src/components/BulkUploadTestsModal.tsx
@@ -863,6 +863,20 @@ export function BulkUploadTestsModal({
         }
 
         setParsedTests(tests);
+
+        // Now that the tests parsed, the required "Assign tests to agents"
+        // picker renders below the preview. Scroll it into view so the user
+        // notices they must link at least one agent before the upload button
+        // enables. Skipped when the modal is locked to a single agent (the
+        // picker isn't shown then). The timeout lets the section mount first.
+        if (!lockedAgentUuid) {
+          setTimeout(() => {
+            assignAgentsSectionRef.current?.scrollIntoView({
+              behavior: "smooth",
+              block: "end",
+            });
+          }, 50);
+        }
       },
       error: (error) => {
         setParseError(`Failed to parse CSV: ${error.message}`);

--- a/src/components/BulkUploadTestsModal.tsx
+++ b/src/components/BulkUploadTestsModal.tsx
@@ -865,11 +865,11 @@ export function BulkUploadTestsModal({
 
         setParsedTests(tests);
 
-        // Now that the tests parsed, the required "Assign tests to agents"
+        // Now that the tests parsed, the optional "Assign tests to agents"
         // picker renders below the preview. Scroll it into view so the user
-        // notices they must link at least one agent before the upload button
-        // enables. Skipped when the modal is locked to a single agent (the
-        // picker isn't shown then). The timeout lets the section mount first.
+        // notices they can link the tests to agents here. Skipped when the
+        // modal is locked to a single agent (the picker isn't shown then).
+        // The timeout lets the section mount first.
         if (!lockedAgentUuid) {
           setTimeout(() => {
             assignAgentsSectionRef.current?.scrollIntoView({
@@ -939,9 +939,9 @@ export function BulkUploadTestsModal({
       } = { type: testType, tests };
       if (lockedAgentUuid) {
         body.agent_uuids = [lockedAgentUuid];
-      } else {
-        // Unlocked (global /tests) uploads must link to at least one agent;
-        // the submit button stays disabled until one is picked.
+      } else if (selectedAgentUuids.length > 0) {
+        // Linking to agents is optional in the global /tests flow; only send
+        // the field when the user actually picked some.
         body.agent_uuids = selectedAgentUuids;
       }
 
@@ -1722,20 +1722,23 @@ export function BulkUploadTestsModal({
             </div>
           )}
 
-          {/* Step 3: Assign to Agents (required, hidden when modal is
-              locked to a specific agent — see lockedAgentUuid prop). Bulk
-              uploads must link to at least one agent so the new tests are
-              never orphaned in the library. */}
+          {/* Step 3: Assign to Agents (optional, hidden when modal is locked
+              to a specific agent — see lockedAgentUuid prop). Linking is not
+              required: tests can be uploaded to the library and attached to an
+              agent later, so a workspace with no agents yet isn't blocked. */}
           {testType && parsedTests.length > 0 && !lockedAgentUuid && (
             <div ref={assignAgentsSectionRef}>
               <div className="flex items-center gap-2 mb-1">
                 <span className="text-sm font-medium text-foreground">
                   Assign tests to agents
                 </span>
-                <span className="text-red-500">*</span>
+                <span className="text-xs font-normal text-muted-foreground">
+                  (optional)
+                </span>
               </div>
               <p className="text-xs text-muted-foreground mb-3">
-                Select one or more agents to link these tests to.
+                Optionally link these tests to one or more agents — you can
+                attach them later instead.
               </p>
               <MultiAgentPicker
                 selectedAgentUuids={selectedAgentUuids}
@@ -1781,11 +1784,7 @@ export function BulkUploadTestsModal({
                 </button>
                 <button
                   onClick={handleSubmit}
-                  disabled={
-                    isUploading ||
-                    parsedTests.length === 0 ||
-                    (!lockedAgentUuid && selectedAgentUuids.length === 0)
-                  }
+                  disabled={isUploading || parsedTests.length === 0}
                   className="h-10 px-5 rounded-lg text-sm font-medium bg-foreground text-background hover:opacity-90 transition-opacity cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2"
                 >
                   {isUploading ? (

--- a/src/components/BulkUploadTestsModal.tsx
+++ b/src/components/BulkUploadTestsModal.tsx
@@ -174,8 +174,9 @@ const TOOL_CALL_FIELDS: GuidelineField[] = [
     name: "tool",
     meta: "(required, string)",
     description:
-      'The identifier of the tool the agent is expected to call. For custom tools, use the tool name exactly as configured under your Tools tab. For Calibrate inbuilt tools, use the inbuilt tool id (currently end_call for the End-conversation tool). The tool must exist on your workspace — uploads referencing unknown tools are rejected before submit.',
-    example: '"book_room"   // or "end_call" for the inbuilt End-conversation tool',
+      "The identifier of the tool the agent is expected to call. For custom tools, use the tool name exactly as configured under your Tools tab. For Calibrate inbuilt tools, use the inbuilt tool id (currently end_call for the End-conversation tool). The tool must exist on your workspace — uploads referencing unknown tools are rejected before submit.",
+    example:
+      '"book_room"   // or "end_call" for the inbuilt End-conversation tool',
   },
   {
     name: "arguments",
@@ -218,6 +219,10 @@ export function BulkUploadTestsModal({
   // the upload as soon as data is available without forcing a re-upload.
   const [pendingFile, setPendingFile] = useState<File | null>(null);
   const [selectedAgentUuids, setSelectedAgentUuids] = useState<string[]>([]);
+  // Number of agents in the workspace, learned from the agent picker once it
+  // loads. `null` = not resolved yet. When it resolves to 0 the whole "Assign
+  // tests to agents" section is hidden (nothing to pick).
+  const [agentCount, setAgentCount] = useState<number | null>(null);
   const [isUploading, setIsUploading] = useState(false);
   const [uploadError, setUploadError] = useState<string | null>(null);
   const [uploadWarnings, setUploadWarnings] = useState<string[] | null>(null);
@@ -268,6 +273,7 @@ export function BulkUploadTestsModal({
       setParseError(null);
       setPendingFile(null);
       setSelectedAgentUuids([]);
+      setAgentCount(null);
       setIsUploading(false);
       setUploadError(null);
       setUploadWarnings(null);
@@ -530,12 +536,11 @@ export function BulkUploadTestsModal({
         {
           name: "tool_calls",
           description:
-            'A JSON array of expected tool call objects. Each object describes a tool the agent is expected to call and what arguments to expect. The array may contain multiple entries if the agent is expected to call multiple tools — order is not significant. Each object has the following fields:',
+            "A JSON array of expected tool call objects. Each object describes a tool the agent is expected to call and what arguments to expect. The array may contain multiple entries if the agent is expected to call multiple tools — order is not significant. Each object has the following fields:",
           fields: TOOL_CALL_FIELDS,
           trailingExamples: [
             {
-              label:
-                "Example 1 — single tool call with exact-match arguments",
+              label: "Example 1 — single tool call with exact-match arguments",
               example:
                 '[{\n  "tool": "book_room",\n  "arguments": {\n    "room": { "match_type": "exact", "value": "101" }\n  }\n}]',
             },
@@ -1725,8 +1730,13 @@ export function BulkUploadTestsModal({
           {/* Step 3: Assign to Agents (optional, hidden when modal is locked
               to a specific agent — see lockedAgentUuid prop). Linking is not
               required: tests can be uploaded to the library and attached to an
-              agent later, so a workspace with no agents yet isn't blocked. */}
-          {testType && parsedTests.length > 0 && !lockedAgentUuid && (
+              agent later, so a workspace with no agents yet isn't blocked.
+              The whole section is also hidden once we learn the workspace has
+              no agents at all (agentCount === 0) — nothing to pick. */}
+          {testType &&
+            parsedTests.length > 0 &&
+            !lockedAgentUuid &&
+            agentCount !== 0 && (
             <div ref={assignAgentsSectionRef}>
               <div className="flex items-center gap-2 mb-1">
                 <span className="text-sm font-medium text-foreground">
@@ -1737,12 +1747,13 @@ export function BulkUploadTestsModal({
                 </span>
               </div>
               <p className="text-xs text-muted-foreground mb-3">
-                Optionally link these tests to one or more agents — you can
-                attach them later instead.
+                Automatically link these tests to one or more agents but you can
+                also attach them later
               </p>
               <MultiAgentPicker
                 selectedAgentUuids={selectedAgentUuids}
                 onToggleAgent={toggleAgentSelection}
+                onAgentsLoaded={(agents) => setAgentCount(agents.length)}
               />
             </div>
           )}

--- a/src/components/ExportZipButton.tsx
+++ b/src/components/ExportZipButton.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { reportError } from "@/lib/reportError";
 
 import React, { useState } from "react";
 import JSZip from "jszip";
@@ -101,7 +102,7 @@ export function ExportZipButton({
             result.reason instanceof Error
               ? result.reason.message
               : String(result.reason);
-          console.error(`Export: failed to fetch ${file.url}`, result.reason);
+          reportError(`Export: failed to fetch ${file.url}`, result.reason);
           zip.file(`${file.path}.error.txt`, message);
         }
       });

--- a/src/components/NewSimulationDialog.tsx
+++ b/src/components/NewSimulationDialog.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { reportError } from "@/lib/reportError";
 
 import React, { useState } from "react";
 import { signOut } from "next-auth/react";
@@ -74,7 +75,7 @@ export function NewSimulationDialog({
         onCreateSimulation(simulationUuid);
       }
     } catch (err) {
-      console.error("Error creating simulation:", err);
+      reportError("Error creating simulation:", err);
       setError(
         err instanceof Error ? err.message : "Failed to create simulation"
       );

--- a/src/components/TestRunnerDialog.tsx
+++ b/src/components/TestRunnerDialog.tsx
@@ -162,15 +162,6 @@ export function TestRunnerDialog({
   // immediately re-trigger the auto-open, making the list view unreachable.
   const hasAutoSelectedRef = useRef(false);
 
-  // Debug: Log when selectedTestUuid changes
-  useEffect(() => {
-    console.log("selectedTestUuid changed to:", selectedTestUuid);
-    console.log(
-      "testResults:",
-      testResults.map((r) => ({ uuid: r.test.uuid, name: r.test.name })),
-    );
-  }, [selectedTestUuid, testResults]);
-
   // Auto-open the first completed test when nothing is selected. Covers both
   // - live runs: as soon as one test transitions to passed/failed (and the
   //   user hasn't manually picked anything), open it.
@@ -854,16 +845,6 @@ export function TestRunnerDialog({
   const selectedResult = testResults.find(
     (r) => r.test.uuid === selectedTestUuid,
   );
-
-  // Debug: Log selectedResult
-  useEffect(() => {
-    console.log(
-      "selectedResult:",
-      selectedResult
-        ? { name: selectedResult.test.name, status: selectedResult.status }
-        : null,
-    );
-  }, [selectedResult]);
 
   const passedTests = testResults.filter((r) => r.status === "passed");
   const failedTests = testResults.filter((r) => r.status === "failed");

--- a/src/components/TestRunnerDialog.tsx
+++ b/src/components/TestRunnerDialog.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { reportError } from "@/lib/reportError";
 
 import React, { useState, useEffect, useRef } from "react";
 import { signOut } from "next-auth/react";
@@ -470,7 +471,7 @@ export function TestRunnerDialog({
         }
       }
     } catch (error) {
-      console.error("Error polling task status:", error);
+      reportError("Error polling task status:", error);
       setRunStatus("failed");
       setIsRunning(false);
       setCurrentTaskId(null);
@@ -492,7 +493,7 @@ export function TestRunnerDialog({
 
     const backendUrl = process.env.NEXT_PUBLIC_BACKEND_URL;
     if (!backendUrl) {
-      console.error("BACKEND_URL environment variable is not set");
+      reportError("BACKEND_URL environment variable is not set");
       setIsRunning(false);
       return;
     }
@@ -542,7 +543,7 @@ export function TestRunnerDialog({
       // Also poll immediately to get the first result
       pollTaskStatus(newTaskId, backendUrl);
     } catch (error) {
-      console.error("Error starting test run:", error);
+      reportError("Error starting test run:", error);
       setTestResults((prev) =>
         prev.map((r) => ({
           ...r,
@@ -741,7 +742,7 @@ export function TestRunnerDialog({
 
     const backendUrl = process.env.NEXT_PUBLIC_BACKEND_URL;
     if (!backendUrl) {
-      console.error("BACKEND_URL environment variable is not set");
+      reportError("BACKEND_URL environment variable is not set");
       setIsRunning(false);
       return;
     }
@@ -810,7 +811,7 @@ export function TestRunnerDialog({
         setIsRunning(false);
       }
     } catch (error) {
-      console.error("Error retrying failed tests:", error);
+      reportError("Error retrying failed tests:", error);
       setTestResults((prev) =>
         prev.map((r) =>
           r.status === "running"

--- a/src/components/agent-tabs/AddToolDialog.tsx
+++ b/src/components/agent-tabs/AddToolDialog.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { reportError } from "@/lib/reportError";
 
 import React, { useState } from "react";
 import { signOut } from "next-auth/react";
@@ -88,7 +89,7 @@ export function AddToolDialog({
       // Close dialog and reset state
       handleClose();
     } catch (err) {
-      console.error("Error adding tools to agent:", err);
+      reportError("Error adding tools to agent:", err);
     }
   };
 

--- a/src/components/agent-tabs/DeleteToolDialog.tsx
+++ b/src/components/agent-tabs/DeleteToolDialog.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { reportError } from "@/lib/reportError";
 
 import React, { useState } from "react";
 import { signOut } from "next-auth/react";
@@ -76,7 +77,7 @@ export function DeleteToolDialog({
       onToolDeleted(tool.uuid);
       onClose();
     } catch (err) {
-      console.error("Error removing tool from agent:", err);
+      reportError("Error removing tool from agent:", err);
     } finally {
       setIsDeleting(false);
     }

--- a/src/components/agent-tabs/TestsTabContent.tsx
+++ b/src/components/agent-tabs/TestsTabContent.tsx
@@ -2400,10 +2400,10 @@ export function TestsTabContent({
           deleteMode === "permanent"
             ? testsToDeleteBulk.length > 0
               ? `Are you sure you want to permanently delete ${testsToDeleteBulk.length} test${testsToDeleteBulk.length > 1 ? "s" : ""} from your library? This will remove them from every agent and cannot be undone.`
-              : `Permanently deleting "${testToDelete?.name}" will remove it from every agent that uses it and cannot be undone.`
+              : `Permanently deleting this test will remove it from every agent that uses it and cannot be undone.`
             : testsToDeleteBulk.length > 0
               ? `Are you sure you want to remove ${testsToDeleteBulk.length} test${testsToDeleteBulk.length > 1 ? "s" : ""} from this agent?`
-              : `Are you sure you want to remove "${testToDelete?.name}" from this agent? It will stay in your test library and on any other agents that use it.`
+              : `Are you sure you want to remove this test from this agent? It will stay in your test library and on any other agents that use it.`
         }
         // Keep confirmText a single word — the dialog auto-suffixes "ing..." while
         // submitting by stripping a trailing 'e', which only works on one-token labels.

--- a/src/components/agent-tabs/TestsTabContent.tsx
+++ b/src/components/agent-tabs/TestsTabContent.tsx
@@ -713,14 +713,13 @@ export function TestsTabContent({
         throw new Error("Failed to add tests to agent");
       }
 
-      // Prepend the newly-attached tests so they surface at the top of the
-      // table (most-recently-added first) rather than the bottom.
-      const selected = new Set(testUuids);
-      const addedTests = availableTests.filter((t) => selected.has(t.uuid));
-      setAgentTests((prev) => [...addedTests, ...prev]);
+      // Refetch the agent's tests instead of locally splicing them in, so the
+      // table reflects the backend's ordering rather than a hardcoded
+      // top/bottom placement.
       setShowTestDropdown(false);
       setSearchQuery("");
       setSelectedAvailableUuids(new Set());
+      await fetchAgentTests();
     } catch (err) {
       console.error("Error adding tests to agent:", err);
     } finally {

--- a/src/components/agent-tabs/TestsTabContent.tsx
+++ b/src/components/agent-tabs/TestsTabContent.tsx
@@ -713,10 +713,11 @@ export function TestsTabContent({
         throw new Error("Failed to add tests to agent");
       }
 
-      // Add the newly-attached tests to local state, preserving order.
+      // Prepend the newly-attached tests so they surface at the top of the
+      // table (most-recently-added first) rather than the bottom.
       const selected = new Set(testUuids);
       const addedTests = availableTests.filter((t) => selected.has(t.uuid));
-      setAgentTests((prev) => [...prev, ...addedTests]);
+      setAgentTests((prev) => [...addedTests, ...prev]);
       setShowTestDropdown(false);
       setSearchQuery("");
       setSelectedAvailableUuids(new Set());

--- a/src/components/agent-tabs/TestsTabContent.tsx
+++ b/src/components/agent-tabs/TestsTabContent.tsx
@@ -144,6 +144,48 @@ function formatRelativeTime(dateString: string): string {
   return `${diffInYears}y ago`;
 }
 
+/**
+ * Square check indicator shared by every test checkbox — the attach-existing
+ * dropdown (select-all + rows) and the agent tests table (select-all + desktop
+ * and mobile rows). Renders only the box and checkmark; the caller owns the
+ * click target. Pass `hoverBorder` for the table variant (border highlights on
+ * hover) and `className` for layout tweaks like `mt-0.5`.
+ */
+function TestCheckbox({
+  checked,
+  hoverBorder = false,
+  className = "",
+}: {
+  checked: boolean;
+  hoverBorder?: boolean;
+  className?: string;
+}) {
+  const stateClass = checked
+    ? "bg-foreground border-foreground"
+    : `border-border${hoverBorder ? " hover:border-muted-foreground" : ""}`;
+  return (
+    <span
+      className={`w-5 h-5 rounded border flex-shrink-0 flex items-center justify-center transition-colors ${stateClass} ${className}`}
+    >
+      {checked && (
+        <svg
+          className="w-3 h-3 text-background"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+          strokeWidth={3}
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M4.5 12.75l6 6 9-13.5"
+          />
+        </svg>
+      )}
+    </span>
+  );
+}
+
 type TestsTabContentProps = {
   agentUuid: string;
   agentName?: string;
@@ -1365,29 +1407,7 @@ export function TestsTabContent({
               onClick={toggleSelectAllAvailable}
               className="w-full flex items-center gap-2.5 px-4 py-2 border-b border-border hover:bg-muted/50 transition-colors cursor-pointer text-left"
             >
-              <span
-                className={`w-5 h-5 rounded border flex-shrink-0 flex items-center justify-center transition-colors ${
-                  allFilteredAvailableSelected
-                    ? "bg-foreground border-foreground"
-                    : "border-border"
-                }`}
-              >
-                {allFilteredAvailableSelected && (
-                  <svg
-                    className="w-3 h-3 text-background"
-                    fill="none"
-                    viewBox="0 0 24 24"
-                    stroke="currentColor"
-                    strokeWidth={3}
-                  >
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      d="M4.5 12.75l6 6 9-13.5"
-                    />
-                  </svg>
-                )}
-              </span>
+              <TestCheckbox checked={allFilteredAvailableSelected} />
               <span className="text-sm font-medium text-foreground">
                 Select all
                 {searchQuery ? " matching" : ""}
@@ -1437,29 +1457,7 @@ export function TestsTabContent({
                     onClick={() => toggleAvailableTest(test.uuid)}
                     className="w-full flex items-start gap-2.5 px-4 py-3 text-left hover:bg-muted/50 transition-colors cursor-pointer border-b border-border last:border-b-0"
                   >
-                    <span
-                      className={`mt-0.5 w-5 h-5 rounded border flex-shrink-0 flex items-center justify-center transition-colors ${
-                        checked
-                          ? "bg-foreground border-foreground"
-                          : "border-border"
-                      }`}
-                    >
-                      {checked && (
-                        <svg
-                          className="w-3 h-3 text-background"
-                          fill="none"
-                          viewBox="0 0 24 24"
-                          stroke="currentColor"
-                          strokeWidth={3}
-                        >
-                          <path
-                            strokeLinecap="round"
-                            strokeLinejoin="round"
-                            d="M4.5 12.75l6 6 9-13.5"
-                          />
-                        </svg>
-                      )}
-                    </span>
+                    <TestCheckbox checked={checked} className="mt-0.5" />
                     <span className="min-w-0 flex-1">
                       <span className="block text-sm font-medium text-foreground truncate">
                         {test.name}
@@ -2051,31 +2049,17 @@ export function TestsTabContent({
                       <button
                         type="button"
                         onClick={toggleSelectAll}
-                        className={`w-5 h-5 rounded border flex-shrink-0 flex items-center justify-center transition-colors cursor-pointer ${
-                          selectedTestUuids.size ===
-                            filteredAgentTests.length &&
-                          filteredAgentTests.length > 0
-                            ? "bg-foreground border-foreground"
-                            : "border-border hover:border-muted-foreground"
-                        }`}
+                        className="cursor-pointer"
                         title="Select all"
                       >
-                        {selectedTestUuids.size === filteredAgentTests.length &&
-                          filteredAgentTests.length > 0 && (
-                            <svg
-                              className="w-3 h-3 text-background"
-                              fill="none"
-                              viewBox="0 0 24 24"
-                              stroke="currentColor"
-                              strokeWidth={3}
-                            >
-                              <path
-                                strokeLinecap="round"
-                                strokeLinejoin="round"
-                                d="M4.5 12.75l6 6 9-13.5"
-                              />
-                            </svg>
-                          )}
+                        <TestCheckbox
+                          checked={
+                            selectedTestUuids.size ===
+                              filteredAgentTests.length &&
+                            filteredAgentTests.length > 0
+                          }
+                          hoverBorder
+                        />
                       </button>
                     </div>
                     <div className="text-sm font-medium text-muted-foreground">
@@ -2103,28 +2087,13 @@ export function TestsTabContent({
                             e.stopPropagation();
                             toggleTestSelection(test.uuid);
                           }}
-                          className={`w-5 h-5 rounded border flex-shrink-0 flex items-center justify-center transition-colors cursor-pointer ${
-                            selectedTestUuids.has(test.uuid)
-                              ? "bg-foreground border-foreground"
-                              : "border-border hover:border-muted-foreground"
-                          }`}
+                          className="cursor-pointer"
                           title="Select test"
                         >
-                          {selectedTestUuids.has(test.uuid) && (
-                            <svg
-                              className="w-3 h-3 text-background"
-                              fill="none"
-                              viewBox="0 0 24 24"
-                              stroke="currentColor"
-                              strokeWidth={3}
-                            >
-                              <path
-                                strokeLinecap="round"
-                                strokeLinejoin="round"
-                                d="M4.5 12.75l6 6 9-13.5"
-                              />
-                            </svg>
-                          )}
+                          <TestCheckbox
+                            checked={selectedTestUuids.has(test.uuid)}
+                            hoverBorder
+                          />
                         </button>
                       </div>
                       {/* Name Column */}
@@ -2267,28 +2236,13 @@ export function TestsTabContent({
                               e.stopPropagation();
                               toggleTestSelection(test.uuid);
                             }}
-                            className={`w-5 h-5 mt-0.5 rounded border flex-shrink-0 flex items-center justify-center transition-colors cursor-pointer ${
-                              selectedTestUuids.has(test.uuid)
-                                ? "bg-foreground border-foreground"
-                                : "border-border hover:border-muted-foreground"
-                            }`}
+                            className="mt-0.5 cursor-pointer"
                             title="Select test"
                           >
-                            {selectedTestUuids.has(test.uuid) && (
-                              <svg
-                                className="w-3 h-3 text-background"
-                                fill="none"
-                                viewBox="0 0 24 24"
-                                stroke="currentColor"
-                                strokeWidth={3}
-                              >
-                                <path
-                                  strokeLinecap="round"
-                                  strokeLinejoin="round"
-                                  d="M4.5 12.75l6 6 9-13.5"
-                                />
-                              </svg>
-                            )}
+                            <TestCheckbox
+                              checked={selectedTestUuids.has(test.uuid)}
+                              hoverBorder
+                            />
                           </button>
                           <div className="flex-1 min-w-0">
                             <h4 className="text-sm font-medium text-foreground truncate">

--- a/src/components/agent-tabs/TestsTabContent.tsx
+++ b/src/components/agent-tabs/TestsTabContent.tsx
@@ -192,6 +192,13 @@ export function TestsTabContent({
   // UI state
   const [showTestDropdown, setShowTestDropdown] = useState(false);
   const [searchQuery, setSearchQuery] = useState("");
+  // Attach-existing dropdown multi-select. Holds the uuids ticked in the
+  // dropdown (distinct from `selectedTestUuids`, which drives the agent
+  // tests table's bulk actions). Cleared whenever the dropdown closes.
+  const [selectedAvailableUuids, setSelectedAvailableUuids] = useState<
+    Set<string>
+  >(new Set());
+  const [isAddingTests, setIsAddingTests] = useState(false);
   const [testsSearchQuery, setTestsSearchQuery] = useState("");
   // Filter the agent's tests by test type. "all" shows both kinds; "response"
   // is Next Reply, "tool_call" is Tool Call. The "select all" checkbox keys
@@ -428,6 +435,7 @@ export function TestsTabContent({
       ) {
         setShowTestDropdown(false);
         setSearchQuery("");
+        setSelectedAvailableUuids(new Set());
       }
     };
 
@@ -619,6 +627,14 @@ export function TestsTabContent({
         test.description.toLowerCase().includes(searchQuery.toLowerCase())),
   );
 
+  // True when every currently-visible (filtered) dropdown row is selected;
+  // drives the select-all header's checked state.
+  const allFilteredAvailableSelected =
+    filteredAvailableTests.length > 0 &&
+    filteredAvailableTests.every((test) =>
+      selectedAvailableUuids.has(test.uuid),
+    );
+
   // Filter agent tests by search query AND test type. Both filters apply
   // together (AND). The type filter also constrains the select-all checkbox
   // since it operates on `filteredAgentTests`.
@@ -632,14 +648,50 @@ export function TestsTabContent({
     );
   });
 
-  // Add test to agent
-  const handleSelectTest = async (test: TestData) => {
+  // Toggle a single test's selection in the attach-existing dropdown.
+  const toggleAvailableTest = (uuid: string) => {
+    setSelectedAvailableUuids((prev) => {
+      const next = new Set(prev);
+      if (next.has(uuid)) {
+        next.delete(uuid);
+      } else {
+        next.add(uuid);
+      }
+      return next;
+    });
+  };
+
+  // Select-all toggle scoped to the *filtered* dropdown list, so when a
+  // search query narrows the dropdown only those rows get selected.
+  const toggleSelectAllAvailable = () => {
+    const filteredUuids = filteredAvailableTests.map((t) => t.uuid);
+    const allFilteredSelected =
+      filteredUuids.length > 0 &&
+      filteredUuids.every((uuid) => selectedAvailableUuids.has(uuid));
+    setSelectedAvailableUuids((prev) => {
+      const next = new Set(prev);
+      if (allFilteredSelected) {
+        filteredUuids.forEach((uuid) => next.delete(uuid));
+      } else {
+        filteredUuids.forEach((uuid) => next.add(uuid));
+      }
+      return next;
+    });
+  };
+
+  // Attach all selected tests to the agent in a single request. The
+  // /agent-tests endpoint accepts an array of test_uuids, so a multi-select
+  // add is one POST rather than one per test.
+  const handleAddSelectedTests = async () => {
+    if (selectedAvailableUuids.size === 0) return;
     try {
+      setIsAddingTests(true);
       const backendUrl = process.env.NEXT_PUBLIC_BACKEND_URL;
       if (!backendUrl) {
         throw new Error("BACKEND_URL environment variable is not set");
       }
 
+      const testUuids = Array.from(selectedAvailableUuids);
       const response = await fetch(`${backendUrl}/agent-tests`, {
         method: "POST",
         headers: {
@@ -648,7 +700,7 @@ export function TestsTabContent({
         },
         body: JSON.stringify({
           agent_uuid: agentUuid,
-          test_uuids: [test.uuid],
+          test_uuids: testUuids,
         }),
       });
 
@@ -658,15 +710,20 @@ export function TestsTabContent({
       }
 
       if (!response.ok) {
-        throw new Error("Failed to add test to agent");
+        throw new Error("Failed to add tests to agent");
       }
 
-      // Add the test to local state
-      setAgentTests((prev) => [...prev, test]);
+      // Add the newly-attached tests to local state, preserving order.
+      const selected = new Set(testUuids);
+      const addedTests = availableTests.filter((t) => selected.has(t.uuid));
+      setAgentTests((prev) => [...prev, ...addedTests]);
       setShowTestDropdown(false);
       setSearchQuery("");
+      setSelectedAvailableUuids(new Set());
     } catch (err) {
-      console.error("Error adding test to agent:", err);
+      console.error("Error adding tests to agent:", err);
+    } finally {
+      setIsAddingTests(false);
     }
   };
 
@@ -1299,6 +1356,43 @@ export function TestsTabContent({
               />
             </div>
           </div>
+          {/* Select-all header — scoped to the filtered list so a search
+              query narrows what "select all" picks. */}
+          {!allTestsLoading && filteredAvailableTests.length > 0 && (
+            <button
+              type="button"
+              onClick={toggleSelectAllAvailable}
+              className="w-full flex items-center gap-2.5 px-4 py-2 border-b border-border hover:bg-muted/50 transition-colors cursor-pointer text-left"
+            >
+              <span
+                className={`w-5 h-5 rounded border flex-shrink-0 flex items-center justify-center transition-colors ${
+                  allFilteredAvailableSelected
+                    ? "bg-foreground border-foreground"
+                    : "border-border"
+                }`}
+              >
+                {allFilteredAvailableSelected && (
+                  <svg
+                    className="w-3 h-3 text-background"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                    strokeWidth={3}
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      d="M4.5 12.75l6 6 9-13.5"
+                    />
+                  </svg>
+                )}
+              </span>
+              <span className="text-sm font-medium text-foreground">
+                Select all
+                {searchQuery ? " matching" : ""}
+              </span>
+            </button>
+          )}
           <div className="max-h-64 overflow-y-auto">
             {allTestsLoading ? (
               <div className="flex items-center justify-center py-8">
@@ -1322,34 +1416,87 @@ export function TestsTabContent({
                   ></path>
                 </svg>
               </div>
-            ) : filteredAvailableTests.length === 0 ? (
+            ) : availableTests.length === 0 ? (
               <div className="py-8 text-center">
                 <p className="text-sm text-muted-foreground">
-                  {searchQuery ? "No tests found" : "No tests available"}
+                  All tests have been added to this agent
                 </p>
               </div>
+            ) : filteredAvailableTests.length === 0 ? (
+              <div className="py-8 text-center">
+                <p className="text-sm text-muted-foreground">No tests found</p>
+              </div>
             ) : (
-              filteredAvailableTests.map((test) => (
-                <button
-                  key={test.uuid}
-                  onClick={() => handleSelectTest(test)}
-                  className="w-full px-4 py-3 text-left hover:bg-muted/50 transition-colors cursor-pointer border-b border-border last:border-b-0"
-                >
-                  <p className="text-sm font-medium text-foreground truncate">
-                    {test.name}
-                  </p>
-                  {test.description && (
-                    <p className="text-xs text-muted-foreground mt-0.5 line-clamp-2">
-                      {test.description}
-                    </p>
-                  )}
-                  <span className="inline-block mt-1 px-2 py-0.5 text-xs rounded-full bg-muted text-muted-foreground">
-                    {testTypeLabel(test.type)}
-                  </span>
-                </button>
-              ))
+              filteredAvailableTests.map((test) => {
+                const checked = selectedAvailableUuids.has(test.uuid);
+                return (
+                  <button
+                    key={test.uuid}
+                    type="button"
+                    onClick={() => toggleAvailableTest(test.uuid)}
+                    className="w-full flex items-start gap-2.5 px-4 py-3 text-left hover:bg-muted/50 transition-colors cursor-pointer border-b border-border last:border-b-0"
+                  >
+                    <span
+                      className={`mt-0.5 w-5 h-5 rounded border flex-shrink-0 flex items-center justify-center transition-colors ${
+                        checked
+                          ? "bg-foreground border-foreground"
+                          : "border-border"
+                      }`}
+                    >
+                      {checked && (
+                        <svg
+                          className="w-3 h-3 text-background"
+                          fill="none"
+                          viewBox="0 0 24 24"
+                          stroke="currentColor"
+                          strokeWidth={3}
+                        >
+                          <path
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                            d="M4.5 12.75l6 6 9-13.5"
+                          />
+                        </svg>
+                      )}
+                    </span>
+                    <span className="min-w-0 flex-1">
+                      <span className="block text-sm font-medium text-foreground truncate">
+                        {test.name}
+                      </span>
+                      {test.description && (
+                        <span className="block text-xs text-muted-foreground mt-0.5 line-clamp-2">
+                          {test.description}
+                        </span>
+                      )}
+                      <span className="inline-block mt-1 px-2 py-0.5 text-xs rounded-full bg-muted text-muted-foreground">
+                        {testTypeLabel(test.type)}
+                      </span>
+                    </span>
+                  </button>
+                );
+              })
             )}
           </div>
+          {/* Footer — confirm the multi-select. Hidden when there's nothing
+              to attach so the empty/loading states stand alone. */}
+          {!allTestsLoading && availableTests.length > 0 && (
+            <div className="p-3 border-t border-border">
+              <button
+                type="button"
+                onClick={handleAddSelectedTests}
+                disabled={selectedAvailableUuids.size === 0 || isAddingTests}
+                className="w-full h-9 rounded-md text-sm font-medium bg-foreground text-background transition-opacity cursor-pointer hover:opacity-90 disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                {isAddingTests
+                  ? "Adding..."
+                  : selectedAvailableUuids.size > 0
+                    ? `Add ${selectedAvailableUuids.size} ${
+                        selectedAvailableUuids.size === 1 ? "test" : "tests"
+                      }`
+                    : "Add tests"}
+              </button>
+            </div>
+          )}
         </div>
       )}
     </div>
@@ -1581,107 +1728,7 @@ export function TestsTabContent({
 
           {/* Right group: add-more-tests buttons. */}
           <div className="flex flex-wrap items-center gap-2 md:gap-3">
-            <div className="relative" ref={dropdownRef}>
-              <button
-                onClick={() => setShowTestDropdown(!showTestDropdown)}
-                className={ADD_TEST_BUTTON_CLASS}
-              >
-                Add test
-              </button>
-
-              {/* Test Selection Dropdown */}
-              {showTestDropdown && (
-                <div className="absolute top-full left-0 mt-2 w-80 bg-background border border-border rounded-lg shadow-lg z-50">
-                  {/* Search Input */}
-                  <div className="p-3 border-b border-border">
-                    <div className="relative">
-                      <div className="absolute inset-y-0 left-0 flex items-center pl-3 pointer-events-none">
-                        <svg
-                          className="w-4 h-4 text-muted-foreground"
-                          fill="none"
-                          viewBox="0 0 24 24"
-                          stroke="currentColor"
-                          strokeWidth={2}
-                        >
-                          <path
-                            strokeLinecap="round"
-                            strokeLinejoin="round"
-                            d="M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 5.196a7.5 7.5 0 0010.607 10.607z"
-                          />
-                        </svg>
-                      </div>
-                      <input
-                        type="text"
-                        value={searchQuery}
-                        onChange={(e) => setSearchQuery(e.target.value)}
-                        placeholder="Search tests"
-                        className="w-full h-9 pl-9 pr-3 rounded-md text-sm border border-border bg-background text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-accent focus:border-transparent"
-                        autoFocus
-                      />
-                    </div>
-                  </div>
-
-                  {/* Tests List */}
-                  <div className="max-h-64 overflow-y-auto">
-                    {allTestsLoading ? (
-                      <div className="flex items-center justify-center py-8">
-                        <svg
-                          className="w-5 h-5 animate-spin text-muted-foreground"
-                          fill="none"
-                          viewBox="0 0 24 24"
-                        >
-                          <circle
-                            className="opacity-25"
-                            cx="12"
-                            cy="12"
-                            r="10"
-                            stroke="currentColor"
-                            strokeWidth="4"
-                          ></circle>
-                          <path
-                            className="opacity-75"
-                            fill="currentColor"
-                            d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
-                          ></path>
-                        </svg>
-                      </div>
-                    ) : availableTests.length === 0 ? (
-                      <div className="py-8 text-center">
-                        <p className="text-sm text-muted-foreground">
-                          All tests have been added to this agent
-                        </p>
-                      </div>
-                    ) : filteredAvailableTests.length === 0 ? (
-                      <div className="py-8 text-center">
-                        <p className="text-sm text-muted-foreground">
-                          No tests found
-                        </p>
-                      </div>
-                    ) : (
-                      filteredAvailableTests.map((test) => (
-                        <button
-                          key={test.uuid}
-                          onClick={() => handleSelectTest(test)}
-                          className="w-full px-4 py-3 text-left hover:bg-muted/50 transition-colors cursor-pointer border-b border-border last:border-b-0"
-                        >
-                          <p className="text-sm font-medium text-foreground truncate">
-                            {test.name}
-                          </p>
-                          {test.description && (
-                            <p className="text-xs text-muted-foreground mt-0.5 line-clamp-2">
-                              {test.description}
-                            </p>
-                          )}
-                          <span className="inline-block mt-1 px-2 py-0.5 text-xs rounded-full bg-muted text-muted-foreground">
-                            {testTypeLabel(test.type)}
-                          </span>
-                        </button>
-                      ))
-                    )}
-                  </div>
-                </div>
-              )}
-            </div>
+            {renderAddTestControl()}
             {/* Create test / Bulk upload (new tests, auto-attached to this agent) */}
             {renderNewTestButtons()}
           </div>

--- a/src/components/agent-tabs/TestsTabContent.tsx
+++ b/src/components/agent-tabs/TestsTabContent.tsx
@@ -2040,8 +2040,13 @@ export function TestsTabContent({
               <>
                 {/* Desktop Table */}
                 <div className="hidden md:block border border-border rounded-xl overflow-hidden">
+                  {/* The list scrolls on its own so the search, filters, and
+                      surrounding page chrome stay in place for long test
+                      lists; the header is pinned to the top via `sticky` and
+                      given an opaque background so rows don't show through. */}
+                  <div className="overflow-y-auto max-h-[60vh]">
                   {/* Table Header */}
-                  <div className="grid grid-cols-[40px_minmax(0,1fr)_120px_auto_auto_auto] gap-4 px-4 py-2 border-b border-border bg-muted/30">
+                  <div className="grid grid-cols-[40px_minmax(0,1fr)_120px_auto_auto_auto] gap-4 px-4 py-2 border-b border-border bg-background sticky top-0 z-10">
                     <div className="flex items-center">
                       <button
                         type="button"
@@ -2243,10 +2248,11 @@ export function TestsTabContent({
                         </button>
                       </div>
                     </div>
-                  ))}
+                    ))}
+                  </div>
                 </div>
                 {/* Mobile Cards */}
-                <div className="md:hidden space-y-3">
+                <div className="md:hidden space-y-3 overflow-y-auto max-h-[60vh]">
                   {filteredAgentTests.map((test) => (
                     <div
                       key={test.uuid}

--- a/src/components/agent-tabs/TestsTabContent.tsx
+++ b/src/components/agent-tabs/TestsTabContent.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { reportError } from "@/lib/reportError";
 
 import React, { useState, useEffect, useRef, useCallback } from "react";
 import { signOut } from "next-auth/react";
@@ -339,7 +340,7 @@ export function TestsTabContent({
       const data: TestData[] = await response.json();
       setAgentTests(data);
     } catch (err) {
-      console.error("Error fetching agent tests:", err);
+      reportError("Error fetching agent tests:", err);
       setAgentTestsError(
         err instanceof Error ? err.message : "Failed to load agent tests",
       );
@@ -385,7 +386,7 @@ export function TestsTabContent({
       setAllTests(data);
       setAllTestsFetched(true);
     } catch (err) {
-      console.error("Error fetching tests:", err);
+      reportError("Error fetching tests:", err);
     } finally {
       setAllTestsLoading(false);
       // Mark the attempt complete regardless of outcome so the empty-
@@ -475,14 +476,14 @@ export function TestsTabContent({
 
         if (!response.ok) {
           // Silently handle errors for past runs - it's not critical
-          console.error("Failed to fetch past runs");
+          reportError("Failed to fetch past runs");
           return;
         }
 
         const data = await response.json();
         setPastRuns(data.runs || []);
       } catch (err) {
-        console.error("Error fetching past runs:", err);
+        reportError("Error fetching past runs:", err);
       } finally {
         setPastRunsLoading(false);
       }
@@ -576,7 +577,7 @@ export function TestsTabContent({
             }),
           );
         } catch (err) {
-          console.error(`Error polling run ${run.uuid}:`, err);
+          reportError(`Error polling run ${run.uuid}:`, err);
           // Mark this specific run as failed
           setPastRuns((prev) =>
             prev.map((r) =>
@@ -721,7 +722,7 @@ export function TestsTabContent({
       setSelectedAvailableUuids(new Set());
       await fetchAgentTests();
     } catch (err) {
-      console.error("Error adding tests to agent:", err);
+      reportError("Error adding tests to agent:", err);
     } finally {
       setIsAddingTests(false);
     }
@@ -818,7 +819,7 @@ export function TestsTabContent({
       setValidationAttempted(false);
       setCreateDialogOpen(false);
     } catch (err) {
-      console.error("Error creating test:", err);
+      reportError("Error creating test:", err);
       setCreateError(
         err instanceof Error ? err.message : "Failed to create test",
       );
@@ -898,7 +899,7 @@ export function TestsTabContent({
         setInitialEvaluators([]);
       }
     } catch (err) {
-      console.error("Error fetching test:", err);
+      reportError("Error fetching test:", err);
       setCreateError(
         err instanceof Error ? err.message : "Failed to load test",
       );
@@ -962,7 +963,7 @@ export function TestsTabContent({
         setInitialEvaluators([]);
       }
     } catch (err) {
-      console.error("Error duplicating test:", err);
+      reportError("Error duplicating test:", err);
       setCreateError(
         err instanceof Error ? err.message : "Failed to load test",
       );
@@ -1039,7 +1040,7 @@ export function TestsTabContent({
       setCreateDialogOpen(false);
       resetTestDialog();
     } catch (err) {
-      console.error("Error updating test:", err);
+      reportError("Error updating test:", err);
       setCreateError(
         err instanceof Error ? err.message : "Failed to update test",
       );
@@ -1266,7 +1267,7 @@ export function TestsTabContent({
       setSelectedTestUuids(new Set());
       closeDeleteDialog();
     } catch (err) {
-      console.error(
+      reportError(
         deleteMode === "permanent"
           ? "Error deleting test(s):"
           : "Error removing test(s) from agent:",

--- a/src/components/evaluations/SpeechToTextEvaluation.tsx
+++ b/src/components/evaluations/SpeechToTextEvaluation.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { reportError } from "@/lib/reportError";
 
 import { useState, useRef, useEffect } from "react";
 import { useRouter } from "next/navigation";
@@ -224,7 +225,7 @@ export function SpeechToTextEvaluation({
             })),
         );
       } catch (err) {
-        console.error("Error fetching evaluators:", err);
+        reportError("Error fetching evaluators:", err);
       } finally {
         setEvaluatorsLoading(false);
       }
@@ -304,7 +305,7 @@ export function SpeechToTextEvaluation({
     try {
       const backendUrl = process.env.NEXT_PUBLIC_BACKEND_URL;
       if (!backendUrl) {
-        console.error("BACKEND_URL environment variable is not set");
+        reportError("BACKEND_URL environment variable is not set");
         setIsEvaluating(false);
         return;
       }
@@ -362,7 +363,7 @@ export function SpeechToTextEvaluation({
         router.push(`/stt/${result.task_id}`);
       }
     } catch (error) {
-      console.error("Error evaluating:", error);
+      reportError("Error evaluating:", error);
       setIsEvaluating(false);
     }
   };

--- a/src/components/evaluations/TextToSpeechEvaluation.tsx
+++ b/src/components/evaluations/TextToSpeechEvaluation.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { reportError } from "@/lib/reportError";
 
 import { useState, useRef, useEffect } from "react";
 import { useRouter } from "next/navigation";
@@ -196,7 +197,7 @@ export function TextToSpeechEvaluation({ evaluateRef, onEvaluatingChange, initia
             }))
         );
       } catch (err) {
-        console.error("Error fetching evaluators:", err);
+        reportError("Error fetching evaluators:", err);
       } finally {
         setEvaluatorsLoading(false);
       }
@@ -304,7 +305,7 @@ export function TextToSpeechEvaluation({ evaluateRef, onEvaluatingChange, initia
     try {
       const backendUrl = process.env.NEXT_PUBLIC_BACKEND_URL;
       if (!backendUrl) {
-        console.error("BACKEND_URL environment variable is not set");
+        reportError("BACKEND_URL environment variable is not set");
         setIsEvaluating(false);
         return;
       }
@@ -360,7 +361,7 @@ export function TextToSpeechEvaluation({ evaluateRef, onEvaluatingChange, initia
         router.push(`/tts/${result.task_id}`);
       }
     } catch (error) {
-      console.error("Error evaluating:", error);
+      reportError("Error evaluating:", error);
       setIsEvaluating(false);
     }
   };

--- a/src/components/simulation-tabs/SimulationRunsTab.tsx
+++ b/src/components/simulation-tabs/SimulationRunsTab.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { reportError } from "@/lib/reportError";
 
 import React, { useState, useEffect } from "react";
 import Link from "next/link";
@@ -61,7 +62,7 @@ export function SimulationRunsTab({ simulationUuid }: SimulationRunsTabProps) {
         const data = await response.json();
         setRuns(data.runs || []);
       } catch (err) {
-        console.error("Error fetching runs:", err);
+        reportError("Error fetching runs:", err);
         setError(err instanceof Error ? err.message : "Failed to load runs");
       } finally {
         setIsLoading(false);

--- a/src/hooks/useCrudResource.ts
+++ b/src/hooks/useCrudResource.ts
@@ -1,4 +1,5 @@
 "use client";
+import { reportError } from "@/lib/reportError";
 
 import { useState, useEffect, useCallback } from "react";
 import { apiGet, apiPost, apiPut, apiDelete } from "@/lib/api";
@@ -61,7 +62,7 @@ export function useCrudResource<T extends { uuid: string }>({
       const data = await apiGet<T[]>(endpoint, accessToken);
       setItems(data);
     } catch (err) {
-      console.error(`Error fetching ${endpoint}:`, err);
+      reportError(`Error fetching ${endpoint}:`, err);
       setError(err instanceof Error ? err.message : `Failed to load data`);
     } finally {
       setIsLoading(false);
@@ -88,7 +89,7 @@ export function useCrudResource<T extends { uuid: string }>({
         
         return newItem;
       } catch (err) {
-        console.error(`Error creating ${endpoint}:`, err);
+        reportError(`Error creating ${endpoint}:`, err);
         setCreateError(err instanceof Error ? err.message : "Failed to create");
         return null;
       } finally {
@@ -113,7 +114,7 @@ export function useCrudResource<T extends { uuid: string }>({
         
         return updatedItem;
       } catch (err) {
-        console.error(`Error updating ${endpoint}/${id}:`, err);
+        reportError(`Error updating ${endpoint}/${id}:`, err);
         setCreateError(err instanceof Error ? err.message : "Failed to update");
         return null;
       } finally {
@@ -137,7 +138,7 @@ export function useCrudResource<T extends { uuid: string }>({
         
         return true;
       } catch (err) {
-        console.error(`Error deleting ${endpoint}/${id}:`, err);
+        reportError(`Error deleting ${endpoint}/${id}:`, err);
         return false;
       } finally {
         setIsDeleting(false);
@@ -196,7 +197,7 @@ export function useFetchResource<T>({
       const result = await apiGet<T>(`${endpoint}/${id}`, accessToken);
       setData(result);
     } catch (err) {
-      console.error(`Error fetching ${endpoint}/${id}:`, err);
+      reportError(`Error fetching ${endpoint}/${id}:`, err);
       setError(err instanceof Error ? err.message : "Failed to load");
     } finally {
       setIsLoading(false);

--- a/src/hooks/useDatasetManagement.ts
+++ b/src/hooks/useDatasetManagement.ts
@@ -1,3 +1,4 @@
+import { reportError } from "@/lib/reportError";
 import { useState, useCallback, useEffect } from "react";
 import { toast } from "sonner";
 import {
@@ -51,7 +52,7 @@ export function useDatasetManagement(
       setDeleteDatasetId(null);
       onDeleted?.(uuid);
     } catch (err) {
-      console.error("Failed to delete dataset:", err);
+      reportError("Failed to delete dataset:", err);
       toast.error("Failed to delete dataset. Please try again.");
     } finally {
       setIsDeletingDataset(false);
@@ -71,7 +72,7 @@ export function useDatasetManagement(
       setNewDatasetName("");
       onCreated(dataset.uuid);
     } catch (err) {
-      console.error("Failed to create dataset:", err);
+      reportError("Failed to create dataset:", err);
       toast.error("Failed to create dataset. Please try again.");
     } finally {
       setIsCreating(false);

--- a/src/hooks/useOpenRouterModels.ts
+++ b/src/hooks/useOpenRouterModels.ts
@@ -1,4 +1,5 @@
 "use client";
+import { reportError } from "@/lib/reportError";
 
 import { useState, useEffect, useCallback } from "react";
 import type { LLMProvider, LLMModel } from "@/components/agent-tabs/constants/providers";
@@ -222,7 +223,7 @@ export function useOpenRouterModels(): {
           }
         })
         .catch((err: unknown) => {
-          console.error("Failed to fetch OpenRouter models:", err);
+          reportError("Failed to fetch OpenRouter models:", err);
           if (!cancelled) {
             setIsLoading(false);
             const isDisabled =

--- a/src/hooks/useOrganizations.ts
+++ b/src/hooks/useOrganizations.ts
@@ -1,4 +1,5 @@
 "use client";
+import { reportError } from "@/lib/reportError";
 
 import { useCallback, useEffect, useRef, useState } from "react";
 import { apiClient, apiDelete, apiGet, apiPost } from "@/lib/api";
@@ -85,7 +86,7 @@ export async function fetchOrganizationsDedup(
       cachedForToken = accessToken;
       return data;
     } catch (err) {
-      console.error("Error fetching organizations:", err);
+      reportError("Error fetching organizations:", err);
       return null;
     } finally {
       inFlightFetch = null;
@@ -180,7 +181,7 @@ export function useOrganizations(
         notifyOrganizationsChanged(instanceRef.current);
         return created;
       } catch (err) {
-        console.error("Error creating organization:", err);
+        reportError("Error creating organization:", err);
         throw err;
       }
     },
@@ -205,7 +206,7 @@ export function useOrganizations(
         notifyOrganizationsChanged(instanceRef.current);
         return updated;
       } catch (err) {
-        console.error("Error renaming organization:", err);
+        reportError("Error renaming organization:", err);
         throw err;
       }
     },
@@ -280,7 +281,7 @@ export function useOrgMembers(
       );
       setMembers(data);
     } catch (err) {
-      console.error("Error fetching members:", err);
+      reportError("Error fetching members:", err);
       setError(err instanceof Error ? err.message : "Failed to load members");
     } finally {
       setIsLoading(false);
@@ -365,7 +366,7 @@ export function useWorkspaceApiKeys(
       );
       setApiKeys(data);
     } catch (err) {
-      console.error("Error fetching API keys:", err);
+      reportError("Error fetching API keys:", err);
       setError(err instanceof Error ? err.message : "Failed to load API keys");
     } finally {
       setIsLoading(false);

--- a/src/hooks/useVerifyConnection.ts
+++ b/src/hooks/useVerifyConnection.ts
@@ -1,4 +1,5 @@
 "use client";
+import { reportError } from "@/lib/reportError";
 
 import { useState, useCallback } from "react";
 import { signOut } from "next-auth/react";
@@ -84,7 +85,7 @@ export function useVerifyConnection(): VerifyConnectionResult {
 
         return await handleResponse(response);
       } catch (err) {
-        console.error("Error verifying connection:", err);
+        reportError("Error verifying connection:", err);
         setVerifyError(
           err instanceof Error ? err.message : "Verification failed",
         );
@@ -132,7 +133,7 @@ export function useVerifyConnection(): VerifyConnectionResult {
 
         return await handleResponse(response);
       } catch (err) {
-        console.error("Error verifying connection:", err);
+        reportError("Error verifying connection:", err);
         setVerifyError(
           err instanceof Error ? err.message : "Verification failed",
         );

--- a/src/lib/parseBackendError.ts
+++ b/src/lib/parseBackendError.ts
@@ -1,3 +1,4 @@
+import { reportError } from "@/lib/reportError";
 /**
  * Shared backend-error parsing for surfaces that POST to the calibrate API
  * and need to render the failure to a user.
@@ -122,7 +123,7 @@ export async function parseBackendErrorResponse(
 
   if (res.status >= 500) {
     if (logPrefix && body?.detail) {
-      console.error(`${logPrefix}: server error`, res.status, body.detail);
+      reportError(`${logPrefix}: server error`, res.status, body.detail);
     }
     return GENERIC_5XX_MESSAGE;
   }
@@ -145,7 +146,7 @@ export function parseBackendErrorMessage(
   const status = Number(match[1]);
   const rawBody = match[2];
   if (status >= 500) {
-    console.error("Server error from apiClient:", status, rawBody);
+    reportError("Server error from apiClient:", status, rawBody);
     return GENERIC_5XX_MESSAGE;
   }
   let parsed: DetailObject;

--- a/src/lib/reportError.ts
+++ b/src/lib/reportError.ts
@@ -1,0 +1,27 @@
+import * as Sentry from "@sentry/nextjs";
+
+/**
+ * Report an error to Sentry — the single place catch blocks should funnel
+ * failures through instead of `console.error`.
+ *
+ * Drop-in for `console.error(...)`: the call shape is identical (a message
+ * string followed by the caught error and/or extra context), but the failure
+ * is captured by Sentry rather than vanishing into the browser console. The
+ * console output is preserved in development for local debugging.
+ *
+ * @param message  Short human description of where/what failed.
+ * @param details  The caught error plus any extra context (status, ids, …).
+ */
+export function reportError(message: string, ...details: unknown[]): void {
+  // Keep the familiar console output while developing locally.
+  if (process.env.NODE_ENV !== "production") {
+    console.error(message, ...details);
+  }
+
+  // Prefer a real Error from the args as the captured exception so Sentry
+  // keeps the original stack trace; otherwise synthesize one from the message.
+  const error = details.find((d) => d instanceof Error);
+  Sentry.captureException(error ?? new Error(message), {
+    extra: { message, details },
+  });
+}


### PR DESCRIPTION
## What
- Tests page: the count under the search bar now reflects search-filtered rows, not the full list.
- Agent Tests tab: attach-existing dropdown is now multi-select with a filter-scoped "Select all"; newly-attached tests appear at the top of the table.
- Agent Tests tab: the tests list scrolls on its own (capped height, sticky header) so the search, filters, and past-runs panel stay in place for long lists.
- Bulk upload (global /tests): linking to at least one agent is now required, and the modal scrolls to the agent picker once the CSV parses.
- AddTestDialog: clicking outside only prompts "Discard changes?" when the form actually differs from its saved/initial state.

## Notes
- The required-agent rule applies only to the global bulk upload; the agent Tests tab path stays locked to its agent. If a workspace has no agents, that upload can't complete until one exists.
- "New test at top" covers the optimistic attach-existing flow; create/bulk flows re-fetch and follow backend ordering.
- The list scroll uses a fixed 60vh cap (matches the past-runs panel) rather than a flex-fill layout.