### PR TITLE
Show pass/fail/error breakdown for unit-test runs

### DIFF
--- a/src/app/tests/page.tsx
+++ b/src/app/tests/page.tsx
@@ -28,7 +28,7 @@ import { DeleteIconButton } from "@/components/ui/DeleteIconButton";
 import { DuplicateIconButton } from "@/components/ui/DuplicateIconButton";
 import { Tooltip } from "@/components/Tooltip";
 import { useSidebarState } from "@/lib/sidebar";
-import { testTypeLabel } from "@/lib/testTypes";
+import { testTypeLabel, getUnitTestBreakdown } from "@/lib/testTypes";
 import { POLLING_INTERVAL_MS } from "@/constants/polling";
 import {
   readBulkNameConflictMessage,
@@ -106,28 +106,6 @@ function getRunDisplayName(run: AllRun): string {
     if (testName) return testName;
   }
   return `${totalTests} test${totalTests !== 1 ? "s" : ""}`;
-}
-
-// Bucket a unit-test run's per-test results into passed / failed / errored.
-// Genuine failures come back with `passed: false`; errored tests never reached
-// evaluation and surface with no verdict (`passed: null`) — or an explicit
-// `error` / `status: "error"`. The runs-list payload omits the `error` field,
-// so the `passed == null` signal is what separates errored from failed. Only
-// called for terminal runs, so a null verdict means errored, not still-running.
-// Returns null when the run has no usable per-test results.
-function getUnitTestBreakdown(
-  run: AllRun,
-): { passed: number; failed: number; errored: number } | null {
-  const results = run.results ?? [];
-  if (results.length === 0) return null;
-  const isPassed = (r: TestRunResult) =>
-    r.passed === true || r.status === "passed";
-  const isErrored = (r: TestRunResult) =>
-    !!r.error || r.status === "error" || r.passed === null || r.passed === undefined;
-  const passed = results.filter((r) => isPassed(r)).length;
-  const errored = results.filter((r) => !isPassed(r) && isErrored(r)).length;
-  const failed = results.length - passed - errored;
-  return { passed, failed, errored };
 }
 
 function formatRelativeTime(dateString: string): string {
@@ -1579,7 +1557,7 @@ function LLMPageInner() {
                               // errored out shows "N Pass / N Fail / N Error"
                               // instead of a single blanket "Error" pill. Fall
                               // back to run-level status when there are no results.
-                              const breakdown = getUnitTestBreakdown(run);
+                              const breakdown = getUnitTestBreakdown(run.results);
                               if (!breakdown) {
                                 return run.status === "failed" || run.error ? (
                                   <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-red-500/20 text-red-500">Error</span>
@@ -1643,7 +1621,7 @@ function LLMPageInner() {
                               </span>
                             ) : run.type === "llm-unit-test" ? (
                               (() => {
-                                const breakdown = getUnitTestBreakdown(run);
+                                const breakdown = getUnitTestBreakdown(run.results);
                                 if (!breakdown) {
                                   return run.status === "failed" || run.error ? (
                                     <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-red-500/20 text-red-500">Error</span>

--- a/src/app/tests/page.tsx
+++ b/src/app/tests/page.tsx
@@ -65,6 +65,8 @@ type Tool = {
 type TestRunResult = {
   name?: string;
   passed: boolean | null;
+  status?: string;
+  error?: string | null;
   output?: Record<string, any> | null;
   test_case?: {
     name?: string;
@@ -104,6 +106,28 @@ function getRunDisplayName(run: AllRun): string {
     if (testName) return testName;
   }
   return `${totalTests} test${totalTests !== 1 ? "s" : ""}`;
+}
+
+// Bucket a unit-test run's per-test results into passed / failed / errored.
+// Genuine failures come back with `passed: false`; errored tests never reached
+// evaluation and surface with no verdict (`passed: null`) — or an explicit
+// `error` / `status: "error"`. The runs-list payload omits the `error` field,
+// so the `passed == null` signal is what separates errored from failed. Only
+// called for terminal runs, so a null verdict means errored, not still-running.
+// Returns null when the run has no usable per-test results.
+function getUnitTestBreakdown(
+  run: AllRun,
+): { passed: number; failed: number; errored: number } | null {
+  const results = run.results ?? [];
+  if (results.length === 0) return null;
+  const isPassed = (r: TestRunResult) =>
+    r.passed === true || r.status === "passed";
+  const isErrored = (r: TestRunResult) =>
+    !!r.error || r.status === "error" || r.passed === null || r.passed === undefined;
+  const passed = results.filter((r) => isPassed(r)).length;
+  const errored = results.filter((r) => !isPassed(r) && isErrored(r)).length;
+  const failed = results.length - passed - errored;
+  return { passed, failed, errored };
 }
 
 function formatRelativeTime(dateString: string): string {
@@ -1549,17 +1573,36 @@ function LLMPageInner() {
                               </svg>
                               Running
                             </span>
+                          ) : run.type === "llm-unit-test" ? (
+                            (() => {
+                              // Prefer a per-test breakdown so a run whose tests
+                              // errored out shows "N Pass / N Fail / N Error"
+                              // instead of a single blanket "Error" pill. Fall
+                              // back to run-level status when there are no results.
+                              const breakdown = getUnitTestBreakdown(run);
+                              if (!breakdown) {
+                                return run.status === "failed" || run.error ? (
+                                  <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-red-500/20 text-red-500">Error</span>
+                                ) : (
+                                  <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-green-500/20 text-green-500">Complete</span>
+                                );
+                              }
+                              return (
+                                <>
+                                  {breakdown.passed > 0 && (
+                                    <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-green-500/20 text-green-500">{breakdown.passed} Pass</span>
+                                  )}
+                                  {breakdown.failed > 0 && (
+                                    <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-red-500/20 text-red-500">{breakdown.failed} Fail</span>
+                                  )}
+                                  {breakdown.errored > 0 && (
+                                    <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-amber-500/20 text-amber-500">{breakdown.errored} Error</span>
+                                  )}
+                                </>
+                              );
+                            })()
                           ) : run.status === "failed" || run.error ? (
                             <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-red-500/20 text-red-500">Error</span>
-                          ) : run.type === "llm-unit-test" ? (
-                            <>
-                              {run.passed !== null && run.passed > 0 && (
-                                <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-green-500/20 text-green-500">{run.passed} Pass</span>
-                              )}
-                              {run.failed !== null && run.failed > 0 && (
-                                <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-red-500/20 text-red-500">{run.failed} Fail</span>
-                              )}
-                            </>
                           ) : (
                             <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-green-500/20 text-green-500">Complete</span>
                           )}
@@ -1598,17 +1641,32 @@ function LLMPageInner() {
                                 </svg>
                                 Running
                               </span>
+                            ) : run.type === "llm-unit-test" ? (
+                              (() => {
+                                const breakdown = getUnitTestBreakdown(run);
+                                if (!breakdown) {
+                                  return run.status === "failed" || run.error ? (
+                                    <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-red-500/20 text-red-500">Error</span>
+                                  ) : (
+                                    <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-green-500/20 text-green-500">Complete</span>
+                                  );
+                                }
+                                return (
+                                  <>
+                                    {breakdown.passed > 0 && (
+                                      <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-green-500/20 text-green-500">{breakdown.passed} Pass</span>
+                                    )}
+                                    {breakdown.failed > 0 && (
+                                      <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-red-500/20 text-red-500">{breakdown.failed} Fail</span>
+                                    )}
+                                    {breakdown.errored > 0 && (
+                                      <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-amber-500/20 text-amber-500">{breakdown.errored} Error</span>
+                                    )}
+                                  </>
+                                );
+                              })()
                             ) : run.status === "failed" || run.error ? (
                               <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-red-500/20 text-red-500">Error</span>
-                            ) : run.type === "llm-unit-test" ? (
-                              <>
-                                {run.passed !== null && run.passed > 0 && (
-                                  <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-green-500/20 text-green-500">{run.passed} Pass</span>
-                                )}
-                                {run.failed !== null && run.failed > 0 && (
-                                  <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-red-500/20 text-red-500">{run.failed} Fail</span>
-                                )}
-                              </>
                             ) : (
                               <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-green-500/20 text-green-500">Complete</span>
                             )}

--- a/src/components/agent-tabs/TestsTabContent.tsx
+++ b/src/components/agent-tabs/TestsTabContent.tsx
@@ -53,6 +53,8 @@ type TestDetail = TestData & {
 type TestRunResult = {
   name?: string; // Test name (used in in-progress responses)
   passed: boolean | null; // null means test is still running
+  status?: string; // "passed" | "failed" | ... when present
+  error?: string | null; // set when the test errored out before evaluating
   output?: Record<string, any> | null;
   test_case?: {
     name?: string;
@@ -60,6 +62,24 @@ type TestRunResult = {
     evaluation?: Record<string, any>;
   } | null;
 };
+
+// Bucket a unit-test run's per-test results into passed / failed / errored,
+// mirroring the categorisation used in TestRunOutputsPanel and the public
+// test-run page. Errored tests carry an `error` and are kept out of the
+// `failed` bucket so the three counts sum to the total. Returns null when the
+// run has no usable per-test results (e.g. it crashed before producing any).
+function getUnitTestBreakdown(
+  run: TestRun,
+): { passed: number; failed: number; errored: number } | null {
+  const results = run.results ?? [];
+  if (results.length === 0) return null;
+  const isPassed = (r: TestRunResult) =>
+    r.passed === true || r.status === "passed";
+  const errored = results.filter((r) => !!r.error).length;
+  const passed = results.filter((r) => isPassed(r)).length;
+  const failed = results.filter((r) => !isPassed(r) && !r.error).length;
+  return { passed, failed, errored };
+}
 
 type TestRun = {
   uuid: string;
@@ -1594,23 +1614,48 @@ export function TestsTabContent({
                     </svg>
                     Running
                   </span>
+                ) : run.type === "llm-unit-test" ? (
+                  (() => {
+                    // Prefer a per-test breakdown so a run whose tests errored
+                    // out shows "N Success / N Fail / N Error" instead of a
+                    // single blanket "Error" pill. Fall back to the run-level
+                    // status only when there are no usable results.
+                    const breakdown = getUnitTestBreakdown(run);
+                    if (!breakdown) {
+                      return run.status === "failed" ? (
+                        <span className="inline-flex items-center whitespace-nowrap px-2 py-0.5 rounded text-xs font-medium bg-red-100 text-red-700 dark:bg-red-500/20 dark:text-red-500">
+                          Error
+                        </span>
+                      ) : (
+                        <span className="inline-flex items-center whitespace-nowrap px-2 py-0.5 rounded text-xs font-medium bg-green-100 text-green-700 dark:bg-green-500/20 dark:text-green-500">
+                          Complete
+                        </span>
+                      );
+                    }
+                    return (
+                      <>
+                        {breakdown.passed > 0 && (
+                          <span className="inline-flex items-center whitespace-nowrap px-2 py-0.5 rounded text-xs font-medium bg-green-100 text-green-700 dark:bg-green-500/20 dark:text-green-500">
+                            {breakdown.passed} Success
+                          </span>
+                        )}
+                        {breakdown.failed > 0 && (
+                          <span className="inline-flex items-center whitespace-nowrap px-2 py-0.5 rounded text-xs font-medium bg-red-100 text-red-700 dark:bg-red-500/20 dark:text-red-500">
+                            {breakdown.failed} Fail
+                          </span>
+                        )}
+                        {breakdown.errored > 0 && (
+                          <span className="inline-flex items-center whitespace-nowrap px-2 py-0.5 rounded text-xs font-medium bg-amber-100 text-amber-700 dark:bg-amber-500/20 dark:text-amber-500">
+                            {breakdown.errored} Error
+                          </span>
+                        )}
+                      </>
+                    );
+                  })()
                 ) : run.status === "failed" ? (
                   <span className="inline-flex items-center whitespace-nowrap px-2 py-0.5 rounded text-xs font-medium bg-red-100 text-red-700 dark:bg-red-500/20 dark:text-red-500">
                     Error
                   </span>
-                ) : run.type === "llm-unit-test" ? (
-                  <>
-                    {run.passed !== null && run.passed > 0 && (
-                      <span className="inline-flex items-center whitespace-nowrap px-2 py-0.5 rounded text-xs font-medium bg-green-100 text-green-700 dark:bg-green-500/20 dark:text-green-500">
-                        {run.passed} Success
-                      </span>
-                    )}
-                    {run.failed !== null && run.failed > 0 && (
-                      <span className="inline-flex items-center whitespace-nowrap px-2 py-0.5 rounded text-xs font-medium bg-red-100 text-red-700 dark:bg-red-500/20 dark:text-red-500">
-                        {run.failed} Fail
-                      </span>
-                    )}
-                  </>
                 ) : (
                   <span className="inline-flex items-center whitespace-nowrap px-2 py-0.5 rounded text-xs font-medium bg-green-100 text-green-700 dark:bg-green-500/20 dark:text-green-500">
                     Complete

--- a/src/components/agent-tabs/TestsTabContent.tsx
+++ b/src/components/agent-tabs/TestsTabContent.tsx
@@ -1594,7 +1594,7 @@ export function TestsTabContent({
               <span className="hidden sm:block sm:w-full sm:min-w-0 text-sm text-muted-foreground text-right tabular-nums">
                 {formatRelativeTime(run.updated_at)}
               </span>
-              <div className="flex flex-wrap items-center sm:justify-end gap-2 sm:flex-nowrap sm:justify-self-end">
+              <div className="flex flex-wrap items-center sm:justify-end gap-2 sm:justify-self-end">
                 {run.status === "pending" ||
                 run.status === "queued" ||
                 run.status === "in_progress" ? (

--- a/src/components/agent-tabs/TestsTabContent.tsx
+++ b/src/components/agent-tabs/TestsTabContent.tsx
@@ -63,11 +63,15 @@ type TestRunResult = {
   } | null;
 };
 
-// Bucket a unit-test run's per-test results into passed / failed / errored,
-// mirroring the categorisation used in TestRunOutputsPanel and the public
-// test-run page. Errored tests carry an `error` and are kept out of the
-// `failed` bucket so the three counts sum to the total. Returns null when the
-// run has no usable per-test results (e.g. it crashed before producing any).
+// Bucket a unit-test run's per-test results into passed / failed / errored.
+// Genuine failures come back with `passed: false` (evaluation ran and the test
+// did not pass); errored tests never reached evaluation, so they surface with
+// no verdict (`passed: null`) — or, on the detail endpoint, an explicit
+// `error` / `status: "error"`. The runs-list payload omits the `error` field,
+// so the `passed == null` signal is what separates errored from failed here.
+// This is only called for terminal runs (the badge branch above already
+// handles pending/queued/in_progress), so a null verdict means errored, not
+// "still running". Returns null when the run has no usable per-test results.
 function getUnitTestBreakdown(
   run: TestRun,
 ): { passed: number; failed: number; errored: number } | null {
@@ -75,9 +79,11 @@ function getUnitTestBreakdown(
   if (results.length === 0) return null;
   const isPassed = (r: TestRunResult) =>
     r.passed === true || r.status === "passed";
-  const errored = results.filter((r) => !!r.error).length;
+  const isErrored = (r: TestRunResult) =>
+    !!r.error || r.status === "error" || r.passed === null || r.passed === undefined;
   const passed = results.filter((r) => isPassed(r)).length;
-  const failed = results.filter((r) => !isPassed(r) && !r.error).length;
+  const errored = results.filter((r) => !isPassed(r) && isErrored(r)).length;
+  const failed = results.length - passed - errored;
   return { passed, failed, errored };
 }
 

--- a/src/components/agent-tabs/TestsTabContent.tsx
+++ b/src/components/agent-tabs/TestsTabContent.tsx
@@ -20,7 +20,7 @@ import {
 import { BulkUploadTestsModal } from "@/components/BulkUploadTestsModal";
 import { POLLING_INTERVAL_MS } from "@/constants/polling";
 import { showLimitToast } from "@/constants/limits";
-import { testTypeLabel } from "@/lib/testTypes";
+import { testTypeLabel, getUnitTestBreakdown } from "@/lib/testTypes";
 import {
   readBulkNameConflictMessage,
   readNameConflictMessage,
@@ -62,30 +62,6 @@ type TestRunResult = {
     evaluation?: Record<string, any>;
   } | null;
 };
-
-// Bucket a unit-test run's per-test results into passed / failed / errored.
-// Genuine failures come back with `passed: false` (evaluation ran and the test
-// did not pass); errored tests never reached evaluation, so they surface with
-// no verdict (`passed: null`) — or, on the detail endpoint, an explicit
-// `error` / `status: "error"`. The runs-list payload omits the `error` field,
-// so the `passed == null` signal is what separates errored from failed here.
-// This is only called for terminal runs (the badge branch above already
-// handles pending/queued/in_progress), so a null verdict means errored, not
-// "still running". Returns null when the run has no usable per-test results.
-function getUnitTestBreakdown(
-  run: TestRun,
-): { passed: number; failed: number; errored: number } | null {
-  const results = run.results ?? [];
-  if (results.length === 0) return null;
-  const isPassed = (r: TestRunResult) =>
-    r.passed === true || r.status === "passed";
-  const isErrored = (r: TestRunResult) =>
-    !!r.error || r.status === "error" || r.passed === null || r.passed === undefined;
-  const passed = results.filter((r) => isPassed(r)).length;
-  const errored = results.filter((r) => !isPassed(r) && isErrored(r)).length;
-  const failed = results.length - passed - errored;
-  return { passed, failed, errored };
-}
 
 type TestRun = {
   uuid: string;
@@ -1618,7 +1594,7 @@ export function TestsTabContent({
                     // out shows "N Success / N Fail / N Error" instead of a
                     // single blanket "Error" pill. Fall back to the run-level
                     // status only when there are no usable results.
-                    const breakdown = getUnitTestBreakdown(run);
+                    const breakdown = getUnitTestBreakdown(run.results);
                     if (!breakdown) {
                       return run.status === "failed" ? (
                         <span className="inline-flex items-center whitespace-nowrap px-2 py-0.5 rounded text-xs font-medium bg-red-100 text-red-700 dark:bg-red-500/20 dark:text-red-500">

--- a/src/components/agent-tabs/TestsTabContent.tsx
+++ b/src/components/agent-tabs/TestsTabContent.tsx
@@ -107,17 +107,9 @@ function getTestRunDisplayName(run: TestRun): string {
     return `${modelCount} model${modelCount !== 1 ? "s" : ""}`;
   }
 
-  // For llm-unit-test: if only 1 test and it has a name, show the test name
+  // For llm-unit-test: always show the test count ("1 test" / "N tests"),
+  // including single-test runs (previously these showed the test name).
   const totalTests = run.total_tests ?? run.results?.length ?? 0;
-  if (totalTests === 1 && run.results?.[0]) {
-    // Check name field first (in-progress), then test_case.name (completed)
-    const testName = run.results[0].name || run.results[0].test_case?.name;
-    if (testName) {
-      return testName;
-    }
-  }
-
-  // Otherwise show "N tests"
   return `${totalTests} test${totalTests !== 1 ? "s" : ""}`;
 }
 

--- a/src/lib/testTypes.ts
+++ b/src/lib/testTypes.ts
@@ -30,3 +30,41 @@ export function testTypeLabel(
       return fallback;
   }
 }
+
+/**
+ * Minimal per-test result shape needed to categorise a run. Both the agent
+ * Tests tab and the /tests Runs table have richer local `TestRunResult` types;
+ * those are structurally compatible with this.
+ */
+export type UnitTestResultLike = {
+  passed: boolean | null;
+  status?: string;
+  error?: string | null;
+};
+
+/**
+ * Bucket a unit-test run's per-test results into passed / failed / errored.
+ *
+ * Genuine failures come back with `passed: false` (evaluation ran and the test
+ * did not pass); errored tests never reached evaluation, so they surface with
+ * no verdict (`passed: null`) — or, on the detail endpoint, an explicit
+ * `error` / `status: "error"`. The runs-list payload omits the `error` field,
+ * so the `passed == null` signal is what separates errored from failed here.
+ *
+ * Only meaningful for terminal runs (callers gate out pending/queued/
+ * in_progress first), so a null verdict means errored, not "still running".
+ * Returns `null` when the run has no usable per-test results.
+ */
+export function getUnitTestBreakdown(
+  results: UnitTestResultLike[] | null | undefined,
+): { passed: number; failed: number; errored: number } | null {
+  if (!results || results.length === 0) return null;
+  const isPassed = (r: UnitTestResultLike) =>
+    r.passed === true || r.status === "passed";
+  const isErrored = (r: UnitTestResultLike) =>
+    !!r.error || r.status === "error" || r.passed === null || r.passed === undefined;
+  const passed = results.filter((r) => isPassed(r)).length;
+  const errored = results.filter((r) => !isPassed(r) && isErrored(r)).length;
+  const failed = results.length - passed - errored;
+  return { passed, failed, errored };
+}


### PR DESCRIPTION
## What
- Unit-test runs in both the agent Tests tab and the global /tests Runs table now show a `N Pass / N Fail / N Error` breakdown instead of a blanket "Error" pill when the run errored out.
- Errored tests are derived from the missing verdict (`passed: null`) since the runs-list payload omits the per-test `error` field; failures (`passed: false`) and errored are bucketed separately.
- Past-runs pills now wrap to two lines, and single-test runs show "1 test" instead of the test name.

## Notes
- The errored/failed split assumes the runs-list endpoint returns errored tests with `passed: null`. If the backend instead returns `passed: false` for them, they're indistinguishable from real failures in the list and would need a backend field. Detail views are unaffected (they use the per-test `error` field).