### PR TITLE
Improve test/benchmark result dialog UX

### DIFF
--- a/src/components/TestRunnerDialog.tsx
+++ b/src/components/TestRunnerDialog.tsx
@@ -877,7 +877,7 @@ export function TestRunnerDialog({
           {/* Left: title + pass/fail stats */}
           <div className="flex items-center gap-3 min-w-0">
             <div className="min-w-0">
-              <div className="flex items-center gap-2">
+              <div className="flex items-center gap-2 md:gap-3">
                 {(runStatus === "queued" || runStatus === "in_progress") && (
                   <span
                     className="relative flex h-2.5 w-2.5 shrink-0"
@@ -890,23 +890,23 @@ export function TestRunnerDialog({
                 <h2 className="text-base md:text-lg font-semibold text-foreground truncate">
                   {runName ?? "Test run"}
                 </h2>
+                {/* Passed/Failed counts - desktop only */}
+                {!isOverallError &&
+                  testResults.length > 0 &&
+                  (passedTests.length > 0 ||
+                    failedTests.length > 0 ||
+                    erroredTests.length > 0) && (
+                    <div className="hidden md:block shrink-0">
+                      <TestStats
+                        passedCount={passedTests.length}
+                        failedCount={failedTests.length}
+                        erroredCount={erroredTests.length}
+                      />
+                    </div>
+                  )}
               </div>
               <p className="text-xs text-muted-foreground truncate">{agentName}</p>
             </div>
-            {/* Passed/Failed counts - desktop only */}
-            {!isOverallError &&
-              testResults.length > 0 &&
-              (passedTests.length > 0 ||
-                failedTests.length > 0 ||
-                erroredTests.length > 0) && (
-                <div className="hidden md:block">
-                  <TestStats
-                    passedCount={passedTests.length}
-                    failedCount={failedTests.length}
-                    erroredCount={erroredTests.length}
-                  />
-                </div>
-              )}
           </div>
           {/* Previous/Next pager - centered, desktop only */}
           {nav && selectedTestUuid && (

--- a/src/components/TestRunnerDialog.tsx
+++ b/src/components/TestRunnerDialog.tsx
@@ -874,7 +874,7 @@ export function TestRunnerDialog({
       <div className="bg-background rounded-none md:rounded-xl w-full max-w-[92rem] h-full md:h-[92vh] flex flex-col shadow-2xl">
         {/* Header */}
         <div className="relative flex items-center justify-between gap-3 px-4 md:px-6 py-3 md:py-4 border-b border-border">
-          {/* Left: title + action buttons */}
+          {/* Left: title + pass/fail stats */}
           <div className="flex items-center gap-3 min-w-0">
             <div className="min-w-0">
               <div className="flex items-center gap-2">
@@ -893,6 +893,34 @@ export function TestRunnerDialog({
               </div>
               <p className="text-xs text-muted-foreground truncate">{agentName}</p>
             </div>
+            {/* Passed/Failed counts - desktop only */}
+            {!isOverallError &&
+              testResults.length > 0 &&
+              (passedTests.length > 0 ||
+                failedTests.length > 0 ||
+                erroredTests.length > 0) && (
+                <div className="hidden md:block">
+                  <TestStats
+                    passedCount={passedTests.length}
+                    failedCount={failedTests.length}
+                    erroredCount={erroredTests.length}
+                  />
+                </div>
+              )}
+          </div>
+          {/* Previous/Next pager - centered, desktop only */}
+          {nav && selectedTestUuid && (
+            <div className="hidden md:flex absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2">
+              <ResultPager
+                currentIndex={nav.currentIndex}
+                total={nav.total}
+                onPrev={nav.goPrev}
+                onNext={nav.goNext}
+              />
+            </div>
+          )}
+          {/* Right: action buttons + close */}
+          <div className="flex items-center gap-2 shrink-0">
             {/* Export results — only shown when run is done */}
             {runStatus === "done" && testResults.length > 0 && (
               <div className="hidden md:block">
@@ -928,34 +956,6 @@ export function TestRunnerDialog({
                 />
               </div>
             )}
-          </div>
-          {/* Previous/Next pager - centered, desktop only */}
-          {nav && selectedTestUuid && (
-            <div className="hidden md:flex absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2">
-              <ResultPager
-                currentIndex={nav.currentIndex}
-                total={nav.total}
-                onPrev={nav.goPrev}
-                onNext={nav.goNext}
-              />
-            </div>
-          )}
-          {/* Right: stats + close */}
-          <div className="flex items-center gap-3 shrink-0">
-            {/* Passed/Failed counts - desktop only */}
-            {!isOverallError &&
-              testResults.length > 0 &&
-              (passedTests.length > 0 ||
-                failedTests.length > 0 ||
-                erroredTests.length > 0) && (
-                <div className="hidden md:block">
-                  <TestStats
-                    passedCount={passedTests.length}
-                    failedCount={failedTests.length}
-                    erroredCount={erroredTests.length}
-                  />
-                </div>
-              )}
             <button
               onClick={onClose}
               className="flex items-center justify-center w-8 h-8 rounded-md hover:bg-muted transition-colors cursor-pointer shrink-0"

--- a/src/components/TestRunnerDialog.tsx
+++ b/src/components/TestRunnerDialog.tsx
@@ -877,9 +877,20 @@ export function TestRunnerDialog({
           {/* Left: title + action buttons */}
           <div className="flex items-center gap-3 min-w-0">
             <div className="min-w-0">
-              <h2 className="text-base md:text-lg font-semibold text-foreground truncate">
-                {runName ?? "Test run"}
-              </h2>
+              <div className="flex items-center gap-2">
+                {(runStatus === "queued" || runStatus === "in_progress") && (
+                  <span
+                    className="relative flex h-2.5 w-2.5 shrink-0"
+                    title="Run in progress"
+                  >
+                    <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-yellow-400 opacity-75" />
+                    <span className="relative inline-flex h-2.5 w-2.5 rounded-full bg-yellow-400" />
+                  </span>
+                )}
+                <h2 className="text-base md:text-lg font-semibold text-foreground truncate">
+                  {runName ?? "Test run"}
+                </h2>
+              </div>
               <p className="text-xs text-muted-foreground truncate">{agentName}</p>
             </div>
             {/* Export results — only shown when run is done */}

--- a/src/components/eval-details/BenchmarkOutputsPanel.tsx
+++ b/src/components/eval-details/BenchmarkOutputsPanel.tsx
@@ -130,6 +130,43 @@ export function BenchmarkOutputsPanel({
   const listContainerRef = useRef<HTMLDivElement>(null);
   const selectedRowRef = useRef<HTMLButtonElement>(null);
 
+  // Count how many tests fall in each filterable status across all models, so
+  // we only render a pill when there's something to filter to. A pill is shown
+  // only if its count > 0, and the whole pill row is hidden when fewer than two
+  // statuses are present (i.e. everything passed / failed / errored — nothing
+  // meaningful to filter between).
+  const statusCounts = useMemo(() => {
+    let passed = 0;
+    let failed = 0;
+    let errored = 0;
+    for (const m of modelResults) {
+      for (const tr of m.test_results ?? []) {
+        const status = benchmarkTestStatus(tr);
+        if (status === "passed") passed++;
+        else if (status === "failed") failed++;
+        else if (status === "error") errored++;
+      }
+    }
+    return { passed, failed, errored };
+  }, [modelResults]);
+  const distinctStatuses =
+    (statusCounts.passed > 0 ? 1 : 0) +
+    (statusCounts.failed > 0 ? 1 : 0) +
+    (statusCounts.errored > 0 ? 1 : 0);
+  const showFilterPills = distinctStatuses >= 2;
+
+  // If the active filter's status disappears (live runs change counts) or the
+  // pills are hidden entirely, fall back to showing all tests.
+  useEffect(() => {
+    if (statusFilter === "all") return;
+    const stillValid =
+      showFilterPills &&
+      ((statusFilter === "passed" && statusCounts.passed > 0) ||
+        (statusFilter === "failed" && statusCounts.failed > 0) ||
+        (statusFilter === "errored" && statusCounts.errored > 0));
+    if (!stillValid) setStatusFilter("all");
+  }, [statusFilter, statusCounts, showFilterPills]);
+
   const getSelectedTestResult = (): BenchmarkTestResult | null => {
     if (!selectedTest) return null;
     const modelResult = modelResults.find((m) => m.model === selectedTest.model);
@@ -273,39 +310,45 @@ export function BenchmarkOutputsPanel({
         {showControls && modelResults.length > 0 && (
           <div className="shrink-0 border-b border-border flex items-center justify-between px-3 py-2">
             <div className="flex items-center gap-1.5">
-              <button
-                type="button"
-                onClick={() => setStatusFilter(statusFilter === "passed" ? "all" : "passed")}
-                className={`inline-flex items-center px-2.5 py-1 rounded-md text-xs font-medium cursor-pointer transition-colors ${
-                  statusFilter === "passed"
-                    ? "bg-green-100 text-green-700 dark:bg-green-500/30 dark:text-green-400 ring-1 ring-green-500/50"
-                    : "bg-green-100/50 text-green-700/60 dark:bg-green-500/10 dark:text-green-400/60 hover:bg-green-100 hover:dark:bg-green-500/20"
-                }`}
-              >
-                Passed
-              </button>
-              <button
-                type="button"
-                onClick={() => setStatusFilter(statusFilter === "failed" ? "all" : "failed")}
-                className={`inline-flex items-center px-2.5 py-1 rounded-md text-xs font-medium cursor-pointer transition-colors ${
-                  statusFilter === "failed"
-                    ? "bg-red-100 text-red-700 dark:bg-red-500/30 dark:text-red-400 ring-1 ring-red-500/50"
-                    : "bg-red-100/50 text-red-700/60 dark:bg-red-500/10 dark:text-red-400/60 hover:bg-red-100 hover:dark:bg-red-500/20"
-                }`}
-              >
-                Failed
-              </button>
-              <button
-                type="button"
-                onClick={() => setStatusFilter(statusFilter === "errored" ? "all" : "errored")}
-                className={`inline-flex items-center px-2.5 py-1 rounded-md text-xs font-medium cursor-pointer transition-colors ${
-                  statusFilter === "errored"
-                    ? "bg-amber-100 text-amber-700 dark:bg-amber-500/30 dark:text-amber-400 ring-1 ring-amber-500/50"
-                    : "bg-amber-100/50 text-amber-700/60 dark:bg-amber-500/10 dark:text-amber-400/60 hover:bg-amber-100 hover:dark:bg-amber-500/20"
-                }`}
-              >
-                Errored
-              </button>
+              {showFilterPills && statusCounts.passed > 0 && (
+                <button
+                  type="button"
+                  onClick={() => setStatusFilter(statusFilter === "passed" ? "all" : "passed")}
+                  className={`inline-flex items-center px-2.5 py-1 rounded-md text-xs font-medium cursor-pointer transition-colors ${
+                    statusFilter === "passed"
+                      ? "bg-green-100 text-green-700 dark:bg-green-500/30 dark:text-green-400 ring-1 ring-green-500/50"
+                      : "bg-green-100/50 text-green-700/60 dark:bg-green-500/10 dark:text-green-400/60 hover:bg-green-100 hover:dark:bg-green-500/20"
+                  }`}
+                >
+                  Passed
+                </button>
+              )}
+              {showFilterPills && statusCounts.failed > 0 && (
+                <button
+                  type="button"
+                  onClick={() => setStatusFilter(statusFilter === "failed" ? "all" : "failed")}
+                  className={`inline-flex items-center px-2.5 py-1 rounded-md text-xs font-medium cursor-pointer transition-colors ${
+                    statusFilter === "failed"
+                      ? "bg-red-100 text-red-700 dark:bg-red-500/30 dark:text-red-400 ring-1 ring-red-500/50"
+                      : "bg-red-100/50 text-red-700/60 dark:bg-red-500/10 dark:text-red-400/60 hover:bg-red-100 hover:dark:bg-red-500/20"
+                  }`}
+                >
+                  Failed
+                </button>
+              )}
+              {showFilterPills && statusCounts.errored > 0 && (
+                <button
+                  type="button"
+                  onClick={() => setStatusFilter(statusFilter === "errored" ? "all" : "errored")}
+                  className={`inline-flex items-center px-2.5 py-1 rounded-md text-xs font-medium cursor-pointer transition-colors ${
+                    statusFilter === "errored"
+                      ? "bg-amber-100 text-amber-700 dark:bg-amber-500/30 dark:text-amber-400 ring-1 ring-amber-500/50"
+                      : "bg-amber-100/50 text-amber-700/60 dark:bg-amber-500/10 dark:text-amber-400/60 hover:bg-amber-100 hover:dark:bg-amber-500/20"
+                  }`}
+                >
+                  Errored
+                </button>
+              )}
             </div>
             <button
               type="button"

--- a/src/components/eval-details/BenchmarkOutputsPanel.tsx
+++ b/src/components/eval-details/BenchmarkOutputsPanel.tsx
@@ -573,7 +573,7 @@ function ModelSection({
       </button>
 
       {isExpanded && (
-        <div className="px-4 pb-3">
+        <div className="px-4 pt-3 pb-3">
           {(() => {
             const resultsCount = modelResult.test_results?.length ?? 0;
             const expectedCount = Math.max(totalTests, testNames.length, resultsCount);

--- a/src/components/eval-details/BenchmarkOutputsPanel.tsx
+++ b/src/components/eval-details/BenchmarkOutputsPanel.tsx
@@ -166,7 +166,7 @@ export function BenchmarkOutputsPanel({
       ),
     [modelResults, formatModelName],
   );
-  const listColumnWidth = `clamp(20rem, calc(${longestModelNameChars}ch + 12rem), 42rem)`;
+  const listColumnWidth = `clamp(18rem, calc(${longestModelNameChars} * 0.5rem + 8.5rem), 30rem)`;
 
   // If the active filter's status disappears (live runs change counts) or the
   // pills are hidden entirely, fall back to showing all tests.

--- a/src/components/eval-details/BenchmarkOutputsPanel.tsx
+++ b/src/components/eval-details/BenchmarkOutputsPanel.tsx
@@ -481,7 +481,7 @@ function ModelSection({
     <div className="border-b border-border">
       <button
         onClick={onToggle}
-        className="w-full px-4 py-3 flex items-center justify-between hover:bg-muted/50 transition-colors cursor-pointer"
+        className="sticky top-0 z-10 bg-background w-full px-4 py-3 flex items-center justify-between border-b border-border hover:bg-muted/50 transition-colors cursor-pointer"
       >
         <div className="flex items-center gap-2 min-w-0">
           <svg

--- a/src/components/eval-details/BenchmarkOutputsPanel.tsx
+++ b/src/components/eval-details/BenchmarkOutputsPanel.tsx
@@ -478,7 +478,7 @@ export function BenchmarkOutputsPanel({
       {/* Right Panel - Evaluators / Expected Tool Calls (desktop only).
           On mobile this content is rendered inline by `TestDetailView`. */}
       {selectedTestResult && !selectedTestResult.error && selectedTestResult.passed !== null && (
-        <div className="hidden md:flex w-[32rem] border-l border-border flex-col overflow-hidden">
+        <div className="hidden md:flex w-[26rem] border-l border-border flex-col overflow-hidden">
           <div className="flex-1 overflow-y-auto">
             <EvaluationCriteriaPanel
               testName={selectedTestName}

--- a/src/components/eval-details/BenchmarkOutputsPanel.tsx
+++ b/src/components/eval-details/BenchmarkOutputsPanel.tsx
@@ -566,14 +566,14 @@ function ModelSection({
 
             if (expectedCount === 0 && !hasResults) {
               return (
-                <div className="ml-4 px-3 py-2 text-sm text-muted-foreground">
+                <div className="px-3 py-2 text-sm text-muted-foreground">
                   {isProcessing ? "Processing..." : "No test results"}
                 </div>
               );
             }
 
             return (
-              <div className="space-y-1 ml-4">
+              <div className="space-y-1">
                 {Array.from({ length: expectedCount }).map((_, index) => {
                   const testResult = modelResult.test_results?.[index];
                   const hasResult = !!testResult;

--- a/src/components/eval-details/BenchmarkOutputsPanel.tsx
+++ b/src/components/eval-details/BenchmarkOutputsPanel.tsx
@@ -166,7 +166,7 @@ export function BenchmarkOutputsPanel({
       ),
     [modelResults, formatModelName],
   );
-  const listColumnWidth = `clamp(18rem, calc(${longestModelNameChars} * 0.5rem + 8.5rem), 30rem)`;
+  const listColumnWidth = `clamp(18rem, calc(${longestModelNameChars} * 0.5rem + 11rem), 32rem)`;
 
   // If the active filter's status disappears (live runs change counts) or the
   // pills are hidden entirely, fall back to showing all tests.
@@ -558,7 +558,7 @@ function ModelSection({
           )}
         </div>
         {!isProcessing && modelResult.success !== null && (
-          <div className="flex items-center gap-2 text-xs flex-shrink-0">
+          <div className="flex items-center gap-2 text-xs flex-shrink-0 ml-4">
             {(statusFilter === "all" || statusFilter === "passed") && (
               <span className="text-green-500">{passedCount} passed</span>
             )}

--- a/src/components/eval-details/BenchmarkOutputsPanel.tsx
+++ b/src/components/eval-details/BenchmarkOutputsPanel.tsx
@@ -155,6 +155,19 @@ export function BenchmarkOutputsPanel({
     (statusCounts.errored > 0 ? 1 : 0);
   const showFilterPills = distinctStatuses >= 2;
 
+  // Size the model-list column to fit the longest model name so it never
+  // truncates. Budget extra room for the chevron, gaps, padding, and the
+  // per-model pass/fail counts; clamp so it stays reasonable on both ends.
+  const longestModelNameChars = useMemo(
+    () =>
+      modelResults.reduce(
+        (max, m) => Math.max(max, formatModelName(m.model).length),
+        0,
+      ),
+    [modelResults, formatModelName],
+  );
+  const listColumnWidth = `clamp(20rem, calc(${longestModelNameChars}ch + 12rem), 42rem)`;
+
   // If the active filter's status disappears (live runs change counts) or the
   // pills are hidden entirely, fall back to showing all tests.
   useEffect(() => {
@@ -292,7 +305,8 @@ export function BenchmarkOutputsPanel({
     <div className="flex h-full overflow-hidden" style={height ? { height } : undefined}>
       {/* Left Panel - Model list with tests */}
       <div
-        className={`w-full md:w-80 border-r border-border flex flex-col overflow-hidden ${
+        style={{ "--list-w": listColumnWidth } as React.CSSProperties}
+        className={`w-full md:w-[var(--list-w)] shrink-0 border-r border-border flex flex-col overflow-hidden ${
           selectedTest ? "hidden md:flex" : "flex"
         }`}
       >

--- a/src/components/eval-details/BenchmarkOutputsPanel.tsx
+++ b/src/components/eval-details/BenchmarkOutputsPanel.tsx
@@ -298,7 +298,7 @@ export function BenchmarkOutputsPanel({
       >
         {/* Search */}
         {modelResults.length > 0 && (
-          <div className="shrink-0 border-b border-border p-3">
+          <div className="shrink-0 p-3">
             <SearchInput
               value={searchQuery}
               onChange={setSearchQuery}

--- a/src/components/eval-details/TestRunOutputsPanel.tsx
+++ b/src/components/eval-details/TestRunOutputsPanel.tsx
@@ -191,11 +191,11 @@ export function TestRunOutputsPanel({
             </div>
           )}
           {groups.map((group) => (
-            <div key={group.key} className="p-4">
+            <div key={group.key}>
               <button
                 type="button"
                 onClick={() => toggleSection(group.key)}
-                className="w-full text-sm font-medium text-muted-foreground mb-2 flex items-center gap-2 cursor-pointer hover:text-foreground transition-colors"
+                className="sticky top-0 z-10 bg-background w-full text-sm font-medium text-muted-foreground px-4 py-3 flex items-center gap-2 cursor-pointer hover:text-foreground transition-colors border-b border-border"
               >
                 <svg
                   className={`w-3 h-3 text-muted-foreground transition-transform shrink-0 ${collapsedSections.has(group.key) ? "" : "rotate-90"}`}
@@ -207,7 +207,7 @@ export function TestRunOutputsPanel({
                 {group.label} ({group.items.length})
               </button>
               {!collapsedSections.has(group.key) && (
-                <div className="space-y-1">
+                <div className="space-y-1 px-4 py-2">
                   {group.items.map((result) => (
                     <button
                       key={result.id}

--- a/src/components/eval-details/TestRunOutputsPanel.tsx
+++ b/src/components/eval-details/TestRunOutputsPanel.tsx
@@ -266,7 +266,7 @@ export function TestRunOutputsPanel({
       {/* Right Panel - Evaluators / Expected Tool Calls (desktop only).
           On mobile this content is rendered inline by `TestDetailView`. */}
       {selectedResult && !isErrored(selectedResult) && (selectedResult.status === "passed" || selectedResult.status === "failed") && (
-        <div className="hidden md:flex w-[32rem] border-l border-border flex-col overflow-hidden">
+        <div className="hidden md:flex w-[26rem] border-l border-border flex-col overflow-hidden">
           <div className="flex-1 overflow-y-auto">
             <EvaluationCriteriaPanel
               testName={selectedResult.name}


### PR DESCRIPTION
## What
- Add a pulsing yellow dot next to the run name in the test-run dialog header while the run is queued or in progress.
- Make the Passed/Failed (and per-model benchmark) section headers sticky so the current section heading stays pinned while its rows scroll, and the next section pushes it out.

## Notes
- The benchmark dialog already had a status badge in its header, so the dot was added only to the test runner.