### PR TITLE
Show latency & cost for LLM tests and benchmarks

### DIFF
--- a/src/app/public/benchmark/[token]/page.tsx
+++ b/src/app/public/benchmark/[token]/page.tsx
@@ -14,10 +14,11 @@ type LeaderboardSummary = {
   passed: string;
   total: string;
   pass_rate: string;
-  /** Mean per-test latency (ms) / cost (USD) as CSV strings — mean only,
-   * blank/null when no case reported one. Absent on older jobs. */
+  /** Mean per-test latency (ms) / cost (USD) / total tokens as CSV strings —
+   * mean only, blank/null when no case reported one. Absent on older jobs. */
   latency_ms?: string | null;
   cost?: string | null;
+  total_tokens?: string | null;
 };
 
 type BenchmarkStatusResponse = {

--- a/src/app/public/benchmark/[token]/page.tsx
+++ b/src/app/public/benchmark/[token]/page.tsx
@@ -14,6 +14,10 @@ type LeaderboardSummary = {
   passed: string;
   total: string;
   pass_rate: string;
+  /** Average per-test latency (ms) / cost (USD) aggregates. Absent on older
+   * jobs that pre-date latency/cost tracking. */
+  avg_latency_ms?: number | string | null;
+  avg_cost?: number | string | null;
 };
 
 type BenchmarkStatusResponse = {

--- a/src/app/public/benchmark/[token]/page.tsx
+++ b/src/app/public/benchmark/[token]/page.tsx
@@ -14,10 +14,10 @@ type LeaderboardSummary = {
   passed: string;
   total: string;
   pass_rate: string;
-  /** Average per-test latency (ms) / cost (USD) aggregates. Absent on older
-   * jobs that pre-date latency/cost tracking. */
-  avg_latency_ms?: number | string | null;
-  avg_cost?: number | string | null;
+  /** Mean per-test latency (ms) / cost (USD) as CSV strings — mean only,
+   * blank/null when no case reported one. Absent on older jobs. */
+  latency_ms?: string | null;
+  cost?: string | null;
 };
 
 type BenchmarkStatusResponse = {

--- a/src/app/public/test-run/[token]/page.tsx
+++ b/src/app/public/test-run/[token]/page.tsx
@@ -29,9 +29,10 @@ type TestCaseResult = {
   chat_history?: { role: string; content: string }[];
   evaluation?: { passed: boolean; message?: string; details?: Record<string, any> };
   judge_results?: JudgeResult[] | null;
-  /** Per-case agent latency (ms) / cost (USD). */
+  /** Per-case agent latency (ms) / cost (USD) / total tokens. */
   latency_ms?: number | null;
   cost?: number | null;
+  total_tokens?: number | null;
   error?: string;
 };
 
@@ -44,9 +45,10 @@ type TestRunStatusResponse = {
   results?: TestCaseResult[];
   /** Top-level per-evaluator metadata block — see TestRunEvaluator. */
   evaluators?: TestRunEvaluator[];
-  /** Aggregate per-test latency / cost ({mean,min,max,count} | null). */
+  /** Aggregate per-test latency / cost / total tokens ({mean,min,max,count} | null). */
   latency_ms?: AggStat;
   cost?: AggStat;
+  total_tokens?: AggStat;
   error?: string;
 };
 
@@ -164,6 +166,7 @@ export default function PublicTestRunPage() {
             total={passed + failed}
             latency={data.latency_ms ?? null}
             cost={data.cost ?? null}
+            tokens={data.total_tokens ?? null}
             evaluatorSummary={buildEvaluatorSummaryFromResults(
               results,
               Object.fromEntries(

--- a/src/app/public/test-run/[token]/page.tsx
+++ b/src/app/public/test-run/[token]/page.tsx
@@ -14,7 +14,8 @@ import { PublicPageLayout, PublicNotFound, PublicLoading } from "@/components/Pu
 import { TestRunOutputsPanel, TestRunSummary } from "@/components/eval-details";
 import { ExportResultsButton } from "@/components/ExportResultsButton";
 import { buildTestRunCsv } from "@/lib/exportTestResults";
-import type { BenchmarkEvaluatorSummaryEntry } from "@/lib/benchmarkEvaluatorSummary";
+import { buildEvaluatorSummaryFromResults } from "@/lib/testRunSummary";
+import type { AggStat } from "@/lib/llmMetrics";
 
 type TestCaseResult = {
   test_uuid?: string;
@@ -28,6 +29,9 @@ type TestCaseResult = {
   chat_history?: { role: string; content: string }[];
   evaluation?: { passed: boolean; message?: string; details?: Record<string, any> };
   judge_results?: JudgeResult[] | null;
+  /** Per-case agent latency (ms) / cost (USD). */
+  latency_ms?: number | null;
+  cost?: number | null;
   error?: string;
 };
 
@@ -40,11 +44,9 @@ type TestRunStatusResponse = {
   results?: TestCaseResult[];
   /** Top-level per-evaluator metadata block — see TestRunEvaluator. */
   evaluators?: TestRunEvaluator[];
-  /** Aggregate summary block (per-evaluator metrics + latency/cost). */
-  evaluator_summary?: BenchmarkEvaluatorSummaryEntry[] | null;
-  pass_rate?: number | null;
-  avg_latency_ms?: number | null;
-  avg_cost?: number | null;
+  /** Aggregate per-test latency / cost ({mean,min,max,count} | null). */
+  latency_ms?: AggStat;
+  cost?: AggStat;
   error?: string;
 };
 
@@ -154,15 +156,20 @@ export default function PublicTestRunPage() {
           )}
         </div>
 
-        {/* Summary tab */}
+        {/* Summary tab. Single runs don't carry a backend evaluator_summary,
+            so derive per-evaluator metrics from the cases' judge_results. */}
         {activeTab === "summary" && (
           <TestRunSummary
             passed={passed}
             total={passed + failed}
-            passRate={data.pass_rate}
-            avgLatencyMs={data.avg_latency_ms}
-            avgCost={data.avg_cost}
-            evaluatorSummary={data.evaluator_summary}
+            latency={data.latency_ms ?? null}
+            cost={data.cost ?? null}
+            evaluatorSummary={buildEvaluatorSummaryFromResults(
+              results,
+              Object.fromEntries(
+                (data.evaluators ?? []).map((e) => [e.uuid, e]),
+              ),
+            )}
             enableEvaluatorLinks={false}
           />
         )}

--- a/src/app/public/test-run/[token]/page.tsx
+++ b/src/app/public/test-run/[token]/page.tsx
@@ -11,9 +11,10 @@ import {
   type PagerNav,
 } from "@/components/test-results/shared";
 import { PublicPageLayout, PublicNotFound, PublicLoading } from "@/components/PublicPageLayout";
-import { TestRunOutputsPanel } from "@/components/eval-details";
+import { TestRunOutputsPanel, TestRunSummary } from "@/components/eval-details";
 import { ExportResultsButton } from "@/components/ExportResultsButton";
 import { buildTestRunCsv } from "@/lib/exportTestResults";
+import type { BenchmarkEvaluatorSummaryEntry } from "@/lib/benchmarkEvaluatorSummary";
 
 type TestCaseResult = {
   test_uuid?: string;
@@ -39,6 +40,11 @@ type TestRunStatusResponse = {
   results?: TestCaseResult[];
   /** Top-level per-evaluator metadata block — see TestRunEvaluator. */
   evaluators?: TestRunEvaluator[];
+  /** Aggregate summary block (per-evaluator metrics + latency/cost). */
+  evaluator_summary?: BenchmarkEvaluatorSummaryEntry[] | null;
+  pass_rate?: number | null;
+  avg_latency_ms?: number | null;
+  avg_cost?: number | null;
   error?: string;
 };
 
@@ -56,6 +62,7 @@ export default function PublicTestRunPage() {
   const [notFound, setNotFound] = useState(false);
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [nav, setNav] = useState<PagerNav | null>(null);
+  const [activeTab, setActiveTab] = useState<"summary" | "outputs">("summary");
 
   useEffect(() => { document.title = "LLM unit test | Calibrate"; }, []);
 
@@ -91,9 +98,8 @@ export default function PublicTestRunPage() {
 
   const results = data.results ?? [];
   const passed = results.filter((r) => getStatus(r) === "passed").length;
-  // Errored tests carry an `error` and are shown as their own category in the
-  // list; keep them out of the "failed" count so the summary matches.
-  const errored = results.filter((r) => !!r.error).length;
+  // Errored tests carry an `error`; keep them out of the pass-rate denominator
+  // so the rate matches the scored tests.
   const failed = results.filter(
     (r) => getStatus(r) === "failed" && !r.error,
   ).length;
@@ -101,25 +107,20 @@ export default function PublicTestRunPage() {
   return (
     <PublicPageLayout title="LLM unit test" contentClassName="max-w-[92rem]">
       <div className="space-y-4 md:space-y-6">
-        {/* Summary stats */}
-        <div className="relative flex items-center justify-between gap-4">
-          <div className="flex items-center gap-4">
-            <div className="flex items-center gap-2">
-              <span className="inline-flex items-center px-2.5 py-1 rounded-md text-xs font-medium bg-green-100 text-green-700 dark:bg-green-500/20 dark:text-green-400">
-                {passed} passed
-              </span>
-              <span className="inline-flex items-center px-2.5 py-1 rounded-md text-xs font-medium bg-red-100 text-red-700 dark:bg-red-500/20 dark:text-red-400">
-                {failed} failed
-              </span>
-              {errored > 0 && (
-                <span className="inline-flex items-center px-2.5 py-1 rounded-md text-xs font-medium bg-amber-100 text-amber-700 dark:bg-amber-500/20 dark:text-amber-400">
-                  {errored} errored
-                </span>
-              )}
-            </div>
-            <span className="text-[13px] text-muted-foreground">{results.length} total tests</span>
+        {/* Tab nav */}
+        <div className="relative flex items-end justify-between gap-2 border-b border-border">
+          <div className="flex gap-2">
+            {(["summary", "outputs"] as const).map((tab) => (
+              <button
+                key={tab}
+                onClick={() => setActiveTab(tab)}
+                className={`px-4 py-2 text-[13px] font-medium border-b-2 transition-colors cursor-pointer capitalize ${activeTab === tab ? "border-foreground text-foreground" : "border-transparent text-muted-foreground hover:text-foreground"}`}
+              >
+                {tab}
+              </button>
+            ))}
           </div>
-          {nav && selectedId && (
+          {activeTab === "outputs" && nav && selectedId && (
             <div className="hidden md:flex absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2">
               <ResultPager
                 currentIndex={nav.currentIndex}
@@ -130,28 +131,44 @@ export default function PublicTestRunPage() {
             </div>
           )}
           {results.length > 0 && (
-            <ExportResultsButton
-              filename={`test-run-${token}`}
-              getRows={() =>
-                buildTestRunCsv(
-                  results.map((r) => ({
-                    name: r.name || r.test_case?.name || r.test_name,
-                    status: getStatus(r),
-                    output: r.output,
-                    testCase: r.test_case,
-                    reasoning: r.reasoning,
-                    judgeResults: r.judge_results,
-                  })),
-                  Object.fromEntries(
-                    (data.evaluators ?? []).map((e) => [e.uuid, e]),
-                  ),
-                )
-              }
-            />
+            <div className="pb-2">
+              <ExportResultsButton
+                filename={`test-run-${token}`}
+                getRows={() =>
+                  buildTestRunCsv(
+                    results.map((r) => ({
+                      name: r.name || r.test_case?.name || r.test_name,
+                      status: getStatus(r),
+                      output: r.output,
+                      testCase: r.test_case,
+                      reasoning: r.reasoning,
+                      judgeResults: r.judge_results,
+                    })),
+                    Object.fromEntries(
+                      (data.evaluators ?? []).map((e) => [e.uuid, e]),
+                    ),
+                  )
+                }
+              />
+            </div>
           )}
         </div>
 
-        {results.length > 0 && (
+        {/* Summary tab */}
+        {activeTab === "summary" && (
+          <TestRunSummary
+            passed={passed}
+            total={passed + failed}
+            passRate={data.pass_rate}
+            avgLatencyMs={data.avg_latency_ms}
+            avgCost={data.avg_cost}
+            evaluatorSummary={data.evaluator_summary}
+            enableEvaluatorLinks={false}
+          />
+        )}
+
+        {/* Outputs tab */}
+        {activeTab === "outputs" && results.length > 0 && (
           <div className="border border-border rounded-xl overflow-hidden" style={{ height: "calc(100vh - 220px)", minHeight: 620 }}>
             <TestRunOutputsPanel
               results={results.map((r, i) => ({

--- a/src/components/AddTestDialog.tsx
+++ b/src/components/AddTestDialog.tsx
@@ -5,7 +5,6 @@ import React, {
   useState,
   useEffect,
   useLayoutEffect,
-  useMemo,
   useRef,
   useCallback,
 } from "react";
@@ -21,11 +20,7 @@ import {
 } from "@/lib/toolParams";
 import { INBUILT_TOOLS } from "@/constants/inbuilt-tools";
 import { useHideFloatingButton } from "@/components/AppLayout";
-import {
-  formatTurnTimestamp,
-  TestDetailView,
-  type TestCaseHistory,
-} from "@/components/test-results/shared";
+import { formatTurnTimestamp } from "@/components/test-results/shared";
 
 // A single expected parameter row in a tool-call test. The shape is recursive:
 // `object`-typed parameters carry their own `properties` (nested rows) so the
@@ -1168,69 +1163,6 @@ export function AddTestDialog({
   });
 
   const [pendingFocusId, setPendingFocusId] = useState<string | null>(null);
-
-  // Conversation-history view mode: the editable "form" or a read-only chat
-  // "preview" that renders the same bubbles the result pages use.
-  const [conversationView, setConversationView] = useState<"form" | "preview">(
-    "form",
-  );
-
-  // Convert the editable `chatMessages` into the API history shape that
-  // `TestDetailView` renders. Mirrors `buildConfig`'s history conversion but
-  // keys tool calls by the stable message id (rather than a fresh UUID) so the
-  // preview is deterministic across re-renders.
-  const previewHistory = useMemo<TestCaseHistory[]>(() => {
-    const history: TestCaseHistory[] = [];
-    for (const message of chatMessages) {
-      const ts = message.createdAt ? { created_at: message.createdAt } : {};
-      if (message.role === "agent") {
-        history.push({ role: "assistant", content: message.content, ...ts });
-      } else if (message.role === "user") {
-        history.push({ role: "user", content: message.content, ...ts });
-      } else if (message.role === "tool_call") {
-        const toolCallId = message.id;
-        const argsObj: Record<string, any> = {};
-        for (const param of message.toolParams ?? []) {
-          if (message.isWebhook && param.group === "body") {
-            (argsObj.body ??= {})[param.name] = param.value;
-          } else if (message.isWebhook && param.group === "query") {
-            (argsObj.query ??= {})[param.name] = param.value;
-          } else {
-            argsObj[param.name] = param.value;
-          }
-        }
-        history.push({
-          role: "assistant",
-          tool_calls: [
-            {
-              id: toolCallId,
-              function: {
-                name: message.toolName || "",
-                arguments: JSON.stringify(argsObj),
-              },
-              type: "function",
-            },
-          ],
-          ...ts,
-        });
-        const linkedResponse = chatMessages.find(
-          (m) =>
-            m.role === "tool_response" && m.linkedToolCallId === message.id,
-        );
-        if (linkedResponse && linkedResponse.content.trim()) {
-          history.push({
-            role: "tool",
-            content: linkedResponse.content,
-            tool_call_id: toolCallId,
-            ...(linkedResponse.createdAt
-              ? { created_at: linkedResponse.createdAt }
-              : {}),
-          });
-        }
-      }
-    }
-    return history;
-  }, [chatMessages]);
 
   const addChatMessage = (role: "agent" | "user") => {
     const id = Date.now().toString();
@@ -3737,46 +3669,9 @@ export function AddTestDialog({
                 </p>
               </div>
             </div>
-            {/* View toggle: editable form vs read-only chat preview */}
-            <div className="flex items-center justify-end px-4 md:px-6 py-2 border-b border-border">
-              <div className="inline-flex items-center rounded-lg border border-border bg-background p-0.5">
-                <button
-                  type="button"
-                  onClick={() => setConversationView("form")}
-                  className={`px-3 py-1 text-xs font-medium rounded-md cursor-pointer transition-colors ${
-                    conversationView === "form"
-                      ? "bg-muted text-foreground"
-                      : "text-muted-foreground hover:text-foreground"
-                  }`}
-                >
-                  Form
-                </button>
-                <button
-                  type="button"
-                  onClick={() => setConversationView("preview")}
-                  className={`px-3 py-1 text-xs font-medium rounded-md cursor-pointer transition-colors ${
-                    conversationView === "preview"
-                      ? "bg-muted text-foreground"
-                      : "text-muted-foreground hover:text-foreground"
-                  }`}
-                >
-                  Preview
-                </button>
-              </div>
-            </div>
             {/* Chat Messages Area */}
-            <div
-              className={`flex-1 overflow-y-auto overflow-x-visible ${
-                conversationView === "preview" ? "" : "p-4 md:p-6"
-              }`}
-            >
-              {conversationView === "preview" ? (
-                <TestDetailView
-                  history={previewHistory}
-                  passed={false}
-                  highlightEvalTarget={requireAssistantLastMessage}
-                />
-              ) : chatMessages.length === 0 ? (
+            <div className="flex-1 overflow-y-auto overflow-x-visible p-4 md:p-6">
+              {chatMessages.length === 0 ? (
                 /* Empty State Placeholder */
                 <div className="h-full flex flex-col items-center justify-center text-center px-8">
                   {/* Globe with chat icon */}

--- a/src/components/AddTestDialog.tsx
+++ b/src/components/AddTestDialog.tsx
@@ -5,6 +5,7 @@ import React, {
   useState,
   useEffect,
   useLayoutEffect,
+  useMemo,
   useRef,
   useCallback,
 } from "react";
@@ -20,7 +21,11 @@ import {
 } from "@/lib/toolParams";
 import { INBUILT_TOOLS } from "@/constants/inbuilt-tools";
 import { useHideFloatingButton } from "@/components/AppLayout";
-import { formatTurnTimestamp } from "@/components/test-results/shared";
+import {
+  formatTurnTimestamp,
+  TestDetailView,
+  type TestCaseHistory,
+} from "@/components/test-results/shared";
 
 // A single expected parameter row in a tool-call test. The shape is recursive:
 // `object`-typed parameters carry their own `properties` (nested rows) so the
@@ -1163,6 +1168,69 @@ export function AddTestDialog({
   });
 
   const [pendingFocusId, setPendingFocusId] = useState<string | null>(null);
+
+  // Conversation-history view mode: the editable "form" or a read-only chat
+  // "preview" that renders the same bubbles the result pages use.
+  const [conversationView, setConversationView] = useState<"form" | "preview">(
+    "form",
+  );
+
+  // Convert the editable `chatMessages` into the API history shape that
+  // `TestDetailView` renders. Mirrors `buildConfig`'s history conversion but
+  // keys tool calls by the stable message id (rather than a fresh UUID) so the
+  // preview is deterministic across re-renders.
+  const previewHistory = useMemo<TestCaseHistory[]>(() => {
+    const history: TestCaseHistory[] = [];
+    for (const message of chatMessages) {
+      const ts = message.createdAt ? { created_at: message.createdAt } : {};
+      if (message.role === "agent") {
+        history.push({ role: "assistant", content: message.content, ...ts });
+      } else if (message.role === "user") {
+        history.push({ role: "user", content: message.content, ...ts });
+      } else if (message.role === "tool_call") {
+        const toolCallId = message.id;
+        const argsObj: Record<string, any> = {};
+        for (const param of message.toolParams ?? []) {
+          if (message.isWebhook && param.group === "body") {
+            (argsObj.body ??= {})[param.name] = param.value;
+          } else if (message.isWebhook && param.group === "query") {
+            (argsObj.query ??= {})[param.name] = param.value;
+          } else {
+            argsObj[param.name] = param.value;
+          }
+        }
+        history.push({
+          role: "assistant",
+          tool_calls: [
+            {
+              id: toolCallId,
+              function: {
+                name: message.toolName || "",
+                arguments: JSON.stringify(argsObj),
+              },
+              type: "function",
+            },
+          ],
+          ...ts,
+        });
+        const linkedResponse = chatMessages.find(
+          (m) =>
+            m.role === "tool_response" && m.linkedToolCallId === message.id,
+        );
+        if (linkedResponse && linkedResponse.content.trim()) {
+          history.push({
+            role: "tool",
+            content: linkedResponse.content,
+            tool_call_id: toolCallId,
+            ...(linkedResponse.createdAt
+              ? { created_at: linkedResponse.createdAt }
+              : {}),
+          });
+        }
+      }
+    }
+    return history;
+  }, [chatMessages]);
 
   const addChatMessage = (role: "agent" | "user") => {
     const id = Date.now().toString();
@@ -3669,9 +3737,46 @@ export function AddTestDialog({
                 </p>
               </div>
             </div>
+            {/* View toggle: editable form vs read-only chat preview */}
+            <div className="flex items-center justify-end px-4 md:px-6 py-2 border-b border-border">
+              <div className="inline-flex items-center rounded-lg border border-border bg-background p-0.5">
+                <button
+                  type="button"
+                  onClick={() => setConversationView("form")}
+                  className={`px-3 py-1 text-xs font-medium rounded-md cursor-pointer transition-colors ${
+                    conversationView === "form"
+                      ? "bg-muted text-foreground"
+                      : "text-muted-foreground hover:text-foreground"
+                  }`}
+                >
+                  Form
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setConversationView("preview")}
+                  className={`px-3 py-1 text-xs font-medium rounded-md cursor-pointer transition-colors ${
+                    conversationView === "preview"
+                      ? "bg-muted text-foreground"
+                      : "text-muted-foreground hover:text-foreground"
+                  }`}
+                >
+                  Preview
+                </button>
+              </div>
+            </div>
             {/* Chat Messages Area */}
-            <div className="flex-1 overflow-y-auto overflow-x-visible p-4 md:p-6">
-              {chatMessages.length === 0 ? (
+            <div
+              className={`flex-1 overflow-y-auto overflow-x-visible ${
+                conversationView === "preview" ? "" : "p-4 md:p-6"
+              }`}
+            >
+              {conversationView === "preview" ? (
+                <TestDetailView
+                  history={previewHistory}
+                  passed={false}
+                  highlightEvalTarget={requireAssistantLastMessage}
+                />
+              ) : chatMessages.length === 0 ? (
                 /* Empty State Placeholder */
                 <div className="h-full flex flex-col items-center justify-center text-center px-8">
                   {/* Globe with chat icon */}

--- a/src/components/BenchmarkResultsDialog.tsx
+++ b/src/components/BenchmarkResultsDialog.tsx
@@ -32,6 +32,10 @@ type LeaderboardSummary = {
   passed: string;
   total: string;
   pass_rate: string;
+  /** Average per-test latency (ms) / cost (USD) aggregates. Absent on older
+   * jobs that pre-date latency/cost tracking. */
+  avg_latency_ms?: number | string | null;
+  avg_cost?: number | string | null;
 };
 
 type BenchmarkStatusResponse = {

--- a/src/components/BenchmarkResultsDialog.tsx
+++ b/src/components/BenchmarkResultsDialog.tsx
@@ -32,10 +32,11 @@ type LeaderboardSummary = {
   passed: string;
   total: string;
   pass_rate: string;
-  /** Mean per-test latency (ms) / cost (USD) as CSV strings — mean only,
-   * blank/null when no case reported one. Absent on older jobs. */
+  /** Mean per-test latency (ms) / cost (USD) / total tokens as CSV strings —
+   * mean only, blank/null when no case reported one. Absent on older jobs. */
   latency_ms?: string | null;
   cost?: string | null;
+  total_tokens?: string | null;
 };
 
 type BenchmarkStatusResponse = {

--- a/src/components/BenchmarkResultsDialog.tsx
+++ b/src/components/BenchmarkResultsDialog.tsx
@@ -32,10 +32,10 @@ type LeaderboardSummary = {
   passed: string;
   total: string;
   pass_rate: string;
-  /** Average per-test latency (ms) / cost (USD) aggregates. Absent on older
-   * jobs that pre-date latency/cost tracking. */
-  avg_latency_ms?: number | string | null;
-  avg_cost?: number | string | null;
+  /** Mean per-test latency (ms) / cost (USD) as CSV strings — mean only,
+   * blank/null when no case reported one. Absent on older jobs. */
+  latency_ms?: string | null;
+  cost?: string | null;
 };
 
 type BenchmarkStatusResponse = {

--- a/src/components/DownloadableTable.tsx
+++ b/src/components/DownloadableTable.tsx
@@ -94,15 +94,16 @@ export function DownloadableTable({
         </button>
       </div>
 
-      {/* Table */}
-      <div className="border rounded-xl overflow-hidden">
+      {/* Table — scrolls horizontally instead of cramming/wrapping columns
+          when there are many (headers and cells stay single-line). */}
+      <div className="border rounded-xl overflow-x-auto">
         <table className="w-full">
           <thead className="bg-muted/50 border-b border-border">
             <tr>
               {columns.map((col) => (
                 <th
                   key={col.key}
-                  className="px-4 py-3 text-left text-sm font-medium text-foreground"
+                  className="px-4 py-3 text-left text-sm font-medium text-foreground whitespace-nowrap"
                 >
                   {col.header}
                 </th>
@@ -118,7 +119,7 @@ export function DownloadableTable({
                 {columns.map((col) => (
                   <td
                     key={col.key}
-                    className="px-4 py-3 text-sm text-foreground"
+                    className="px-4 py-3 text-sm text-foreground whitespace-nowrap"
                   >
                     {col.render ? col.render(row[col.key], row) : row[col.key]}
                   </td>

--- a/src/components/TestRunnerDialog.tsx
+++ b/src/components/TestRunnerDialog.tsx
@@ -1,7 +1,7 @@
 "use client";
 import { reportError } from "@/lib/reportError";
 
-import React, { useState, useEffect, useRef } from "react";
+import React, { useState, useEffect, useMemo, useRef } from "react";
 import { signOut } from "next-auth/react";
 import { useAccessToken } from "@/hooks";
 import { getDefaultHeaders } from "@/lib/api";
@@ -20,7 +20,8 @@ import { ShareButton } from "@/components/ShareButton";
 import { ExportResultsButton } from "@/components/ExportResultsButton";
 import { TestRunOutputsPanel, TestRunSummary } from "./eval-details";
 import { buildTestRunCsv } from "@/lib/exportTestResults";
-import type { BenchmarkEvaluatorSummaryEntry } from "@/lib/benchmarkEvaluatorSummary";
+import { buildEvaluatorSummaryFromResults } from "@/lib/testRunSummary";
+import type { AggStat } from "@/lib/llmMetrics";
 import {
   fetchDefaultLLMNextReplyEvaluator,
   type DefaultEvaluatorSummary,
@@ -79,6 +80,11 @@ type TestCaseResult = {
   /** Per-evaluator verdicts for response tests. Null for tool-call tests
    * and absent for legacy rows. */
   judge_results?: JudgeResult[] | null;
+  /** Per-case agent latency (ms) / cost (USD). Lifted to the top level by the
+   * backend (not inside `output`). Null while the case is running, for
+   * eval-only runs, and — for cost — the `openai` provider. */
+  latency_ms?: number | null;
+  cost?: number | null;
   error?: string;
 };
 
@@ -96,16 +102,11 @@ type TestRunStatusResponse = {
    * for every uuid referenced by judge_results (synthesises stubs for
    * legacy rows). */
   evaluators?: TestRunEvaluator[];
-  /** Aggregate per-evaluator metrics across the run (binary pass rate /
-   * rating mean). Same shape benchmark uses per model. Absent on older runs. */
-  evaluator_summary?: BenchmarkEvaluatorSummaryEntry[] | null;
-  /** Overall pass rate as a percentage (0–100). Optional — the summary falls
-   * back to passed/total_tests when absent. */
-  pass_rate?: number | null;
-  /** Average per-test latency in milliseconds (backend aggregate). */
-  avg_latency_ms?: number | null;
-  /** Average per-test cost in USD (backend aggregate). */
-  avg_cost?: number | null;
+  /** Aggregate per-test latency / cost ({mean,min,max,count} | null) across
+   * the whole run. Null for eval-only runs or before metrics land; cost is
+   * also null for the `openai` provider. */
+  latency_ms?: AggStat;
+  cost?: AggStat;
   results_s3_prefix?: string;
   error?: string;
   is_public?: boolean;
@@ -168,14 +169,11 @@ export function TestRunnerDialog({
   // a uuid-keyed map below and passed into TestRunOutputsPanel as the
   // source of truth for per-evaluator metadata.
   const [runEvaluators, setRunEvaluators] = useState<TestRunEvaluator[]>([]);
-  // Aggregate summary block (per-evaluator metrics + latency/cost) surfaced
-  // on the Summary tab once the run is done.
-  const [evaluatorSummary, setEvaluatorSummary] = useState<
-    BenchmarkEvaluatorSummaryEntry[]
-  >([]);
-  const [summaryPassRate, setSummaryPassRate] = useState<number | null>(null);
-  const [avgLatencyMs, setAvgLatencyMs] = useState<number | null>(null);
-  const [avgCost, setAvgCost] = useState<number | null>(null);
+  // Aggregate latency / cost blocks from the run-status response, surfaced on
+  // the Summary tab. Per-evaluator metrics aren't sent for single runs, so we
+  // derive those client-side from each case's judge_results (see useMemo below).
+  const [latencyAgg, setLatencyAgg] = useState<AggStat>(null);
+  const [costAgg, setCostAgg] = useState<AggStat>(null);
   // Which tab is showing. Tabs only render once the run is done; we default to
   // the Summary tab on completion (mirrors the benchmark dialog).
   const [activeTab, setActiveTab] = useState<"summary" | "outputs">("outputs");
@@ -187,13 +185,11 @@ export function TestRunnerDialog({
   // immediately re-trigger the auto-open, making the list view unreachable.
   const hasAutoSelectedRef = useRef(false);
 
-  // Clear the aggregate summary block so a prior run's numbers can't leak into
+  // Clear the aggregate latency/cost so a prior run's numbers can't leak into
   // a fresh run / past-run view that omits the fields.
   const resetSummary = () => {
-    setEvaluatorSummary([]);
-    setSummaryPassRate(null);
-    setAvgLatencyMs(null);
-    setAvgCost(null);
+    setLatencyAgg(null);
+    setCostAgg(null);
   };
 
   // Auto-open the first completed test when nothing is selected. Covers both
@@ -358,18 +354,10 @@ export function TestRunnerDialog({
       setRunEvaluators(
         Array.isArray(result.evaluators) ? result.evaluators : [],
       );
-      // Sync the aggregate summary block (latency / cost / per-evaluator).
-      // Always set (including the empty case) so a prior run can't leak in.
-      setEvaluatorSummary(
-        Array.isArray(result.evaluator_summary) ? result.evaluator_summary : [],
-      );
-      setSummaryPassRate(
-        typeof result.pass_rate === "number" ? result.pass_rate : null,
-      );
-      setAvgLatencyMs(
-        typeof result.avg_latency_ms === "number" ? result.avg_latency_ms : null,
-      );
-      setAvgCost(typeof result.avg_cost === "number" ? result.avg_cost : null);
+      // Sync the aggregate latency / cost blocks. Always set (including the
+      // null case) so a prior run's numbers can't leak in.
+      setLatencyAgg(result.latency_ms ?? null);
+      setCostAgg(result.cost ?? null);
 
       // Update test results based on polling response
       setTestResults((prev) => {
@@ -918,6 +906,18 @@ export function TestRunnerDialog({
   const runningTests = testResults.filter((r) => r.status === "running");
   const pendingTests = testResults.filter((r) => r.status === "pending");
 
+  // Per-evaluator metrics for the Summary tab. Single test runs don't ship a
+  // backend `evaluator_summary` block (only benchmarks do), so aggregate it
+  // from each case's judge_results against the run's evaluator metadata.
+  const evaluatorSummary = useMemo(
+    () =>
+      buildEvaluatorSummaryFromResults(
+        testResults.map((r) => ({ judge_results: r.judgeResults })),
+        Object.fromEntries(runEvaluators.map((e) => [e.uuid, e])),
+      ),
+    [testResults, runEvaluators],
+  );
+
   // Check if the entire run errored (all tests have errors, none have real results)
   const isOverallError =
     runStatus === "failed" &&
@@ -1072,9 +1072,8 @@ export function TestRunnerDialog({
                 <TestRunSummary
                   passed={passedTests.length}
                   total={passedTests.length + failedTests.length}
-                  passRate={summaryPassRate}
-                  avgLatencyMs={avgLatencyMs}
-                  avgCost={avgCost}
+                  latency={latencyAgg}
+                  cost={costAgg}
                   evaluatorSummary={evaluatorSummary}
                 />
               </div>

--- a/src/components/TestRunnerDialog.tsx
+++ b/src/components/TestRunnerDialog.tsx
@@ -930,7 +930,7 @@ export function TestRunnerDialog({
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm p-0 md:p-4">
       <div className="bg-background rounded-none md:rounded-xl w-full max-w-[92rem] h-full md:h-[92vh] flex flex-col shadow-2xl">
         {/* Header */}
-        <div className="relative flex items-center justify-between gap-3 px-4 md:px-6 py-3 md:py-4 border-b border-border">
+        <div className="relative flex items-center justify-between gap-3 px-4 md:px-6 py-3 md:py-4">
           {/* Left: title + agent name */}
           <div className="flex items-center gap-3 min-w-0">
             <div className="min-w-0">

--- a/src/components/TestRunnerDialog.tsx
+++ b/src/components/TestRunnerDialog.tsx
@@ -80,11 +80,12 @@ type TestCaseResult = {
   /** Per-evaluator verdicts for response tests. Null for tool-call tests
    * and absent for legacy rows. */
   judge_results?: JudgeResult[] | null;
-  /** Per-case agent latency (ms) / cost (USD). Lifted to the top level by the
-   * backend (not inside `output`). Null while the case is running, for
-   * eval-only runs, and — for cost — the `openai` provider. */
+  /** Per-case agent latency (ms) / cost (USD) / total tokens. Lifted to the
+   * top level by the backend (not inside `output`). Null while the case is
+   * running, for eval-only runs, and — for cost — the `openai` provider. */
   latency_ms?: number | null;
   cost?: number | null;
+  total_tokens?: number | null;
   error?: string;
 };
 
@@ -102,11 +103,12 @@ type TestRunStatusResponse = {
    * for every uuid referenced by judge_results (synthesises stubs for
    * legacy rows). */
   evaluators?: TestRunEvaluator[];
-  /** Aggregate per-test latency / cost ({mean,min,max,count} | null) across
-   * the whole run. Null for eval-only runs or before metrics land; cost is
-   * also null for the `openai` provider. */
+  /** Aggregate per-test latency / cost / total tokens ({mean,min,max,count} |
+   * null) across the whole run. Null for eval-only runs or before metrics
+   * land; cost is also null for the `openai` provider. */
   latency_ms?: AggStat;
   cost?: AggStat;
+  total_tokens?: AggStat;
   results_s3_prefix?: string;
   error?: string;
   is_public?: boolean;
@@ -174,6 +176,7 @@ export function TestRunnerDialog({
   // derive those client-side from each case's judge_results (see useMemo below).
   const [latencyAgg, setLatencyAgg] = useState<AggStat>(null);
   const [costAgg, setCostAgg] = useState<AggStat>(null);
+  const [tokensAgg, setTokensAgg] = useState<AggStat>(null);
   // Which tab is showing. Tabs only render once the run is done; we default to
   // the Summary tab on completion (mirrors the benchmark dialog).
   const [activeTab, setActiveTab] = useState<"summary" | "outputs">("outputs");
@@ -190,6 +193,7 @@ export function TestRunnerDialog({
   const resetSummary = () => {
     setLatencyAgg(null);
     setCostAgg(null);
+    setTokensAgg(null);
   };
 
   // Auto-open the first completed test when nothing is selected. Covers both
@@ -358,6 +362,7 @@ export function TestRunnerDialog({
       // null case) so a prior run's numbers can't leak in.
       setLatencyAgg(result.latency_ms ?? null);
       setCostAgg(result.cost ?? null);
+      setTokensAgg(result.total_tokens ?? null);
 
       // Update test results based on polling response
       setTestResults((prev) => {
@@ -1074,6 +1079,7 @@ export function TestRunnerDialog({
                   total={passedTests.length + failedTests.length}
                   latency={latencyAgg}
                   cost={costAgg}
+                  tokens={tokensAgg}
                   evaluatorSummary={evaluatorSummary}
                 />
               </div>

--- a/src/components/TestRunnerDialog.tsx
+++ b/src/components/TestRunnerDialog.tsx
@@ -18,8 +18,9 @@ import { POLLING_INTERVAL_MS } from "@/constants/polling";
 import { useHideFloatingButton } from "@/components/AppLayout";
 import { ShareButton } from "@/components/ShareButton";
 import { ExportResultsButton } from "@/components/ExportResultsButton";
-import { TestRunOutputsPanel } from "./eval-details";
+import { TestRunOutputsPanel, TestRunSummary } from "./eval-details";
 import { buildTestRunCsv } from "@/lib/exportTestResults";
+import type { BenchmarkEvaluatorSummaryEntry } from "@/lib/benchmarkEvaluatorSummary";
 import {
   fetchDefaultLLMNextReplyEvaluator,
   type DefaultEvaluatorSummary,
@@ -95,6 +96,16 @@ type TestRunStatusResponse = {
    * for every uuid referenced by judge_results (synthesises stubs for
    * legacy rows). */
   evaluators?: TestRunEvaluator[];
+  /** Aggregate per-evaluator metrics across the run (binary pass rate /
+   * rating mean). Same shape benchmark uses per model. Absent on older runs. */
+  evaluator_summary?: BenchmarkEvaluatorSummaryEntry[] | null;
+  /** Overall pass rate as a percentage (0–100). Optional — the summary falls
+   * back to passed/total_tests when absent. */
+  pass_rate?: number | null;
+  /** Average per-test latency in milliseconds (backend aggregate). */
+  avg_latency_ms?: number | null;
+  /** Average per-test cost in USD (backend aggregate). */
+  avg_cost?: number | null;
   results_s3_prefix?: string;
   error?: string;
   is_public?: boolean;
@@ -157,6 +168,17 @@ export function TestRunnerDialog({
   // a uuid-keyed map below and passed into TestRunOutputsPanel as the
   // source of truth for per-evaluator metadata.
   const [runEvaluators, setRunEvaluators] = useState<TestRunEvaluator[]>([]);
+  // Aggregate summary block (per-evaluator metrics + latency/cost) surfaced
+  // on the Summary tab once the run is done.
+  const [evaluatorSummary, setEvaluatorSummary] = useState<
+    BenchmarkEvaluatorSummaryEntry[]
+  >([]);
+  const [summaryPassRate, setSummaryPassRate] = useState<number | null>(null);
+  const [avgLatencyMs, setAvgLatencyMs] = useState<number | null>(null);
+  const [avgCost, setAvgCost] = useState<number | null>(null);
+  // Which tab is showing. Tabs only render once the run is done; we default to
+  // the Summary tab on completion (mirrors the benchmark dialog).
+  const [activeTab, setActiveTab] = useState<"summary" | "outputs">("outputs");
   const pollingIntervalRef = useRef<NodeJS.Timeout | null>(null);
   // Tracks whether the dialog has already auto-opened a completed test for
   // this open lifecycle. Set back to false on every dialog open / new run /
@@ -164,6 +186,15 @@ export function TestRunnerDialog({
   // Without this guard, clicking the in-dialog "back to list" button would
   // immediately re-trigger the auto-open, making the list view unreachable.
   const hasAutoSelectedRef = useRef(false);
+
+  // Clear the aggregate summary block so a prior run's numbers can't leak into
+  // a fresh run / past-run view that omits the fields.
+  const resetSummary = () => {
+    setEvaluatorSummary([]);
+    setSummaryPassRate(null);
+    setAvgLatencyMs(null);
+    setAvgCost(null);
+  };
 
   // Auto-open the first completed test when nothing is selected. Covers both
   // - live runs: as soon as one test transitions to passed/failed (and the
@@ -222,6 +253,8 @@ export function TestRunnerDialog({
     hasAutoSelectedRef.current = false;
     setCurrentTaskId(taskId);
     setRunEvaluators([]);
+    resetSummary();
+    setActiveTab("outputs");
 
     const isInProgress =
       initialRunStatus === "pending" ||
@@ -268,6 +301,8 @@ export function TestRunnerDialog({
     hasAutoSelectedRef.current = false;
     setCurrentTaskId(null);
     setRunEvaluators([]);
+    resetSummary();
+    setActiveTab("outputs");
     const initialResults: TestResult[] = tests.map((test) => ({
       test,
       status: "pending",
@@ -323,6 +358,18 @@ export function TestRunnerDialog({
       setRunEvaluators(
         Array.isArray(result.evaluators) ? result.evaluators : [],
       );
+      // Sync the aggregate summary block (latency / cost / per-evaluator).
+      // Always set (including the empty case) so a prior run can't leak in.
+      setEvaluatorSummary(
+        Array.isArray(result.evaluator_summary) ? result.evaluator_summary : [],
+      );
+      setSummaryPassRate(
+        typeof result.pass_rate === "number" ? result.pass_rate : null,
+      );
+      setAvgLatencyMs(
+        typeof result.avg_latency_ms === "number" ? result.avg_latency_ms : null,
+      );
+      setAvgCost(typeof result.avg_cost === "number" ? result.avg_cost : null);
 
       // Update test results based on polling response
       setTestResults((prev) => {
@@ -459,6 +506,17 @@ export function TestRunnerDialog({
         if (pollingIntervalRef.current) {
           clearInterval(pollingIntervalRef.current);
           pollingIntervalRef.current = null;
+        }
+
+        // Land on the Summary tab when the run finishes cleanly (mirrors the
+        // benchmark dialog). Polling has stopped by now, so this fires once on
+        // completion and won't fight a later manual tab switch. Skip on failure
+        // since there's no useful summary to show.
+        if (
+          (result.status === "completed" || result.status === "done") &&
+          !result.error
+        ) {
+          setActiveTab("summary");
         }
 
         // If there's an overall error, update remaining pending tests
@@ -893,8 +951,8 @@ export function TestRunnerDialog({
               <p className="text-xs text-muted-foreground truncate">{agentName}</p>
             </div>
           </div>
-          {/* Previous/Next pager - centered, desktop only */}
-          {nav && selectedTestUuid && (
+          {/* Previous/Next pager - centered, desktop only. Outputs tab only. */}
+          {activeTab === "outputs" && nav && selectedTestUuid && (
             <div className="hidden md:flex absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2">
               <ResultPager
                 currentIndex={nav.currentIndex}
@@ -979,7 +1037,48 @@ export function TestRunnerDialog({
             </div>
           </div>
         ) : (
-          /* Content - Split panel */
+          /* Content */
+          <div className="flex-1 flex flex-col overflow-hidden">
+            {/* Tab nav - only once the run is done (mirrors the benchmark dialog) */}
+            {runStatus === "done" && (
+              <div className="border-b border-border px-4 md:px-6 pt-2 overflow-x-auto hide-scrollbar shrink-0">
+                <div className="flex gap-3 md:gap-4 lg:gap-6">
+                  <button
+                    onClick={() => setActiveTab("summary")}
+                    className={`pb-3 px-1 text-sm md:text-base font-medium border-b-2 transition-colors cursor-pointer whitespace-nowrap flex-shrink-0 ${
+                      activeTab === "summary"
+                        ? "border-foreground text-foreground"
+                        : "border-transparent text-muted-foreground hover:text-foreground"
+                    }`}
+                  >
+                    Summary
+                  </button>
+                  <button
+                    onClick={() => setActiveTab("outputs")}
+                    className={`pb-3 px-1 text-sm md:text-base font-medium border-b-2 transition-colors cursor-pointer whitespace-nowrap flex-shrink-0 ${
+                      activeTab === "outputs"
+                        ? "border-foreground text-foreground"
+                        : "border-transparent text-muted-foreground hover:text-foreground"
+                    }`}
+                  >
+                    Outputs
+                  </button>
+                </div>
+              </div>
+            )}
+
+            {runStatus === "done" && activeTab === "summary" ? (
+              <div className="flex-1 overflow-hidden">
+                <TestRunSummary
+                  passed={passedTests.length}
+                  total={passedTests.length + failedTests.length}
+                  passRate={summaryPassRate}
+                  avgLatencyMs={avgLatencyMs}
+                  avgCost={avgCost}
+                  evaluatorSummary={evaluatorSummary}
+                />
+              </div>
+            ) : (
           <div className="flex-1 overflow-hidden">
             <TestRunOutputsPanel
               results={testResults.map((r) => ({
@@ -1002,6 +1101,8 @@ export function TestRunnerDialog({
               )}
               legacyDefaultEvaluator={defaultNextReplyEvaluator}
             />
+          </div>
+            )}
           </div>
         )}
       </div>

--- a/src/components/eval-details/BenchmarkCombinedLeaderboard.tsx
+++ b/src/components/eval-details/BenchmarkCombinedLeaderboard.tsx
@@ -13,6 +13,8 @@ import {
   formatLatencyMs,
   formatCostUsd,
   formatTokens,
+  formatPercent,
+  formatRating,
   METRIC_LABELS,
 } from "@/lib/llmMetrics";
 
@@ -49,7 +51,7 @@ function columnsFromPayload(
       header: benchmarkScoreLabel,
       render: (v) =>
         typeof v === "number" && Number.isFinite(v) ? (
-          `${v.toFixed(1)}%`
+          formatPercent(v)
         ) : (
           <span className="text-muted-foreground">—</span>
         ),
@@ -105,7 +107,7 @@ function columnsFromPayload(
       header,
       render: (v) =>
         typeof v === "number" && Number.isFinite(v) ? (
-          ev.type === "binary" ? `${v.toFixed(1)}%` : v.toFixed(2)
+          ev.type === "binary" ? formatPercent(v) : formatRating(v)
         ) : (
           <span className="text-muted-foreground">—</span>
         ),

--- a/src/components/eval-details/BenchmarkCombinedLeaderboard.tsx
+++ b/src/components/eval-details/BenchmarkCombinedLeaderboard.tsx
@@ -9,6 +9,7 @@ import {
   type BenchmarkLeaderboardSummaryRow,
   type BenchmarkModelLike,
 } from "@/lib/benchmarkEvaluatorSummary";
+import { formatLatencyMs, formatCostUsd } from "@/lib/llmMetrics";
 
 type BenchmarkCombinedLeaderboardProps = {
   leaderboardSummary?: BenchmarkLeaderboardSummaryRow[];
@@ -44,6 +45,32 @@ function columnsFromPayload(
       render: (v) =>
         typeof v === "number" && Number.isFinite(v) ? (
           `${v.toFixed(1)}%`
+        ) : (
+          <span className="text-muted-foreground">—</span>
+        ),
+    });
+  }
+
+  if (payload.plan.showLatency) {
+    cols.push({
+      key: "avg_latency_ms",
+      header: "Avg latency",
+      render: (v) =>
+        typeof v === "number" && Number.isFinite(v) ? (
+          formatLatencyMs(v)
+        ) : (
+          <span className="text-muted-foreground">—</span>
+        ),
+    });
+  }
+
+  if (payload.plan.showCost) {
+    cols.push({
+      key: "avg_cost",
+      header: "Avg cost",
+      render: (v) =>
+        typeof v === "number" && Number.isFinite(v) ? (
+          formatCostUsd(v)
         ) : (
           <span className="text-muted-foreground">—</span>
         ),

--- a/src/components/eval-details/BenchmarkCombinedLeaderboard.tsx
+++ b/src/components/eval-details/BenchmarkCombinedLeaderboard.tsx
@@ -9,7 +9,12 @@ import {
   type BenchmarkLeaderboardSummaryRow,
   type BenchmarkModelLike,
 } from "@/lib/benchmarkEvaluatorSummary";
-import { formatLatencyMs, formatCostUsd, formatTokens } from "@/lib/llmMetrics";
+import {
+  formatLatencyMs,
+  formatCostUsd,
+  formatTokens,
+  METRIC_LABELS,
+} from "@/lib/llmMetrics";
 
 type BenchmarkCombinedLeaderboardProps = {
   leaderboardSummary?: BenchmarkLeaderboardSummaryRow[];
@@ -54,7 +59,7 @@ function columnsFromPayload(
   if (payload.plan.showLatency) {
     cols.push({
       key: "avg_latency_ms",
-      header: "Avg latency",
+      header: METRIC_LABELS.latency,
       render: (v) =>
         typeof v === "number" && Number.isFinite(v) ? (
           formatLatencyMs(v)
@@ -67,7 +72,7 @@ function columnsFromPayload(
   if (payload.plan.showCost) {
     cols.push({
       key: "avg_cost",
-      header: "Avg cost",
+      header: METRIC_LABELS.cost,
       render: (v) =>
         typeof v === "number" && Number.isFinite(v) ? (
           formatCostUsd(v)
@@ -80,7 +85,7 @@ function columnsFromPayload(
   if (payload.plan.showTokens) {
     cols.push({
       key: "avg_tokens",
-      header: "Avg tokens",
+      header: METRIC_LABELS.tokens,
       render: (v) =>
         typeof v === "number" && Number.isFinite(v) ? (
           formatTokens(v)

--- a/src/components/eval-details/BenchmarkCombinedLeaderboard.tsx
+++ b/src/components/eval-details/BenchmarkCombinedLeaderboard.tsx
@@ -9,7 +9,7 @@ import {
   type BenchmarkLeaderboardSummaryRow,
   type BenchmarkModelLike,
 } from "@/lib/benchmarkEvaluatorSummary";
-import { formatLatencyMs, formatCostUsd } from "@/lib/llmMetrics";
+import { formatLatencyMs, formatCostUsd, formatTokens } from "@/lib/llmMetrics";
 
 type BenchmarkCombinedLeaderboardProps = {
   leaderboardSummary?: BenchmarkLeaderboardSummaryRow[];
@@ -71,6 +71,19 @@ function columnsFromPayload(
       render: (v) =>
         typeof v === "number" && Number.isFinite(v) ? (
           formatCostUsd(v)
+        ) : (
+          <span className="text-muted-foreground">—</span>
+        ),
+    });
+  }
+
+  if (payload.plan.showTokens) {
+    cols.push({
+      key: "avg_tokens",
+      header: "Avg tokens",
+      render: (v) =>
+        typeof v === "number" && Number.isFinite(v) ? (
+          formatTokens(v)
         ) : (
           <span className="text-muted-foreground">—</span>
         ),

--- a/src/components/eval-details/BenchmarkOutputsPanel.tsx
+++ b/src/components/eval-details/BenchmarkOutputsPanel.tsx
@@ -15,6 +15,7 @@ import {
 import { SearchInput } from "@/components/ui/SearchInput";
 import type { DefaultEvaluatorSummary } from "@/lib/defaultEvaluators";
 import type { BenchmarkEvaluatorSummaryEntry } from "@/lib/benchmarkEvaluatorSummary";
+import type { AggStat } from "@/lib/llmMetrics";
 
 export type BenchmarkTestResult = {
   name?: string;
@@ -28,6 +29,10 @@ export type BenchmarkTestResult = {
    * tool-call tests; legacy rows omit the field and fall back to the
    * legacy single-reasoning UI. */
   judge_results?: JudgeResult[] | null;
+  /** Per-case agent latency (ms) / cost (USD). Null while running, for
+   * eval-only runs, and — for cost — the `openai` provider. */
+  latency_ms?: number | null;
+  cost?: number | null;
 };
 
 export type BenchmarkModelResult = {
@@ -40,6 +45,11 @@ export type BenchmarkModelResult = {
   test_results: BenchmarkTestResult[] | null;
   /** Aggregate per evaluator from metrics.json criteria (finished models). Optional / null on older jobs. */
   evaluator_summary?: BenchmarkEvaluatorSummaryEntry[] | null;
+  /** This model's aggregate latency / cost ({mean,min,max,count} | null). For
+   * the leaderboard table we use `leaderboard_summary` (mean strings) instead;
+   * use these blocks when the full min/max/count is needed. */
+  latency_ms?: AggStat;
+  cost?: AggStat;
 };
 
 type BenchmarkOutputsPanelProps = {

--- a/src/components/eval-details/BenchmarkOutputsPanel.tsx
+++ b/src/components/eval-details/BenchmarkOutputsPanel.tsx
@@ -29,10 +29,11 @@ export type BenchmarkTestResult = {
    * tool-call tests; legacy rows omit the field and fall back to the
    * legacy single-reasoning UI. */
   judge_results?: JudgeResult[] | null;
-  /** Per-case agent latency (ms) / cost (USD). Null while running, for
-   * eval-only runs, and — for cost — the `openai` provider. */
+  /** Per-case agent latency (ms) / cost (USD) / total tokens. Null while
+   * running, for eval-only runs, and — for cost — the `openai` provider. */
   latency_ms?: number | null;
   cost?: number | null;
+  total_tokens?: number | null;
 };
 
 export type BenchmarkModelResult = {
@@ -45,11 +46,12 @@ export type BenchmarkModelResult = {
   test_results: BenchmarkTestResult[] | null;
   /** Aggregate per evaluator from metrics.json criteria (finished models). Optional / null on older jobs. */
   evaluator_summary?: BenchmarkEvaluatorSummaryEntry[] | null;
-  /** This model's aggregate latency / cost ({mean,min,max,count} | null). For
-   * the leaderboard table we use `leaderboard_summary` (mean strings) instead;
-   * use these blocks when the full min/max/count is needed. */
+  /** This model's aggregate latency / cost / total tokens ({mean,min,max,count}
+   * | null). For the leaderboard table we use `leaderboard_summary` (mean
+   * strings) instead; use these blocks when the full min/max/count is needed. */
   latency_ms?: AggStat;
   cost?: AggStat;
+  total_tokens?: AggStat;
 };
 
 type BenchmarkOutputsPanelProps = {

--- a/src/components/eval-details/BenchmarkOutputsPanel.tsx
+++ b/src/components/eval-details/BenchmarkOutputsPanel.tsx
@@ -488,7 +488,7 @@ export function BenchmarkOutputsPanel({
       {/* Right Panel - Evaluators / Expected Tool Calls (desktop only).
           On mobile this content is rendered inline by `TestDetailView`. */}
       {selectedTestResult && !selectedTestResult.error && selectedTestResult.passed !== null && (
-        <div className="hidden md:flex w-[26rem] border-l border-border flex-col overflow-hidden">
+        <div className="hidden md:flex w-[32rem] border-l border-border flex-col overflow-hidden">
           <div className="flex-1 overflow-y-auto">
             <EvaluationCriteriaPanel
               testName={selectedTestName}

--- a/src/components/eval-details/TestRunOutputsPanel.tsx
+++ b/src/components/eval-details/TestRunOutputsPanel.tsx
@@ -266,7 +266,7 @@ export function TestRunOutputsPanel({
       {/* Right Panel - Evaluators / Expected Tool Calls (desktop only).
           On mobile this content is rendered inline by `TestDetailView`. */}
       {selectedResult && !isErrored(selectedResult) && (selectedResult.status === "passed" || selectedResult.status === "failed") && (
-        <div className="hidden md:flex w-[26rem] border-l border-border flex-col overflow-hidden">
+        <div className="hidden md:flex w-[32rem] border-l border-border flex-col overflow-hidden">
           <div className="flex-1 overflow-y-auto">
             <EvaluationCriteriaPanel
               testName={selectedResult.name}

--- a/src/components/eval-details/TestRunSummary.tsx
+++ b/src/components/eval-details/TestRunSummary.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import Link from "next/link";
 import { Tooltip } from "@/components/Tooltip";
-import { formatLatencyMs, formatCostUsd } from "@/lib/llmMetrics";
+import { formatLatencyMs, formatCostUsd, type AggStat } from "@/lib/llmMetrics";
 import {
   benchmarkRatingEvaluatorCaption,
   type BenchmarkEvaluatorSummaryEntry,
@@ -10,16 +10,14 @@ import {
 type TestRunSummaryProps = {
   /** Tests that passed evaluation. */
   passed: number;
-  /** Total tests scored (excludes errored tests when the backend reports them
-   * separately; pass whatever denominator the pass rate is computed against). */
+  /** Total tests scored (excludes errored tests; the pass-rate denominator). */
   total: number;
-  /** Overall pass rate as a percentage (0–100). Falls back to passed/total
-   * when omitted. */
-  passRate?: number | null;
-  /** Average per-test latency in milliseconds. */
-  avgLatencyMs?: number | null;
-  /** Average per-test cost in USD. */
-  avgCost?: number | null;
+  /** Aggregate per-test latency block (`{mean,min,max,count}`). Null for
+   * eval-only runs or before metrics land. */
+  latency?: AggStat;
+  /** Aggregate per-test cost block. Null for eval-only runs and for the
+   * `openai` provider (no cost reported). */
+  cost?: AggStat;
   /** Per-evaluator aggregates (same shape benchmark uses), single model. */
   evaluatorSummary?: BenchmarkEvaluatorSummaryEntry[] | null;
   /** Disable evaluator detail links for public share pages. */
@@ -114,20 +112,23 @@ function evaluatorCardContent(entry: BenchmarkEvaluatorSummaryEntry): {
 export function TestRunSummary({
   passed,
   total,
-  passRate,
-  avgLatencyMs,
-  avgCost,
+  latency,
+  cost,
   evaluatorSummary,
   enableEvaluatorLinks = true,
 }: TestRunSummaryProps) {
-  const rate =
-    typeof passRate === "number" && Number.isFinite(passRate)
-      ? passRate
-      : total > 0
-        ? (passed / total) * 100
-        : null;
+  const rate = total > 0 ? (passed / total) * 100 : null;
 
   const evaluators = evaluatorSummary ?? [];
+
+  // Range subtitle (min–max) for an aggregate, or a "n cases" hint. Only shown
+  // when the block is present; null blocks fall through to a plain "—" value.
+  const latencySubtitle = latency
+    ? `${formatLatencyMs(latency.min)} – ${formatLatencyMs(latency.max)}`
+    : undefined;
+  const costSubtitle = cost
+    ? `${formatCostUsd(cost.min)} – ${formatCostUsd(cost.max)}`
+    : undefined;
 
   return (
     <div className="p-4 md:p-6 space-y-6 overflow-y-auto h-full">
@@ -139,8 +140,16 @@ export function TestRunSummary({
             value={rate !== null ? `${rate.toFixed(1)}%` : "—"}
             subtitle={`${passed}/${total} passed`}
           />
-          <MetricCard label="Avg latency" value={formatLatencyMs(avgLatencyMs)} />
-          <MetricCard label="Avg cost" value={formatCostUsd(avgCost)} />
+          <MetricCard
+            label="Avg latency"
+            value={formatLatencyMs(latency?.mean)}
+            subtitle={latencySubtitle}
+          />
+          <MetricCard
+            label="Avg cost"
+            value={formatCostUsd(cost?.mean)}
+            subtitle={costSubtitle}
+          />
         </div>
       </div>
 

--- a/src/components/eval-details/TestRunSummary.tsx
+++ b/src/components/eval-details/TestRunSummary.tsx
@@ -140,7 +140,11 @@ function evaluatorCardContent(entry: BenchmarkEvaluatorSummaryEntry): {
     };
   }
   return {
-    label: benchmarkRatingEvaluatorCaption(name, entry.scale_min, entry.scale_max),
+    label: benchmarkRatingEvaluatorCaption(
+      name,
+      entry.scale_min,
+      entry.scale_max,
+    ),
     value: Number.isFinite(entry.scale_max)
       ? `${parseFloat(entry.mean.toFixed(2))}/${entry.scale_max}`
       : `${parseFloat(entry.mean.toFixed(2))}`,
@@ -192,20 +196,22 @@ export function TestRunSummary({
             label="Average latency"
             value={formatLatencyMs(latency?.mean)}
             subtitle={latencySubtitle}
-            info="Average agent response time across all tests in this run. Evaluation time is excluded."
+            info="Average agent response time across all tests"
           />
           <MetricCard
             label="Average cost"
             value={formatCostUsd(cost?.mean)}
             subtitle={costSubtitle}
-            info="Average cost per test across all tests in this run."
+            info="Average cost per test across all tests"
           />
         </div>
       </div>
 
       {evaluators.length > 0 && (
         <div>
-          <h2 className="text-base md:text-lg font-semibold mb-3">Evaluators</h2>
+          <h2 className="text-base md:text-lg font-semibold mb-3">
+            Evaluators
+          </h2>
           <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
             {evaluators.map((entry) => {
               const { label, value, subtitle, progress } =

--- a/src/components/eval-details/TestRunSummary.tsx
+++ b/src/components/eval-details/TestRunSummary.tsx
@@ -94,21 +94,27 @@ function CardFooter({
 }
 
 // One metric card (matches the SimulationMetricsGrid card style). `progress`
-// adds a pass-rate bar; `subtitle` is the small caption below the value.
+// adds a pass-rate bar; `subtitle` is the small caption below the value;
+// `info` adds a hover tooltip (ⓘ) next to the label.
 function MetricCard({
   label,
   value,
   subtitle,
   progress,
+  info,
 }: {
   label: string;
   value: string;
   subtitle?: string;
   progress?: number;
+  info?: string;
 }) {
   return (
     <div className="border border-border rounded-xl p-4 bg-muted/10">
-      <div className="text-[12px] text-muted-foreground mb-1">{label}</div>
+      <div className="text-[12px] text-muted-foreground mb-1 flex items-center gap-1.5">
+        <span>{label}</span>
+        {info && <Tooltip content={info}>{descriptionIcon}</Tooltip>}
+      </div>
       <div className="text-[18px] font-semibold text-foreground">{value}</div>
       <CardFooter progress={progress} subtitle={subtitle} />
     </div>
@@ -186,11 +192,13 @@ export function TestRunSummary({
             label="Average latency"
             value={formatLatencyMs(latency?.mean)}
             subtitle={latencySubtitle}
+            info="Average agent response time across all tests in this run. Evaluation time is excluded."
           />
           <MetricCard
             label="Average cost"
             value={formatCostUsd(cost?.mean)}
             subtitle={costSubtitle}
+            info="Average cost per test across all tests in this run."
           />
         </div>
       </div>

--- a/src/components/eval-details/TestRunSummary.tsx
+++ b/src/components/eval-details/TestRunSummary.tsx
@@ -1,7 +1,12 @@
 import React from "react";
 import Link from "next/link";
 import { Tooltip } from "@/components/Tooltip";
-import { formatLatencyMs, formatCostUsd, type AggStat } from "@/lib/llmMetrics";
+import {
+  formatLatencyMs,
+  formatCostUsd,
+  formatTokens,
+  type AggStat,
+} from "@/lib/llmMetrics";
 import {
   benchmarkRatingEvaluatorCaption,
   type BenchmarkEvaluatorSummaryEntry,
@@ -18,6 +23,8 @@ type TestRunSummaryProps = {
   /** Aggregate per-test cost block. Null for eval-only runs and for the
    * `openai` provider (no cost reported). */
   cost?: AggStat;
+  /** Aggregate per-test total-token block. Null for eval-only runs. */
+  tokens?: AggStat;
   /** Per-evaluator aggregates (same shape benchmark uses), single model. */
   evaluatorSummary?: BenchmarkEvaluatorSummaryEntry[] | null;
   /** Disable evaluator detail links for public share pages. */
@@ -163,6 +170,7 @@ export function TestRunSummary({
   total,
   latency,
   cost,
+  tokens,
   evaluatorSummary,
   enableEvaluatorLinks = true,
 }: TestRunSummaryProps) {
@@ -181,11 +189,15 @@ export function TestRunSummary({
     cost && cost.count > 1 && cost.min !== cost.max
       ? `${formatCostUsd(cost.min)} – ${formatCostUsd(cost.max)}`
       : undefined;
+  const tokensSubtitle =
+    tokens && tokens.count > 1 && tokens.min !== tokens.max
+      ? `${formatTokens(tokens.min)} – ${formatTokens(tokens.max)}`
+      : undefined;
 
   return (
     <div className="p-4 md:p-6 space-y-6 overflow-y-auto h-full">
       <div>
-        <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
           <MetricCard
             label="Pass rate"
             value={rate !== null ? `${parseFloat(rate.toFixed(1))}%` : "—"}
@@ -203,6 +215,12 @@ export function TestRunSummary({
             value={formatCostUsd(cost?.mean)}
             subtitle={costSubtitle}
             info="Average cost per test across all tests"
+          />
+          <MetricCard
+            label="Average tokens"
+            value={formatTokens(tokens?.mean)}
+            subtitle={tokensSubtitle}
+            info="Average total input + output tokens per test across all tests"
           />
         </div>
       </div>

--- a/src/components/eval-details/TestRunSummary.tsx
+++ b/src/components/eval-details/TestRunSummary.tsx
@@ -58,35 +58,71 @@ const linkIcon = (
   </svg>
 );
 
-// One metric card (matches the SimulationMetricsGrid card style). `subtitle`
-// is the small caption shown inline next to the headline value (e.g. "12/15").
-function MetricCard({
-  label,
-  value,
+// Card footer: a thin pass-rate progress bar with the count beside it
+// (`progress` set), or a plain caption line (latency/cost range, rating
+// count). Renders nothing when there's neither.
+function CardFooter({
+  progress,
   subtitle,
 }: {
-  label: string;
-  value: string;
+  /** Fill percentage (0–100) for the progress bar. Omit to skip the bar. */
+  progress?: number;
   subtitle?: string;
 }) {
+  if (progress == null && !subtitle) return null;
+  if (progress == null) {
+    return (
+      <div className="text-[11px] text-muted-foreground mt-1.5">{subtitle}</div>
+    );
+  }
+  const pct = Math.max(0, Math.min(100, progress));
   return (
-    <div className="border border-border rounded-xl p-4 bg-muted/10">
-      <div className="text-[12px] text-muted-foreground mb-1">{label}</div>
-      <div className="flex items-baseline gap-1.5 flex-wrap">
-        <span className="text-[18px] font-semibold text-foreground">{value}</span>
-        {subtitle && (
-          <span className="text-[11px] text-muted-foreground">{subtitle}</span>
-        )}
+    <div className="flex items-center gap-2 mt-2">
+      <div className="h-1.5 flex-1 rounded-full bg-muted overflow-hidden">
+        <div
+          className="h-full rounded-full bg-green-500"
+          style={{ width: `${pct}%` }}
+        />
       </div>
+      {subtitle && (
+        <span className="text-[11px] text-muted-foreground tabular-nums shrink-0">
+          {subtitle}
+        </span>
+      )}
     </div>
   );
 }
 
-// Headline value + subtitle for one evaluator aggregate.
+// One metric card (matches the SimulationMetricsGrid card style). `progress`
+// adds a pass-rate bar; `subtitle` is the small caption below the value.
+function MetricCard({
+  label,
+  value,
+  subtitle,
+  progress,
+}: {
+  label: string;
+  value: string;
+  subtitle?: string;
+  progress?: number;
+}) {
+  return (
+    <div className="border border-border rounded-xl p-4 bg-muted/10">
+      <div className="text-[12px] text-muted-foreground mb-1">{label}</div>
+      <div className="text-[18px] font-semibold text-foreground">{value}</div>
+      <CardFooter progress={progress} subtitle={subtitle} />
+    </div>
+  );
+}
+
+// Headline value + caption (+ optional pass-rate bar) for one evaluator
+// aggregate. Binary evaluators get the bar; rating evaluators just show the
+// mean and the case count.
 function evaluatorCardContent(entry: BenchmarkEvaluatorSummaryEntry): {
   label: string;
   value: string;
   subtitle?: string;
+  progress?: number;
 } {
   const name = entry.name ?? entry.metric_key;
   if (entry.type === "binary") {
@@ -94,6 +130,7 @@ function evaluatorCardContent(entry: BenchmarkEvaluatorSummaryEntry): {
       label: name,
       value: `${parseFloat(entry.pass_rate.toFixed(1))}%`,
       subtitle: `${entry.passed}/${entry.total} passed`,
+      progress: entry.pass_rate,
     };
   }
   return {
@@ -140,6 +177,7 @@ export function TestRunSummary({
             label="Pass rate"
             value={rate !== null ? `${parseFloat(rate.toFixed(1))}%` : "—"}
             subtitle={`${passed}/${total} passed`}
+            progress={rate ?? undefined}
           />
           <MetricCard
             label="Avg latency"
@@ -159,7 +197,8 @@ export function TestRunSummary({
           <h2 className="text-base md:text-lg font-semibold mb-3">Evaluators</h2>
           <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
             {evaluators.map((entry) => {
-              const { label, value, subtitle } = evaluatorCardContent(entry);
+              const { label, value, subtitle, progress } =
+                evaluatorCardContent(entry);
               const uuid = entry.evaluator_uuid;
               const cardInner = (
                 <>
@@ -172,16 +211,10 @@ export function TestRunSummary({
                     )}
                     {uuid && enableEvaluatorLinks && linkIcon}
                   </div>
-                  <div className="flex items-baseline gap-1.5 flex-wrap">
-                    <span className="text-[18px] font-semibold text-foreground">
-                      {value}
-                    </span>
-                    {subtitle && (
-                      <span className="text-[11px] text-muted-foreground">
-                        {subtitle}
-                      </span>
-                    )}
+                  <div className="text-[18px] font-semibold text-foreground">
+                    {value}
                   </div>
+                  <CardFooter progress={progress} subtitle={subtitle} />
                 </>
               );
               if (uuid && enableEvaluatorLinks) {

--- a/src/components/eval-details/TestRunSummary.tsx
+++ b/src/components/eval-details/TestRunSummary.tsx
@@ -5,6 +5,8 @@ import {
   formatLatencyMs,
   formatCostUsd,
   formatTokens,
+  formatPercent,
+  formatRating,
   METRIC_LABELS,
   type AggStat,
 } from "@/lib/llmMetrics";
@@ -142,7 +144,7 @@ function evaluatorCardContent(entry: BenchmarkEvaluatorSummaryEntry): {
   if (entry.type === "binary") {
     return {
       label: name,
-      value: `${parseFloat(entry.pass_rate.toFixed(1))}%`,
+      value: formatPercent(entry.pass_rate),
       subtitle: `${entry.passed}/${entry.total}`,
       progress: entry.pass_rate,
     };
@@ -154,8 +156,8 @@ function evaluatorCardContent(entry: BenchmarkEvaluatorSummaryEntry): {
       entry.scale_max,
     ),
     value: Number.isFinite(entry.scale_max)
-      ? `${parseFloat(entry.mean.toFixed(2))}/${entry.scale_max}`
-      : `${parseFloat(entry.mean.toFixed(2))}`,
+      ? `${formatRating(entry.mean)}/${entry.scale_max}`
+      : formatRating(entry.mean),
     subtitle: `mean of ${entry.count}`,
   };
 }
@@ -201,7 +203,7 @@ export function TestRunSummary({
         <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
           <MetricCard
             label="Pass rate"
-            value={rate !== null ? `${parseFloat(rate.toFixed(1))}%` : "—"}
+            value={formatPercent(rate)}
             subtitle={`${passed}/${total}`}
             progress={rate ?? undefined}
           />

--- a/src/components/eval-details/TestRunSummary.tsx
+++ b/src/components/eval-details/TestRunSummary.tsx
@@ -160,14 +160,17 @@ export function TestRunSummary({
 
   const evaluators = evaluatorSummary ?? [];
 
-  // Range subtitle (min–max) for an aggregate, or a "n cases" hint. Only shown
-  // when the block is present; null blocks fall through to a plain "—" value.
-  const latencySubtitle = latency
-    ? `${formatLatencyMs(latency.min)} – ${formatLatencyMs(latency.max)}`
-    : undefined;
-  const costSubtitle = cost
-    ? `${formatCostUsd(cost.min)} – ${formatCostUsd(cost.max)}`
-    : undefined;
+  // Min–max range subtitle for an aggregate. Skipped when there's a single
+  // sample or every case had the same value (the range would just repeat the
+  // mean), and for null blocks (which render a plain "—" value).
+  const latencySubtitle =
+    latency && latency.count > 1 && latency.min !== latency.max
+      ? `${formatLatencyMs(latency.min)} – ${formatLatencyMs(latency.max)}`
+      : undefined;
+  const costSubtitle =
+    cost && cost.count > 1 && cost.min !== cost.max
+      ? `${formatCostUsd(cost.min)} – ${formatCostUsd(cost.max)}`
+      : undefined;
 
   return (
     <div className="p-4 md:p-6 space-y-6 overflow-y-auto h-full">
@@ -180,12 +183,12 @@ export function TestRunSummary({
             progress={rate ?? undefined}
           />
           <MetricCard
-            label="Avg latency"
+            label="Average latency"
             value={formatLatencyMs(latency?.mean)}
             subtitle={latencySubtitle}
           />
           <MetricCard
-            label="Avg cost"
+            label="Average cost"
             value={formatCostUsd(cost?.mean)}
             subtitle={costSubtitle}
           />

--- a/src/components/eval-details/TestRunSummary.tsx
+++ b/src/components/eval-details/TestRunSummary.tsx
@@ -129,7 +129,7 @@ function evaluatorCardContent(entry: BenchmarkEvaluatorSummaryEntry): {
     return {
       label: name,
       value: `${parseFloat(entry.pass_rate.toFixed(1))}%`,
-      subtitle: `${entry.passed}/${entry.total} passed`,
+      subtitle: `${entry.passed}/${entry.total}`,
       progress: entry.pass_rate,
     };
   }
@@ -176,7 +176,7 @@ export function TestRunSummary({
           <MetricCard
             label="Pass rate"
             value={rate !== null ? `${parseFloat(rate.toFixed(1))}%` : "—"}
-            subtitle={`${passed}/${total} passed`}
+            subtitle={`${passed}/${total}`}
             progress={rate ?? undefined}
           />
           <MetricCard

--- a/src/components/eval-details/TestRunSummary.tsx
+++ b/src/components/eval-details/TestRunSummary.tsx
@@ -1,0 +1,200 @@
+import React from "react";
+import Link from "next/link";
+import { Tooltip } from "@/components/Tooltip";
+import { formatLatencyMs, formatCostUsd } from "@/lib/llmMetrics";
+import {
+  benchmarkRatingEvaluatorCaption,
+  type BenchmarkEvaluatorSummaryEntry,
+} from "@/lib/benchmarkEvaluatorSummary";
+
+type TestRunSummaryProps = {
+  /** Tests that passed evaluation. */
+  passed: number;
+  /** Total tests scored (excludes errored tests when the backend reports them
+   * separately; pass whatever denominator the pass rate is computed against). */
+  total: number;
+  /** Overall pass rate as a percentage (0–100). Falls back to passed/total
+   * when omitted. */
+  passRate?: number | null;
+  /** Average per-test latency in milliseconds. */
+  avgLatencyMs?: number | null;
+  /** Average per-test cost in USD. */
+  avgCost?: number | null;
+  /** Per-evaluator aggregates (same shape benchmark uses), single model. */
+  evaluatorSummary?: BenchmarkEvaluatorSummaryEntry[] | null;
+  /** Disable evaluator detail links for public share pages. */
+  enableEvaluatorLinks?: boolean;
+};
+
+const descriptionIcon = (
+  <svg
+    className="w-3.5 h-3.5 text-muted-foreground hover:text-foreground transition-colors cursor-pointer"
+    fill="none"
+    viewBox="0 0 24 24"
+    stroke="currentColor"
+    strokeWidth={2}
+    aria-hidden="true"
+  >
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      d="M11.25 11.25l.041-.02a.75.75 0 011.063.852l-.708 2.836a.75.75 0 001.063.853l.041-.021M21 12a9 9 0 11-18 0 9 9 0 0118 0zm-9-3.75h.008v.008H12V8.25z"
+    />
+  </svg>
+);
+
+const linkIcon = (
+  <svg
+    className="ml-auto w-3.5 h-3.5 text-muted-foreground group-hover:text-foreground transition-colors"
+    fill="none"
+    viewBox="0 0 24 24"
+    stroke="currentColor"
+    strokeWidth={2}
+    aria-hidden="true"
+  >
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      d="M13.5 6H5.25A2.25 2.25 0 003 8.25v10.5A2.25 2.25 0 005.25 21h10.5A2.25 2.25 0 0018 18.75V10.5m-10.5 6L21 3m0 0h-5.25M21 3v5.25"
+    />
+  </svg>
+);
+
+// One metric card (matches the SimulationMetricsGrid card style). `subtitle`
+// is the small caption under the headline value (e.g. "12/15").
+function MetricCard({
+  label,
+  value,
+  subtitle,
+}: {
+  label: string;
+  value: string;
+  subtitle?: string;
+}) {
+  return (
+    <div className="border border-border rounded-xl p-4 bg-muted/10">
+      <div className="text-[12px] text-muted-foreground mb-1">{label}</div>
+      <div className="text-[18px] font-semibold text-foreground">{value}</div>
+      {subtitle && (
+        <div className="text-[11px] text-muted-foreground mt-0.5">{subtitle}</div>
+      )}
+    </div>
+  );
+}
+
+// Headline value + subtitle for one evaluator aggregate.
+function evaluatorCardContent(entry: BenchmarkEvaluatorSummaryEntry): {
+  label: string;
+  value: string;
+  subtitle?: string;
+} {
+  const name = entry.name ?? entry.metric_key;
+  if (entry.type === "binary") {
+    return {
+      label: name,
+      value: `${entry.pass_rate.toFixed(1)}%`,
+      subtitle: `${entry.passed}/${entry.total} passed`,
+    };
+  }
+  return {
+    label: benchmarkRatingEvaluatorCaption(name, entry.scale_min, entry.scale_max),
+    value: Number.isFinite(entry.scale_max)
+      ? `${parseFloat(entry.mean.toFixed(2))}/${entry.scale_max}`
+      : entry.mean.toFixed(2),
+    subtitle: `mean of ${entry.count}`,
+  };
+}
+
+/**
+ * High-level summary for a single-model LLM test run: overall pass rate,
+ * average latency, average cost, and one card per evaluator. Mirrors the
+ * benchmark leaderboard's per-evaluator + pass-rate view, minus the
+ * cross-model comparison.
+ */
+export function TestRunSummary({
+  passed,
+  total,
+  passRate,
+  avgLatencyMs,
+  avgCost,
+  evaluatorSummary,
+  enableEvaluatorLinks = true,
+}: TestRunSummaryProps) {
+  const rate =
+    typeof passRate === "number" && Number.isFinite(passRate)
+      ? passRate
+      : total > 0
+        ? (passed / total) * 100
+        : null;
+
+  const evaluators = evaluatorSummary ?? [];
+
+  return (
+    <div className="p-4 md:p-6 space-y-6 overflow-y-auto h-full">
+      <div>
+        <h2 className="text-base md:text-lg font-semibold mb-3">Overview</h2>
+        <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
+          <MetricCard
+            label="Pass rate"
+            value={rate !== null ? `${rate.toFixed(1)}%` : "—"}
+            subtitle={`${passed}/${total} passed`}
+          />
+          <MetricCard label="Avg latency" value={formatLatencyMs(avgLatencyMs)} />
+          <MetricCard label="Avg cost" value={formatCostUsd(avgCost)} />
+        </div>
+      </div>
+
+      {evaluators.length > 0 && (
+        <div>
+          <h2 className="text-base md:text-lg font-semibold mb-3">Evaluators</h2>
+          <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
+            {evaluators.map((entry) => {
+              const { label, value, subtitle } = evaluatorCardContent(entry);
+              const uuid = entry.evaluator_uuid;
+              const cardInner = (
+                <>
+                  <div className="text-[12px] text-muted-foreground mb-1 flex items-center gap-1.5">
+                    <span>{label}</span>
+                    {entry.description && (
+                      <Tooltip content={entry.description}>
+                        {descriptionIcon}
+                      </Tooltip>
+                    )}
+                    {uuid && enableEvaluatorLinks && linkIcon}
+                  </div>
+                  <div className="text-[18px] font-semibold text-foreground">
+                    {value}
+                  </div>
+                  {subtitle && (
+                    <div className="text-[11px] text-muted-foreground mt-0.5">
+                      {subtitle}
+                    </div>
+                  )}
+                </>
+              );
+              if (uuid && enableEvaluatorLinks) {
+                return (
+                  <Link
+                    key={entry.metric_key}
+                    href={`/evaluators/${uuid}`}
+                    className="group block border border-border rounded-xl p-4 bg-muted/10 hover:border-foreground/40 hover:bg-muted/30 transition-colors cursor-pointer"
+                  >
+                    {cardInner}
+                  </Link>
+                );
+              }
+              return (
+                <div
+                  key={entry.metric_key}
+                  className="border border-border rounded-xl p-4 bg-muted/10"
+                >
+                  {cardInner}
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/eval-details/TestRunSummary.tsx
+++ b/src/components/eval-details/TestRunSummary.tsx
@@ -133,7 +133,6 @@ export function TestRunSummary({
   return (
     <div className="p-4 md:p-6 space-y-6 overflow-y-auto h-full">
       <div>
-        <h2 className="text-base md:text-lg font-semibold mb-3">Overview</h2>
         <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
           <MetricCard
             label="Pass rate"

--- a/src/components/eval-details/TestRunSummary.tsx
+++ b/src/components/eval-details/TestRunSummary.tsx
@@ -90,7 +90,7 @@ function evaluatorCardContent(entry: BenchmarkEvaluatorSummaryEntry): {
   if (entry.type === "binary") {
     return {
       label: name,
-      value: `${entry.pass_rate.toFixed(1)}%`,
+      value: `${parseFloat(entry.pass_rate.toFixed(1))}%`,
       subtitle: `${entry.passed}/${entry.total} passed`,
     };
   }
@@ -98,7 +98,7 @@ function evaluatorCardContent(entry: BenchmarkEvaluatorSummaryEntry): {
     label: benchmarkRatingEvaluatorCaption(name, entry.scale_min, entry.scale_max),
     value: Number.isFinite(entry.scale_max)
       ? `${parseFloat(entry.mean.toFixed(2))}/${entry.scale_max}`
-      : entry.mean.toFixed(2),
+      : `${parseFloat(entry.mean.toFixed(2))}`,
     subtitle: `mean of ${entry.count}`,
   };
 }
@@ -136,7 +136,7 @@ export function TestRunSummary({
         <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
           <MetricCard
             label="Pass rate"
-            value={rate !== null ? `${rate.toFixed(1)}%` : "—"}
+            value={rate !== null ? `${parseFloat(rate.toFixed(1))}%` : "—"}
             subtitle={`${passed}/${total} passed`}
           />
           <MetricCard

--- a/src/components/eval-details/TestRunSummary.tsx
+++ b/src/components/eval-details/TestRunSummary.tsx
@@ -5,6 +5,7 @@ import {
   formatLatencyMs,
   formatCostUsd,
   formatTokens,
+  METRIC_LABELS,
   type AggStat,
 } from "@/lib/llmMetrics";
 import {
@@ -205,19 +206,19 @@ export function TestRunSummary({
             progress={rate ?? undefined}
           />
           <MetricCard
-            label="Average latency"
+            label={METRIC_LABELS.latency}
             value={formatLatencyMs(latency?.mean)}
             subtitle={latencySubtitle}
             info="Average agent response time across all tests"
           />
           <MetricCard
-            label="Average cost"
+            label={METRIC_LABELS.cost}
             value={formatCostUsd(cost?.mean)}
             subtitle={costSubtitle}
             info="Average cost per test across all tests"
           />
           <MetricCard
-            label="Average tokens"
+            label={METRIC_LABELS.tokens}
             value={formatTokens(tokens?.mean)}
             subtitle={tokensSubtitle}
             info="Average total input + output tokens per test across all tests"

--- a/src/components/eval-details/TestRunSummary.tsx
+++ b/src/components/eval-details/TestRunSummary.tsx
@@ -59,7 +59,7 @@ const linkIcon = (
 );
 
 // One metric card (matches the SimulationMetricsGrid card style). `subtitle`
-// is the small caption under the headline value (e.g. "12/15").
+// is the small caption shown inline next to the headline value (e.g. "12/15").
 function MetricCard({
   label,
   value,
@@ -72,10 +72,12 @@ function MetricCard({
   return (
     <div className="border border-border rounded-xl p-4 bg-muted/10">
       <div className="text-[12px] text-muted-foreground mb-1">{label}</div>
-      <div className="text-[18px] font-semibold text-foreground">{value}</div>
-      {subtitle && (
-        <div className="text-[11px] text-muted-foreground mt-0.5">{subtitle}</div>
-      )}
+      <div className="flex items-baseline gap-1.5 flex-wrap">
+        <span className="text-[18px] font-semibold text-foreground">{value}</span>
+        {subtitle && (
+          <span className="text-[11px] text-muted-foreground">{subtitle}</span>
+        )}
+      </div>
     </div>
   );
 }
@@ -170,14 +172,16 @@ export function TestRunSummary({
                     )}
                     {uuid && enableEvaluatorLinks && linkIcon}
                   </div>
-                  <div className="text-[18px] font-semibold text-foreground">
-                    {value}
+                  <div className="flex items-baseline gap-1.5 flex-wrap">
+                    <span className="text-[18px] font-semibold text-foreground">
+                      {value}
+                    </span>
+                    {subtitle && (
+                      <span className="text-[11px] text-muted-foreground">
+                        {subtitle}
+                      </span>
+                    )}
                   </div>
-                  {subtitle && (
-                    <div className="text-[11px] text-muted-foreground mt-0.5">
-                      {subtitle}
-                    </div>
-                  )}
                 </>
               );
               if (uuid && enableEvaluatorLinks) {

--- a/src/components/eval-details/index.ts
+++ b/src/components/eval-details/index.ts
@@ -45,6 +45,8 @@ export { BenchmarkCombinedLeaderboard } from "./BenchmarkCombinedLeaderboard";
 export { TestRunOutputsPanel } from "./TestRunOutputsPanel";
 export type { TestRunResult } from "./TestRunOutputsPanel";
 
+export { TestRunSummary } from "./TestRunSummary";
+
 export { SimulationMetricsGrid, LATENCY_KEYS } from "./SimulationMetricsGrid";
 export type { MetricData } from "./SimulationMetricsGrid";
 

--- a/src/lib/benchmarkEvaluatorSummary.ts
+++ b/src/lib/benchmarkEvaluatorSummary.ts
@@ -52,6 +52,9 @@ export type BenchmarkLeaderboardSummaryRow = {
   /** Mean per-test cost in USD — CSV string (mean only), blank / null when no
    * case reported one (e.g. the `openai` provider). */
   cost?: string | null;
+  /** Mean per-test total tokens — CSV string (mean only), blank / null when no
+   * case reported one. */
+  total_tokens?: string | null;
 };
 
 export type BenchmarkCombinedEvaluatorColumn = {
@@ -74,6 +77,8 @@ export type BenchmarkCombinedLeaderboardPayload = {
     showLatency: boolean;
     /** True when at least one model reported an average cost. */
     showCost: boolean;
+    /** True when at least one model reported average total tokens. */
+    showTokens: boolean;
     evaluators: BenchmarkCombinedEvaluatorColumn[];
   };
 };
@@ -230,6 +235,7 @@ export function buildBenchmarkCombinedLeaderboardPayload(
   const rows: Record<string, unknown>[] = [];
   let showLatency = false;
   let showCost = false;
+  let showTokens = false;
 
   for (const model of modelsOrdered) {
     const lbRow = leaderboardSummary?.find(
@@ -253,6 +259,11 @@ export function buildBenchmarkCombinedLeaderboardPayload(
       if (cost !== undefined) {
         row.avg_cost = cost;
         showCost = true;
+      }
+      const tokens = toFiniteNumber(lbRow.total_tokens);
+      if (tokens !== undefined) {
+        row.avg_tokens = tokens;
+        showTokens = true;
       }
     }
 
@@ -301,6 +312,14 @@ export function buildBenchmarkCombinedLeaderboardPayload(
     });
   }
 
+  if (showTokens) {
+    allCharts.push({
+      title: "Avg tokens",
+      dataKey: "avg_tokens",
+      formatTooltip: (v) => Math.round(v).toLocaleString("en-US"),
+    });
+  }
+
   for (const ev of evaluators) {
     if (ev.type === "binary") {
       allCharts.push({
@@ -338,6 +357,7 @@ export function buildBenchmarkCombinedLeaderboardPayload(
       showOverallPassRate,
       showLatency,
       showCost,
+      showTokens,
       evaluators,
     },
   };

--- a/src/lib/benchmarkEvaluatorSummary.ts
+++ b/src/lib/benchmarkEvaluatorSummary.ts
@@ -4,6 +4,7 @@
  */
 
 import type { ChartConfig } from "@/components/eval-details/LeaderboardTab";
+import { METRIC_LABELS } from "@/lib/llmMetrics";
 
 export type BenchmarkEvaluatorSummaryBinary = {
   metric_key: string;
@@ -296,7 +297,7 @@ export function buildBenchmarkCombinedLeaderboardPayload(
 
   if (showLatency) {
     allCharts.push({
-      title: "Avg latency (s)",
+      title: `${METRIC_LABELS.latency} (s)`,
       dataKey: "avg_latency_ms",
       formatTooltip: (v) =>
         v >= 1000 ? `${(v / 1000).toFixed(2)} s` : `${Math.round(v)} ms`,
@@ -306,7 +307,7 @@ export function buildBenchmarkCombinedLeaderboardPayload(
 
   if (showCost) {
     allCharts.push({
-      title: "Avg cost (USD)",
+      title: `${METRIC_LABELS.cost} (USD)`,
       dataKey: "avg_cost",
       formatTooltip: (v) => `$${v < 0.01 ? v.toFixed(6) : v.toFixed(4)}`,
     });
@@ -314,7 +315,7 @@ export function buildBenchmarkCombinedLeaderboardPayload(
 
   if (showTokens) {
     allCharts.push({
-      title: "Avg tokens",
+      title: METRIC_LABELS.tokens,
       dataKey: "avg_tokens",
       formatTooltip: (v) => Math.round(v).toLocaleString("en-US"),
     });

--- a/src/lib/benchmarkEvaluatorSummary.ts
+++ b/src/lib/benchmarkEvaluatorSummary.ts
@@ -45,13 +45,13 @@ export type BenchmarkLeaderboardSummaryRow = {
   passed?: string;
   total?: string;
   pass_rate: string;
-  /** Average per-test latency in milliseconds (backend aggregate). Optional /
-   * absent on older jobs that pre-date latency tracking. May arrive as a
-   * number or a numeric string. */
-  avg_latency_ms?: number | string | null;
-  /** Average per-test cost in USD (backend aggregate). Optional / absent on
-   * older jobs. May arrive as a number or a numeric string. */
-  avg_cost?: number | string | null;
+  /** Mean per-test latency in milliseconds — CSV string (mean only), blank /
+   * null when no case reported one. For the full {mean,min,max,count} use
+   * `model_results[].latency_ms` instead. */
+  latency_ms?: string | null;
+  /** Mean per-test cost in USD — CSV string (mean only), blank / null when no
+   * case reported one (e.g. the `openai` provider). */
+  cost?: string | null;
 };
 
 export type BenchmarkCombinedEvaluatorColumn = {
@@ -244,12 +244,12 @@ export function buildBenchmarkCombinedLeaderboardPayload(
       row.total = lbRow.total;
       const pr = parseFloat(lbRow.pass_rate);
       row.pass_rate = Number.isFinite(pr) ? pr : undefined;
-      const latency = toFiniteNumber(lbRow.avg_latency_ms);
+      const latency = toFiniteNumber(lbRow.latency_ms);
       if (latency !== undefined) {
         row.avg_latency_ms = latency;
         showLatency = true;
       }
-      const cost = toFiniteNumber(lbRow.avg_cost);
+      const cost = toFiniteNumber(lbRow.cost);
       if (cost !== undefined) {
         row.avg_cost = cost;
         showCost = true;

--- a/src/lib/benchmarkEvaluatorSummary.ts
+++ b/src/lib/benchmarkEvaluatorSummary.ts
@@ -45,6 +45,13 @@ export type BenchmarkLeaderboardSummaryRow = {
   passed?: string;
   total?: string;
   pass_rate: string;
+  /** Average per-test latency in milliseconds (backend aggregate). Optional /
+   * absent on older jobs that pre-date latency tracking. May arrive as a
+   * number or a numeric string. */
+  avg_latency_ms?: number | string | null;
+  /** Average per-test cost in USD (backend aggregate). Optional / absent on
+   * older jobs. May arrive as a number or a numeric string. */
+  avg_cost?: number | string | null;
 };
 
 export type BenchmarkCombinedEvaluatorColumn = {
@@ -63,9 +70,21 @@ export type BenchmarkCombinedLeaderboardPayload = {
   plan: {
     showPassedTotal: boolean;
     showOverallPassRate: boolean;
+    /** True when at least one model reported an average latency. */
+    showLatency: boolean;
+    /** True when at least one model reported an average cost. */
+    showCost: boolean;
     evaluators: BenchmarkCombinedEvaluatorColumn[];
   };
 };
+
+/** Coerce a latency / cost field (number or numeric string) to a finite
+ * number, or `undefined` when missing / unparseable. */
+function toFiniteNumber(v: unknown): number | undefined {
+  if (v == null) return undefined;
+  const n = typeof v === "number" ? v : parseFloat(String(v));
+  return Number.isFinite(n) ? n : undefined;
+}
 
 /** Table header and chart title for rating evaluators: `Name (min–max)` when scale is finite. */
 export function benchmarkRatingEvaluatorCaption(
@@ -209,6 +228,8 @@ export function buildBenchmarkCombinedLeaderboardPayload(
 
   const modelsOrdered = orderedCanonicalModels(leaderboardSummary, modelResults);
   const rows: Record<string, unknown>[] = [];
+  let showLatency = false;
+  let showCost = false;
 
   for (const model of modelsOrdered) {
     const lbRow = leaderboardSummary?.find(
@@ -223,6 +244,16 @@ export function buildBenchmarkCombinedLeaderboardPayload(
       row.total = lbRow.total;
       const pr = parseFloat(lbRow.pass_rate);
       row.pass_rate = Number.isFinite(pr) ? pr : undefined;
+      const latency = toFiniteNumber(lbRow.avg_latency_ms);
+      if (latency !== undefined) {
+        row.avg_latency_ms = latency;
+        showLatency = true;
+      }
+      const cost = toFiniteNumber(lbRow.avg_cost);
+      if (cost !== undefined) {
+        row.avg_cost = cost;
+        showCost = true;
+      }
     }
 
     for (const ev of evaluators) {
@@ -249,6 +280,24 @@ export function buildBenchmarkCombinedLeaderboardPayload(
       dataKey: "pass_rate",
       yDomain: [0, 100],
       formatTooltip: (v) => `${v.toFixed(1)}%`,
+    });
+  }
+
+  if (showLatency) {
+    allCharts.push({
+      title: "Avg latency (s)",
+      dataKey: "avg_latency_ms",
+      formatTooltip: (v) =>
+        v >= 1000 ? `${(v / 1000).toFixed(2)} s` : `${Math.round(v)} ms`,
+      yTickFormatter: (v) => `${(v / 1000).toFixed(1)}`,
+    });
+  }
+
+  if (showCost) {
+    allCharts.push({
+      title: "Avg cost (USD)",
+      dataKey: "avg_cost",
+      formatTooltip: (v) => `$${v < 0.01 ? v.toFixed(6) : v.toFixed(4)}`,
     });
   }
 
@@ -287,6 +336,8 @@ export function buildBenchmarkCombinedLeaderboardPayload(
     plan: {
       showPassedTotal,
       showOverallPassRate,
+      showLatency,
+      showCost,
       evaluators,
     },
   };

--- a/src/lib/benchmarkEvaluatorSummary.ts
+++ b/src/lib/benchmarkEvaluatorSummary.ts
@@ -4,7 +4,14 @@
  */
 
 import type { ChartConfig } from "@/components/eval-details/LeaderboardTab";
-import { METRIC_LABELS } from "@/lib/llmMetrics";
+import {
+  METRIC_LABELS,
+  formatLatencyMs,
+  formatCostUsd,
+  formatTokens,
+  formatPercent,
+  formatRating,
+} from "@/lib/llmMetrics";
 
 export type BenchmarkEvaluatorSummaryBinary = {
   metric_key: string;
@@ -291,7 +298,7 @@ export function buildBenchmarkCombinedLeaderboardPayload(
       title: benchmarkScoreLabel,
       dataKey: "pass_rate",
       yDomain: [0, 100],
-      formatTooltip: (v) => `${v.toFixed(1)}%`,
+      formatTooltip: (v) => formatPercent(v),
     });
   }
 
@@ -299,8 +306,7 @@ export function buildBenchmarkCombinedLeaderboardPayload(
     allCharts.push({
       title: `${METRIC_LABELS.latency} (s)`,
       dataKey: "avg_latency_ms",
-      formatTooltip: (v) =>
-        v >= 1000 ? `${(v / 1000).toFixed(2)} s` : `${Math.round(v)} ms`,
+      formatTooltip: (v) => formatLatencyMs(v),
       yTickFormatter: (v) => `${(v / 1000).toFixed(1)}`,
     });
   }
@@ -309,7 +315,7 @@ export function buildBenchmarkCombinedLeaderboardPayload(
     allCharts.push({
       title: `${METRIC_LABELS.cost} (USD)`,
       dataKey: "avg_cost",
-      formatTooltip: (v) => `$${v < 0.01 ? v.toFixed(6) : v.toFixed(4)}`,
+      formatTooltip: (v) => formatCostUsd(v),
     });
   }
 
@@ -317,7 +323,7 @@ export function buildBenchmarkCombinedLeaderboardPayload(
     allCharts.push({
       title: METRIC_LABELS.tokens,
       dataKey: "avg_tokens",
-      formatTooltip: (v) => Math.round(v).toLocaleString("en-US"),
+      formatTooltip: (v) => formatTokens(v),
     });
   }
 
@@ -327,7 +333,7 @@ export function buildBenchmarkCombinedLeaderboardPayload(
         title: ev.label,
         dataKey: ev.dataKey,
         yDomain: [0, 100],
-        formatTooltip: (v) => `${v.toFixed(1)}%`,
+        formatTooltip: (v) => formatPercent(v),
       });
     } else {
       const sm = ev.scale_min;
@@ -340,7 +346,7 @@ export function buildBenchmarkCombinedLeaderboardPayload(
         title: benchmarkRatingEvaluatorCaption(ev.label, sm, sx),
         dataKey: ev.dataKey,
         yDomain,
-        formatTooltip: (v) => v.toFixed(2),
+        formatTooltip: (v) => formatRating(v),
       });
     }
   }

--- a/src/lib/llmMetrics.ts
+++ b/src/lib/llmMetrics.ts
@@ -20,6 +20,17 @@ export type AggStat = {
 } | null;
 
 /**
+ * Shared display labels for the per-test latency / cost / token aggregates,
+ * reused by the test Summary cards and the benchmark leaderboard so the two
+ * always read identically (and avoid the cramped "Avg" abbreviation).
+ */
+export const METRIC_LABELS = {
+  latency: "Average latency",
+  cost: "Average cost",
+  tokens: "Average tokens",
+} as const;
+
+/**
  * Format an average latency in milliseconds. Sub-second values render as
  * whole milliseconds (`850 ms`); anything ≥ 1s renders as seconds with two
  * decimals (`1.23 s`). Returns an em dash for missing / non-finite input so

--- a/src/lib/llmMetrics.ts
+++ b/src/lib/llmMetrics.ts
@@ -5,6 +5,21 @@
  */
 
 /**
+ * Aggregate latency / cost block returned by the backend (same shape for
+ * test-runs and per-model benchmarks). `count` is how many cases actually
+ * reported a value — it can be lower than the total test count (a "partial
+ * data" hint) and is never zero-filled. The whole block is `null` for
+ * eval-only runs or before `metrics.json` lands; cost is also `null` for the
+ * `openai` provider. Always null-check.
+ */
+export type AggStat = {
+  mean: number;
+  min: number;
+  max: number;
+  count: number;
+} | null;
+
+/**
  * Format an average latency in milliseconds. Sub-second values render as
  * whole milliseconds (`850 ms`); anything ≥ 1s renders as seconds with two
  * decimals (`1.23 s`). Returns an em dash for missing / non-finite input so

--- a/src/lib/llmMetrics.ts
+++ b/src/lib/llmMetrics.ts
@@ -70,3 +70,32 @@ export function formatTokens(tokens: number | null | undefined): string {
   if (!Number.isFinite(n)) return "—";
   return Math.round(n).toLocaleString("en-US");
 }
+
+/**
+ * Format a percentage (0–100) with up to `decimals` places, dropping trailing
+ * zeros so whole values show no decimals (100%, not 100.0%). Returns an em
+ * dash for missing / non-finite input.
+ */
+export function formatPercent(
+  value: number | null | undefined,
+  decimals = 1,
+): string {
+  if (value == null) return "—";
+  const n = Number(value);
+  if (!Number.isFinite(n)) return "—";
+  return `${parseFloat(n.toFixed(decimals))}%`;
+}
+
+/**
+ * Format a rating/score with up to `decimals` places, dropping trailing zeros
+ * (4, not 4.00). Returns an em dash for missing / non-finite input.
+ */
+export function formatRating(
+  value: number | null | undefined,
+  decimals = 2,
+): string {
+  if (value == null) return "—";
+  const n = Number(value);
+  if (!Number.isFinite(n)) return "—";
+  return `${parseFloat(n.toFixed(decimals))}`;
+}

--- a/src/lib/llmMetrics.ts
+++ b/src/lib/llmMetrics.ts
@@ -48,3 +48,14 @@ export function formatCostUsd(usd: number | null | undefined): string {
   // parseFloat drops trailing zeros so whole values show no decimals ($2, not $2.00).
   return `$${parseFloat(n.toFixed(decimals))}`;
 }
+
+/**
+ * Format a token count as a rounded integer with thousands separators
+ * (1,234). Returns an em dash for missing / non-finite input.
+ */
+export function formatTokens(tokens: number | null | undefined): string {
+  if (tokens == null) return "—";
+  const n = Number(tokens);
+  if (!Number.isFinite(n)) return "—";
+  return Math.round(n).toLocaleString("en-US");
+}

--- a/src/lib/llmMetrics.ts
+++ b/src/lib/llmMetrics.ts
@@ -29,7 +29,8 @@ export function formatLatencyMs(ms: number | null | undefined): string {
   if (ms == null) return "—";
   const n = Number(ms);
   if (!Number.isFinite(n)) return "—";
-  if (n >= 1000) return `${(n / 1000).toFixed(2)} s`;
+  // parseFloat drops trailing zeros so whole values show no decimals (2 s, not 2.00 s).
+  if (n >= 1000) return `${parseFloat((n / 1000).toFixed(2))} s`;
   return `${Math.round(n)} ms`;
 }
 
@@ -44,5 +45,6 @@ export function formatCostUsd(usd: number | null | undefined): string {
   if (!Number.isFinite(n)) return "—";
   if (n === 0) return "$0";
   const decimals = n >= 1 ? 2 : n >= 0.01 ? 4 : 6;
-  return `$${n.toFixed(decimals)}`;
+  // parseFloat drops trailing zeros so whole values show no decimals ($2, not $2.00).
+  return `$${parseFloat(n.toFixed(decimals))}`;
 }

--- a/src/lib/llmMetrics.ts
+++ b/src/lib/llmMetrics.ts
@@ -1,0 +1,33 @@
+/**
+ * Display formatters for the latency / cost numbers the backend now returns
+ * for LLM test-runs and benchmarks. Shared by the single-model test summary
+ * and the benchmark leaderboard so the two always format the same way.
+ */
+
+/**
+ * Format an average latency in milliseconds. Sub-second values render as
+ * whole milliseconds (`850 ms`); anything ≥ 1s renders as seconds with two
+ * decimals (`1.23 s`). Returns an em dash for missing / non-finite input so
+ * callers can render it directly.
+ */
+export function formatLatencyMs(ms: number | null | undefined): string {
+  if (ms == null) return "—";
+  const n = Number(ms);
+  if (!Number.isFinite(n)) return "—";
+  if (n >= 1000) return `${(n / 1000).toFixed(2)} s`;
+  return `${Math.round(n)} ms`;
+}
+
+/**
+ * Format a cost in USD. Per-test costs are tiny, so precision scales with
+ * magnitude: ≥ $1 → 2 decimals, ≥ $0.01 → 4 decimals, otherwise 6 decimals.
+ * Returns an em dash for missing / non-finite input.
+ */
+export function formatCostUsd(usd: number | null | undefined): string {
+  if (usd == null) return "—";
+  const n = Number(usd);
+  if (!Number.isFinite(n)) return "—";
+  if (n === 0) return "$0";
+  const decimals = n >= 1 ? 2 : n >= 0.01 ? 4 : 6;
+  return `$${n.toFixed(decimals)}`;
+}

--- a/src/lib/testRunSummary.ts
+++ b/src/lib/testRunSummary.ts
@@ -1,0 +1,95 @@
+/**
+ * Single-model test runs don't ship a backend `evaluator_summary` block (only
+ * benchmarks do, per model). So we aggregate the per-case `judge_results` into
+ * the same `BenchmarkEvaluatorSummaryEntry` shape the benchmark leaderboard
+ * uses — binary evaluators → pass rate, rating evaluators → mean — so the test
+ * Summary tab can render per-evaluator metrics with the same cards.
+ */
+
+import type { JudgeResult, TestRunEvaluator } from "@/components/test-results/shared";
+import type { BenchmarkEvaluatorSummaryEntry } from "./benchmarkEvaluatorSummary";
+
+type ResultLike = { judge_results?: JudgeResult[] | null };
+
+/**
+ * Group every row's `judge_results` by evaluator and produce one aggregate
+ * entry per evaluator (first-seen order). Binary evaluators count `match`
+ * verdicts; rating evaluators average `score`. Rows without a verdict for an
+ * evaluator are skipped, so `count`/`total` reflect only scored cases.
+ * Returns `[]` when no row carries judge results.
+ */
+export function buildEvaluatorSummaryFromResults(
+  results: ResultLike[],
+  evaluatorsByUuid: Record<string, TestRunEvaluator>,
+): BenchmarkEvaluatorSummaryEntry[] {
+  const order: string[] = [];
+  const byUuid = new Map<string, JudgeResult[]>();
+
+  for (const r of results) {
+    const jrs = r.judge_results;
+    if (!Array.isArray(jrs)) continue;
+    for (const jr of jrs) {
+      const uuid = jr.evaluator_uuid;
+      if (!uuid) continue;
+      if (!byUuid.has(uuid)) {
+        byUuid.set(uuid, []);
+        order.push(uuid);
+      }
+      byUuid.get(uuid)!.push(jr);
+    }
+  }
+
+  const out: BenchmarkEvaluatorSummaryEntry[] = [];
+  for (const uuid of order) {
+    const jrs = byUuid.get(uuid)!;
+    const ev = evaluatorsByUuid[uuid];
+    const name = ev?.name;
+    const description = ev?.description ?? null;
+
+    // A rating evaluator is identified by its metadata, or — for legacy rows
+    // without metadata — by any numeric `score` verdict.
+    const isRating =
+      ev?.output_type === "rating" ||
+      (ev?.output_type !== "binary" &&
+        jrs.some((j) => j.score !== null && j.score !== undefined));
+
+    if (isRating) {
+      const scores = jrs
+        .map((j) => j.score)
+        .filter((s): s is number => typeof s === "number" && Number.isFinite(s));
+      if (scores.length === 0) continue;
+      const sum = scores.reduce((a, b) => a + b, 0);
+      out.push({
+        metric_key: uuid,
+        name,
+        description,
+        evaluator_uuid: uuid,
+        type: "rating",
+        mean: sum / scores.length,
+        min: Math.min(...scores),
+        max: Math.max(...scores),
+        count: scores.length,
+        scale_min: typeof ev?.scale_min === "number" ? ev.scale_min : NaN,
+        scale_max: typeof ev?.scale_max === "number" ? ev.scale_max : NaN,
+      });
+    } else {
+      const matches = jrs
+        .map((j) => j.match)
+        .filter((m): m is boolean => typeof m === "boolean");
+      if (matches.length === 0) continue;
+      const passed = matches.filter(Boolean).length;
+      out.push({
+        metric_key: uuid,
+        name,
+        description,
+        evaluator_uuid: uuid,
+        type: "binary",
+        passed,
+        total: matches.length,
+        pass_rate: (passed / matches.length) * 100,
+      });
+    }
+  }
+
+  return out;
+}


### PR DESCRIPTION
## What
- Single-model test dialog gets a **Summary** tab: overall pass rate, avg latency, avg cost, and per-evaluator metrics (binary pass rate / rating mean). Same view added to the public test-run share page.
- Benchmark leaderboard gets **avg latency** and **avg cost** columns + charts per model, fed from `leaderboard_summary` (flows to the public benchmark page too).
- Per-evaluator metrics for single runs are derived client-side from each case's `judge_results` (the backend only ships `evaluator_summary` for benchmarks).

## Notes
- Everything is null-safe: aggregate blocks are `null` for eval-only runs / before metrics land, and cost is `null` for the `openai` provider — both render as "—" and hide their columns.
- Row-level latency/cost is intentionally not shown (aggregates only), but the per-case fields are typed for future use.
- Skipped: sortable leaderboard columns (kept parity with the existing non-sortable table) and latency/cost in the runs *list* views.
- Branch is behind `main` by one commit that touches `TestRunnerDialog` header spacing — may need a trivial rebase.