### PR TITLE
Add Errored category and name search to test/benchmark results

### DIFF
--- a/src/app/public/benchmark/[token]/page.tsx
+++ b/src/app/public/benchmark/[token]/page.tsx
@@ -5,7 +5,7 @@ import { useParams } from "next/navigation";
 import { PublicPageLayout, PublicNotFound, PublicLoading } from "@/components/PublicPageLayout";
 import { BenchmarkCombinedLeaderboard, BenchmarkOutputsPanel } from "@/components/eval-details";
 import type { BenchmarkModelResult } from "@/components/eval-details";
-import type { TestRunEvaluator } from "@/components/test-results/shared";
+import { ResultPager, type TestRunEvaluator, type PagerNav } from "@/components/test-results/shared";
 import { ExportResultsButton } from "@/components/ExportResultsButton";
 import { buildBenchmarkCsv } from "@/lib/exportTestResults";
 
@@ -36,6 +36,7 @@ export default function PublicBenchmarkPage() {
   const [activeTab, setActiveTab] = useState<"leaderboard" | "outputs">("leaderboard");
   const [expandedModels, setExpandedModels] = useState<Set<string>>(new Set());
   const [selectedTest, setSelectedTest] = useState<{ model: string; testIndex: number } | null>(null);
+  const [nav, setNav] = useState<PagerNav | null>(null);
 
   useEffect(() => { document.title = "LLM benchmark | Calibrate"; }, []);
 
@@ -98,6 +99,16 @@ export default function PublicBenchmarkPage() {
               </button>
             ))}
           </div>
+          {activeTab === "outputs" && nav && selectedTest && (
+            <div className="hidden md:flex flex-1 justify-center pb-2">
+              <ResultPager
+                currentIndex={nav.currentIndex}
+                total={nav.total}
+                onPrev={nav.goPrev}
+                onNext={nav.goNext}
+              />
+            </div>
+          )}
           {data.model_results && data.model_results.length > 0 && (
             <div className="pb-2">
               <ExportResultsButton
@@ -146,6 +157,7 @@ export default function PublicBenchmarkPage() {
               selectedTest={selectedTest}
               onSelectTest={(model, testIndex) => setSelectedTest({ model, testIndex })}
               onClearSelection={() => setSelectedTest(null)}
+              onNavChange={setNav}
               showControls={true}
               evaluatorsByUuid={Object.fromEntries(
                 (data.evaluators ?? []).map((e) => [e.uuid, e]),

--- a/src/app/public/benchmark/[token]/page.tsx
+++ b/src/app/public/benchmark/[token]/page.tsx
@@ -87,7 +87,7 @@ export default function PublicBenchmarkPage() {
     <PublicPageLayout title="LLM benchmark" contentClassName="max-w-[92rem]">
       <div className="space-y-4 md:space-y-6">
         {/* Tab nav */}
-        <div className="flex items-end justify-between gap-2 border-b border-border">
+        <div className="relative flex items-end justify-between gap-2 border-b border-border">
           <div className="flex gap-2">
             {(["leaderboard", "outputs"] as const).map((tab) => (
               <button
@@ -100,7 +100,7 @@ export default function PublicBenchmarkPage() {
             ))}
           </div>
           {activeTab === "outputs" && nav && selectedTest && (
-            <div className="hidden md:flex flex-1 justify-center pb-2">
+            <div className="hidden md:flex absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2">
               <ResultPager
                 currentIndex={nav.currentIndex}
                 total={nav.total}

--- a/src/app/public/test-run/[token]/page.tsx
+++ b/src/app/public/test-run/[token]/page.tsx
@@ -102,7 +102,7 @@ export default function PublicTestRunPage() {
     <PublicPageLayout title="LLM unit test" contentClassName="max-w-[92rem]">
       <div className="space-y-4 md:space-y-6">
         {/* Summary stats */}
-        <div className="flex items-center justify-between gap-4">
+        <div className="relative flex items-center justify-between gap-4">
           <div className="flex items-center gap-4">
             <div className="flex items-center gap-2">
               <span className="inline-flex items-center px-2.5 py-1 rounded-md text-xs font-medium bg-green-100 text-green-700 dark:bg-green-500/20 dark:text-green-400">
@@ -120,7 +120,7 @@ export default function PublicTestRunPage() {
             <span className="text-[13px] text-muted-foreground">{results.length} total tests</span>
           </div>
           {nav && selectedId && (
-            <div className="hidden md:flex flex-1 justify-center">
+            <div className="hidden md:flex absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2">
               <ResultPager
                 currentIndex={nav.currentIndex}
                 total={nav.total}

--- a/src/app/public/test-run/[token]/page.tsx
+++ b/src/app/public/test-run/[token]/page.tsx
@@ -88,7 +88,12 @@ export default function PublicTestRunPage() {
 
   const results = data.results ?? [];
   const passed = results.filter((r) => getStatus(r) === "passed").length;
-  const failed = results.filter((r) => getStatus(r) === "failed").length;
+  // Errored tests carry an `error` and are shown as their own category in the
+  // list; keep them out of the "failed" count so the summary matches.
+  const errored = results.filter((r) => !!r.error).length;
+  const failed = results.filter(
+    (r) => getStatus(r) === "failed" && !r.error,
+  ).length;
 
   return (
     <PublicPageLayout title="LLM unit test" contentClassName="max-w-[92rem]">
@@ -103,6 +108,11 @@ export default function PublicTestRunPage() {
               <span className="inline-flex items-center px-2.5 py-1 rounded-md text-xs font-medium bg-red-100 text-red-700 dark:bg-red-500/20 dark:text-red-400">
                 {failed} failed
               </span>
+              {errored > 0 && (
+                <span className="inline-flex items-center px-2.5 py-1 rounded-md text-xs font-medium bg-amber-100 text-amber-700 dark:bg-amber-500/20 dark:text-amber-400">
+                  {errored} errored
+                </span>
+              )}
             </div>
             <span className="text-[13px] text-muted-foreground">{results.length} total tests</span>
           </div>

--- a/src/app/public/test-run/[token]/page.tsx
+++ b/src/app/public/test-run/[token]/page.tsx
@@ -7,6 +7,8 @@ import {
   TestCaseData,
   JudgeResult,
   TestRunEvaluator,
+  ResultPager,
+  type PagerNav,
 } from "@/components/test-results/shared";
 import { PublicPageLayout, PublicNotFound, PublicLoading } from "@/components/PublicPageLayout";
 import { TestRunOutputsPanel } from "@/components/eval-details";
@@ -53,6 +55,7 @@ export default function PublicTestRunPage() {
   const [isLoading, setIsLoading] = useState(true);
   const [notFound, setNotFound] = useState(false);
   const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [nav, setNav] = useState<PagerNav | null>(null);
 
   useEffect(() => { document.title = "LLM unit test | Calibrate"; }, []);
 
@@ -116,6 +119,16 @@ export default function PublicTestRunPage() {
             </div>
             <span className="text-[13px] text-muted-foreground">{results.length} total tests</span>
           </div>
+          {nav && selectedId && (
+            <div className="hidden md:flex flex-1 justify-center">
+              <ResultPager
+                currentIndex={nav.currentIndex}
+                total={nav.total}
+                onPrev={nav.goPrev}
+                onNext={nav.goNext}
+              />
+            </div>
+          )}
           {results.length > 0 && (
             <ExportResultsButton
               filename={`test-run-${token}`}
@@ -155,6 +168,7 @@ export default function PublicTestRunPage() {
               selectedId={selectedId}
               onSelect={setSelectedId}
               onClearSelection={() => setSelectedId(null)}
+              onNavChange={setNav}
               evaluatorsByUuid={Object.fromEntries(
                 (data.evaluators ?? []).map((e) => [e.uuid, e]),
               )}

--- a/src/components/BenchmarkResultsDialog.tsx
+++ b/src/components/BenchmarkResultsDialog.tsx
@@ -491,7 +491,7 @@ export function BenchmarkResultsDialog({
     <div className="fixed inset-0 z-50 flex items-center justify-center p-0 md:p-4 bg-black/50 backdrop-blur-sm">
       <div className="bg-background rounded-none md:rounded-xl w-full max-w-[92rem] h-full md:h-[92vh] flex flex-col shadow-2xl">
         {/* Header */}
-        <div className="flex items-center justify-between px-4 md:px-6 py-3 md:py-4">
+        <div className="relative flex items-center justify-between px-4 md:px-6 py-3 md:py-4">
           <div className="min-w-0">
             <div className="flex items-center gap-2 md:gap-3 min-w-0">
               <h2 className="text-base md:text-lg font-semibold text-foreground truncate">
@@ -505,7 +505,7 @@ export function BenchmarkResultsDialog({
           </div>
           {/* Previous/Next pager - centered, desktop only, outputs tab */}
           {activeTab === "outputs" && nav && selectedTest && (
-            <div className="hidden md:flex flex-1 justify-center">
+            <div className="hidden md:flex absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2">
               <ResultPager
                 currentIndex={nav.currentIndex}
                 total={nav.total}

--- a/src/components/BenchmarkResultsDialog.tsx
+++ b/src/components/BenchmarkResultsDialog.tsx
@@ -5,7 +5,9 @@ import React, { useState, useEffect, useRef } from "react";
 import {
   CloseIcon,
   SpinnerIcon,
+  ResultPager,
   type TestRunEvaluator,
+  type PagerNav,
 } from "./test-results/shared";
 import {
   BenchmarkOutputsPanel,
@@ -86,6 +88,7 @@ export function BenchmarkResultsDialog({
     model: string;
     testIndex: number;
   } | null>(null);
+  const [nav, setNav] = useState<PagerNav | null>(null);
 
   // Loading and data state
   const [isInitialLoading, setIsInitialLoading] = useState(true);
@@ -500,6 +503,17 @@ export function BenchmarkResultsDialog({
             </div>
             <p className="text-xs text-muted-foreground truncate">{agentName}</p>
           </div>
+          {/* Previous/Next pager - centered, desktop only, outputs tab */}
+          {activeTab === "outputs" && nav && selectedTest && (
+            <div className="hidden md:flex flex-1 justify-center">
+              <ResultPager
+                currentIndex={nav.currentIndex}
+                total={nav.total}
+                onPrev={nav.goPrev}
+                onNext={nav.goNext}
+              />
+            </div>
+          )}
           <div className="flex items-center gap-2">
             {/* Export results — only shown when benchmark is done */}
             {isDone && !error && hasAnyResults && (
@@ -684,6 +698,7 @@ export function BenchmarkResultsDialog({
                 selectedTest={selectedTest}
                 onSelectTest={handleTestSelect}
                 onClearSelection={() => setSelectedTest(null)}
+                onNavChange={setNav}
                 testNames={testNames}
                 formatModelName={(n) => n.replace("__", "/")}
                 showControls={isDone}

--- a/src/components/TestRunnerDialog.tsx
+++ b/src/components/TestRunnerDialog.tsx
@@ -874,7 +874,7 @@ export function TestRunnerDialog({
       <div className="bg-background rounded-none md:rounded-xl w-full max-w-[92rem] h-full md:h-[92vh] flex flex-col shadow-2xl">
         {/* Header */}
         <div className="relative flex items-center justify-between gap-3 px-4 md:px-6 py-3 md:py-4 border-b border-border">
-          {/* Left: title + stats + actions */}
+          {/* Left: title + action buttons */}
           <div className="flex items-center gap-3 min-w-0">
             <div className="min-w-0">
               <h2 className="text-base md:text-lg font-semibold text-foreground truncate">
@@ -882,20 +882,6 @@ export function TestRunnerDialog({
               </h2>
               <p className="text-xs text-muted-foreground truncate">{agentName}</p>
             </div>
-            {/* Passed/Failed counts - desktop only */}
-            {!isOverallError &&
-              testResults.length > 0 &&
-              (passedTests.length > 0 ||
-                failedTests.length > 0 ||
-                erroredTests.length > 0) && (
-                <div className="hidden md:block">
-                  <TestStats
-                    passedCount={passedTests.length}
-                    failedCount={failedTests.length}
-                    erroredCount={erroredTests.length}
-                  />
-                </div>
-              )}
             {/* Export results — only shown when run is done */}
             {runStatus === "done" && testResults.length > 0 && (
               <div className="hidden md:block">
@@ -943,13 +929,29 @@ export function TestRunnerDialog({
               />
             </div>
           )}
-          {/* Right: close */}
-          <button
-            onClick={onClose}
-            className="flex items-center justify-center w-8 h-8 rounded-md hover:bg-muted transition-colors cursor-pointer shrink-0"
-          >
-            <CloseIcon className="w-5 h-5" />
-          </button>
+          {/* Right: stats + close */}
+          <div className="flex items-center gap-3 shrink-0">
+            {/* Passed/Failed counts - desktop only */}
+            {!isOverallError &&
+              testResults.length > 0 &&
+              (passedTests.length > 0 ||
+                failedTests.length > 0 ||
+                erroredTests.length > 0) && (
+                <div className="hidden md:block">
+                  <TestStats
+                    passedCount={passedTests.length}
+                    failedCount={failedTests.length}
+                    erroredCount={erroredTests.length}
+                  />
+                </div>
+              )}
+            <button
+              onClick={onClose}
+              className="flex items-center justify-center w-8 h-8 rounded-md hover:bg-muted transition-colors cursor-pointer shrink-0"
+            >
+              <CloseIcon className="w-5 h-5" />
+            </button>
+          </div>
         </div>
 
         {/* Overall Error State - replaces split panel */}

--- a/src/components/TestRunnerDialog.tsx
+++ b/src/components/TestRunnerDialog.tsx
@@ -848,7 +848,12 @@ export function TestRunnerDialog({
   );
 
   const passedTests = testResults.filter((r) => r.status === "passed");
-  const failedTests = testResults.filter((r) => r.status === "failed");
+  // Errored tests carry an `error` and are surfaced as their own category in
+  // the list; keep them out of the "failed" count so the header matches.
+  const erroredTests = testResults.filter((r) => !!r.error);
+  const failedTests = testResults.filter(
+    (r) => r.status === "failed" && !r.error,
+  );
   const queuedTests = testResults.filter((r) => r.status === "queued");
   const runningTests = testResults.filter((r) => r.status === "running");
   const pendingTests = testResults.filter((r) => r.status === "pending");
@@ -876,11 +881,14 @@ export function TestRunnerDialog({
             {/* Passed/Failed counts - desktop only */}
             {!isOverallError &&
               testResults.length > 0 &&
-              (passedTests.length > 0 || failedTests.length > 0) && (
+              (passedTests.length > 0 ||
+                failedTests.length > 0 ||
+                erroredTests.length > 0) && (
                 <div className="hidden md:block">
                   <TestStats
                     passedCount={passedTests.length}
                     failedCount={failedTests.length}
+                    erroredCount={erroredTests.length}
                   />
                 </div>
               )}

--- a/src/components/TestRunnerDialog.tsx
+++ b/src/components/TestRunnerDialog.tsx
@@ -12,6 +12,8 @@ import {
   TestRunEvaluator,
   CloseIcon,
   TestStats,
+  ResultPager,
+  type PagerNav,
 } from "./test-results/shared";
 import { POLLING_INTERVAL_MS } from "@/constants/polling";
 import { useHideFloatingButton } from "@/components/AppLayout";
@@ -141,6 +143,7 @@ export function TestRunnerDialog({
   const backendAccessToken = useAccessToken();
   const [testResults, setTestResults] = useState<TestResult[]>([]);
   const [selectedTestUuid, setSelectedTestUuid] = useState<string | null>(null);
+  const [nav, setNav] = useState<PagerNav | null>(null);
   const [isRunning, setIsRunning] = useState(false);
   const [runStatus, setRunStatus] = useState<
     "queued" | "in_progress" | "done" | "failed"
@@ -877,6 +880,17 @@ export function TestRunnerDialog({
             </h2>
             <p className="text-xs text-muted-foreground truncate">{agentName}</p>
           </div>
+          {/* Previous/Next pager - centered, desktop only */}
+          {nav && selectedTestUuid && (
+            <div className="hidden md:flex flex-1 justify-center">
+              <ResultPager
+                currentIndex={nav.currentIndex}
+                total={nav.total}
+                onPrev={nav.goPrev}
+                onNext={nav.goNext}
+              />
+            </div>
+          )}
           <div className="flex items-center gap-3">
             {/* Passed/Failed counts - desktop only */}
             {!isOverallError &&
@@ -982,6 +996,7 @@ export function TestRunnerDialog({
               selectedId={selectedTestUuid}
               onSelect={setSelectedTestUuid}
               onClearSelection={() => setSelectedTestUuid(null)}
+              onNavChange={setNav}
               evaluatorsByUuid={Object.fromEntries(
                 runEvaluators.map((e) => [e.uuid, e]),
               )}

--- a/src/components/TestRunnerDialog.tsx
+++ b/src/components/TestRunnerDialog.tsx
@@ -873,7 +873,7 @@ export function TestRunnerDialog({
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm p-0 md:p-4">
       <div className="bg-background rounded-none md:rounded-xl w-full max-w-[92rem] h-full md:h-[92vh] flex flex-col shadow-2xl">
         {/* Header */}
-        <div className="flex items-center justify-between px-4 md:px-6 py-3 md:py-4 border-b border-border">
+        <div className="relative flex items-center justify-between px-4 md:px-6 py-3 md:py-4 border-b border-border">
           <div className="min-w-0">
             <h2 className="text-base md:text-lg font-semibold text-foreground truncate">
               {runName ?? "Test run"}
@@ -882,7 +882,7 @@ export function TestRunnerDialog({
           </div>
           {/* Previous/Next pager - centered, desktop only */}
           {nav && selectedTestUuid && (
-            <div className="hidden md:flex flex-1 justify-center">
+            <div className="hidden md:flex absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2">
               <ResultPager
                 currentIndex={nav.currentIndex}
                 total={nav.total}

--- a/src/components/TestRunnerDialog.tsx
+++ b/src/components/TestRunnerDialog.tsx
@@ -873,25 +873,15 @@ export function TestRunnerDialog({
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm p-0 md:p-4">
       <div className="bg-background rounded-none md:rounded-xl w-full max-w-[92rem] h-full md:h-[92vh] flex flex-col shadow-2xl">
         {/* Header */}
-        <div className="relative flex items-center justify-between px-4 md:px-6 py-3 md:py-4 border-b border-border">
-          <div className="min-w-0">
-            <h2 className="text-base md:text-lg font-semibold text-foreground truncate">
-              {runName ?? "Test run"}
-            </h2>
-            <p className="text-xs text-muted-foreground truncate">{agentName}</p>
-          </div>
-          {/* Previous/Next pager - centered, desktop only */}
-          {nav && selectedTestUuid && (
-            <div className="hidden md:flex absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2">
-              <ResultPager
-                currentIndex={nav.currentIndex}
-                total={nav.total}
-                onPrev={nav.goPrev}
-                onNext={nav.goNext}
-              />
+        <div className="relative flex items-center justify-between gap-3 px-4 md:px-6 py-3 md:py-4 border-b border-border">
+          {/* Left: title + stats + actions */}
+          <div className="flex items-center gap-3 min-w-0">
+            <div className="min-w-0">
+              <h2 className="text-base md:text-lg font-semibold text-foreground truncate">
+                {runName ?? "Test run"}
+              </h2>
+              <p className="text-xs text-muted-foreground truncate">{agentName}</p>
             </div>
-          )}
-          <div className="flex items-center gap-3">
             {/* Passed/Failed counts - desktop only */}
             {!isOverallError &&
               testResults.length > 0 &&
@@ -941,13 +931,25 @@ export function TestRunnerDialog({
                 />
               </div>
             )}
-            <button
-              onClick={onClose}
-              className="flex items-center justify-center w-8 h-8 rounded-md hover:bg-muted transition-colors cursor-pointer"
-            >
-              <CloseIcon className="w-5 h-5" />
-            </button>
           </div>
+          {/* Previous/Next pager - centered, desktop only */}
+          {nav && selectedTestUuid && (
+            <div className="hidden md:flex absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2">
+              <ResultPager
+                currentIndex={nav.currentIndex}
+                total={nav.total}
+                onPrev={nav.goPrev}
+                onNext={nav.goNext}
+              />
+            </div>
+          )}
+          {/* Right: close */}
+          <button
+            onClick={onClose}
+            className="flex items-center justify-center w-8 h-8 rounded-md hover:bg-muted transition-colors cursor-pointer shrink-0"
+          >
+            <CloseIcon className="w-5 h-5" />
+          </button>
         </div>
 
         {/* Overall Error State - replaces split panel */}

--- a/src/components/eval-details/BenchmarkOutputsPanel.tsx
+++ b/src/components/eval-details/BenchmarkOutputsPanel.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 import {
   TestCaseOutput,
   TestCaseData,
@@ -8,8 +8,9 @@ import {
   TestDetailView,
   EmptyStateView,
   EvaluationCriteriaPanel,
-  ResultPager,
   isTypingTarget,
+  scrollRowByPage,
+  type PagerNav,
 } from "@/components/test-results/shared";
 import { SearchInput } from "@/components/ui/SearchInput";
 import type { DefaultEvaluatorSummary } from "@/lib/defaultEvaluators";
@@ -65,6 +66,9 @@ type BenchmarkOutputsPanelProps = {
   enableEvaluatorLinks?: boolean;
   /** Default correctness evaluator used for legacy next-reply criteria. */
   legacyDefaultEvaluator?: DefaultEvaluatorSummary | null;
+  /** Reports Previous/Next navigation state so a parent (the dialog header)
+   * can render the pager. Must be a stable callback (e.g. a useState setter). */
+  onNavChange?: (nav: PagerNav) => void;
 };
 
 export function BenchmarkOutputsPanel({
@@ -83,10 +87,13 @@ export function BenchmarkOutputsPanel({
   evaluatorsByUuid,
   enableEvaluatorLinks = true,
   legacyDefaultEvaluator,
+  onNavChange,
 }: BenchmarkOutputsPanelProps) {
   const [statusFilter, setStatusFilter] = useState<"all" | "passed" | "failed" | "errored">("all");
   const [searchQuery, setSearchQuery] = useState("");
-  // Ref to the currently-selected row, so navigation keeps it in view.
+  // Refs to the list scroll container and the currently-selected row, so
+  // navigation keeps the selection in view (a page at a time).
+  const listContainerRef = useRef<HTMLDivElement>(null);
   const selectedRowRef = useRef<HTMLButtonElement>(null);
 
   const getSelectedTestResult = (): BenchmarkTestResult | null => {
@@ -99,26 +106,30 @@ export function BenchmarkOutputsPanel({
   const selectedTestResult = getSelectedTestResult();
 
   // Flattened display order across all models (respecting the status filter
-  // and search), used by the Previous/Next pager in the detail panel.
-  const pagerQuery = searchQuery.trim().toLowerCase();
-  const pagerFilterStatus = statusFilter === "errored" ? "error" : statusFilter;
-  const orderedTests: { model: string; testIndex: number }[] = [];
-  for (const m of modelResults) {
-    (m.test_results ?? []).forEach((tr, index) => {
-      const status = tr.error
-        ? "error"
-        : tr.passed === null
-          ? "running"
-          : tr.passed
-            ? "passed"
-            : "failed";
-      if (statusFilter !== "all" && status !== pagerFilterStatus) return;
-      const testName =
-        tr.name || tr.test_case?.name || testNames[index] || `Test ${index + 1}`;
-      if (pagerQuery && !testName.toLowerCase().includes(pagerQuery)) return;
-      orderedTests.push({ model: m.model, testIndex: index });
-    });
-  }
+  // and search), used by the Previous/Next pager the parent renders in the
+  // dialog header.
+  const orderedTests = useMemo(() => {
+    const q = searchQuery.trim().toLowerCase();
+    const fStatus = statusFilter === "errored" ? "error" : statusFilter;
+    const out: { model: string; testIndex: number }[] = [];
+    for (const m of modelResults) {
+      (m.test_results ?? []).forEach((tr, index) => {
+        const status = tr.error
+          ? "error"
+          : tr.passed === null
+            ? "running"
+            : tr.passed
+              ? "passed"
+              : "failed";
+        if (statusFilter !== "all" && status !== fStatus) return;
+        const name =
+          tr.name || tr.test_case?.name || testNames[index] || `Test ${index + 1}`;
+        if (q && !name.toLowerCase().includes(q)) return;
+        out.push({ model: m.model, testIndex: index });
+      });
+    }
+    return out;
+  }, [modelResults, statusFilter, searchQuery, testNames]);
   const currentTestIndex = selectedTest
     ? orderedTests.findIndex(
         (t) =>
@@ -145,6 +156,30 @@ export function BenchmarkOutputsPanel({
       selectAndReveal(orderedTests[currentTestIndex + 1]);
   };
 
+  // Surface navigation state to the parent (dialog header pager).
+  useEffect(() => {
+    if (!onNavChange) return;
+    const idx = selectedTest
+      ? orderedTests.findIndex(
+          (t) =>
+            t.model === selectedTest.model &&
+            t.testIndex === selectedTest.testIndex,
+        )
+      : -1;
+    onNavChange({
+      currentIndex: idx,
+      total: orderedTests.length,
+      goPrev: () => {
+        if (idx > 0) selectAndReveal(orderedTests[idx - 1]);
+      },
+      goNext: () => {
+        if (idx >= 0 && idx < orderedTests.length - 1)
+          selectAndReveal(orderedTests[idx + 1]);
+      },
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [onNavChange, orderedTests, selectedTest, expandedModels]);
+
   // Arrow-key navigation: Up = previous, Down = next. Ignored while typing in
   // an input (e.g. the search box).
   useEffect(() => {
@@ -164,9 +199,10 @@ export function BenchmarkOutputsPanel({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectedTest, currentTestIndex, orderedTests.length]);
 
-  // Keep the selected row visible in the list as the selection changes.
+  // Keep the selected row visible in the list as the selection changes,
+  // scrolling a page at a time rather than row by row.
   useEffect(() => {
-    selectedRowRef.current?.scrollIntoView({ block: "nearest" });
+    scrollRowByPage(listContainerRef.current, selectedRowRef.current);
   }, [selectedTest?.model, selectedTest?.testIndex]);
 
   const selectedTestName = selectedTest
@@ -253,7 +289,7 @@ export function BenchmarkOutputsPanel({
             </button>
           </div>
         )}
-        <div className="flex-1 overflow-y-auto">
+        <div ref={listContainerRef} className="flex-1 overflow-y-auto">
           {modelResults.length > 0 ? (
             modelResults.map((modelResult) => (
               <ModelSection
@@ -295,24 +331,6 @@ export function BenchmarkOutputsPanel({
               </svg>
               Back to models
             </button>
-          </div>
-        )}
-
-        {selectedTest && (
-          <ResultPager
-            currentIndex={currentTestIndex}
-            total={orderedTests.length}
-            onPrev={goPrevTest}
-            onNext={goNextTest}
-          />
-        )}
-        {/* Selected test name — pinned above the scrolling conversation, with
-            horizontal scroll for names wider than the panel. */}
-        {selectedTest && selectedTestName && (
-          <div className="flex-shrink-0 border-b border-border px-4 py-2 overflow-x-auto">
-            <span className="block text-sm font-semibold text-foreground whitespace-nowrap">
-              {selectedTestName}
-            </span>
           </div>
         )}
 
@@ -367,6 +385,7 @@ export function BenchmarkOutputsPanel({
         <div className="hidden md:flex w-[32rem] border-l border-border flex-col overflow-hidden">
           <div className="flex-1 overflow-y-auto">
             <EvaluationCriteriaPanel
+              testName={selectedTestName}
               evaluation={selectedTestResult.test_case?.evaluation}
               testCaseEvaluators={selectedTestResult.test_case?.evaluators}
               passed={selectedTestResult.passed}

--- a/src/components/eval-details/BenchmarkOutputsPanel.tsx
+++ b/src/components/eval-details/BenchmarkOutputsPanel.tsx
@@ -8,6 +8,7 @@ import {
   TestDetailView,
   EmptyStateView,
   EvaluationCriteriaPanel,
+  ResultPager,
 } from "@/components/test-results/shared";
 import { SearchInput } from "@/components/ui/SearchInput";
 import type { DefaultEvaluatorSummary } from "@/lib/defaultEvaluators";
@@ -93,6 +94,53 @@ export function BenchmarkOutputsPanel({
   };
 
   const selectedTestResult = getSelectedTestResult();
+
+  // Flattened display order across all models (respecting the status filter
+  // and search), used by the Previous/Next pager in the detail panel.
+  const pagerQuery = searchQuery.trim().toLowerCase();
+  const pagerFilterStatus = statusFilter === "errored" ? "error" : statusFilter;
+  const orderedTests: { model: string; testIndex: number }[] = [];
+  for (const m of modelResults) {
+    (m.test_results ?? []).forEach((tr, index) => {
+      const status = tr.error
+        ? "error"
+        : tr.passed === null
+          ? "running"
+          : tr.passed
+            ? "passed"
+            : "failed";
+      if (statusFilter !== "all" && status !== pagerFilterStatus) return;
+      const testName =
+        tr.name || tr.test_case?.name || testNames[index] || `Test ${index + 1}`;
+      if (pagerQuery && !testName.toLowerCase().includes(pagerQuery)) return;
+      orderedTests.push({ model: m.model, testIndex: index });
+    });
+  }
+  const currentTestIndex = selectedTest
+    ? orderedTests.findIndex(
+        (t) =>
+          t.model === selectedTest.model && t.testIndex === selectedTest.testIndex,
+      )
+    : -1;
+  // Stepping across model boundaries should reveal the target's model so the
+  // list highlight stays in sync.
+  const selectAndReveal = (t: { model: string; testIndex: number }) => {
+    if (!expandedModels.has(t.model)) {
+      if (onSetExpandedModels) {
+        onSetExpandedModels(new Set([...expandedModels, t.model]));
+      } else {
+        onToggleModel(t.model);
+      }
+    }
+    onSelectTest(t.model, t.testIndex);
+  };
+  const goPrevTest = () => {
+    if (currentTestIndex > 0) selectAndReveal(orderedTests[currentTestIndex - 1]);
+  };
+  const goNextTest = () => {
+    if (currentTestIndex >= 0 && currentTestIndex < orderedTests.length - 1)
+      selectAndReveal(orderedTests[currentTestIndex + 1]);
+  };
 
   return (
     <div className="flex h-full overflow-hidden" style={height ? { height } : undefined}>
@@ -213,6 +261,15 @@ export function BenchmarkOutputsPanel({
               Back to models
             </button>
           </div>
+        )}
+
+        {selectedTest && (
+          <ResultPager
+            currentIndex={currentTestIndex}
+            total={orderedTests.length}
+            onPrev={goPrevTest}
+            onNext={goNextTest}
+          />
         )}
 
         <div className="flex-1 overflow-y-auto">

--- a/src/components/eval-details/BenchmarkOutputsPanel.tsx
+++ b/src/components/eval-details/BenchmarkOutputsPanel.tsx
@@ -71,6 +71,40 @@ type BenchmarkOutputsPanelProps = {
   onNavChange?: (nav: PagerNav) => void;
 };
 
+// Derive a benchmark test's display status, shared by the pager ordering and
+// the rendered rows so they always agree.
+function benchmarkTestStatus(
+  tr: BenchmarkTestResult,
+): "error" | "running" | "passed" | "failed" {
+  if (tr.error) return "error";
+  if (tr.passed === null) return "running";
+  return tr.passed ? "passed" : "failed";
+}
+
+// Display name for a benchmark test row (falls back to the placeholder name
+// when the result hasn't arrived yet).
+function benchmarkTestName(
+  tr: BenchmarkTestResult | undefined,
+  index: number,
+  testNames: string[],
+): string {
+  return tr?.name || tr?.test_case?.name || testNames[index] || `Test ${index + 1}`;
+}
+
+// Whether a row passes the current status filter + search query. "errored" is
+// the filter label for the "error" status. `query` must already be lowercased.
+function matchesBenchmarkFilters(
+  status: string,
+  name: string,
+  statusFilter: "all" | "passed" | "failed" | "errored",
+  query: string,
+): boolean {
+  const fStatus = statusFilter === "errored" ? "error" : statusFilter;
+  if (statusFilter !== "all" && status !== fStatus) return false;
+  if (query && !name.toLowerCase().includes(query)) return false;
+  return true;
+}
+
 export function BenchmarkOutputsPanel({
   modelResults,
   expandedModels,
@@ -110,21 +144,12 @@ export function BenchmarkOutputsPanel({
   // dialog header.
   const orderedTests = useMemo(() => {
     const q = searchQuery.trim().toLowerCase();
-    const fStatus = statusFilter === "errored" ? "error" : statusFilter;
     const out: { model: string; testIndex: number }[] = [];
     for (const m of modelResults) {
       (m.test_results ?? []).forEach((tr, index) => {
-        const status = tr.error
-          ? "error"
-          : tr.passed === null
-            ? "running"
-            : tr.passed
-              ? "passed"
-              : "failed";
-        if (statusFilter !== "all" && status !== fStatus) return;
-        const name =
-          tr.name || tr.test_case?.name || testNames[index] || `Test ${index + 1}`;
-        if (q && !name.toLowerCase().includes(q)) return;
+        const status = benchmarkTestStatus(tr);
+        const name = benchmarkTestName(tr, index, testNames);
+        if (!matchesBenchmarkFilters(status, name, statusFilter, q)) return;
         out.push({ model: m.model, testIndex: index });
       });
     }
@@ -192,7 +217,6 @@ export function BenchmarkOutputsPanel({
           s.selectAndReveal(s.orderedTests[i + 1]);
       },
     });
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [onNavChange, currentTestIndex, orderedTests.length]);
 
   // Arrow-key navigation: Up = previous, Down = next. Ignored while typing in
@@ -515,21 +539,16 @@ function ModelSection({
                   if (!hasResult && !showRunningSpinner) return null;
 
                   const status = hasResult
-                    ? testResult.error
-                      ? "error"
-                      : testResult.passed === null ? "running" : testResult.passed ? "passed" : "failed"
+                    ? benchmarkTestStatus(testResult)
                     : "running";
+                  const testName = benchmarkTestName(testResult, index, testNames);
 
-                  // statusFilter uses "errored" as the label for the "error" status.
-                  const filterStatus = statusFilter === "errored" ? "error" : statusFilter;
-                  if (statusFilter !== "all" && status !== filterStatus) return null;
+                  if (!matchesBenchmarkFilters(status, testName, statusFilter, query))
+                    return null;
 
-                  const isSelected = selectedTest?.model === modelResult.model && selectedTest?.testIndex === index;
-                  const testName = hasResult
-                    ? testResult.name || testResult.test_case?.name || testNames[index] || `Test ${index + 1}`
-                    : testNames[index] || `Test ${index + 1}`;
-
-                  if (query && !testName.toLowerCase().includes(query)) return null;
+                  const isSelected =
+                    selectedTest?.model === modelResult.model &&
+                    selectedTest?.testIndex === index;
 
                   if (hasResult) {
                     return (

--- a/src/components/eval-details/BenchmarkOutputsPanel.tsx
+++ b/src/components/eval-details/BenchmarkOutputsPanel.tsx
@@ -156,29 +156,44 @@ export function BenchmarkOutputsPanel({
       selectAndReveal(orderedTests[currentTestIndex + 1]);
   };
 
-  // Surface navigation state to the parent (dialog header pager).
+  // Keep the latest list/selection in a ref so the reported goPrev/goNext stay
+  // stable while reading fresh values when invoked.
+  const navStateRef = useRef({ orderedTests, selectedTest, selectAndReveal });
+  navStateRef.current = { orderedTests, selectedTest, selectAndReveal };
+
+  // Surface navigation state to the parent (dialog header pager). Depends only
+  // on the primitive index/length so it doesn't re-fire every render — the
+  // `modelResults` prop (and thus `orderedTests`) is rebuilt by callers each
+  // render, which would otherwise loop setState in the parent.
   useEffect(() => {
     if (!onNavChange) return;
-    const idx = selectedTest
-      ? orderedTests.findIndex(
-          (t) =>
-            t.model === selectedTest.model &&
-            t.testIndex === selectedTest.testIndex,
-        )
-      : -1;
     onNavChange({
-      currentIndex: idx,
+      currentIndex: currentTestIndex,
       total: orderedTests.length,
       goPrev: () => {
-        if (idx > 0) selectAndReveal(orderedTests[idx - 1]);
+        const s = navStateRef.current;
+        const st = s.selectedTest;
+        const i = st
+          ? s.orderedTests.findIndex(
+              (t) => t.model === st.model && t.testIndex === st.testIndex,
+            )
+          : -1;
+        if (i > 0) s.selectAndReveal(s.orderedTests[i - 1]);
       },
       goNext: () => {
-        if (idx >= 0 && idx < orderedTests.length - 1)
-          selectAndReveal(orderedTests[idx + 1]);
+        const s = navStateRef.current;
+        const st = s.selectedTest;
+        const i = st
+          ? s.orderedTests.findIndex(
+              (t) => t.model === st.model && t.testIndex === st.testIndex,
+            )
+          : -1;
+        if (i >= 0 && i < s.orderedTests.length - 1)
+          s.selectAndReveal(s.orderedTests[i + 1]);
       },
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [onNavChange, orderedTests, selectedTest, expandedModels]);
+  }, [onNavChange, currentTestIndex, orderedTests.length]);
 
   // Arrow-key navigation: Up = previous, Down = next. Ignored while typing in
   // an input (e.g. the search box).

--- a/src/components/eval-details/BenchmarkOutputsPanel.tsx
+++ b/src/components/eval-details/BenchmarkOutputsPanel.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import {
   TestCaseOutput,
   TestCaseData,
@@ -86,6 +86,8 @@ export function BenchmarkOutputsPanel({
 }: BenchmarkOutputsPanelProps) {
   const [statusFilter, setStatusFilter] = useState<"all" | "passed" | "failed" | "errored">("all");
   const [searchQuery, setSearchQuery] = useState("");
+  // Ref to the currently-selected row, so navigation keeps it in view.
+  const selectedRowRef = useRef<HTMLButtonElement>(null);
 
   const getSelectedTestResult = (): BenchmarkTestResult | null => {
     if (!selectedTest) return null;
@@ -161,6 +163,11 @@ export function BenchmarkOutputsPanel({
     return () => window.removeEventListener("keydown", handler);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectedTest, currentTestIndex, orderedTests.length]);
+
+  // Keep the selected row visible in the list as the selection changes.
+  useEffect(() => {
+    selectedRowRef.current?.scrollIntoView({ block: "nearest" });
+  }, [selectedTest?.model, selectedTest?.testIndex]);
 
   const selectedTestName = selectedTest
     ? selectedTestResult?.name ||
@@ -261,6 +268,7 @@ export function BenchmarkOutputsPanel({
                 searchQuery={searchQuery}
                 formatModelName={formatModelName}
                 showRunningSpinner={showRunningSpinner}
+                selectedRowRef={selectedRowRef}
               />
             ))
           ) : (
@@ -387,6 +395,7 @@ function ModelSection({
   searchQuery,
   formatModelName,
   showRunningSpinner = false,
+  selectedRowRef,
 }: {
   modelResult: BenchmarkModelResult;
   isExpanded: boolean;
@@ -398,6 +407,7 @@ function ModelSection({
   searchQuery: string;
   formatModelName: (name: string) => string;
   showRunningSpinner?: boolean;
+  selectedRowRef: React.RefObject<HTMLButtonElement | null>;
 }) {
   const isProcessing = modelResult.success === null;
   const hasResults = modelResult.test_results && modelResult.test_results.length > 0;
@@ -491,6 +501,7 @@ function ModelSection({
                     return (
                       <button
                         key={index}
+                        ref={isSelected ? selectedRowRef : undefined}
                         type="button"
                         onClick={() => onTestSelect(index)}
                         className={`w-full flex items-center gap-2 px-3 py-2 rounded-lg cursor-pointer transition-colors ${

--- a/src/components/eval-details/BenchmarkOutputsPanel.tsx
+++ b/src/components/eval-details/BenchmarkOutputsPanel.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import {
   TestCaseOutput,
   TestCaseData,
@@ -9,6 +9,7 @@ import {
   EmptyStateView,
   EvaluationCriteriaPanel,
   ResultPager,
+  isTypingTarget,
 } from "@/components/test-results/shared";
 import { SearchInput } from "@/components/ui/SearchInput";
 import type { DefaultEvaluatorSummary } from "@/lib/defaultEvaluators";
@@ -142,6 +143,32 @@ export function BenchmarkOutputsPanel({
       selectAndReveal(orderedTests[currentTestIndex + 1]);
   };
 
+  // Arrow-key navigation: Up = previous, Down = next. Ignored while typing in
+  // an input (e.g. the search box).
+  useEffect(() => {
+    if (!selectedTest) return;
+    const handler = (e: KeyboardEvent) => {
+      if (isTypingTarget(e.target) || e.metaKey || e.ctrlKey || e.altKey) return;
+      if (e.key === "ArrowUp") {
+        e.preventDefault();
+        goPrevTest();
+      } else if (e.key === "ArrowDown") {
+        e.preventDefault();
+        goNextTest();
+      }
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectedTest, currentTestIndex, orderedTests.length]);
+
+  const selectedTestName = selectedTest
+    ? selectedTestResult?.name ||
+      selectedTestResult?.test_case?.name ||
+      testNames[selectedTest.testIndex] ||
+      `Test ${selectedTest.testIndex + 1}`
+    : "";
+
   return (
     <div className="flex h-full overflow-hidden" style={height ? { height } : undefined}>
       {/* Left Panel - Model list with tests */}
@@ -270,6 +297,15 @@ export function BenchmarkOutputsPanel({
             onPrev={goPrevTest}
             onNext={goNextTest}
           />
+        )}
+        {/* Selected test name — pinned above the scrolling conversation, with
+            horizontal scroll for names wider than the panel. */}
+        {selectedTest && selectedTestName && (
+          <div className="flex-shrink-0 border-b border-border px-4 py-2 overflow-x-auto">
+            <span className="block text-sm font-semibold text-foreground whitespace-nowrap">
+              {selectedTestName}
+            </span>
+          </div>
         )}
 
         <div className="flex-1 overflow-y-auto">

--- a/src/components/eval-details/BenchmarkOutputsPanel.tsx
+++ b/src/components/eval-details/BenchmarkOutputsPanel.tsx
@@ -9,6 +9,7 @@ import {
   EmptyStateView,
   EvaluationCriteriaPanel,
 } from "@/components/test-results/shared";
+import { SearchInput } from "@/components/ui/SearchInput";
 import type { DefaultEvaluatorSummary } from "@/lib/defaultEvaluators";
 import type { BenchmarkEvaluatorSummaryEntry } from "@/lib/benchmarkEvaluatorSummary";
 
@@ -18,6 +19,8 @@ export type BenchmarkTestResult = {
   reasoning?: string;
   output?: TestCaseOutput;
   test_case?: TestCaseData;
+  /** Set when the test errored out (neither passed nor failed evaluation). */
+  error?: string;
   /** Per-evaluator verdicts for response (next-reply) tests. Null for
    * tool-call tests; legacy rows omit the field and fall back to the
    * legacy single-reasoning UI. */
@@ -79,7 +82,8 @@ export function BenchmarkOutputsPanel({
   enableEvaluatorLinks = true,
   legacyDefaultEvaluator,
 }: BenchmarkOutputsPanelProps) {
-  const [statusFilter, setStatusFilter] = useState<"all" | "passed" | "failed">("all");
+  const [statusFilter, setStatusFilter] = useState<"all" | "passed" | "failed" | "errored">("all");
+  const [searchQuery, setSearchQuery] = useState("");
 
   const getSelectedTestResult = (): BenchmarkTestResult | null => {
     if (!selectedTest) return null;
@@ -98,6 +102,16 @@ export function BenchmarkOutputsPanel({
           selectedTest ? "hidden md:flex" : "flex"
         }`}
       >
+        {/* Search */}
+        {modelResults.length > 0 && (
+          <div className="shrink-0 border-b border-border p-3">
+            <SearchInput
+              value={searchQuery}
+              onChange={setSearchQuery}
+              placeholder="Search tests"
+            />
+          </div>
+        )}
         {/* Filter pills + collapse/expand */}
         {showControls && modelResults.length > 0 && (
           <div className="shrink-0 border-b border-border flex items-center justify-between px-3 py-2">
@@ -123,6 +137,17 @@ export function BenchmarkOutputsPanel({
                 }`}
               >
                 Failed
+              </button>
+              <button
+                type="button"
+                onClick={() => setStatusFilter(statusFilter === "errored" ? "all" : "errored")}
+                className={`inline-flex items-center px-2.5 py-1 rounded-md text-xs font-medium cursor-pointer transition-colors ${
+                  statusFilter === "errored"
+                    ? "bg-amber-100 text-amber-700 dark:bg-amber-500/30 dark:text-amber-400 ring-1 ring-amber-500/50"
+                    : "bg-amber-100/50 text-amber-700/60 dark:bg-amber-500/10 dark:text-amber-400/60 hover:bg-amber-100 hover:dark:bg-amber-500/20"
+                }`}
+              >
+                Errored
               </button>
             </div>
             <button
@@ -158,6 +183,7 @@ export function BenchmarkOutputsPanel({
                 onTestSelect={(testIndex) => onSelectTest(modelResult.model, testIndex)}
                 testNames={testNames}
                 statusFilter={statusFilter}
+                searchQuery={searchQuery}
                 formatModelName={formatModelName}
                 showRunningSpinner={showRunningSpinner}
               />
@@ -191,7 +217,21 @@ export function BenchmarkOutputsPanel({
 
         <div className="flex-1 overflow-y-auto">
           {selectedTestResult ? (
-            selectedTestResult.passed === null && showRunningSpinner ? (
+            selectedTestResult.error ? (
+              <div className="p-4 md:p-6">
+                <div className="bg-red-500/10 border border-red-500/30 rounded-lg p-4">
+                  <div className="flex items-center gap-2 mb-2">
+                    <svg className="w-5 h-5 text-red-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                      <path strokeLinecap="round" strokeLinejoin="round" d="M12 9v3.75m9-.75a9 9 0 11-18 0 9 9 0 0118 0zm-9 3.75h.008v.008H12v-.008z" />
+                    </svg>
+                    <span className="font-medium text-red-500">Something went wrong</span>
+                  </div>
+                  <p className="text-sm text-red-400">
+                    This test errored out before it could be evaluated. Please reach out to us if this issue persists.
+                  </p>
+                </div>
+              </div>
+            ) : selectedTestResult.passed === null && showRunningSpinner ? (
               <div className="flex items-center justify-center h-full">
                 <div className="flex items-center gap-3">
                   <svg className="w-5 h-5 animate-spin text-muted-foreground" fill="none" viewBox="0 0 24 24">
@@ -222,7 +262,7 @@ export function BenchmarkOutputsPanel({
 
       {/* Right Panel - Evaluators / Expected Tool Calls (desktop only).
           On mobile this content is rendered inline by `TestDetailView`. */}
-      {selectedTestResult && selectedTestResult.passed !== null && (
+      {selectedTestResult && !selectedTestResult.error && selectedTestResult.passed !== null && (
         <div className="hidden md:flex w-[32rem] border-l border-border flex-col overflow-hidden">
           <div className="flex-1 overflow-y-auto">
             <EvaluationCriteriaPanel
@@ -251,6 +291,7 @@ function ModelSection({
   onTestSelect,
   testNames,
   statusFilter,
+  searchQuery,
   formatModelName,
   showRunningSpinner = false,
 }: {
@@ -260,15 +301,20 @@ function ModelSection({
   selectedTest: { model: string; testIndex: number } | null;
   onTestSelect: (testIndex: number) => void;
   testNames: string[];
-  statusFilter: "all" | "passed" | "failed";
+  statusFilter: "all" | "passed" | "failed" | "errored";
+  searchQuery: string;
   formatModelName: (name: string) => string;
   showRunningSpinner?: boolean;
 }) {
   const isProcessing = modelResult.success === null;
   const hasResults = modelResult.test_results && modelResult.test_results.length > 0;
   const passedCount = modelResult.passed ?? 0;
-  const failedCount = modelResult.failed ?? 0;
+  const erroredCount = (modelResult.test_results ?? []).filter((t) => t?.error).length;
+  // Errored tests may be lumped into the API's `failed` count — subtract them
+  // so the header buckets line up with the categorised rows below.
+  const failedCount = Math.max((modelResult.failed ?? 0) - erroredCount, 0);
   const totalTests = modelResult.total_tests ?? testNames.length;
+  const query = searchQuery.trim().toLowerCase();
 
   return (
     <div className="border-b border-border">
@@ -301,6 +347,9 @@ function ModelSection({
             {(statusFilter === "all" || statusFilter === "failed") && (
               <span className="text-red-500">{failedCount} failed</span>
             )}
+            {(statusFilter === "all" || statusFilter === "errored") && erroredCount > 0 && (
+              <span className="text-amber-500">{erroredCount} errored</span>
+            )}
           </div>
         )}
       </button>
@@ -329,15 +378,21 @@ function ModelSection({
                   if (!hasResult && !showRunningSpinner) return null;
 
                   const status = hasResult
-                    ? testResult.passed === null ? "running" : testResult.passed ? "passed" : "failed"
+                    ? testResult.error
+                      ? "error"
+                      : testResult.passed === null ? "running" : testResult.passed ? "passed" : "failed"
                     : "running";
 
-                  if (statusFilter !== "all" && status !== statusFilter) return null;
+                  // statusFilter uses "errored" as the label for the "error" status.
+                  const filterStatus = statusFilter === "errored" ? "error" : statusFilter;
+                  if (statusFilter !== "all" && status !== filterStatus) return null;
 
                   const isSelected = selectedTest?.model === modelResult.model && selectedTest?.testIndex === index;
                   const testName = hasResult
                     ? testResult.name || testResult.test_case?.name || testNames[index] || `Test ${index + 1}`
                     : testNames[index] || `Test ${index + 1}`;
+
+                  if (query && !testName.toLowerCase().includes(query)) return null;
 
                   if (hasResult) {
                     return (
@@ -349,7 +404,7 @@ function ModelSection({
                           isSelected ? "bg-muted" : "hover:bg-muted/50"
                         }`}
                       >
-                        <StatusIcon status={status as "running" | "passed" | "failed"} />
+                        <StatusIcon status={status as "running" | "passed" | "failed" | "error"} />
                         <span className="text-sm text-foreground truncate">{testName}</span>
                       </button>
                     );

--- a/src/components/eval-details/TestRunOutputsPanel.tsx
+++ b/src/components/eval-details/TestRunOutputsPanel.tsx
@@ -128,22 +128,34 @@ export function TestRunOutputsPanel({
       onSelect(orderedItems[currentIndex + 1].id);
   };
 
-  // Surface navigation state to the parent (dialog header pager).
+  // Keep the latest list/selection in a ref so the reported goPrev/goNext stay
+  // stable while reading fresh values when invoked.
+  const navStateRef = useRef({ orderedItems, selectedId, onSelect });
+  navStateRef.current = { orderedItems, selectedId, onSelect };
+
+  // Surface navigation state to the parent (dialog header pager). Depends only
+  // on the primitive index/length so it doesn't re-fire every render — the
+  // `results` prop (and thus `orderedItems`) is rebuilt by callers each render,
+  // which would otherwise loop setState in the parent.
   useEffect(() => {
     if (!onNavChange) return;
-    const idx = orderedItems.findIndex((r) => r.id === selectedId);
     onNavChange({
-      currentIndex: idx,
+      currentIndex,
       total: orderedItems.length,
       goPrev: () => {
-        if (idx > 0) onSelect(orderedItems[idx - 1].id);
+        const s = navStateRef.current;
+        const i = s.orderedItems.findIndex((r) => r.id === s.selectedId);
+        if (i > 0) s.onSelect(s.orderedItems[i - 1].id);
       },
       goNext: () => {
-        if (idx >= 0 && idx < orderedItems.length - 1)
-          onSelect(orderedItems[idx + 1].id);
+        const s = navStateRef.current;
+        const i = s.orderedItems.findIndex((r) => r.id === s.selectedId);
+        if (i >= 0 && i < s.orderedItems.length - 1)
+          s.onSelect(s.orderedItems[i + 1].id);
       },
     });
-  }, [onNavChange, orderedItems, selectedId, onSelect]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [onNavChange, currentIndex, orderedItems.length]);
 
   // Arrow-key navigation: Up = previous, Down = next. Ignored while typing in
   // an input (e.g. the search box).

--- a/src/components/eval-details/TestRunOutputsPanel.tsx
+++ b/src/components/eval-details/TestRunOutputsPanel.tsx
@@ -8,6 +8,7 @@ import {
   TestDetailView as SharedTestDetailView,
   EmptyStateView,
   EvaluationCriteriaPanel,
+  ResultPager,
 } from "@/components/test-results/shared";
 import { SearchInput } from "@/components/ui/SearchInput";
 import type { DefaultEvaluatorSummary } from "@/lib/defaultEvaluators";
@@ -91,6 +92,18 @@ export function TestRunOutputsPanel({
 
   const selectedResult = results.find((r) => r.id === selectedId);
 
+  // Flattened display order (group order, respecting the search filter) used
+  // by the Previous/Next pager in the detail panel.
+  const orderedItems = groups.flatMap((g) => g.items);
+  const currentIndex = orderedItems.findIndex((r) => r.id === selectedId);
+  const goPrev = () => {
+    if (currentIndex > 0) onSelect(orderedItems[currentIndex - 1].id);
+  };
+  const goNext = () => {
+    if (currentIndex >= 0 && currentIndex < orderedItems.length - 1)
+      onSelect(orderedItems[currentIndex + 1].id);
+  };
+
   return (
     <div className="flex h-full overflow-hidden" style={height ? { height } : undefined}>
       {/* Left Panel - Test List */}
@@ -171,6 +184,12 @@ export function TestRunOutputsPanel({
                 </button>
               </div>
             )}
+            <ResultPager
+              currentIndex={currentIndex}
+              total={orderedItems.length}
+              onPrev={goPrev}
+              onNext={goNext}
+            />
             <div className="flex-1 overflow-y-auto">
               <TestResultDetail
                 result={selectedResult}

--- a/src/components/eval-details/TestRunOutputsPanel.tsx
+++ b/src/components/eval-details/TestRunOutputsPanel.tsx
@@ -9,6 +9,7 @@ import {
   EmptyStateView,
   EvaluationCriteriaPanel,
 } from "@/components/test-results/shared";
+import { SearchInput } from "@/components/ui/SearchInput";
 import type { DefaultEvaluatorSummary } from "@/lib/defaultEvaluators";
 
 export type TestRunResult = {
@@ -60,6 +61,7 @@ export function TestRunOutputsPanel({
   legacyDefaultEvaluator,
 }: TestRunOutputsPanelProps) {
   const [collapsedSections, setCollapsedSections] = useState<Set<string>>(new Set());
+  const [searchQuery, setSearchQuery] = useState("");
 
   const toggleSection = (key: string) => {
     setCollapsedSections((prev) => {
@@ -69,12 +71,22 @@ export function TestRunOutputsPanel({
     });
   };
 
+  // A test that surfaced an `error` neither passed nor failed evaluation —
+  // it errored out. Bucket those separately from genuine evaluation failures.
+  const isErrored = (r: TestRunResult) => !!r.error;
+
+  const query = searchQuery.trim().toLowerCase();
+  const filteredResults = query
+    ? results.filter((r) => r.name.toLowerCase().includes(query))
+    : results;
+
   const groups: StatusGroup[] = [
-    { key: "failed", label: "Failed", dotColor: "bg-red-500", items: results.filter((r) => r.status === "failed") },
-    { key: "passed", label: "Passed", dotColor: "bg-green-500", items: results.filter((r) => r.status === "passed") },
-    { key: "queued", label: "Queued", dotColor: "bg-gray-400", items: results.filter((r) => r.status === "queued") },
-    { key: "running", label: "Running", dotColor: "bg-yellow-500 animate-pulse", items: results.filter((r) => r.status === "running") },
-    { key: "pending", label: "Pending", dotColor: "bg-gray-400", items: results.filter((r) => r.status === "pending") },
+    { key: "failed", label: "Failed", dotColor: "bg-red-500", items: filteredResults.filter((r) => r.status === "failed" && !isErrored(r)) },
+    { key: "errored", label: "Errored", dotColor: "bg-amber-500", items: filteredResults.filter((r) => isErrored(r)) },
+    { key: "passed", label: "Passed", dotColor: "bg-green-500", items: filteredResults.filter((r) => r.status === "passed") },
+    { key: "queued", label: "Queued", dotColor: "bg-gray-400", items: filteredResults.filter((r) => r.status === "queued") },
+    { key: "running", label: "Running", dotColor: "bg-yellow-500 animate-pulse", items: filteredResults.filter((r) => r.status === "running") },
+    { key: "pending", label: "Pending", dotColor: "bg-gray-400", items: filteredResults.filter((r) => r.status === "pending") },
   ].filter((g) => g.items.length > 0);
 
   const selectedResult = results.find((r) => r.id === selectedId);
@@ -87,7 +99,20 @@ export function TestRunOutputsPanel({
           selectedId ? "hidden md:flex" : "flex"
         }`}
       >
+        {/* Search */}
+        <div className="shrink-0 border-b border-border p-3">
+          <SearchInput
+            value={searchQuery}
+            onChange={setSearchQuery}
+            placeholder="Search tests"
+          />
+        </div>
         <div className="flex-1 overflow-y-auto">
+          {groups.length === 0 && query && (
+            <div className="p-4 text-sm text-muted-foreground">
+              No tests match &ldquo;{searchQuery}&rdquo;
+            </div>
+          )}
           {groups.map((group) => (
             <div key={group.key} className="p-4">
               <button
@@ -115,7 +140,7 @@ export function TestRunOutputsPanel({
                         selectedId === result.id ? "bg-muted" : "hover:bg-muted/50"
                       }`}
                     >
-                      <StatusIcon status={result.status} />
+                      <StatusIcon status={isErrored(result) ? "error" : result.status} />
                       <span className="text-sm text-foreground truncate">{result.name}</span>
                     </button>
                   ))}
@@ -162,7 +187,7 @@ export function TestRunOutputsPanel({
 
       {/* Right Panel - Evaluators / Expected Tool Calls (desktop only).
           On mobile this content is rendered inline by `TestDetailView`. */}
-      {selectedResult && (selectedResult.status === "passed" || selectedResult.status === "failed") && (
+      {selectedResult && !isErrored(selectedResult) && (selectedResult.status === "passed" || selectedResult.status === "failed") && (
         <div className="hidden md:flex w-[32rem] border-l border-border flex-col overflow-hidden">
           <div className="flex-1 overflow-y-auto">
             <EvaluationCriteriaPanel

--- a/src/components/eval-details/TestRunOutputsPanel.tsx
+++ b/src/components/eval-details/TestRunOutputsPanel.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import {
   TestCaseOutput,
   TestCaseData,
@@ -64,6 +64,8 @@ export function TestRunOutputsPanel({
 }: TestRunOutputsPanelProps) {
   const [collapsedSections, setCollapsedSections] = useState<Set<string>>(new Set());
   const [searchQuery, setSearchQuery] = useState("");
+  // Ref to the currently-selected row, so navigation keeps it in view.
+  const selectedRowRef = useRef<HTMLButtonElement>(null);
 
   const toggleSection = (key: string) => {
     setCollapsedSections((prev) => {
@@ -124,6 +126,11 @@ export function TestRunOutputsPanel({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectedId, currentIndex, orderedItems.length]);
 
+  // Keep the selected row visible in the list as the selection changes.
+  useEffect(() => {
+    selectedRowRef.current?.scrollIntoView({ block: "nearest" });
+  }, [selectedId]);
+
   return (
     <div className="flex h-full overflow-hidden" style={height ? { height } : undefined}>
       {/* Left Panel - Test List */}
@@ -167,6 +174,7 @@ export function TestRunOutputsPanel({
                   {group.items.map((result) => (
                     <button
                       key={result.id}
+                      ref={selectedId === result.id ? selectedRowRef : undefined}
                       type="button"
                       onClick={() => onSelect(result.id)}
                       className={`w-full flex items-center gap-2 px-3 py-2 rounded-lg cursor-pointer transition-colors ${

--- a/src/components/eval-details/TestRunOutputsPanel.tsx
+++ b/src/components/eval-details/TestRunOutputsPanel.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useRef, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import {
   TestCaseOutput,
   TestCaseData,
@@ -102,23 +102,10 @@ export function TestRunOutputsPanel({
 
   const selectedResult = results.find((r) => r.id === selectedId);
 
-  // Flattened display order (group order, respecting the search filter) used
-  // by the Previous/Next pager that the parent renders in the dialog header.
-  const orderedItems = useMemo(() => {
-    const q = searchQuery.trim().toLowerCase();
-    const fr = q
-      ? results.filter((r) => r.name.toLowerCase().includes(q))
-      : results;
-    const err = (r: TestRunResult) => !!r.error;
-    return [
-      ...fr.filter((r) => r.status === "failed" && !err(r)),
-      ...fr.filter((r) => err(r)),
-      ...fr.filter((r) => r.status === "passed"),
-      ...fr.filter((r) => r.status === "queued"),
-      ...fr.filter((r) => r.status === "running"),
-      ...fr.filter((r) => r.status === "pending"),
-    ];
-  }, [results, searchQuery]);
+  // Flattened display order — the same buckets/order as the rendered `groups`,
+  // so the Previous/Next pager (parent renders it in the dialog header) always
+  // matches the visible list. `groups` is already filtered by search above.
+  const orderedItems = groups.flatMap((g) => g.items);
   const currentIndex = orderedItems.findIndex((r) => r.id === selectedId);
   const goPrev = () => {
     if (currentIndex > 0) onSelect(orderedItems[currentIndex - 1].id);
@@ -154,7 +141,6 @@ export function TestRunOutputsPanel({
           s.onSelect(s.orderedItems[i + 1].id);
       },
     });
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [onNavChange, currentIndex, orderedItems.length]);
 
   // Arrow-key navigation: Up = previous, Down = next. Ignored while typing in

--- a/src/components/eval-details/TestRunOutputsPanel.tsx
+++ b/src/components/eval-details/TestRunOutputsPanel.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 import {
   TestCaseOutput,
   TestCaseData,
@@ -8,8 +8,9 @@ import {
   TestDetailView as SharedTestDetailView,
   EmptyStateView,
   EvaluationCriteriaPanel,
-  ResultPager,
   isTypingTarget,
+  scrollRowByPage,
+  type PagerNav,
 } from "@/components/test-results/shared";
 import { SearchInput } from "@/components/ui/SearchInput";
 import type { DefaultEvaluatorSummary } from "@/lib/defaultEvaluators";
@@ -43,6 +44,9 @@ type TestRunOutputsPanelProps = {
   enableEvaluatorLinks?: boolean;
   /** Default correctness evaluator used for legacy next-reply criteria. */
   legacyDefaultEvaluator?: DefaultEvaluatorSummary | null;
+  /** Reports Previous/Next navigation state so a parent (the dialog header)
+   * can render the pager. Must be a stable callback (e.g. a useState setter). */
+  onNavChange?: (nav: PagerNav) => void;
 };
 
 type StatusGroup = {
@@ -61,10 +65,13 @@ export function TestRunOutputsPanel({
   evaluatorsByUuid,
   enableEvaluatorLinks = true,
   legacyDefaultEvaluator,
+  onNavChange,
 }: TestRunOutputsPanelProps) {
   const [collapsedSections, setCollapsedSections] = useState<Set<string>>(new Set());
   const [searchQuery, setSearchQuery] = useState("");
-  // Ref to the currently-selected row, so navigation keeps it in view.
+  // Refs to the list scroll container and the currently-selected row, so
+  // navigation keeps the selection in view (a page at a time).
+  const listContainerRef = useRef<HTMLDivElement>(null);
   const selectedRowRef = useRef<HTMLButtonElement>(null);
 
   const toggleSection = (key: string) => {
@@ -96,8 +103,22 @@ export function TestRunOutputsPanel({
   const selectedResult = results.find((r) => r.id === selectedId);
 
   // Flattened display order (group order, respecting the search filter) used
-  // by the Previous/Next pager in the detail panel.
-  const orderedItems = groups.flatMap((g) => g.items);
+  // by the Previous/Next pager that the parent renders in the dialog header.
+  const orderedItems = useMemo(() => {
+    const q = searchQuery.trim().toLowerCase();
+    const fr = q
+      ? results.filter((r) => r.name.toLowerCase().includes(q))
+      : results;
+    const err = (r: TestRunResult) => !!r.error;
+    return [
+      ...fr.filter((r) => r.status === "failed" && !err(r)),
+      ...fr.filter((r) => err(r)),
+      ...fr.filter((r) => r.status === "passed"),
+      ...fr.filter((r) => r.status === "queued"),
+      ...fr.filter((r) => r.status === "running"),
+      ...fr.filter((r) => r.status === "pending"),
+    ];
+  }, [results, searchQuery]);
   const currentIndex = orderedItems.findIndex((r) => r.id === selectedId);
   const goPrev = () => {
     if (currentIndex > 0) onSelect(orderedItems[currentIndex - 1].id);
@@ -106,6 +127,23 @@ export function TestRunOutputsPanel({
     if (currentIndex >= 0 && currentIndex < orderedItems.length - 1)
       onSelect(orderedItems[currentIndex + 1].id);
   };
+
+  // Surface navigation state to the parent (dialog header pager).
+  useEffect(() => {
+    if (!onNavChange) return;
+    const idx = orderedItems.findIndex((r) => r.id === selectedId);
+    onNavChange({
+      currentIndex: idx,
+      total: orderedItems.length,
+      goPrev: () => {
+        if (idx > 0) onSelect(orderedItems[idx - 1].id);
+      },
+      goNext: () => {
+        if (idx >= 0 && idx < orderedItems.length - 1)
+          onSelect(orderedItems[idx + 1].id);
+      },
+    });
+  }, [onNavChange, orderedItems, selectedId, onSelect]);
 
   // Arrow-key navigation: Up = previous, Down = next. Ignored while typing in
   // an input (e.g. the search box).
@@ -126,9 +164,10 @@ export function TestRunOutputsPanel({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectedId, currentIndex, orderedItems.length]);
 
-  // Keep the selected row visible in the list as the selection changes.
+  // Keep the selected row visible in the list as the selection changes,
+  // scrolling a page at a time rather than row by row.
   useEffect(() => {
-    selectedRowRef.current?.scrollIntoView({ block: "nearest" });
+    scrollRowByPage(listContainerRef.current, selectedRowRef.current);
   }, [selectedId]);
 
   return (
@@ -147,7 +186,7 @@ export function TestRunOutputsPanel({
             placeholder="Search tests"
           />
         </div>
-        <div className="flex-1 overflow-y-auto">
+        <div ref={listContainerRef} className="flex-1 overflow-y-auto">
           {groups.length === 0 && query && (
             <div className="p-4 text-sm text-muted-foreground">
               No tests match &ldquo;{searchQuery}&rdquo;
@@ -212,19 +251,6 @@ export function TestRunOutputsPanel({
                 </button>
               </div>
             )}
-            <ResultPager
-              currentIndex={currentIndex}
-              total={orderedItems.length}
-              onPrev={goPrev}
-              onNext={goNext}
-            />
-            {/* Selected test name — pinned above the scrolling conversation,
-                with horizontal scroll for names wider than the panel. */}
-            <div className="flex-shrink-0 border-b border-border px-4 py-2 overflow-x-auto">
-              <span className="block text-sm font-semibold text-foreground whitespace-nowrap">
-                {selectedResult.name}
-              </span>
-            </div>
             <div className="flex-1 overflow-y-auto">
               <TestResultDetail
                 result={selectedResult}
@@ -245,6 +271,7 @@ export function TestRunOutputsPanel({
         <div className="hidden md:flex w-[32rem] border-l border-border flex-col overflow-hidden">
           <div className="flex-1 overflow-y-auto">
             <EvaluationCriteriaPanel
+              testName={selectedResult.name}
               evaluation={selectedResult.testCase?.evaluation}
               testCaseEvaluators={selectedResult.testCase?.evaluators}
               passed={

--- a/src/components/eval-details/TestRunOutputsPanel.tsx
+++ b/src/components/eval-details/TestRunOutputsPanel.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import {
   TestCaseOutput,
   TestCaseData,
@@ -9,6 +9,7 @@ import {
   EmptyStateView,
   EvaluationCriteriaPanel,
   ResultPager,
+  isTypingTarget,
 } from "@/components/test-results/shared";
 import { SearchInput } from "@/components/ui/SearchInput";
 import type { DefaultEvaluatorSummary } from "@/lib/defaultEvaluators";
@@ -104,6 +105,25 @@ export function TestRunOutputsPanel({
       onSelect(orderedItems[currentIndex + 1].id);
   };
 
+  // Arrow-key navigation: Up = previous, Down = next. Ignored while typing in
+  // an input (e.g. the search box).
+  useEffect(() => {
+    if (!selectedId) return;
+    const handler = (e: KeyboardEvent) => {
+      if (isTypingTarget(e.target) || e.metaKey || e.ctrlKey || e.altKey) return;
+      if (e.key === "ArrowUp") {
+        e.preventDefault();
+        goPrev();
+      } else if (e.key === "ArrowDown") {
+        e.preventDefault();
+        goNext();
+      }
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectedId, currentIndex, orderedItems.length]);
+
   return (
     <div className="flex h-full overflow-hidden" style={height ? { height } : undefined}>
       {/* Left Panel - Test List */}
@@ -190,6 +210,13 @@ export function TestRunOutputsPanel({
               onPrev={goPrev}
               onNext={goNext}
             />
+            {/* Selected test name — pinned above the scrolling conversation,
+                with horizontal scroll for names wider than the panel. */}
+            <div className="flex-shrink-0 border-b border-border px-4 py-2 overflow-x-auto">
+              <span className="block text-sm font-semibold text-foreground whitespace-nowrap">
+                {selectedResult.name}
+              </span>
+            </div>
             <div className="flex-1 overflow-y-auto">
               <TestResultDetail
                 result={selectedResult}

--- a/src/components/test-results/shared.tsx
+++ b/src/components/test-results/shared.tsx
@@ -1330,10 +1330,14 @@ export function scrollRowByPage(
   const rowBottom = rowTop + rRect.height;
   const viewTop = container.scrollTop;
   const viewBottom = viewTop + container.clientHeight;
+  let nextTop: number | null = null;
   if (rowBottom > viewBottom) {
-    container.scrollTop = rowTop;
+    nextTop = rowTop;
   } else if (rowTop < viewTop) {
-    container.scrollTop = rowBottom - container.clientHeight;
+    nextTop = rowBottom - container.clientHeight;
+  }
+  if (nextTop !== null) {
+    container.scrollTo({ top: nextTop, behavior: "smooth" });
   }
 }
 

--- a/src/components/test-results/shared.tsx
+++ b/src/components/test-results/shared.tsx
@@ -15,6 +15,7 @@ import {
   DocumentIcon,
   CloseIcon,
   ChevronDownIcon,
+  WarningTriangleIcon,
 } from "@/components/icons";
 import type { DefaultEvaluatorSummary } from "@/lib/defaultEvaluators";
 import { getBinaryLabel, toRatingScale } from "@/lib/binaryLabels";
@@ -209,7 +210,7 @@ function legacyEvaluatorEntry(
 export function StatusIcon({
   status,
 }: {
-  status: "passed" | "failed" | "running" | "pending" | "queued";
+  status: "passed" | "failed" | "error" | "running" | "pending" | "queued";
 }) {
   if (status === "passed") {
     return (
@@ -222,6 +223,13 @@ export function StatusIcon({
     return (
       <div className="w-5 h-5 rounded-full bg-red-500/20 flex items-center justify-center flex-shrink-0">
         <XIcon className="w-3 h-3 text-red-500" />
+      </div>
+    );
+  }
+  if (status === "error") {
+    return (
+      <div className="w-5 h-5 rounded-full bg-amber-500/20 flex items-center justify-center flex-shrink-0">
+        <WarningTriangleIcon className="w-3 h-3 text-amber-500" />
       </div>
     );
   }

--- a/src/components/test-results/shared.tsx
+++ b/src/components/test-results/shared.tsx
@@ -1203,7 +1203,8 @@ export function EvaluationCriteriaPanel({
     <div className="p-4 md:p-6 space-y-4">
       {testName && (
         <div className="-mx-4 md:-mx-6 -mt-4 md:-mt-6 mb-1 px-4 md:px-6 py-2 border-b border-border overflow-x-auto">
-          <span className="block text-sm font-semibold text-foreground whitespace-nowrap">
+          <span className="block text-[11px] text-muted-foreground">Name</span>
+          <span className="block text-xs text-foreground whitespace-nowrap">
             {testName}
           </span>
         </div>

--- a/src/components/test-results/shared.tsx
+++ b/src/components/test-results/shared.tsx
@@ -1197,20 +1197,40 @@ export function EvaluationCriteriaPanel({
 
   return (
     <div className="p-4 md:p-6 space-y-4">
-      <h3 className="text-sm font-semibold text-foreground">
-        {isToolCall ? "Expected Tool Calls" : "Evaluators"}
-      </h3>
+      {!isToolCall && (
+        <h3 className="text-sm font-semibold text-foreground">Evaluators</h3>
+      )}
 
-      {/* Tool-call test: expected tool calls + verdict-coloured reasoning
-          card. The deterministic tool-call match is binary, so we surface
-          it through the same `EvaluatorVerdictCard` (read mode) the
-          response-test per-evaluator cards use — name fixed to "Tool call
-          test", verdict driven by the top-level `passed` field, reasoning
-          attached as the collapsible explainer. While the run is still
-          pending (`passed` null/undefined), we fall back to the neutral
-          reasoning strip so the card doesn't show a misleading colour. */}
+      {/* Tool-call test: the result (pass/fail + reasoning) shows first,
+          followed by the expected tool calls below it. The deterministic
+          tool-call match is binary, so we surface it through the same
+          `EvaluatorVerdictCard` (read mode) the response-test per-evaluator
+          cards use — name fixed to "Tool call test", verdict driven by the
+          top-level `passed` field, reasoning attached as the collapsible
+          explainer. While the run is still pending (`passed` null/undefined),
+          we fall back to the neutral reasoning strip so the card doesn't show
+          a misleading colour. */}
       {isToolCall && (
         <>
+          {typeof passed === "boolean" ? (
+            <EvaluatorVerdictCard
+              mode="read"
+              name="Tool call test"
+              outputType="binary"
+              enableLink={false}
+              match={passed}
+              reasoning={reasoning ?? null}
+            />
+          ) : (
+            <CollapsibleReasoningStrip
+              text={reasoning}
+              mutedBody={false}
+              leadingLabel="Reasoning"
+            />
+          )}
+          <h3 className="text-sm font-semibold text-foreground">
+            Expected Tool Calls
+          </h3>
           {hasExpectedToolCalls ? (
             <div className="space-y-2">
               {evaluation!.tool_calls!.map((tc, i) => {
@@ -1229,22 +1249,6 @@ export function EvaluationCriteriaPanel({
             <p className="text-xs text-muted-foreground">
               No expected tool calls specified
             </p>
-          )}
-          {typeof passed === "boolean" ? (
-            <EvaluatorVerdictCard
-              mode="read"
-              name="Tool call test"
-              outputType="binary"
-              enableLink={false}
-              match={passed}
-              reasoning={reasoning ?? null}
-            />
-          ) : (
-            <CollapsibleReasoningStrip
-              text={reasoning}
-              mutedBody={false}
-              leadingLabel="Reasoning"
-            />
           )}
         </>
       )}

--- a/src/components/test-results/shared.tsx
+++ b/src/components/test-results/shared.tsx
@@ -1303,6 +1303,48 @@ export function EvaluationCriteriaPanel({
   );
 }
 
+// Shared Previous/Next pager for stepping through the selected result in the
+// detail panel. `currentIndex` is the 0-based position in the displayed list
+// (-1 when the selection isn't in the current filtered view); `total` is the
+// list length. Buttons disable at the ends.
+export function ResultPager({
+  currentIndex,
+  total,
+  onPrev,
+  onNext,
+}: {
+  currentIndex: number;
+  total: number;
+  onPrev: () => void;
+  onNext: () => void;
+}) {
+  const hasPrev = currentIndex > 0;
+  const hasNext = currentIndex >= 0 && currentIndex < total - 1;
+  const btn =
+    "inline-flex items-center gap-1 px-2.5 py-1.5 rounded-md text-sm text-foreground hover:bg-muted disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer transition-colors";
+  return (
+    <div className="flex items-center justify-between gap-2 px-4 py-2 border-b border-border flex-shrink-0">
+      <button type="button" onClick={onPrev} disabled={!hasPrev} className={btn}>
+        <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+          <path strokeLinecap="round" strokeLinejoin="round" d="M15 19l-7-7 7-7" />
+        </svg>
+        Previous
+      </button>
+      {total > 0 && currentIndex >= 0 && (
+        <span className="text-xs text-muted-foreground tabular-nums">
+          {currentIndex + 1} of {total}
+        </span>
+      )}
+      <button type="button" onClick={onNext} disabled={!hasNext} className={btn}>
+        Next
+        <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+          <path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7" />
+        </svg>
+      </button>
+    </div>
+  );
+}
+
 // Shared Stats Display Component
 export function TestStats({
   passedCount,

--- a/src/components/test-results/shared.tsx
+++ b/src/components/test-results/shared.tsx
@@ -1202,7 +1202,7 @@ export function EvaluationCriteriaPanel({
   return (
     <div className="p-4 md:p-6 space-y-4">
       {testName && (
-        <div className="-mx-4 md:-mx-6 -mt-4 md:-mt-6 mb-1 px-4 md:px-6 py-2 border-b border-border overflow-x-auto">
+        <div className="overflow-x-auto">
           <span className="block text-[11px] text-muted-foreground">Name</span>
           <span className="block text-xs text-foreground whitespace-nowrap">
             {testName}

--- a/src/components/test-results/shared.tsx
+++ b/src/components/test-results/shared.tsx
@@ -1307,9 +1307,12 @@ export function EvaluationCriteriaPanel({
 export function TestStats({
   passedCount,
   failedCount,
+  erroredCount = 0,
 }: {
   passedCount: number;
   failedCount: number;
+  /** Tests that errored out (neither passed nor failed). Hidden when 0. */
+  erroredCount?: number;
 }) {
   return (
     <div className="flex items-center gap-3 text-sm">
@@ -1321,6 +1324,12 @@ export function TestStats({
         <div className="w-2 h-2 rounded-full bg-red-500"></div>
         <span className="text-muted-foreground">{failedCount} failed</span>
       </div>
+      {erroredCount > 0 && (
+        <div className="flex items-center gap-1.5">
+          <div className="w-2 h-2 rounded-full bg-amber-500"></div>
+          <span className="text-muted-foreground">{erroredCount} errored</span>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/test-results/shared.tsx
+++ b/src/components/test-results/shared.tsx
@@ -1126,6 +1126,7 @@ function EvaluatorPanelCard({
 export function EvaluationCriteriaPanel({
   evaluation,
   testType,
+  testName,
   passed,
   judgeResults,
   reasoning,
@@ -1136,6 +1137,9 @@ export function EvaluationCriteriaPanel({
 }: {
   evaluation?: TestCaseEvaluation;
   testType?: string;
+  /** Selected test name, pinned at the top of the panel above the results.
+   * Full text with horizontal scroll for names wider than the column. */
+  testName?: string;
   /** Top-level test verdict. Used to colour the tool-call evaluator card
    * (green=pass, red=fail). Null/undefined leaves the card neutral, which
    * is the right default while a run is still in progress. */
@@ -1197,6 +1201,13 @@ export function EvaluationCriteriaPanel({
 
   return (
     <div className="p-4 md:p-6 space-y-4">
+      {testName && (
+        <div className="-mx-4 md:-mx-6 -mt-4 md:-mt-6 mb-1 px-4 md:px-6 py-2 border-b border-border overflow-x-auto">
+          <span className="block text-sm font-semibold text-foreground whitespace-nowrap">
+            {testName}
+          </span>
+        </div>
+      )}
       {!isToolCall && (
         <h3 className="text-sm font-semibold text-foreground">Evaluators</h3>
       )}
@@ -1303,6 +1314,29 @@ export function EvaluationCriteriaPanel({
   );
 }
 
+// Scroll a list container so the given row is visible, a page at a time: if the
+// row sits below the viewport it's aligned to the top (revealing a full page of
+// following rows), and if it sits above it's aligned to the bottom. This avoids
+// the row-by-row creep of `scrollIntoView({ block: "nearest" })` during rapid
+// navigation. No-op when the row is already fully visible.
+export function scrollRowByPage(
+  container: HTMLElement | null,
+  row: HTMLElement | null,
+): void {
+  if (!container || !row) return;
+  const cRect = container.getBoundingClientRect();
+  const rRect = row.getBoundingClientRect();
+  const rowTop = rRect.top - cRect.top + container.scrollTop;
+  const rowBottom = rowTop + rRect.height;
+  const viewTop = container.scrollTop;
+  const viewBottom = viewTop + container.clientHeight;
+  if (rowBottom > viewBottom) {
+    container.scrollTop = rowTop;
+  } else if (rowTop < viewTop) {
+    container.scrollTop = rowBottom - container.clientHeight;
+  }
+}
+
 // True when a keyboard event originates from a text-entry element, so global
 // shortcuts (e.g. arrow-key result navigation) don't hijack typing.
 export function isTypingTarget(target: EventTarget | null): boolean {
@@ -1317,10 +1351,21 @@ export function isTypingTarget(target: EventTarget | null): boolean {
   );
 }
 
-// Shared Previous/Next pager for stepping through the selected result in the
-// detail panel. `currentIndex` is the 0-based position in the displayed list
-// (-1 when the selection isn't in the current filtered view); `total` is the
-// list length. Buttons disable at the ends.
+// Navigation state surfaced by the result panels so a parent (e.g. a dialog
+// header) can render the Previous/Next pager outside the panel itself.
+export type PagerNav = {
+  /** 0-based position in the displayed list, or -1 when the current selection
+   * isn't part of the filtered view. */
+  currentIndex: number;
+  /** Number of items in the displayed list. */
+  total: number;
+  goPrev: () => void;
+  goNext: () => void;
+};
+
+// Shared Previous/Next pager. Renders inline (no border/padding of its own) so
+// it can be dropped into a dialog header next to the title and stats. Buttons
+// disable at the ends; the "N of M" counter shows between them.
 export function ResultPager({
   currentIndex,
   total,
@@ -1335,9 +1380,9 @@ export function ResultPager({
   const hasPrev = currentIndex > 0;
   const hasNext = currentIndex >= 0 && currentIndex < total - 1;
   const btn =
-    "inline-flex items-center gap-1 px-2.5 py-1.5 rounded-md text-sm text-foreground hover:bg-muted disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer transition-colors";
+    "inline-flex items-center gap-1 px-2 py-1 rounded-md text-sm text-foreground hover:bg-muted disabled:opacity-40 disabled:cursor-not-allowed cursor-pointer transition-colors shrink-0";
   return (
-    <div className="flex items-center justify-between gap-2 px-4 py-2 border-b border-border flex-shrink-0">
+    <div className="flex items-center gap-2">
       <button type="button" onClick={onPrev} disabled={!hasPrev} className={btn}>
         <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
           <path strokeLinecap="round" strokeLinejoin="round" d="M15 19l-7-7 7-7" />
@@ -1345,7 +1390,7 @@ export function ResultPager({
         Previous
       </button>
       {total > 0 && currentIndex >= 0 && (
-        <span className="text-xs text-muted-foreground tabular-nums">
+        <span className="shrink-0 text-xs text-muted-foreground tabular-nums">
           {currentIndex + 1} of {total}
         </span>
       )}

--- a/src/components/test-results/shared.tsx
+++ b/src/components/test-results/shared.tsx
@@ -1303,6 +1303,20 @@ export function EvaluationCriteriaPanel({
   );
 }
 
+// True when a keyboard event originates from a text-entry element, so global
+// shortcuts (e.g. arrow-key result navigation) don't hijack typing.
+export function isTypingTarget(target: EventTarget | null): boolean {
+  const el = target as HTMLElement | null;
+  if (!el || !el.tagName) return false;
+  const tag = el.tagName.toUpperCase();
+  return (
+    tag === "INPUT" ||
+    tag === "TEXTAREA" ||
+    tag === "SELECT" ||
+    el.isContentEditable
+  );
+}
+
 // Shared Previous/Next pager for stepping through the selected result in the
 // detail panel. `currentIndex` is the 0-based position in the displayed list
 // (-1 when the selection isn't in the current filtered view); `total` is the

--- a/src/components/test-results/shared.tsx
+++ b/src/components/test-results/shared.tsx
@@ -1384,7 +1384,7 @@ export function ResultPager({
   const hasPrev = currentIndex > 0;
   const hasNext = currentIndex >= 0 && currentIndex < total - 1;
   const btn =
-    "inline-flex items-center gap-1 px-2 py-1 rounded-md text-sm text-foreground hover:bg-muted disabled:opacity-40 disabled:cursor-not-allowed cursor-pointer transition-colors shrink-0";
+    "inline-flex items-center gap-1 px-3 py-1.5 rounded-md border border-border bg-background text-sm font-medium text-foreground hover:bg-muted disabled:opacity-40 disabled:cursor-not-allowed cursor-pointer transition-colors shrink-0";
   return (
     <div className="flex items-center gap-2">
       <button type="button" onClick={onPrev} disabled={!hasPrev} className={btn}>
@@ -1394,7 +1394,7 @@ export function ResultPager({
         Previous
       </button>
       {total > 0 && currentIndex >= 0 && (
-        <span className="shrink-0 text-xs text-muted-foreground tabular-nums">
+        <span className="shrink-0 px-1 text-xs text-muted-foreground tabular-nums">
           {currentIndex + 1} of {total}
         </span>
       )}


### PR DESCRIPTION
## What
- Split tests that errored out (carry an `error` string, never produced a pass/fail verdict) into their own amber **Errored** category in both the test-runner and benchmark result panels — previously they were lumped under Failed.
- Add a name search box above each result list to filter test cases.
- Benchmark panel also gets an Errored filter pill and a per-model errored count.

## Notes
- The benchmark per-test `error` field is wired defensively: if the backend doesn't populate it for benchmark runs, the Errored pill/count just won't appear. The test-runner side already receives `error` from the API.