### PR TITLE
Add general (non-conversational) LLM evaluator and task type

### DIFF
--- a/.cursor/rules/app-details.md
+++ b/.cursor/rules/app-details.md
@@ -678,14 +678,17 @@ A reusable sidebar dialog for creating and editing tools. Contains all form logi
 - **Set up custom evaluators**
 - **Duplicate existing evaluators** with a new name
 
-**Evaluator type (use case)** — every evaluator is scoped to one of four use cases via the `evaluator_type` field on the create payload and the GET response:
+**Evaluator type (use case)** — every evaluator is scoped to one of these use cases via the `evaluator_type` field on the create payload and the GET response:
 
-| `evaluator_type` | Label          | Purpose                                                                        | Derived `data_type` |
-| ---------------- | -------------- | ------------------------------------------------------------------------------ | ------------------- |
-| `tts`            | Text to Speech | Evaluate the quality of generated audio (naturalness, pronunciation, clarity). | `audio`             |
-| `stt`            | Speech to Text | Evaluate the accuracy of transcribed text from an audio input.                 | `audio`             |
-| `llm`            | LLM Response   | Given a conversation history, evaluate the agent's next response.              | `text`              |
-| `simulation`     | Simulation     | Evaluate an entire conversation history.                                       | `text`              |
+| `evaluator_type` | Label                | Purpose                                                                                          | Derived `data_type` |
+| ---------------- | -------------------- | ------------------------------------------------------------------------------------------------ | ------------------- |
+| `tts`            | Text to Speech       | Evaluate the quality of generated audio (naturalness, pronunciation, clarity).                   | `audio`             |
+| `stt`            | Speech to Text       | Evaluate the accuracy of transcribed text from an audio input.                                   | `audio`             |
+| `llm`            | Conversational reply | Given a conversation history, evaluate the agent's next response (conversational LLM judge).     | `text`              |
+| `llm-general`    | LLM response         | General, non-conversational LLM judge — evaluate an LLM's output for a single prompt/input (e.g. classification, extraction, summarisation). | `text` |
+| `simulation`     | Simulation           | Evaluate an entire conversation history.                                                         | `text`              |
+
+`llm` was historically labelled "Single LLM response"; it was renamed to **"Conversational reply"** to make its conversation-history bias explicit and free up the generic "LLM response" name for the non-conversational `llm-general` type. Both `llm` and `llm-general` are text judges and both support prompt variables.
 
 The backend uses `stt` (not `speech_to_text`) as the wire value for the speech-to-text use case — keep the `EvaluatorType` union in `src/components/EvaluatorPills.tsx` aligned with this, and never reintroduce `speech_to_text` as a frontend identifier.
 
@@ -719,7 +722,7 @@ Keep route files focused on data loading, API calls, URL state, and orchestratio
 
 **Pills** (`src/components/EvaluatorPills.tsx`) — list rows and the detail header show small status pills near the evaluator name. Components:
 
-- `EvaluatorTypePill` — shows `Text to Speech` / `Speech to Text` / `LLM Response` / `Simulation` with a hover `Tooltip` containing the `EVALUATOR_TYPE_TOOLTIPS` blurb. Use this whenever `evaluator.evaluator_type` is present.
+- `EvaluatorTypePill` — shows `Text to Speech` / `Speech to Text` / `Conversational reply` (`llm`) / `LLM response` (`llm-general`) / `Full conversation` with a hover `Tooltip` containing the `EVALUATOR_TYPE_TOOLTIPS` blurb. Use this whenever `evaluator.evaluator_type` is present.
 - `DataTypePill` — legacy `audio`/`text` pill. Kept as a fallback for evaluators returned without `evaluator_type` (e.g. older defaults). Pattern: `evaluator.evaluator_type ? <EvaluatorTypePill /> : <DataTypePill />`.
 - `KindPill` — `Single` / `Side by side` (with tooltip). **Currently unused on the list and detail pages** while kind is hard-coded to `"single"`; left in place for future use.
 - `OutputTypePill` — `Binary` / `Rating` (with tooltip).
@@ -737,7 +740,7 @@ Keep route files focused on data loading, API calls, URL state, and orchestratio
 
 **Variables — overall rules**
 
-Variables are **only supported for `evaluator_type === "llm"`**. The variable **name set** is pinned by the live version's variables — names cannot be added, renamed, or removed across versions of the same evaluator (the frontend enforces this with an amber-callout gate against newly-typed placeholders). **`description` and `default`, however, can be updated on every new version** — they're forwarded with each `POST /evaluators/{uuid}/versions` body. **`description` is required** in the create and new-version flows (validation gates in §2 and §3 below); on the wire it remains an optional field on the backend `VariableSpec` shape, so the POST body still defensively drops it when blank, but the frontend gate prevents that branch from being reached for LLM evaluators in normal flow. The frontend mirrors this contract in four places:
+Variables are **only supported for `evaluator_type === "llm"` and `evaluator_type === "llm-general"`** (both text LLM judges). The variable **name set** is pinned by the live version's variables — names cannot be added, renamed, or removed across versions of the same evaluator (the frontend enforces this with an amber-callout gate against newly-typed placeholders). **`description` and `default`, however, can be updated on every new version** — they're forwarded with each `POST /evaluators/{uuid}/versions` body. **`description` is required** in the create and new-version flows (validation gates in §2 and §3 below); on the wire it remains an optional field on the backend `VariableSpec` shape, so the POST body still defensively drops it when blank, but the frontend gate prevents that branch from being reached for LLM evaluators in normal flow. The frontend mirrors this contract in four places:
 
 1. **Detail-page version display** (`src/app/evaluators/[uuid]/page.tsx`) — when `v.variables?.length` is truthy, a blue-tinted info callout (`bg-blue-500/5` / `border-blue-500/20`) sits between the `Variables` label and the variable list. It reads "When this evaluator is added to an LLM test, you will be able to fill in the value of each variable for that test." This is purely informational; it does not render for evaluators with no variables (e.g. `pronunciation`, `Helpfulness`). Don't move this callout into the variable rows themselves — it's a one-time hint, not per-variable copy.
 

--- a/src/app/evaluators/page.tsx
+++ b/src/app/evaluators/page.tsx
@@ -27,6 +27,7 @@ import {
 } from "@/components/evaluators/BinaryScaleEditor";
 import { defaultBinaryLabel } from "@/lib/binaryLabels";
 import { UseCasePickerDialog } from "@/components/evaluators/UseCasePickerDialog";
+import { EVALUATOR_USE_CASE_OPTIONS } from "@/components/evaluators/evaluatorUseCases";
 import { Select } from "@/components/ui/Select";
 import { extractVariableNames } from "@/lib/evaluatorVariables";
 import {
@@ -82,51 +83,6 @@ const EVALUATOR_TYPE_TO_DATA_TYPE: Record<EvaluatorType, "text" | "audio"> = {
   "llm-general": "text",
   conversation: "text",
 };
-
-// Ordered for the use-case picker: the most common pick (a single,
-// non-conversational LLM output) leads, the rest of the text/LLM cases
-// follow, and the audio cases are grouped at the end. Descriptions are
-// kept to one short, plain-language line so the picker stays scannable for
-// first-time users; the `group` field drives the section headers and
-// `recommended` flags the "Most common" badge in UseCasePickerDialog.
-const EVALUATOR_TYPE_OPTIONS: {
-  value: EvaluatorType;
-  title: string;
-  description: string;
-  group: "conversation" | "text" | "audio";
-  recommended?: boolean;
-}[] = [
-  {
-    value: "llm",
-    title: "Conversational reply",
-    description: "Judge an agent's next reply in a conversation",
-    group: "conversation",
-  },
-  {
-    value: "conversation",
-    title: "Full conversation",
-    description: "Judge the agent's performance in a whole conversation",
-    group: "conversation",
-  },
-  {
-    value: "llm-general",
-    title: "LLM response",
-    description: "Judge the output of an LLM given a text input",
-    group: "text",
-  },
-  {
-    value: "stt",
-    title: "Speech to Text",
-    description: "Judge transcription accuracy against a reference transcript",
-    group: "audio",
-  },
-  {
-    value: "tts",
-    title: "Text to Speech (TTS)",
-    description: "Judge generated the quality of generated audio",
-    group: "audio",
-  },
-];
 
 async function getEvaluatorErrorMessage(
   response: Response,
@@ -817,7 +773,7 @@ function MetricsPageInner() {
               aria-label="Filter by purpose"
             >
               <option value="all">All purposes</option>
-              {EVALUATOR_TYPE_OPTIONS.map((opt) => (
+              {EVALUATOR_USE_CASE_OPTIONS.map((opt) => (
                 <option key={opt.value} value={opt.value}>
                   {EVALUATOR_TYPE_LABELS[opt.value]}
                 </option>
@@ -1067,7 +1023,7 @@ function MetricsPageInner() {
       {useCasePickerOpen && (
         <UseCasePickerDialog
           initialValue={newEvaluatorType}
-          options={EVALUATOR_TYPE_OPTIONS}
+          options={EVALUATOR_USE_CASE_OPTIONS}
           onCancel={() => {
             setUseCasePickerOpen(false);
             if (!addEvaluatorSidebarOpen) {

--- a/src/app/evaluators/page.tsx
+++ b/src/app/evaluators/page.tsx
@@ -69,9 +69,7 @@ function buildBinaryOutputConfig(rows: BinaryScaleRow[]): {
       scale: rows.map((r) => ({
         value: r.value,
         name: r.name.trim() || defaultBinaryLabel(r.value),
-        ...(r.description.trim()
-          ? { description: r.description.trim() }
-          : {}),
+        ...(r.description.trim() ? { description: r.description.trim() } : {}),
       })),
     },
   };
@@ -95,38 +93,38 @@ const EVALUATOR_TYPE_OPTIONS: {
   value: EvaluatorType;
   title: string;
   description: string;
-  group: "text" | "audio";
+  group: "conversation" | "text" | "audio";
   recommended?: boolean;
 }[] = [
   {
-    value: "llm-general",
-    title: "LLM response",
-    description: "Judge a single AI output — classify, extract, summarise",
-    group: "text",
-    recommended: true,
-  },
-  {
     value: "llm",
     title: "Conversational reply",
-    description: "Judge a chatbot's next reply in a chat",
-    group: "text",
+    description: "Judge an agent's next reply in a conversation",
+    group: "conversation",
   },
   {
     value: "conversation",
     title: "Full conversation",
-    description: "Judge a whole conversation, start to finish",
+    description: "Judge the agent's performance in a whole conversation",
+    group: "conversation",
+  },
+  {
+    value: "llm-general",
+    title: "LLM response",
+    description: "Judge the output of an LLM given a text input",
     group: "text",
+    recommended: true,
   },
   {
     value: "stt",
     title: "Speech to Text",
-    description: "Judge transcription accuracy against a reference",
+    description: "Judge transcription accuracy against a reference transcript",
     group: "audio",
   },
   {
     value: "tts",
     title: "Text to Speech (TTS)",
-    description: "Judge generated audio quality",
+    description: "Judge generated the quality of generated audio",
     group: "audio",
   },
 ];
@@ -253,9 +251,8 @@ function MetricsPageInner() {
     { value: 2, name: "", description: "" },
     { value: 3, name: "", description: "" },
   ]);
-  const [newEvaluatorBinaryScale, setNewEvaluatorBinaryScale] = useState<
-    BinaryScaleRow[]
-  >(defaultBinaryScale());
+  const [newEvaluatorBinaryScale, setNewEvaluatorBinaryScale] =
+    useState<BinaryScaleRow[]>(defaultBinaryScale());
 
   // Delete confirmation state
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
@@ -472,7 +469,9 @@ function MetricsPageInner() {
 
       // Remove the evaluator from local state
       setEvaluators(
-        evaluators.filter((evaluator) => evaluator.uuid !== evaluatorToDelete.uuid),
+        evaluators.filter(
+          (evaluator) => evaluator.uuid !== evaluatorToDelete.uuid,
+        ),
       );
       closeDeleteDialog();
     } catch (err) {
@@ -503,11 +502,11 @@ function MetricsPageInner() {
         const evaluatorsResponse = await fetch(
           `${backendUrl}/evaluators?include_defaults=true`,
           {
-          method: "GET",
-          headers: {
-            accept: "application/json",
-            Authorization: `Bearer ${backendAccessToken}`,
-          },
+            method: "GET",
+            headers: {
+              accept: "application/json",
+              Authorization: `Bearer ${backendAccessToken}`,
+            },
           },
         );
 
@@ -1356,4 +1355,3 @@ function DuplicateEvaluatorDialog({
     </div>
   );
 }
-

--- a/src/app/evaluators/page.tsx
+++ b/src/app/evaluators/page.tsx
@@ -81,6 +81,7 @@ const EVALUATOR_TYPE_TO_DATA_TYPE: Record<EvaluatorType, "text" | "audio"> = {
   tts: "audio",
   stt: "audio",
   llm: "text",
+  "llm-general": "text",
   conversation: "text",
 };
 
@@ -102,9 +103,15 @@ const EVALUATOR_TYPE_OPTIONS: {
   },
   {
     value: "llm",
-    title: "Single LLM response",
+    title: "Conversational reply",
     description:
       "Given a conversation history, evaluate the agent's next response",
+  },
+  {
+    value: "llm-general",
+    title: "LLM response",
+    description:
+      "Evaluate an LLM's output for a single, non-conversational prompt or input (e.g. classification, extraction, summarisation)",
   },
   {
     value: "conversation",
@@ -551,7 +558,7 @@ function MetricsPageInner() {
         newEvaluatorScale.every((row) => row.name.trim().length > 0));
     const detectedVars = extractVariableNames(newEvaluatorSystemPrompt);
     const variableDescriptionsValid =
-      newEvaluatorType !== "llm" ||
+      (newEvaluatorType !== "llm" && newEvaluatorType !== "llm-general") ||
       detectedVars.every(
         (name) =>
           (newEvaluatorVariableDescriptions[name] ?? "").trim().length > 0,
@@ -594,7 +601,8 @@ function MetricsPageInner() {
           version: {
             judge_model: newEvaluatorJudgeModel.id,
             system_prompt: newEvaluatorSystemPrompt.trim(),
-            ...(newEvaluatorType === "llm" &&
+            ...((newEvaluatorType === "llm" ||
+              newEvaluatorType === "llm-general") &&
             extractVariableNames(newEvaluatorSystemPrompt).length > 0
               ? {
                   variables: extractVariableNames(newEvaluatorSystemPrompt).map(
@@ -680,7 +688,8 @@ function MetricsPageInner() {
   const detectedPromptVariables = extractVariableNames(
     newEvaluatorSystemPrompt,
   );
-  const variablesSupported = newEvaluatorType === "llm";
+  const variablesSupported =
+    newEvaluatorType === "llm" || newEvaluatorType === "llm-general";
 
   // Partition into default vs user-owned evaluators
   const defaultEvaluators = evaluators.filter((e) => !e.owner_user_id);

--- a/src/app/evaluators/page.tsx
+++ b/src/app/evaluators/page.tsx
@@ -85,39 +85,49 @@ const EVALUATOR_TYPE_TO_DATA_TYPE: Record<EvaluatorType, "text" | "audio"> = {
   conversation: "text",
 };
 
+// Ordered for the use-case picker: the most common pick (a single,
+// non-conversational LLM output) leads, the rest of the text/LLM cases
+// follow, and the audio cases are grouped at the end. Descriptions are
+// kept to one short, plain-language line so the picker stays scannable for
+// first-time users; the `group` field drives the section headers and
+// `recommended` flags the "Most common" badge in UseCasePickerDialog.
 const EVALUATOR_TYPE_OPTIONS: {
   value: EvaluatorType;
   title: string;
   description: string;
+  group: "text" | "audio";
+  recommended?: boolean;
 }[] = [
   {
-    value: "tts",
-    title: "Text to Speech (TTS)",
-    description:
-      "Evaluate the quality of generated audio (e.g. naturalness, pronunciation, clarity)",
-  },
-  {
-    value: "stt",
-    title: "Speech to Text",
-    description: "Evaluate the transcription quality against a reference text",
+    value: "llm-general",
+    title: "LLM response",
+    description: "Judge a single AI output — classify, extract, summarise",
+    group: "text",
+    recommended: true,
   },
   {
     value: "llm",
     title: "Conversational reply",
-    description:
-      "Given a conversation history, evaluate the agent's next response",
-  },
-  {
-    value: "llm-general",
-    title: "LLM response",
-    description:
-      "Evaluate an LLM's output for a single, non-conversational prompt or input (e.g. classification, extraction, summarisation)",
+    description: "Judge a chatbot's next reply in a chat",
+    group: "text",
   },
   {
     value: "conversation",
     title: "Full conversation",
-    description:
-      "Evaluate the agent's performance during a complete conversation",
+    description: "Judge a whole conversation, start to finish",
+    group: "text",
+  },
+  {
+    value: "stt",
+    title: "Speech to Text",
+    description: "Judge transcription accuracy against a reference",
+    group: "audio",
+  },
+  {
+    value: "tts",
+    title: "Text to Speech (TTS)",
+    description: "Judge generated audio quality",
+    group: "audio",
   },
 ];
 

--- a/src/app/evaluators/page.tsx
+++ b/src/app/evaluators/page.tsx
@@ -113,7 +113,6 @@ const EVALUATOR_TYPE_OPTIONS: {
     title: "LLM response",
     description: "Judge the output of an LLM given a text input",
     group: "text",
-    recommended: true,
   },
   {
     value: "stt",

--- a/src/app/human-alignment/page.tsx
+++ b/src/app/human-alignment/page.tsx
@@ -601,7 +601,7 @@ function HumanLabellingPageInner() {
             <>
               {/* Desktop table */}
               <div className="hidden md:block border border-border rounded-xl overflow-hidden">
-                <div className="grid grid-cols-[minmax(0,1fr)_160px_100px_minmax(0,1.2fr)_40px] gap-4 [&>*:nth-child(3)]:pl-6 px-4 py-2 border-b border-border bg-muted/30">
+                <div className="grid grid-cols-[minmax(0,1fr)_200px_100px_minmax(0,1.2fr)_40px] gap-4 [&>*:nth-child(3)]:pl-6 px-4 py-2 border-b border-border bg-muted/30">
                   <div className="text-sm font-medium text-muted-foreground">
                     Name
                   </div>
@@ -626,7 +626,7 @@ function HumanLabellingPageInner() {
                       onClick={() =>
                         router.push(`/human-alignment/tasks/${task.uuid}`)
                       }
-                      className="grid grid-cols-[minmax(0,1fr)_160px_100px_minmax(0,1.2fr)_40px] gap-4 [&>*:nth-child(3)]:pl-6 px-4 py-3 border-b border-border last:border-b-0 hover:bg-muted/20 transition-colors cursor-pointer items-center"
+                      className="grid grid-cols-[minmax(0,1fr)_200px_100px_minmax(0,1.2fr)_40px] gap-4 [&>*:nth-child(3)]:pl-6 px-4 py-3 border-b border-border last:border-b-0 hover:bg-muted/20 transition-colors cursor-pointer items-center"
                     >
                       <p className="text-sm font-medium text-foreground truncate">
                         {task.name}

--- a/src/app/human-alignment/page.tsx
+++ b/src/app/human-alignment/page.tsx
@@ -58,7 +58,7 @@ type LabellingTaskSummary = {
 type LabellingTaskEvaluator = {
   uuid: string;
   name: string;
-  evaluator_type?: "llm" | "stt" | "tts" | "conversation";
+  evaluator_type?: "llm" | "llm-general" | "stt" | "tts" | "conversation";
   output_type?: "binary" | "rating";
   owner_user_id?: string | null;
 };
@@ -66,7 +66,7 @@ type LabellingTaskEvaluator = {
 type LabellingTask = {
   uuid: string;
   name: string;
-  type?: "llm" | "stt" | "tts" | "conversation";
+  type?: "llm" | "llm-general" | "stt" | "tts" | "conversation";
   description?: string;
   created_at?: string;
   updated_at?: string;
@@ -1255,7 +1255,7 @@ type SeriesRow = {
   current: number | null;
   pairCount: number;
   series: AgreementSeriesPoint[];
-  evaluatorType?: "llm" | "stt" | "tts" | "conversation";
+  evaluatorType?: "llm" | "llm-general" | "stt" | "tts" | "conversation";
   emptyTitle: string;
   emptyDescription: string;
 };
@@ -1292,7 +1292,10 @@ function AgreementOverview({
   tasks: LabellingTask[];
 }) {
   const evaluatorTypeMap = (() => {
-    const m = new Map<string, "llm" | "stt" | "tts" | "conversation">();
+    const m = new Map<
+      string,
+      "llm" | "llm-general" | "stt" | "tts" | "conversation"
+    >();
     for (const t of tasks) {
       for (const ev of t.evaluators ?? []) {
         const type = ev.evaluator_type ?? t.type;

--- a/src/app/human-alignment/tasks/[uuid]/evaluator-runs/[runUuid]/page.tsx
+++ b/src/app/human-alignment/tasks/[uuid]/evaluator-runs/[runUuid]/page.tsx
@@ -547,6 +547,7 @@ export default function EvaluatorRunDetailPage() {
         task &&
         (task.type === "stt" ||
           task.type === "llm" ||
+          task.type === "llm-general" ||
           task.type === "conversation") ? (
           <EvaluatorRunDetailView
             job={job}

--- a/src/app/human-alignment/tasks/[uuid]/page.tsx
+++ b/src/app/human-alignment/tasks/[uuid]/page.tsx
@@ -2103,6 +2103,7 @@ function LabellingTaskPageInner() {
   const llmGeneralEvaluatorDefs = (task?.evaluators ?? []).map((e) => ({
     uuid: e.uuid,
     name: e.name,
+    description: e.description ?? null,
     variables: e.variables ?? [],
   }));
 

--- a/src/app/human-alignment/tasks/[uuid]/page.tsx
+++ b/src/app/human-alignment/tasks/[uuid]/page.tsx
@@ -125,7 +125,7 @@ type SummaryRow = {
 };
 type TaskSummaryResponse = {
   task_id: string;
-  task_type: "stt" | "llm" | "conversation";
+  task_type: "stt" | "llm" | "llm-general" | "conversation";
   evaluators: SummaryEvaluator[];
   annotators: SummaryAnnotator[];
   rows: SummaryRow[];
@@ -229,7 +229,7 @@ type LabellingJob = {
 type LabellingTask = {
   uuid: string;
   name: string;
-  type?: "llm" | "stt" | "tts" | "conversation";
+  type?: "llm" | "llm-general" | "stt" | "tts" | "conversation";
   description?: string;
   created_at?: string;
   updated_at?: string;
@@ -238,7 +238,7 @@ type LabellingTask = {
     name: string;
     description?: string | null;
     slug?: string | null;
-    evaluator_type?: "llm" | "stt" | "tts" | "conversation";
+    evaluator_type?: "llm" | "llm-general" | "stt" | "tts" | "conversation";
     output_type?: "binary" | "rating" | null;
     scale_min?: number | boolean | null;
     scale_max?: number | boolean | null;
@@ -259,7 +259,13 @@ type LabellingTask = {
   item_count?: number;
 };
 
-type TaskKind = "llm" | "stt" | "tts" | "conversation" | undefined;
+type TaskKind =
+  | "llm"
+  | "llm-general"
+  | "stt"
+  | "tts"
+  | "conversation"
+  | undefined;
 
 function previewItemPayload(payload: unknown, kind: TaskKind): string {
   if (payload == null || typeof payload !== "object") {
@@ -289,6 +295,11 @@ function previewItemPayload(payload: unknown, kind: TaskKind): string {
     if (Array.isArray(p.transcript) && p.transcript.length > 0) {
       const first = p.transcript[0] as { content?: unknown };
       if (typeof first?.content === "string") return first.content;
+    }
+  }
+  if (kind === "llm-general") {
+    for (const key of ["output", "response", "completion", "agent_response"]) {
+      if (typeof p[key] === "string" && p[key]) return p[key] as string;
     }
   }
   try {
@@ -4166,6 +4177,7 @@ function LabellingTaskPageInner() {
         task={
           task &&
           (task.type === "llm" ||
+            task.type === "llm-general" ||
             task.type === "stt" ||
             task.type === "conversation")
             ? {

--- a/src/app/human-alignment/tasks/[uuid]/page.tsx
+++ b/src/app/human-alignment/tasks/[uuid]/page.tsx
@@ -2543,9 +2543,7 @@ function LabellingTaskPageInner() {
                     d="M12 4.5v15m7.5-7.5h-15"
                   />
                 </svg>
-                {taskType === "stt" || taskType === "llm-general"
-                  ? "Add items"
-                  : "Add item"}
+                {taskType === "stt" ? "Add items" : "Add item"}
               </button>
               {(() => {
                 // LLM / LLM-response bulk upload references evaluators by

--- a/src/app/human-alignment/tasks/[uuid]/page.tsx
+++ b/src/app/human-alignment/tasks/[uuid]/page.tsx
@@ -1262,6 +1262,7 @@ function LabellingTaskPageInner() {
     {
       uuid: string;
       name: string;
+      description?: string;
       input: string;
       output: string;
       varValues?: Record<string, Record<string, string>>;
@@ -3433,6 +3434,10 @@ function LabellingTaskPageInner() {
                                   {
                                     uuid: item.uuid,
                                     name: `Copy of ${name}`,
+                                    description:
+                                      typeof p?.description === "string"
+                                        ? (p.description as string)
+                                        : "",
                                     input:
                                       typeof p?.input === "string"
                                         ? (p.input as string)
@@ -4154,6 +4159,7 @@ function LabellingTaskPageInner() {
               items: rows.map((r) => ({
                 payload: {
                   ...(r.name ? { name: r.name } : {}),
+                  ...(r.description ? { description: r.description } : {}),
                   input: r.input,
                   output: r.output,
                   ...(Object.keys(r.evaluator_variables).length > 0
@@ -4185,6 +4191,8 @@ function LabellingTaskPageInner() {
             return {
               uuid: it.uuid,
               name: typeof p.name === "string" ? p.name : "",
+              description:
+                typeof p.description === "string" ? p.description : "",
               input: typeof p.input === "string" ? p.input : "",
               output: typeof p.output === "string" ? p.output : "",
               varValues: readEvaluatorVariables(p),
@@ -4208,6 +4216,7 @@ function LabellingTaskPageInner() {
                     uuid: r.uuid,
                     payload: {
                       ...(r.name ? { name: r.name } : {}),
+                      ...(r.description ? { description: r.description } : {}),
                       input: r.input,
                       output: r.output,
                       ...(Object.keys(r.evaluator_variables).length > 0

--- a/src/app/human-alignment/tasks/[uuid]/page.tsx
+++ b/src/app/human-alignment/tasks/[uuid]/page.tsx
@@ -1259,7 +1259,14 @@ function LabellingTaskPageInner() {
   const [editLlmGeneralSingleItemUuid, setEditLlmGeneralSingleItemUuid] =
     useState<string | null>(null);
   const [duplicateLlmGeneralRows, setDuplicateLlmGeneralRows] = useState<
-    { uuid: string; name: string; input: string; output: string }[] | null
+    {
+      uuid: string;
+      name: string;
+      input: string;
+      output: string;
+      varValues?: Record<string, Record<string, string>>;
+    }[]
+    | null
   >(null);
 
   // Sort direction for the items table's Updated at column. Always
@@ -2091,6 +2098,14 @@ function LabellingTaskPageInner() {
     return out;
   };
 
+  // Linked evaluators (with their variable defs) passed to the llm-general
+  // add/edit dialog so it can render per-item variable inputs.
+  const llmGeneralEvaluatorDefs = (task?.evaluators ?? []).map((e) => ({
+    uuid: e.uuid,
+    name: e.name,
+    variables: e.variables ?? [],
+  }));
+
   // Build initialEvaluators[] from the task's linked evaluators using the
   // catalogue for variable definitions, optionally seeded with saved values.
   // If the catalogue hasn't hydrated this evaluator yet but we have saved
@@ -2533,11 +2548,13 @@ function LabellingTaskPageInner() {
                   : "Add item"}
               </button>
               {(() => {
-                // LLM bulk upload references evaluators by name in the
-                // CSV; without any linked evaluators the validator will
-                // reject every row. Disable the button instead.
+                // LLM / LLM-response bulk upload references evaluators by
+                // name in the CSV (variable columns); without any linked
+                // evaluators the validator will reject every row. Disable the
+                // button instead — same gating for both LLM task types.
                 const llmNoEvaluators =
-                  taskType === "llm" && (task?.evaluators?.length ?? 0) === 0;
+                  (taskType === "llm" || taskType === "llm-general") &&
+                  (task?.evaluators?.length ?? 0) === 0;
                 const buttonEl = (
                   <button
                     onClick={() => {
@@ -3425,6 +3442,7 @@ function LabellingTaskPageInner() {
                                       typeof p?.output === "string"
                                         ? (p.output as string)
                                         : "",
+                                    varValues: readEvaluatorVariables(p),
                                   },
                                 ]);
                                 setAddLlmGeneralItemsOpen(true);
@@ -4123,6 +4141,7 @@ function LabellingTaskPageInner() {
 
       <AddLlmGeneralItemsDialog
         isOpen={addLlmGeneralItemsOpen}
+        evaluators={llmGeneralEvaluatorDefs}
         initialRows={duplicateLlmGeneralRows ?? undefined}
         onClose={() => {
           setAddLlmGeneralItemsOpen(false);
@@ -4138,6 +4157,9 @@ function LabellingTaskPageInner() {
                   ...(r.name ? { name: r.name } : {}),
                   input: r.input,
                   output: r.output,
+                  ...(Object.keys(r.evaluator_variables).length > 0
+                    ? { evaluator_variables: r.evaluator_variables }
+                    : {}),
                 },
               })),
             },
@@ -4152,6 +4174,7 @@ function LabellingTaskPageInner() {
       <AddLlmGeneralItemsDialog
         isOpen={editLlmGeneralItemsOpen}
         mode="edit"
+        evaluators={llmGeneralEvaluatorDefs}
         initialRows={items
           .filter((it) =>
             editLlmGeneralSingleItemUuid
@@ -4165,6 +4188,7 @@ function LabellingTaskPageInner() {
               name: typeof p.name === "string" ? p.name : "",
               input: typeof p.input === "string" ? p.input : "",
               output: typeof p.output === "string" ? p.output : "",
+              varValues: readEvaluatorVariables(p),
             };
           })}
         onClose={() => {
@@ -4187,6 +4211,9 @@ function LabellingTaskPageInner() {
                       ...(r.name ? { name: r.name } : {}),
                       input: r.input,
                       output: r.output,
+                      ...(Object.keys(r.evaluator_variables).length > 0
+                        ? { evaluator_variables: r.evaluator_variables }
+                        : {}),
                     },
                   })),
               },
@@ -4208,6 +4235,8 @@ function LabellingTaskPageInner() {
           linkedEvaluators={(task?.evaluators ?? []).map((e) => ({
             uuid: e.uuid,
             name: e.name,
+            slug: e.slug ?? null,
+            variables: e.variables ?? [],
             output_type: e.output_type ?? null,
             scale_min: typeof e.scale_min === "number" ? e.scale_min : null,
             scale_max: typeof e.scale_max === "number" ? e.scale_max : null,

--- a/src/app/human-alignment/tasks/[uuid]/page.tsx
+++ b/src/app/human-alignment/tasks/[uuid]/page.tsx
@@ -30,9 +30,11 @@ import { RefreshButton } from "@/components/RefreshButton";
 import { Tooltip } from "@/components/Tooltip";
 import { DeleteConfirmationDialog } from "@/components/DeleteConfirmationDialog";
 import { AddSttItemsDialog } from "@/components/human-labelling/AddSttItemsDialog";
+import { AddLlmGeneralItemsDialog } from "@/components/human-labelling/AddLlmGeneralItemsDialog";
 import { BulkUploadSttItemsDialog } from "@/components/human-labelling/BulkUploadSttItemsDialog";
 import { BulkUploadConversationItemsDialog } from "@/components/human-labelling/BulkUploadConversationItemsDialog";
 import { BulkUploadLlmItemsDialog } from "@/components/human-labelling/BulkUploadLlmItemsDialog";
+import { BulkUploadLlmGeneralItemsDialog } from "@/components/human-labelling/BulkUploadLlmGeneralItemsDialog";
 import { AssignAnnotatorsDialog } from "@/components/human-labelling/AssignAnnotatorsDialog";
 import { EditTaskDialog } from "@/components/human-labelling/EditTaskDialog";
 import { ItemDetailDialog } from "@/components/human-labelling/ItemDetailDialog";
@@ -298,9 +300,8 @@ function previewItemPayload(payload: unknown, kind: TaskKind): string {
     }
   }
   if (kind === "llm-general") {
-    for (const key of ["output", "response", "completion", "agent_response"]) {
-      if (typeof p[key] === "string" && p[key]) return p[key] as string;
-    }
+    if (typeof p.output === "string" && p.output) return p.output;
+    if (typeof p.input === "string" && p.input) return p.input;
   }
   try {
     return JSON.stringify(payload);
@@ -383,6 +384,9 @@ function buildItemsCsv(
       header: "conversation_history",
     });
     columns.push({ key: "agent_response", header: "agent_response" });
+  } else if (taskType === "llm-general") {
+    columns.push({ key: "input", header: "input" });
+    columns.push({ key: "output", header: "output" });
   }
 
   for (const ev of evaluators) {
@@ -456,6 +460,9 @@ function buildItemsCsv(
         : "";
       out.agent_response =
         typeof p.agent_response === "string" ? p.agent_response : "";
+    } else if (taskType === "llm-general") {
+      out.input = typeof p.input === "string" ? p.input : "";
+      out.output = typeof p.output === "string" ? p.output : "";
     }
 
     for (const ev of evaluators) {
@@ -1247,6 +1254,13 @@ function LabellingTaskPageInner() {
   const [duplicateSttRows, setDuplicateSttRows] = useState<
     { uuid: string; name: string; actual: string; predicted: string }[] | null
   >(null);
+  // llm-general items use their own input/output dialog (non-conversational).
+  const [editLlmGeneralItemsOpen, setEditLlmGeneralItemsOpen] = useState(false);
+  const [editLlmGeneralSingleItemUuid, setEditLlmGeneralSingleItemUuid] =
+    useState<string | null>(null);
+  const [duplicateLlmGeneralRows, setDuplicateLlmGeneralRows] = useState<
+    { uuid: string; name: string; input: string; output: string }[] | null
+  >(null);
 
   // Sort direction for the items table's Updated at column. Always
   // applied to `updated_at` on the backend; defaults to desc (newest
@@ -1635,7 +1649,10 @@ function LabellingTaskPageInner() {
   const taskType =
     task?.type ?? task?.evaluators?.[0]?.evaluator_type;
   const canAddItem =
-    taskType === "llm" || taskType === "conversation" || taskType === "stt";
+    taskType === "llm" ||
+    taskType === "conversation" ||
+    taskType === "stt" ||
+    taskType === "llm-general";
 
   /**
    * Anchor for shift+click range selection — the uuid of the most
@@ -2234,10 +2251,13 @@ function LabellingTaskPageInner() {
   const [editOpen, setEditOpen] = useState(false);
   const [addItemOpen, setAddItemOpen] = useState(false);
   const [addSttItemsOpen, setAddSttItemsOpen] = useState(false);
+  const [addLlmGeneralItemsOpen, setAddLlmGeneralItemsOpen] = useState(false);
   const [bulkUploadSttOpen, setBulkUploadSttOpen] = useState(false);
   const [bulkUploadConversationOpen, setBulkUploadConversationOpen] =
     useState(false);
   const [bulkUploadLlmOpen, setBulkUploadLlmOpen] = useState(false);
+  const [bulkUploadLlmGeneralOpen, setBulkUploadLlmGeneralOpen] =
+    useState(false);
   const [newItemName, setNewItemName] = useState("");
   const [newItemDescription, setNewItemDescription] = useState("");
   const [creatingItem, setCreatingItem] = useState(false);
@@ -2482,6 +2502,9 @@ function LabellingTaskPageInner() {
                   } else if (taskType === "stt") {
                     setDuplicateSttRows(null);
                     setAddSttItemsOpen(true);
+                  } else if (taskType === "llm-general") {
+                    setDuplicateLlmGeneralRows(null);
+                    setAddLlmGeneralItemsOpen(true);
                   }
                 }}
                 disabled={!canAddItem}
@@ -2505,7 +2528,9 @@ function LabellingTaskPageInner() {
                     d="M12 4.5v15m7.5-7.5h-15"
                   />
                 </svg>
-                {taskType === "stt" ? "Add items" : "Add item"}
+                {taskType === "stt" || taskType === "llm-general"
+                  ? "Add items"
+                  : "Add item"}
               </button>
               {(() => {
                 // LLM bulk upload references evaluators by name in the
@@ -2523,6 +2548,8 @@ function LabellingTaskPageInner() {
                         setBulkUploadConversationOpen(true);
                       } else if (taskType === "llm") {
                         setBulkUploadLlmOpen(true);
+                      } else if (taskType === "llm-general") {
+                        setBulkUploadLlmGeneralOpen(true);
                       } else {
                         toast.info(
                           "CSV upload isn't supported yet — coming soon.",
@@ -3366,7 +3393,14 @@ function LabellingTaskPageInner() {
                                   }
                                 : undefined
                             }
-                            onEdit={(uuid) => setEditLlmItemUuid(uuid)}
+                            onEdit={(uuid) => {
+                              if (taskType === "llm-general") {
+                                setEditLlmGeneralSingleItemUuid(uuid);
+                                setEditLlmGeneralItemsOpen(true);
+                              } else {
+                                setEditLlmItemUuid(uuid);
+                              }
+                            }}
                             onDuplicate={(uuid) => {
                               const item = items.find((i) => i.uuid === uuid);
                               if (!item) return;
@@ -3378,6 +3412,24 @@ function LabellingTaskPageInner() {
                                 typeof p?.name === "string"
                                   ? (p.name as string)
                                   : `Item ${item.id}`;
+                              if (taskType === "llm-general") {
+                                setDuplicateLlmGeneralRows([
+                                  {
+                                    uuid: item.uuid,
+                                    name: `Copy of ${name}`,
+                                    input:
+                                      typeof p?.input === "string"
+                                        ? (p.input as string)
+                                        : "",
+                                    output:
+                                      typeof p?.output === "string"
+                                        ? (p.output as string)
+                                        : "",
+                                  },
+                                ]);
+                                setAddLlmGeneralItemsOpen(true);
+                                return;
+                              }
                               const desc =
                                 typeof p?.description === "string"
                                   ? (p.description as string)
@@ -3789,7 +3841,9 @@ function LabellingTaskPageInner() {
         />
       )}
 
-      {!!editLlmItemUuid && taskType !== "stt" && (
+      {!!editLlmItemUuid &&
+        taskType !== "stt" &&
+        taskType !== "llm-general" && (
         <AddTestDialog
           key={editLlmItemUuid}
           isOpen={true}
@@ -4066,6 +4120,107 @@ function LabellingTaskPageInner() {
           setSelectAllTotal(false);
         }}
       />
+
+      <AddLlmGeneralItemsDialog
+        isOpen={addLlmGeneralItemsOpen}
+        initialRows={duplicateLlmGeneralRows ?? undefined}
+        onClose={() => {
+          setAddLlmGeneralItemsOpen(false);
+          setDuplicateLlmGeneralRows(null);
+        }}
+        onSubmit={async (rows) => {
+          if (!accessToken) return;
+          await apiClient(`/annotation-tasks/${uuid}/items`, accessToken, {
+            method: "POST",
+            body: {
+              items: rows.map((r) => ({
+                payload: {
+                  ...(r.name ? { name: r.name } : {}),
+                  input: r.input,
+                  output: r.output,
+                },
+              })),
+            },
+          });
+          handleTabChange("items");
+          await Promise.all([fetchTask(), fetchTaskSummary()]);
+          setAddLlmGeneralItemsOpen(false);
+          setDuplicateLlmGeneralRows(null);
+        }}
+      />
+
+      <AddLlmGeneralItemsDialog
+        isOpen={editLlmGeneralItemsOpen}
+        mode="edit"
+        initialRows={items
+          .filter((it) =>
+            editLlmGeneralSingleItemUuid
+              ? it.uuid === editLlmGeneralSingleItemUuid
+              : selectedItemIds.has(it.uuid),
+          )
+          .map((it) => {
+            const p = (it.payload ?? {}) as Record<string, unknown>;
+            return {
+              uuid: it.uuid,
+              name: typeof p.name === "string" ? p.name : "",
+              input: typeof p.input === "string" ? p.input : "",
+              output: typeof p.output === "string" ? p.output : "",
+            };
+          })}
+        onClose={() => {
+          setEditLlmGeneralItemsOpen(false);
+          setEditLlmGeneralSingleItemUuid(null);
+        }}
+        onSubmit={async (rows) => {
+          if (!accessToken) return;
+          await apiClient<{ updated_count: number }>(
+            `/annotation-tasks/${uuid}/items`,
+            accessToken,
+            {
+              method: "PUT",
+              body: {
+                updates: rows
+                  .filter((r) => !!r.uuid)
+                  .map((r) => ({
+                    uuid: r.uuid,
+                    payload: {
+                      ...(r.name ? { name: r.name } : {}),
+                      input: r.input,
+                      output: r.output,
+                    },
+                  })),
+              },
+            },
+          );
+          await Promise.all([fetchTask(), fetchTaskSummary()]);
+          setEditLlmGeneralItemsOpen(false);
+          setEditLlmGeneralSingleItemUuid(null);
+          setSelectedItemIds(new Set());
+          setSelectAllTotal(false);
+        }}
+      />
+
+      {accessToken && (
+        <BulkUploadLlmGeneralItemsDialog
+          isOpen={bulkUploadLlmGeneralOpen}
+          accessToken={accessToken}
+          taskUuid={uuid}
+          linkedEvaluators={(task?.evaluators ?? []).map((e) => ({
+            uuid: e.uuid,
+            name: e.name,
+            output_type: e.output_type ?? null,
+            scale_min: typeof e.scale_min === "number" ? e.scale_min : null,
+            scale_max: typeof e.scale_max === "number" ? e.scale_max : null,
+          }))}
+          onClose={() => setBulkUploadLlmGeneralOpen(false)}
+          onSuccess={async (count) => {
+            setBulkUploadLlmGeneralOpen(false);
+            handleTabChange("items");
+            await Promise.all([fetchTask(), fetchTaskSummary()]);
+            toast.success(`Added ${count} ${count === 1 ? "item" : "items"}`);
+          }}
+        />
+      )}
 
       {accessToken && (
         <AssignAnnotatorsDialog

--- a/src/app/human-alignment/tasks/[uuid]/page.tsx
+++ b/src/app/human-alignment/tasks/[uuid]/page.tsx
@@ -3115,7 +3115,7 @@ function LabellingTaskPageInner() {
                 </div>
               ) : taskType === "stt" ? (
                 <div className="border border-border rounded-xl overflow-hidden">
-                  <div className="grid grid-cols-[40px_minmax(0,0.6fr)_minmax(0,1fr)_minmax(0,1fr)_200px_180px_300px] gap-6 px-4 py-2 border-b border-border bg-muted/30 items-center">
+                  <div className="grid grid-cols-[40px_minmax(0,1fr)_200px_180px_300px] gap-6 px-4 py-2 border-b border-border bg-muted/30 items-center">
                     <input
                       type="checkbox"
                       checked={allSelected}
@@ -3128,12 +3128,6 @@ function LabellingTaskPageInner() {
                     />
                     <div className="text-sm font-medium text-muted-foreground">
                       Name
-                    </div>
-                    <div className="text-sm font-medium text-muted-foreground">
-                      Reference transcript
-                    </div>
-                    <div className="text-sm font-medium text-muted-foreground">
-                      Predicted transcript
                     </div>
                     <div className="text-sm font-medium text-muted-foreground">
                       Labelled by
@@ -3154,14 +3148,6 @@ function LabellingTaskPageInner() {
                   {items.map((item) => {
                     const p = (item.payload ?? {}) as Record<string, unknown>;
                     const name = typeof p.name === "string" ? p.name : "";
-                    const ref =
-                      typeof p.reference_transcript === "string"
-                        ? p.reference_transcript
-                        : "";
-                    const pred =
-                      typeof p.predicted_transcript === "string"
-                        ? p.predicted_transcript
-                        : "";
                     const isSelected =
                       selectAllTotal || selectedItemIds.has(item.uuid);
                     const labellerIds = labellersByItem.get(item.uuid);
@@ -3181,7 +3167,7 @@ function LabellingTaskPageInner() {
                             }
                             openItemDetail(item.uuid);
                           }}
-                          className={`grid grid-cols-[40px_minmax(0,0.6fr)_minmax(0,1fr)_minmax(0,1fr)_200px_180px_300px] gap-6 px-4 py-3 border-b border-border last:border-b-0 transition-colors items-center cursor-pointer ${
+                          className={`grid grid-cols-[40px_minmax(0,1fr)_200px_180px_300px] gap-6 px-4 py-3 border-b border-border last:border-b-0 transition-colors items-center cursor-pointer ${
                             isSelected ? "bg-muted/30" : "hover:bg-muted/20"
                           }`}
                         >
@@ -3205,12 +3191,6 @@ function LabellingTaskPageInner() {
                           />
                           <p className="text-sm text-foreground line-clamp-2">
                             {name || "—"}
-                          </p>
-                          <p className="text-sm text-foreground line-clamp-2">
-                            {ref || "—"}
-                          </p>
-                          <p className="text-sm text-foreground line-clamp-2">
-                            {pred || "—"}
                           </p>
                           <LabelledByCell
                             labellers={labellerIds}

--- a/src/components/EvaluatorPills.tsx
+++ b/src/components/EvaluatorPills.tsx
@@ -32,12 +32,11 @@ export const EVALUATOR_TYPE_LABELS: Record<EvaluatorType, string> = {
 };
 
 export const EVALUATOR_TYPE_TOOLTIPS: Record<EvaluatorType, string> = {
-  tts: "Evaluate the quality of generated audio.",
-  stt: "Evaluate the output of transcription of an audio.",
-  llm: "Given a conversation history, evaluate the agent's next response.",
-  "llm-general":
-    "Evaluate an LLM's output for a single, non-conversational prompt or input.",
-  conversation: "Evaluate an entire conversation history.",
+  tts: "Evaluate the quality of generated audio",
+  stt: "Evaluate the output of transcription of an audio",
+  llm: "Evaluate the agent's next reply in a conversation",
+  "llm-general": "Evaluate an LLM's output for a given text input",
+  conversation: "Evaluate the agent's performance in a whole conversation",
 };
 
 const EVALUATOR_TYPE_COLORS: Record<EvaluatorType, string> = {

--- a/src/components/EvaluatorPills.tsx
+++ b/src/components/EvaluatorPills.tsx
@@ -5,7 +5,12 @@ import { Tooltip } from "@/components/Tooltip";
 
 type Kind = "single" | "side_by_side";
 type OutputType = "binary" | "rating";
-export type EvaluatorType = "tts" | "stt" | "llm" | "conversation";
+export type EvaluatorType =
+  | "tts"
+  | "stt"
+  | "llm"
+  | "llm-general"
+  | "conversation";
 
 const baseClasses =
   "inline-flex items-center px-2 py-0.5 rounded-md text-[10px] md:text-[11px] font-medium uppercase tracking-wide";
@@ -21,7 +26,8 @@ export function DefaultPill() {
 export const EVALUATOR_TYPE_LABELS: Record<EvaluatorType, string> = {
   tts: "Text to Speech",
   stt: "Speech to Text",
-  llm: "Single LLM response",
+  llm: "Conversational reply",
+  "llm-general": "LLM response",
   conversation: "Full conversation",
 };
 
@@ -29,6 +35,8 @@ export const EVALUATOR_TYPE_TOOLTIPS: Record<EvaluatorType, string> = {
   tts: "Evaluate the quality of generated audio.",
   stt: "Evaluate the output of transcription of an audio.",
   llm: "Given a conversation history, evaluate the agent's next response.",
+  "llm-general":
+    "Evaluate an LLM's output for a single, non-conversational prompt or input.",
   conversation: "Evaluate an entire conversation history.",
 };
 
@@ -36,6 +44,7 @@ const EVALUATOR_TYPE_COLORS: Record<EvaluatorType, string> = {
   tts: "bg-purple-500/10 text-purple-600 dark:text-purple-400",
   stt: "bg-blue-500/10 text-blue-600 dark:text-blue-400",
   llm: "bg-orange-500/10 text-orange-600 dark:text-orange-400",
+  "llm-general": "bg-teal-500/10 text-teal-600 dark:text-teal-400",
   conversation: "bg-pink-500/10 text-pink-600 dark:text-pink-400",
 };
 

--- a/src/components/EvaluatorPills.tsx
+++ b/src/components/EvaluatorPills.tsx
@@ -13,7 +13,7 @@ export type EvaluatorType =
   | "conversation";
 
 const baseClasses =
-  "inline-flex items-center px-2 py-0.5 rounded-md text-[10px] md:text-[11px] font-medium uppercase tracking-wide";
+  "inline-flex items-center whitespace-nowrap px-2 py-0.5 rounded-md text-[10px] md:text-[11px] font-medium uppercase tracking-wide";
 
 export function DefaultPill() {
   return (

--- a/src/components/evaluators/UseCasePickerDialog.tsx
+++ b/src/components/evaluators/UseCasePickerDialog.tsx
@@ -8,7 +8,18 @@ export type EvaluatorTypeOption = {
   value: EvaluatorType;
   title: string;
   description: string;
+  // Drives the section the card is grouped under. Optional so older callers
+  // that pass an ungrouped list still render (everything falls under "text").
+  group?: "text" | "audio";
+  // Flags the "Most common" badge — a starting-point cue for new users.
+  recommended?: boolean;
 };
+
+// Section headers shown above each group of cards, in render order.
+const GROUP_ORDER: { key: "text" | "audio"; label: string }[] = [
+  { key: "text", label: "Text & LLM" },
+  { key: "audio", label: "Audio" },
+];
 
 const TYPE_INACTIVE_CLASSES: Record<EvaluatorType, string> = {
   tts: "border-purple-500/20 bg-purple-500/[0.04] hover:bg-purple-500/10 hover:border-purple-500/40",
@@ -91,33 +102,53 @@ export function UseCasePickerDialog({
           </button>
         </div>
 
-        <div className="flex-1 overflow-y-auto p-4 md:p-6">
-          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-            {options.map((opt) => {
-              const active = selected === opt.value;
-              return (
-                <button
-                  key={opt.value}
-                  type="button"
-                  onClick={() => setSelected(opt.value)}
-                  className={`flex flex-col items-start text-left p-4 rounded-md border transition-colors cursor-pointer ${
-                    active
-                      ? TYPE_ACTIVE_CLASSES[opt.value]
-                      : TYPE_INACTIVE_CLASSES[opt.value]
-                  }`}
-                >
-                  <div
-                    className={`text-sm md:text-base font-medium ${TYPE_TITLE_CLASSES[opt.value]}`}
-                  >
-                    {opt.title}
-                  </div>
-                  <div className="text-xs md:text-sm text-muted-foreground mt-1 leading-relaxed">
-                    {opt.description}
-                  </div>
-                </button>
-              );
-            })}
-          </div>
+        <div className="flex-1 overflow-y-auto p-4 md:p-6 space-y-5">
+          {GROUP_ORDER.map(({ key, label }) => {
+            const groupOptions = options.filter(
+              (o) => (o.group ?? "text") === key,
+            );
+            if (groupOptions.length === 0) return null;
+            return (
+              <div key={key}>
+                <div className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground mb-2.5 px-0.5">
+                  {label}
+                </div>
+                <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                  {groupOptions.map((opt) => {
+                    const active = selected === opt.value;
+                    return (
+                      <button
+                        key={opt.value}
+                        type="button"
+                        onClick={() => setSelected(opt.value)}
+                        className={`flex flex-col items-start text-left p-4 rounded-md border transition-colors cursor-pointer ${
+                          active
+                            ? TYPE_ACTIVE_CLASSES[opt.value]
+                            : TYPE_INACTIVE_CLASSES[opt.value]
+                        }`}
+                      >
+                        <div className="flex items-start justify-between gap-2 w-full">
+                          <div
+                            className={`text-sm md:text-base font-medium ${TYPE_TITLE_CLASSES[opt.value]}`}
+                          >
+                            {opt.title}
+                          </div>
+                          {opt.recommended && (
+                            <span className="shrink-0 inline-flex items-center px-2 py-0.5 rounded-full text-[10px] font-semibold uppercase tracking-wide bg-teal-500/15 text-teal-700 dark:text-teal-300 border border-teal-500/30">
+                              Most common
+                            </span>
+                          )}
+                        </div>
+                        <div className="text-xs md:text-sm text-muted-foreground mt-1 leading-relaxed">
+                          {opt.description}
+                        </div>
+                      </button>
+                    );
+                  })}
+                </div>
+              </div>
+            );
+          })}
         </div>
 
         <div className="flex items-center justify-end gap-2 md:gap-3 px-5 md:px-6 py-4 border-t border-border">

--- a/src/components/evaluators/UseCasePickerDialog.tsx
+++ b/src/components/evaluators/UseCasePickerDialog.tsx
@@ -10,16 +10,18 @@ export type EvaluatorTypeOption = {
   description: string;
   // Drives the section the card is grouped under. Optional so older callers
   // that pass an ungrouped list still render (everything falls under "text").
-  group?: "text" | "audio";
+  group?: "conversation" | "text" | "audio";
   // Flags the "Most common" badge — a starting-point cue for new users.
   recommended?: boolean;
 };
 
 // Section headers shown above each group of cards, in render order.
-const GROUP_ORDER: { key: "text" | "audio"; label: string }[] = [
-  { key: "text", label: "Text & LLM" },
-  { key: "audio", label: "Audio" },
-];
+const GROUP_ORDER: { key: "conversation" | "text" | "audio"; label: string }[] =
+  [
+    { key: "conversation", label: "Conversation" },
+    { key: "text", label: "Text" },
+    { key: "audio", label: "Audio" },
+  ];
 
 const TYPE_INACTIVE_CLASSES: Record<EvaluatorType, string> = {
   tts: "border-purple-500/20 bg-purple-500/[0.04] hover:bg-purple-500/10 hover:border-purple-500/40",

--- a/src/components/evaluators/UseCasePickerDialog.tsx
+++ b/src/components/evaluators/UseCasePickerDialog.tsx
@@ -14,6 +14,8 @@ const TYPE_INACTIVE_CLASSES: Record<EvaluatorType, string> = {
   tts: "border-purple-500/20 bg-purple-500/[0.04] hover:bg-purple-500/10 hover:border-purple-500/40",
   stt: "border-blue-500/20 bg-blue-500/[0.04] hover:bg-blue-500/10 hover:border-blue-500/40",
   llm: "border-orange-500/20 bg-orange-500/[0.04] hover:bg-orange-500/10 hover:border-orange-500/40",
+  "llm-general":
+    "border-teal-500/20 bg-teal-500/[0.04] hover:bg-teal-500/10 hover:border-teal-500/40",
   conversation:
     "border-pink-500/20 bg-pink-500/[0.04] hover:bg-pink-500/10 hover:border-pink-500/40",
 };
@@ -22,6 +24,7 @@ const TYPE_ACTIVE_CLASSES: Record<EvaluatorType, string> = {
   tts: "border-purple-500/60 bg-purple-500/15 ring-1 ring-purple-500/40",
   stt: "border-blue-500/60 bg-blue-500/15 ring-1 ring-blue-500/40",
   llm: "border-orange-500/60 bg-orange-500/15 ring-1 ring-orange-500/40",
+  "llm-general": "border-teal-500/60 bg-teal-500/15 ring-1 ring-teal-500/40",
   conversation: "border-pink-500/60 bg-pink-500/15 ring-1 ring-pink-500/40",
 };
 
@@ -29,6 +32,7 @@ const TYPE_TITLE_CLASSES: Record<EvaluatorType, string> = {
   tts: "text-purple-700 dark:text-purple-300",
   stt: "text-blue-700 dark:text-blue-300",
   llm: "text-orange-700 dark:text-orange-300",
+  "llm-general": "text-teal-700 dark:text-teal-300",
   conversation: "text-pink-700 dark:text-pink-300",
 };
 

--- a/src/components/evaluators/UseCasePickerDialog.tsx
+++ b/src/components/evaluators/UseCasePickerDialog.tsx
@@ -3,51 +3,12 @@
 import { useState } from "react";
 import { useHideFloatingButton } from "@/components/AppLayout";
 import type { EvaluatorType } from "@/components/EvaluatorPills";
+import {
+  EvaluatorUseCaseCards,
+  type EvaluatorUseCaseOption,
+} from "@/components/evaluators/evaluatorUseCases";
 
-export type EvaluatorTypeOption = {
-  value: EvaluatorType;
-  title: string;
-  description: string;
-  // Drives the section the card is grouped under. Optional so older callers
-  // that pass an ungrouped list still render (everything falls under "text").
-  group?: "conversation" | "text" | "audio";
-  // Flags the "Most common" badge — a starting-point cue for new users.
-  recommended?: boolean;
-};
-
-// Section headers shown above each group of cards, in render order.
-const GROUP_ORDER: { key: "conversation" | "text" | "audio"; label: string }[] =
-  [
-    { key: "conversation", label: "Conversation" },
-    { key: "text", label: "Text" },
-    { key: "audio", label: "Audio" },
-  ];
-
-const TYPE_INACTIVE_CLASSES: Record<EvaluatorType, string> = {
-  tts: "border-purple-500/20 bg-purple-500/[0.04] hover:bg-purple-500/10 hover:border-purple-500/40",
-  stt: "border-blue-500/20 bg-blue-500/[0.04] hover:bg-blue-500/10 hover:border-blue-500/40",
-  llm: "border-orange-500/20 bg-orange-500/[0.04] hover:bg-orange-500/10 hover:border-orange-500/40",
-  "llm-general":
-    "border-teal-500/20 bg-teal-500/[0.04] hover:bg-teal-500/10 hover:border-teal-500/40",
-  conversation:
-    "border-pink-500/20 bg-pink-500/[0.04] hover:bg-pink-500/10 hover:border-pink-500/40",
-};
-
-const TYPE_ACTIVE_CLASSES: Record<EvaluatorType, string> = {
-  tts: "border-purple-500/60 bg-purple-500/15 ring-1 ring-purple-500/40",
-  stt: "border-blue-500/60 bg-blue-500/15 ring-1 ring-blue-500/40",
-  llm: "border-orange-500/60 bg-orange-500/15 ring-1 ring-orange-500/40",
-  "llm-general": "border-teal-500/60 bg-teal-500/15 ring-1 ring-teal-500/40",
-  conversation: "border-pink-500/60 bg-pink-500/15 ring-1 ring-pink-500/40",
-};
-
-const TYPE_TITLE_CLASSES: Record<EvaluatorType, string> = {
-  tts: "text-purple-700 dark:text-purple-300",
-  stt: "text-blue-700 dark:text-blue-300",
-  llm: "text-orange-700 dark:text-orange-300",
-  "llm-general": "text-teal-700 dark:text-teal-300",
-  conversation: "text-pink-700 dark:text-pink-300",
-};
+export type EvaluatorTypeOption = EvaluatorUseCaseOption;
 
 type UseCasePickerDialogProps = {
   initialValue: EvaluatorType | null;
@@ -104,53 +65,12 @@ export function UseCasePickerDialog({
           </button>
         </div>
 
-        <div className="flex-1 overflow-y-auto p-4 md:p-6 space-y-5">
-          {GROUP_ORDER.map(({ key, label }) => {
-            const groupOptions = options.filter(
-              (o) => (o.group ?? "text") === key,
-            );
-            if (groupOptions.length === 0) return null;
-            return (
-              <div key={key}>
-                <div className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground mb-2.5 px-0.5">
-                  {label}
-                </div>
-                <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-                  {groupOptions.map((opt) => {
-                    const active = selected === opt.value;
-                    return (
-                      <button
-                        key={opt.value}
-                        type="button"
-                        onClick={() => setSelected(opt.value)}
-                        className={`flex flex-col items-start text-left p-4 rounded-md border transition-colors cursor-pointer ${
-                          active
-                            ? TYPE_ACTIVE_CLASSES[opt.value]
-                            : TYPE_INACTIVE_CLASSES[opt.value]
-                        }`}
-                      >
-                        <div className="flex items-start justify-between gap-2 w-full">
-                          <div
-                            className={`text-sm md:text-base font-medium ${TYPE_TITLE_CLASSES[opt.value]}`}
-                          >
-                            {opt.title}
-                          </div>
-                          {opt.recommended && (
-                            <span className="shrink-0 inline-flex items-center px-2 py-0.5 rounded-full text-[10px] font-semibold uppercase tracking-wide bg-teal-500/15 text-teal-700 dark:text-teal-300 border border-teal-500/30">
-                              Most common
-                            </span>
-                          )}
-                        </div>
-                        <div className="text-xs md:text-sm text-muted-foreground mt-1 leading-relaxed">
-                          {opt.description}
-                        </div>
-                      </button>
-                    );
-                  })}
-                </div>
-              </div>
-            );
-          })}
+        <div className="flex-1 overflow-y-auto p-4 md:p-6">
+          <EvaluatorUseCaseCards
+            options={options}
+            selected={selected}
+            onSelect={setSelected}
+          />
         </div>
 
         <div className="flex items-center justify-end gap-2 md:gap-3 px-5 md:px-6 py-4 border-t border-border">

--- a/src/components/evaluators/evaluatorUseCases.tsx
+++ b/src/components/evaluators/evaluatorUseCases.tsx
@@ -1,0 +1,150 @@
+"use client";
+
+import type { EvaluatorType } from "@/components/EvaluatorPills";
+
+// A selectable use-case card shared by the new-evaluator picker
+// (UseCasePickerDialog) and the labelling-task creator
+// (CreateLabellingTaskDialog) so both read identically. `group` drives the
+// section header; `recommended` flags an optional "Most common" badge.
+export type EvaluatorUseCaseOption = {
+  value: EvaluatorType;
+  title: string;
+  description: string;
+  group: "conversation" | "text" | "audio";
+  recommended?: boolean;
+};
+
+// Canonical, ordered list of evaluator use cases. The evaluator picker shows
+// all of these; the labelling-task creator reuses the same list but filters
+// out `tts` (labelling has no text-to-speech tasks). Keep descriptions to one
+// short, plain-language line so the pickers stay scannable for new users.
+export const EVALUATOR_USE_CASE_OPTIONS: EvaluatorUseCaseOption[] = [
+  {
+    value: "llm",
+    title: "Conversational reply",
+    description: "Judge an agent's next reply in a conversation",
+    group: "conversation",
+  },
+  {
+    value: "conversation",
+    title: "Full conversation",
+    description: "Judge the agent's performance in a whole conversation",
+    group: "conversation",
+  },
+  {
+    value: "llm-general",
+    title: "LLM response",
+    description: "Judge the output of an LLM given a text input",
+    group: "text",
+  },
+  {
+    value: "stt",
+    title: "Speech to Text",
+    description: "Judge transcription accuracy against a reference transcript",
+    group: "audio",
+  },
+  {
+    value: "tts",
+    title: "Text to Speech (TTS)",
+    description: "Judge the quality of generated audio",
+    group: "audio",
+  },
+];
+
+// Section headers shown above each group of cards, in render order.
+const GROUP_ORDER: { key: EvaluatorUseCaseOption["group"]; label: string }[] = [
+  { key: "conversation", label: "Conversation" },
+  { key: "text", label: "Text" },
+  { key: "audio", label: "Audio" },
+];
+
+// Per-type tints, keyed by EvaluatorType so the cards read as the same "type"
+// affordance the user sees on evaluator pills elsewhere.
+const TYPE_INACTIVE_CLASSES: Record<EvaluatorType, string> = {
+  tts: "border-purple-500/20 bg-purple-500/[0.04] hover:bg-purple-500/10 hover:border-purple-500/40",
+  stt: "border-blue-500/20 bg-blue-500/[0.04] hover:bg-blue-500/10 hover:border-blue-500/40",
+  llm: "border-orange-500/20 bg-orange-500/[0.04] hover:bg-orange-500/10 hover:border-orange-500/40",
+  "llm-general":
+    "border-teal-500/20 bg-teal-500/[0.04] hover:bg-teal-500/10 hover:border-teal-500/40",
+  conversation:
+    "border-pink-500/20 bg-pink-500/[0.04] hover:bg-pink-500/10 hover:border-pink-500/40",
+};
+
+const TYPE_ACTIVE_CLASSES: Record<EvaluatorType, string> = {
+  tts: "border-purple-500/60 bg-purple-500/15 ring-1 ring-purple-500/40",
+  stt: "border-blue-500/60 bg-blue-500/15 ring-1 ring-blue-500/40",
+  llm: "border-orange-500/60 bg-orange-500/15 ring-1 ring-orange-500/40",
+  "llm-general": "border-teal-500/60 bg-teal-500/15 ring-1 ring-teal-500/40",
+  conversation: "border-pink-500/60 bg-pink-500/15 ring-1 ring-pink-500/40",
+};
+
+const TYPE_TITLE_CLASSES: Record<EvaluatorType, string> = {
+  tts: "text-purple-700 dark:text-purple-300",
+  stt: "text-blue-700 dark:text-blue-300",
+  llm: "text-orange-700 dark:text-orange-300",
+  "llm-general": "text-teal-700 dark:text-teal-300",
+  conversation: "text-pink-700 dark:text-pink-300",
+};
+
+type EvaluatorUseCaseCardsProps = {
+  options: EvaluatorUseCaseOption[];
+  selected: EvaluatorType | null;
+  onSelect: (value: EvaluatorType) => void;
+};
+
+// Grouped grid of selectable use-case cards. Renders one section per
+// non-empty group (Conversation / Text / Audio), each as a 2-up grid.
+export function EvaluatorUseCaseCards({
+  options,
+  selected,
+  onSelect,
+}: EvaluatorUseCaseCardsProps) {
+  return (
+    <div className="space-y-5">
+      {GROUP_ORDER.map(({ key, label }) => {
+        const groupOptions = options.filter((o) => o.group === key);
+        if (groupOptions.length === 0) return null;
+        return (
+          <div key={key}>
+            <div className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground mb-2.5 px-0.5">
+              {label}
+            </div>
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+              {groupOptions.map((opt) => {
+                const active = selected === opt.value;
+                return (
+                  <button
+                    key={opt.value}
+                    type="button"
+                    onClick={() => onSelect(opt.value)}
+                    className={`flex flex-col items-start text-left p-4 rounded-md border transition-colors cursor-pointer ${
+                      active
+                        ? TYPE_ACTIVE_CLASSES[opt.value]
+                        : TYPE_INACTIVE_CLASSES[opt.value]
+                    }`}
+                  >
+                    <div className="flex items-start justify-between gap-2 w-full">
+                      <div
+                        className={`text-sm md:text-base font-medium ${TYPE_TITLE_CLASSES[opt.value]}`}
+                      >
+                        {opt.title}
+                      </div>
+                      {opt.recommended && (
+                        <span className="shrink-0 inline-flex items-center px-2 py-0.5 rounded-full text-[10px] font-semibold uppercase tracking-wide bg-teal-500/15 text-teal-700 dark:text-teal-300 border border-teal-500/30">
+                          Most common
+                        </span>
+                      )}
+                    </div>
+                    <div className="text-xs md:text-sm text-muted-foreground mt-1 leading-relaxed">
+                      {opt.description}
+                    </div>
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/human-labelling/AddLlmGeneralItemsDialog.tsx
+++ b/src/components/human-labelling/AddLlmGeneralItemsDialog.tsx
@@ -17,6 +17,7 @@ type VarValues = Record<string, Record<string, string>>;
 export type LlmGeneralItemRowSubmission = {
   uuid?: string;
   name: string;
+  description: string;
   input: string;
   output: string;
   evaluator_variables: VarValues;
@@ -34,6 +35,7 @@ type AddLlmGeneralItemsDialogProps = {
   initialRows?: {
     uuid: string;
     name: string;
+    description?: string;
     input: string;
     output: string;
     varValues?: VarValues;
@@ -93,6 +95,7 @@ export function AddLlmGeneralItemsDialog({
   const seed = initialRows?.[0];
   const [uuid, setUuid] = useState<string | undefined>(seed?.uuid);
   const [name, setName] = useState(seed?.name ?? "");
+  const [description, setDescription] = useState(seed?.description ?? "");
   const [input, setInput] = useState(seed?.input ?? "");
   const [output, setOutput] = useState(seed?.output ?? "");
   const [varValues, setVarValues] = useState<VarValues>(() =>
@@ -108,6 +111,7 @@ export function AddLlmGeneralItemsDialog({
       const s = initialRows?.[0];
       setUuid(s?.uuid);
       setName(s?.name ?? "");
+      setDescription(s?.description ?? "");
       setInput(s?.input ?? "");
       setOutput(s?.output ?? "");
       setVarValues(seedVarValues(s?.varValues));
@@ -160,6 +164,7 @@ export function AddLlmGeneralItemsDialog({
         {
           uuid,
           name: name.trim(),
+          description: description.trim(),
           input: input.trim(),
           output: output.trim(),
           evaluator_variables,
@@ -233,6 +238,20 @@ export function AddLlmGeneralItemsDialog({
                 placeholder="Your item name"
                 disabled={submitting}
                 className="w-full h-11 px-4 rounded-lg text-base bg-background text-foreground placeholder:text-muted-foreground border border-border focus:outline-none focus:ring-2 focus:ring-accent disabled:opacity-50"
+              />
+            </div>
+
+            <div>
+              <label className="block text-base font-medium text-foreground mb-2">
+                Description
+              </label>
+              <textarea
+                value={description}
+                onChange={(e) => setDescription(e.target.value)}
+                placeholder="Optional — what is this item about? Shown to annotators alongside the evaluators."
+                disabled={submitting}
+                rows={3}
+                className="w-full px-4 py-2.5 rounded-lg text-base bg-background text-foreground placeholder:text-muted-foreground border border-border focus:outline-none focus:ring-2 focus:ring-accent resize-y disabled:opacity-50"
               />
             </div>
 

--- a/src/components/human-labelling/AddLlmGeneralItemsDialog.tsx
+++ b/src/components/human-labelling/AddLlmGeneralItemsDialog.tsx
@@ -1,0 +1,323 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useHideFloatingButton } from "@/components/AppLayout";
+import { humaniseDetailObject } from "./bulk-upload-shared";
+
+type LlmGeneralRowDraft = {
+  id: string;
+  uuid?: string; // present in edit mode; undefined for new rows
+  name: string;
+  input: string;
+  output: string;
+};
+
+export type LlmGeneralItemRowSubmission = {
+  uuid?: string;
+  name: string;
+  input: string;
+  output: string;
+};
+
+type AddLlmGeneralItemsDialogProps = {
+  isOpen: boolean;
+  mode?: "add" | "edit";
+  initialRows?: {
+    uuid: string;
+    name: string;
+    input: string;
+    output: string;
+  }[];
+  onClose: () => void;
+  onSubmit: (rows: LlmGeneralItemRowSubmission[]) => Promise<void> | void;
+};
+
+function extractApiError(err: unknown, fallback: string): string {
+  if (!(err instanceof Error)) return fallback;
+  const m = err.message.match(/Request failed: \d+ - ([\s\S]+)$/);
+  if (m) {
+    try {
+      const parsed = JSON.parse(m[1]);
+      if (parsed?.detail && typeof parsed.detail === "object") {
+        const msg = humaniseDetailObject(parsed.detail);
+        if (msg) return msg;
+      }
+    } catch {
+      /* ignore */
+    }
+    return m[1];
+  }
+  return err.message || fallback;
+}
+
+const newRow = (): LlmGeneralRowDraft => ({
+  id:
+    typeof crypto !== "undefined" && "randomUUID" in crypto
+      ? crypto.randomUUID()
+      : `${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  name: "",
+  input: "",
+  output: "",
+});
+
+export function AddLlmGeneralItemsDialog({
+  isOpen,
+  mode = "add",
+  initialRows,
+  onClose,
+  onSubmit,
+}: AddLlmGeneralItemsDialogProps) {
+  useHideFloatingButton(isOpen);
+
+  const isEdit = mode === "edit";
+
+  const buildRows = (): LlmGeneralRowDraft[] =>
+    initialRows && initialRows.length > 0
+      ? initialRows.map((r) => ({
+          id: r.uuid,
+          uuid: r.uuid,
+          name: r.name,
+          input: r.input,
+          output: r.output,
+        }))
+      : [newRow()];
+
+  const [rows, setRows] = useState<LlmGeneralRowDraft[]>(buildRows);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Reset rows whenever the dialog opens (so a fresh edit starts from the
+  // latest selected items, and a reopened add starts blank).
+  useEffect(() => {
+    if (isOpen) {
+      setRows(buildRows());
+      setError(null);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isOpen, initialRows]);
+
+  if (!isOpen) return null;
+
+  const updateRow = (id: string, patch: Partial<LlmGeneralRowDraft>) => {
+    setRows((prev) => prev.map((r) => (r.id === id ? { ...r, ...patch } : r)));
+  };
+
+  const removeRow = (id: string) => {
+    setRows((prev) =>
+      prev.length === 1 ? prev : prev.filter((r) => r.id !== id),
+    );
+  };
+
+  const addRow = () => {
+    setRows((prev) => [...prev, newRow()]);
+  };
+
+  const validRows: LlmGeneralItemRowSubmission[] = rows
+    .map((r) => ({
+      uuid: r.uuid,
+      name: r.name.trim(),
+      input: r.input.trim(),
+      output: r.output.trim(),
+    }))
+    .filter((r) => r.name && r.input && r.output);
+
+  const handleClose = () => {
+    if (!submitting) {
+      setError(null);
+      onClose();
+    }
+  };
+
+  const handleSubmit = async () => {
+    if (validRows.length === 0 || submitting) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      await onSubmit(validRows);
+    } catch (err) {
+      setError(
+        extractApiError(
+          err,
+          isEdit ? "Failed to save items" : "Failed to add items",
+        ),
+      );
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm p-4"
+      onClick={handleClose}
+    >
+      <div
+        className="bg-background border border-border rounded-xl w-full max-w-4xl shadow-2xl flex flex-col max-h-[90vh]"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-start justify-between gap-3 px-5 md:px-6 py-4 border-b border-border">
+          <div>
+            <h2 className="text-base md:text-lg font-semibold text-foreground">
+              {isEdit ? "Edit items" : "Add items"}
+            </h2>
+            <p className="text-xs md:text-sm text-muted-foreground mt-1">
+              {isEdit
+                ? "Update the name, input, and output for each row"
+                : "Annotators will judge the output produced for the given input"}
+            </p>
+          </div>
+          <button
+            onClick={handleClose}
+            disabled={submitting}
+            className="flex items-center justify-center w-8 h-8 rounded-md hover:bg-muted transition-colors cursor-pointer flex-shrink-0 disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            <svg
+              className="w-5 h-5"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              strokeWidth={2}
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M6 18L18 6M6 6l12 12"
+              />
+            </svg>
+          </button>
+        </div>
+
+        <div className="flex-1 overflow-y-auto p-4 md:p-6 space-y-2">
+          {/* Column headers (shown once) */}
+          <div className="grid grid-cols-[1fr_2fr_2fr_28px] gap-2 px-1 pb-1">
+            <div className="text-xs font-medium text-muted-foreground">
+              Name
+            </div>
+            <div className="text-xs font-medium text-muted-foreground">
+              Input
+            </div>
+            <div className="text-xs font-medium text-muted-foreground">
+              Output
+            </div>
+            <div />
+          </div>
+
+          {rows.map((row, idx) => (
+            <div
+              key={row.id}
+              className="grid grid-cols-[1fr_2fr_2fr_28px] gap-2 items-start"
+            >
+              <input
+                type="text"
+                value={row.name}
+                onChange={(e) => updateRow(row.id, { name: e.target.value })}
+                placeholder="e.g. Case 1"
+                disabled={submitting}
+                className="w-full h-9 px-3 rounded-md text-sm border border-border bg-background text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-accent disabled:opacity-50"
+              />
+              <textarea
+                value={row.input}
+                onChange={(e) => updateRow(row.id, { input: e.target.value })}
+                placeholder="The prompt or input given to the LLM"
+                disabled={submitting}
+                rows={2}
+                className="w-full min-h-9 px-3 py-2 rounded-md text-sm border border-border bg-background text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-accent disabled:opacity-50 resize-y"
+              />
+              <textarea
+                value={row.output}
+                onChange={(e) => updateRow(row.id, { output: e.target.value })}
+                placeholder="The output the LLM produced"
+                disabled={submitting}
+                rows={2}
+                className="w-full min-h-9 px-3 py-2 rounded-md text-sm border border-border bg-background text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-accent disabled:opacity-50 resize-y"
+              />
+              {isEdit ? (
+                <div />
+              ) : (
+                <button
+                  onClick={() => removeRow(row.id)}
+                  disabled={rows.length === 1 || submitting}
+                  className="w-7 h-7 mt-1 flex items-center justify-center rounded-md text-muted-foreground hover:text-red-500 hover:bg-red-500/10 transition-colors cursor-pointer disabled:opacity-30 disabled:cursor-not-allowed"
+                  aria-label={`Remove item ${idx + 1}`}
+                  title="Remove this item"
+                >
+                  <svg
+                    className="w-4 h-4"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                    strokeWidth={2}
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      d="M6 18L18 6M6 6l12 12"
+                    />
+                  </svg>
+                </button>
+              )}
+            </div>
+          ))}
+
+          {!isEdit && (
+            <button
+              onClick={addRow}
+              disabled={submitting}
+              className="w-full h-10 rounded-md text-sm font-medium border border-dashed border-border bg-background hover:bg-muted/50 text-muted-foreground hover:text-foreground transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-1.5"
+            >
+              <svg
+                className="w-4 h-4"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+                strokeWidth={2}
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M12 4.5v15m7.5-7.5h-15"
+                />
+              </svg>
+              Add another item
+            </button>
+          )}
+
+          {error && (
+            <div className="rounded-md border border-red-500/30 bg-red-500/10 p-3 text-sm text-red-500">
+              {error}
+            </div>
+          )}
+        </div>
+
+        <div className="flex items-center justify-end gap-2 md:gap-3 px-5 md:px-6 py-4 border-t border-border">
+          <div className="flex items-center gap-2 md:gap-3">
+            <button
+              onClick={handleClose}
+              disabled={submitting}
+              className="h-9 md:h-10 px-4 rounded-md text-sm md:text-base font-medium border border-border bg-background dark:bg-muted hover:bg-muted/50 dark:hover:bg-accent transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              Cancel
+            </button>
+            <button
+              onClick={handleSubmit}
+              disabled={validRows.length === 0 || submitting}
+              className="h-9 md:h-10 px-4 rounded-md text-sm md:text-base font-medium bg-foreground text-background hover:opacity-90 transition-opacity cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {submitting
+                ? isEdit
+                  ? "Saving..."
+                  : "Adding..."
+                : isEdit
+                  ? validRows.length > 1
+                    ? `Save ${validRows.length} items`
+                    : "Save item"
+                  : validRows.length > 1
+                    ? `Add ${validRows.length} items`
+                    : "Add item"}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/human-labelling/AddLlmGeneralItemsDialog.tsx
+++ b/src/components/human-labelling/AddLlmGeneralItemsDialog.tsx
@@ -7,6 +7,7 @@ import { humaniseDetailObject } from "./bulk-upload-shared";
 export type LlmGeneralEvaluatorDef = {
   uuid: string;
   name: string;
+  description?: string | null;
   variables: { name: string; description?: string; default?: string }[];
 };
 
@@ -75,7 +76,6 @@ export function AddLlmGeneralItemsDialog({
   const evaluatorsWithVariables = evaluators.filter(
     (e) => e.variables.length > 0,
   );
-  const hasVariables = evaluatorsWithVariables.length > 0;
 
   // Seed each variable from a provided value (edit / duplicate) or its default.
   const seedVarValues = (provided?: VarValues): VarValues => {
@@ -177,9 +177,6 @@ export function AddLlmGeneralItemsDialog({
     }
   };
 
-  const fieldClasses =
-    "w-full px-3 py-2 rounded-md text-sm border border-border bg-background text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-accent disabled:opacity-50 resize-y";
-
   return (
     <div
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm p-4"
@@ -222,60 +219,84 @@ export function AddLlmGeneralItemsDialog({
 
         {/* Body — two panes: form on the left, input/output on the right. */}
         <div className="flex-1 min-h-0 flex flex-col md:flex-row overflow-hidden">
-          {/* Left: name + evaluator variables */}
-          <div className="w-full md:w-1/2 flex flex-col border-b md:border-b-0 md:border-r border-border overflow-y-auto p-4 md:p-6 space-y-5">
-            <div className="space-y-1">
-              <label className="block text-sm font-medium text-foreground">
+          {/* Left: name + evaluators (with variable inputs) — mirrors the
+              AddTestDialog left column. */}
+          <div className="w-full md:w-1/2 flex flex-col border-b md:border-b-0 md:border-r border-border overflow-y-auto p-4 md:p-6 space-y-6">
+            <div>
+              <label className="block text-base font-medium text-foreground mb-2">
                 Name
               </label>
               <input
                 type="text"
                 value={name}
                 onChange={(e) => setName(e.target.value)}
-                placeholder="e.g. Case 1"
+                placeholder="Your item name"
                 disabled={submitting}
-                className="w-full h-9 px-3 rounded-md text-sm border border-border bg-background text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-accent disabled:opacity-50"
+                className="w-full h-11 px-4 rounded-lg text-base bg-background text-foreground placeholder:text-muted-foreground border border-border focus:outline-none focus:ring-2 focus:ring-accent disabled:opacity-50"
               />
             </div>
 
-            {hasVariables && (
-              <div className="space-y-3">
-                <p className="text-sm font-medium text-foreground">
-                  Evaluator variables
-                </p>
-                {evaluatorsWithVariables.map((e) => (
-                  <div key={e.uuid} className="space-y-2">
-                    <p className="text-xs font-semibold text-foreground">
-                      {e.name}
-                    </p>
-                    {e.variables.map((v) => (
-                      <div key={v.name} className="space-y-1">
-                        <label className="block text-[11px] font-mono text-muted-foreground">
-                          {`{{${v.name}}}`}
-                          {v.description ? ` — ${v.description}` : ""}
-                        </label>
-                        <textarea
-                          value={varValues[e.uuid]?.[v.name] ?? ""}
-                          onChange={(ev) =>
-                            updateVar(e.uuid, v.name, ev.target.value)
-                          }
-                          placeholder={`Value for ${v.name}`}
-                          disabled={submitting}
-                          rows={2}
-                          className={fieldClasses}
-                        />
+            {evaluators.length > 0 && (
+              <div>
+                <label className="block text-base font-medium text-foreground mb-2">
+                  Evaluators
+                </label>
+                <div className="space-y-4">
+                  {evaluators.map((e) => (
+                    <div
+                      key={e.uuid}
+                      className="border border-border rounded-lg p-4 bg-background"
+                    >
+                      <div className="min-w-0 mb-3">
+                        <div className="text-sm font-semibold text-foreground">
+                          {e.name}
+                        </div>
+                        {e.description && (
+                          <div className="text-xs text-muted-foreground mt-0.5 line-clamp-2">
+                            {e.description}
+                          </div>
+                        )}
                       </div>
-                    ))}
-                  </div>
-                ))}
+                      {e.variables.length > 0 && (
+                        <div className="space-y-3">
+                          {e.variables.map((v) => {
+                            const placeholder =
+                              v.description && v.description.length > 0
+                                ? v.description
+                                : v.default && v.default.length > 0
+                                  ? v.default
+                                  : `Enter value for {{${v.name}}}`;
+                            return (
+                              <div key={v.name}>
+                                <div className="text-xs text-muted-foreground mb-1.5">
+                                  <code className="font-mono">{`{{${v.name}}}`}</code>
+                                </div>
+                                <textarea
+                                  value={varValues[e.uuid]?.[v.name] ?? ""}
+                                  onChange={(ev) =>
+                                    updateVar(e.uuid, v.name, ev.target.value)
+                                  }
+                                  placeholder={placeholder}
+                                  disabled={submitting}
+                                  rows={4}
+                                  className="w-full px-4 py-3 rounded-lg text-base bg-background text-foreground placeholder:text-muted-foreground border border-border focus:outline-none focus:ring-2 focus:ring-accent resize-none disabled:opacity-50"
+                                />
+                              </div>
+                            );
+                          })}
+                        </div>
+                      )}
+                    </div>
+                  ))}
+                </div>
               </div>
             )}
           </div>
 
           {/* Right: input + output boxes */}
-          <div className="w-full md:w-1/2 flex flex-col bg-muted/30 overflow-y-auto p-4 md:p-6 space-y-4">
-            <div className="space-y-1">
-              <label className="block text-sm font-medium text-foreground">
+          <div className="w-full md:w-1/2 flex flex-col bg-muted/30 overflow-y-auto p-4 md:p-6 space-y-6">
+            <div>
+              <label className="block text-base font-medium text-foreground mb-2">
                 Input
               </label>
               <textarea
@@ -284,11 +305,11 @@ export function AddLlmGeneralItemsDialog({
                 placeholder="The prompt or input given to the LLM"
                 disabled={submitting}
                 rows={8}
-                className={fieldClasses}
+                className="w-full px-4 py-3 rounded-lg text-base bg-background text-foreground placeholder:text-muted-foreground border border-border focus:outline-none focus:ring-2 focus:ring-accent resize-y disabled:opacity-50"
               />
             </div>
-            <div className="space-y-1">
-              <label className="block text-sm font-medium text-foreground">
+            <div>
+              <label className="block text-base font-medium text-foreground mb-2">
                 Output
               </label>
               <textarea
@@ -297,7 +318,7 @@ export function AddLlmGeneralItemsDialog({
                 placeholder="The output the LLM produced"
                 disabled={submitting}
                 rows={8}
-                className={fieldClasses}
+                className="w-full px-4 py-3 rounded-lg text-base bg-background text-foreground placeholder:text-muted-foreground border border-border focus:outline-none focus:ring-2 focus:ring-accent resize-y disabled:opacity-50"
               />
             </div>
           </div>

--- a/src/components/human-labelling/AddLlmGeneralItemsDialog.tsx
+++ b/src/components/human-labelling/AddLlmGeneralItemsDialog.tsx
@@ -3,6 +3,10 @@
 import { useEffect, useState } from "react";
 import { useHideFloatingButton } from "@/components/AppLayout";
 import { humaniseDetailObject } from "./bulk-upload-shared";
+import {
+  DiscardChangesDialog,
+  useUnsavedCloseGuard,
+} from "./unsavedCloseGuard";
 
 export type LlmGeneralEvaluatorDef = {
   uuid: string;
@@ -103,8 +107,6 @@ export function AddLlmGeneralItemsDialog({
   );
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  // Shown when the user tries to close with unsaved changes.
-  const [discardConfirmOpen, setDiscardConfirmOpen] = useState(false);
 
   // Reset whenever the dialog opens so a fresh edit/add starts from the
   // current seed item.
@@ -118,26 +120,9 @@ export function AddLlmGeneralItemsDialog({
       setOutput(s?.output ?? "");
       setVarValues(seedVarValues(s?.varValues));
       setError(null);
-      setDiscardConfirmOpen(false);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isOpen, initialRows]);
-
-  if (!isOpen) return null;
-
-  const updateVar = (evaluatorUuid: string, varName: string, value: string) => {
-    setVarValues((prev) => ({
-      ...prev,
-      [evaluatorUuid]: { ...(prev[evaluatorUuid] ?? {}), [varName]: value },
-    }));
-  };
-
-  // Every variable on every evaluator must have a non-empty value.
-  const varsComplete = evaluatorsWithVariables.every((e) =>
-    e.variables.every((v) => (varValues[e.uuid]?.[v.name] ?? "").trim()),
-  );
-  const valid =
-    !!name.trim() && !!input.trim() && !!output.trim() && varsComplete;
 
   // Unsaved-changes check: any field differs from what the dialog was seeded
   // with (blank for add, the item's values for edit).
@@ -155,19 +140,36 @@ export function AddLlmGeneralItemsDialog({
       ),
     );
 
-  const doClose = () => {
-    setError(null);
-    setDiscardConfirmOpen(false);
-    onClose();
+  const {
+    discardConfirmOpen,
+    closeDiscardConfirm,
+    doClose,
+    attemptClose,
+    handleBackdropClick,
+  } = useUnsavedCloseGuard({
+    isOpen,
+    isDirty,
+    isEdit,
+    submitting,
+    onClose,
+    onBeforeClose: () => setError(null),
+  });
+
+  if (!isOpen) return null;
+
+  const updateVar = (evaluatorUuid: string, varName: string, value: string) => {
+    setVarValues((prev) => ({
+      ...prev,
+      [evaluatorUuid]: { ...(prev[evaluatorUuid] ?? {}), [varName]: value },
+    }));
   };
 
-  // Close request from the ✕ or (edit mode) the backdrop: close straight away
-  // when clean, otherwise confirm discarding.
-  const attemptClose = () => {
-    if (submitting) return;
-    if (isDirty) setDiscardConfirmOpen(true);
-    else doClose();
-  };
+  // Every variable on every evaluator must have a non-empty value.
+  const varsComplete = evaluatorsWithVariables.every((e) =>
+    e.variables.every((v) => (varValues[e.uuid]?.[v.name] ?? "").trim()),
+  );
+  const valid =
+    !!name.trim() && !!input.trim() && !!output.trim() && varsComplete;
 
   const handleSubmit = async () => {
     if (!valid || submitting) return;
@@ -207,12 +209,7 @@ export function AddLlmGeneralItemsDialog({
   return (
     <div
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm p-4"
-      onClick={() => {
-        // Backdrop click is disabled while adding a new item (so accidental
-        // outside clicks can't discard work). When editing an existing item
-        // it closes if unchanged, or asks to discard if there are edits.
-        if (isEdit) attemptClose();
-      }}
+      onClick={handleBackdropClick}
     >
       <div
         className="bg-background border border-border rounded-xl md:rounded-2xl w-full max-w-[90rem] h-[95vh] md:h-[85vh] mx-2 md:mx-4 shadow-2xl flex flex-col overflow-hidden"
@@ -392,42 +389,11 @@ export function AddLlmGeneralItemsDialog({
         </div>
       </div>
 
-      {/* Discard-changes confirmation, shown when closing with unsaved edits. */}
-      {discardConfirmOpen && (
-        <div
-          className="absolute inset-0 z-10 flex items-center justify-center bg-black/50 p-4"
-          onClick={(e) => {
-            e.stopPropagation();
-            setDiscardConfirmOpen(false);
-          }}
-        >
-          <div
-            className="bg-background border border-border rounded-xl w-full max-w-sm shadow-2xl p-5"
-            onClick={(e) => e.stopPropagation()}
-          >
-            <h3 className="text-base font-semibold text-foreground">
-              Discard changes?
-            </h3>
-            <p className="text-sm text-muted-foreground mt-1">
-              You have unsaved changes. If you close now, they&apos;ll be lost.
-            </p>
-            <div className="mt-5 flex items-center justify-end gap-2 md:gap-3">
-              <button
-                onClick={() => setDiscardConfirmOpen(false)}
-                className="h-9 md:h-10 px-4 rounded-md text-sm md:text-base font-medium border border-border bg-background dark:bg-muted hover:bg-muted/50 dark:hover:bg-accent transition-colors cursor-pointer"
-              >
-                Keep editing
-              </button>
-              <button
-                onClick={doClose}
-                className="h-9 md:h-10 px-4 rounded-md text-sm md:text-base font-medium bg-red-600 text-white hover:bg-red-700 transition-colors cursor-pointer"
-              >
-                Discard
-              </button>
-            </div>
-          </div>
-        </div>
-      )}
+      <DiscardChangesDialog
+        open={discardConfirmOpen}
+        onKeepEditing={closeDiscardConfirm}
+        onDiscard={doClose}
+      />
     </div>
   );
 }

--- a/src/components/human-labelling/AddLlmGeneralItemsDialog.tsx
+++ b/src/components/human-labelling/AddLlmGeneralItemsDialog.tsx
@@ -13,15 +13,6 @@ export type LlmGeneralEvaluatorDef = {
 // Per-evaluator, per-variable values: { [evaluatorUuid]: { [varName]: value } }.
 type VarValues = Record<string, Record<string, string>>;
 
-type LlmGeneralRowDraft = {
-  id: string;
-  uuid?: string; // present in edit mode; undefined for new rows
-  name: string;
-  input: string;
-  output: string;
-  varValues: VarValues;
-};
-
 export type LlmGeneralItemRowSubmission = {
   uuid?: string;
   name: string;
@@ -36,6 +27,9 @@ type AddLlmGeneralItemsDialogProps = {
   // Linked evaluators with their variable definitions, used to render the
   // per-item variable inputs and seed defaults.
   evaluators?: LlmGeneralEvaluatorDef[];
+  // A single item to seed the dialog with (edit / duplicate). Kept as an
+  // array for backwards-compatible call sites; only the first entry is used
+  // since the dialog edits one item at a time.
   initialRows?: {
     uuid: string;
     name: string;
@@ -44,6 +38,8 @@ type AddLlmGeneralItemsDialogProps = {
     varValues?: VarValues;
   }[];
   onClose: () => void;
+  // Receives the single edited/added item wrapped in an array so existing
+  // POST/PUT call sites that map over `rows` keep working unchanged.
   onSubmit: (rows: LlmGeneralItemRowSubmission[]) => Promise<void> | void;
 };
 
@@ -65,12 +61,6 @@ function extractApiError(err: unknown, fallback: string): string {
   return err.message || fallback;
 }
 
-function makeId(): string {
-  return typeof crypto !== "undefined" && "randomUUID" in crypto
-    ? crypto.randomUUID()
-    : `${Date.now()}-${Math.random().toString(36).slice(2)}`;
-}
-
 export function AddLlmGeneralItemsDialog({
   isOpen,
   mode = "add",
@@ -87,8 +77,7 @@ export function AddLlmGeneralItemsDialog({
   );
   const hasVariables = evaluatorsWithVariables.length > 0;
 
-  // Build the variable-value map for a row, seeding each variable from a
-  // provided value (edit/duplicate) or the variable's default.
+  // Seed each variable from a provided value (edit / duplicate) or its default.
   const seedVarValues = (provided?: VarValues): VarValues => {
     const out: VarValues = {};
     for (const e of evaluatorsWithVariables) {
@@ -101,35 +90,27 @@ export function AddLlmGeneralItemsDialog({
     return out;
   };
 
-  const newRow = (): LlmGeneralRowDraft => ({
-    id: makeId(),
-    name: "",
-    input: "",
-    output: "",
-    varValues: seedVarValues(),
-  });
-
-  const buildRows = (): LlmGeneralRowDraft[] =>
-    initialRows && initialRows.length > 0
-      ? initialRows.map((r) => ({
-          id: r.uuid,
-          uuid: r.uuid,
-          name: r.name,
-          input: r.input,
-          output: r.output,
-          varValues: seedVarValues(r.varValues),
-        }))
-      : [newRow()];
-
-  const [rows, setRows] = useState<LlmGeneralRowDraft[]>(buildRows);
+  const seed = initialRows?.[0];
+  const [uuid, setUuid] = useState<string | undefined>(seed?.uuid);
+  const [name, setName] = useState(seed?.name ?? "");
+  const [input, setInput] = useState(seed?.input ?? "");
+  const [output, setOutput] = useState(seed?.output ?? "");
+  const [varValues, setVarValues] = useState<VarValues>(() =>
+    seedVarValues(seed?.varValues),
+  );
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  // Reset rows whenever the dialog opens (so a fresh edit starts from the
-  // latest selected items, and a reopened add starts blank).
+  // Reset whenever the dialog opens so a fresh edit/add starts from the
+  // current seed item.
   useEffect(() => {
     if (isOpen) {
-      setRows(buildRows());
+      const s = initialRows?.[0];
+      setUuid(s?.uuid);
+      setName(s?.name ?? "");
+      setInput(s?.input ?? "");
+      setOutput(s?.output ?? "");
+      setVarValues(seedVarValues(s?.varValues));
       setError(null);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -137,76 +118,23 @@ export function AddLlmGeneralItemsDialog({
 
   if (!isOpen) return null;
 
-  const updateRow = (id: string, patch: Partial<LlmGeneralRowDraft>) => {
-    setRows((prev) => prev.map((r) => (r.id === id ? { ...r, ...patch } : r)));
-  };
-
   const updateVar = (
-    id: string,
     evaluatorUuid: string,
     varName: string,
     value: string,
   ) => {
-    setRows((prev) =>
-      prev.map((r) =>
-        r.id === id
-          ? {
-              ...r,
-              varValues: {
-                ...r.varValues,
-                [evaluatorUuid]: {
-                  ...(r.varValues[evaluatorUuid] ?? {}),
-                  [varName]: value,
-                },
-              },
-            }
-          : r,
-      ),
-    );
+    setVarValues((prev) => ({
+      ...prev,
+      [evaluatorUuid]: { ...(prev[evaluatorUuid] ?? {}), [varName]: value },
+    }));
   };
 
-  const removeRow = (id: string) => {
-    setRows((prev) =>
-      prev.length === 1 ? prev : prev.filter((r) => r.id !== id),
-    );
-  };
-
-  const addRow = () => {
-    setRows((prev) => [...prev, newRow()]);
-  };
-
-  // A row's variable values are complete when every variable on every
-  // evaluator has a non-empty value (mirrors the bulk CSV requirement).
-  const rowVarsComplete = (r: LlmGeneralRowDraft): boolean =>
-    evaluatorsWithVariables.every((e) =>
-      e.variables.every((v) => (r.varValues[e.uuid]?.[v.name] ?? "").trim()),
-    );
-
-  const validRows: LlmGeneralItemRowSubmission[] = rows
-    .filter(
-      (r) =>
-        r.name.trim() &&
-        r.input.trim() &&
-        r.output.trim() &&
-        rowVarsComplete(r),
-    )
-    .map((r) => {
-      const evaluator_variables: VarValues = {};
-      for (const e of evaluatorsWithVariables) {
-        const evVals: Record<string, string> = {};
-        for (const v of e.variables) {
-          evVals[v.name] = (r.varValues[e.uuid]?.[v.name] ?? "").trim();
-        }
-        evaluator_variables[e.uuid] = evVals;
-      }
-      return {
-        uuid: r.uuid,
-        name: r.name.trim(),
-        input: r.input.trim(),
-        output: r.output.trim(),
-        evaluator_variables,
-      };
-    });
+  // Every variable on every evaluator must have a non-empty value.
+  const varsComplete = evaluatorsWithVariables.every((e) =>
+    e.variables.every((v) => (varValues[e.uuid]?.[v.name] ?? "").trim()),
+  );
+  const valid =
+    !!name.trim() && !!input.trim() && !!output.trim() && varsComplete;
 
   const handleClose = () => {
     if (!submitting) {
@@ -216,16 +144,32 @@ export function AddLlmGeneralItemsDialog({
   };
 
   const handleSubmit = async () => {
-    if (validRows.length === 0 || submitting) return;
+    if (!valid || submitting) return;
+    const evaluator_variables: VarValues = {};
+    for (const e of evaluatorsWithVariables) {
+      const evVals: Record<string, string> = {};
+      for (const v of e.variables) {
+        evVals[v.name] = (varValues[e.uuid]?.[v.name] ?? "").trim();
+      }
+      evaluator_variables[e.uuid] = evVals;
+    }
     setSubmitting(true);
     setError(null);
     try {
-      await onSubmit(validRows);
+      await onSubmit([
+        {
+          uuid,
+          name: name.trim(),
+          input: input.trim(),
+          output: output.trim(),
+          evaluator_variables,
+        },
+      ]);
     } catch (err) {
       setError(
         extractApiError(
           err,
-          isEdit ? "Failed to save items" : "Failed to add items",
+          isEdit ? "Failed to save item" : "Failed to add item",
         ),
       );
     } finally {
@@ -233,8 +177,8 @@ export function AddLlmGeneralItemsDialog({
     }
   };
 
-  const inputClasses =
-    "w-full min-h-9 px-3 py-2 rounded-md text-sm border border-border bg-background text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-accent disabled:opacity-50 resize-y";
+  const fieldClasses =
+    "w-full px-3 py-2 rounded-md text-sm border border-border bg-background text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-accent disabled:opacity-50 resize-y";
 
   return (
     <div
@@ -242,18 +186,17 @@ export function AddLlmGeneralItemsDialog({
       onClick={handleClose}
     >
       <div
-        className="bg-background border border-border rounded-xl w-full max-w-3xl shadow-2xl flex flex-col max-h-[90vh]"
+        className="bg-background border border-border rounded-xl w-full max-w-5xl shadow-2xl flex flex-col max-h-[90vh]"
         onClick={(e) => e.stopPropagation()}
       >
+        {/* Header */}
         <div className="flex items-start justify-between gap-3 px-5 md:px-6 py-4 border-b border-border">
           <div>
             <h2 className="text-base md:text-lg font-semibold text-foreground">
-              {isEdit ? "Edit items" : "Add items"}
+              {isEdit ? "Edit item" : "Add item"}
             </h2>
             <p className="text-xs md:text-sm text-muted-foreground mt-1">
-              {isEdit
-                ? "Update the name, input, and output for each item"
-                : "Annotators will judge the output produced for the given input"}
+              Annotators will judge the output produced for the given input
             </p>
           </div>
           <button
@@ -277,175 +220,109 @@ export function AddLlmGeneralItemsDialog({
           </button>
         </div>
 
-        <div className="flex-1 overflow-y-auto p-4 md:p-6 space-y-4">
-          {rows.map((row, idx) => (
-            <div
-              key={row.id}
-              className="rounded-xl border border-border p-4 space-y-3 relative"
-            >
-              {!isEdit && rows.length > 1 && (
-                <button
-                  onClick={() => removeRow(row.id)}
-                  disabled={submitting}
-                  className="absolute top-3 right-3 w-7 h-7 flex items-center justify-center rounded-md text-muted-foreground hover:text-red-500 hover:bg-red-500/10 transition-colors cursor-pointer disabled:opacity-30 disabled:cursor-not-allowed"
-                  aria-label={`Remove item ${idx + 1}`}
-                  title="Remove this item"
-                >
-                  <svg
-                    className="w-4 h-4"
-                    fill="none"
-                    viewBox="0 0 24 24"
-                    stroke="currentColor"
-                    strokeWidth={2}
-                  >
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      d="M6 18L18 6M6 6l12 12"
-                    />
-                  </svg>
-                </button>
-              )}
-
-              <div className="space-y-1">
-                <label className="block text-xs font-medium text-muted-foreground">
-                  Name
-                </label>
-                <input
-                  type="text"
-                  value={row.name}
-                  onChange={(e) => updateRow(row.id, { name: e.target.value })}
-                  placeholder="e.g. Case 1"
-                  disabled={submitting}
-                  className="w-full h-9 px-3 rounded-md text-sm border border-border bg-background text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-accent disabled:opacity-50"
-                />
-              </div>
-
-              <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
-                <div className="space-y-1">
-                  <label className="block text-xs font-medium text-muted-foreground">
-                    Input
-                  </label>
-                  <textarea
-                    value={row.input}
-                    onChange={(e) =>
-                      updateRow(row.id, { input: e.target.value })
-                    }
-                    placeholder="The prompt or input given to the LLM"
-                    disabled={submitting}
-                    rows={3}
-                    className={inputClasses}
-                  />
-                </div>
-                <div className="space-y-1">
-                  <label className="block text-xs font-medium text-muted-foreground">
-                    Output
-                  </label>
-                  <textarea
-                    value={row.output}
-                    onChange={(e) =>
-                      updateRow(row.id, { output: e.target.value })
-                    }
-                    placeholder="The output the LLM produced"
-                    disabled={submitting}
-                    rows={3}
-                    className={inputClasses}
-                  />
-                </div>
-              </div>
-
-              {hasVariables && (
-                <div className="space-y-3 border-t border-border pt-3">
-                  <p className="text-xs font-medium text-muted-foreground">
-                    Evaluator variables
-                  </p>
-                  {evaluatorsWithVariables.map((e) => (
-                    <div key={e.uuid} className="space-y-2">
-                      <p className="text-xs font-semibold text-foreground">
-                        {e.name}
-                      </p>
-                      {e.variables.map((v) => (
-                        <div key={v.name} className="space-y-1">
-                          <label className="block text-[11px] font-mono text-muted-foreground">
-                            {`{{${v.name}}}`}
-                            {v.description ? ` — ${v.description}` : ""}
-                          </label>
-                          <textarea
-                            value={row.varValues[e.uuid]?.[v.name] ?? ""}
-                            onChange={(ev) =>
-                              updateVar(row.id, e.uuid, v.name, ev.target.value)
-                            }
-                            placeholder={`Value for ${v.name}`}
-                            disabled={submitting}
-                            rows={2}
-                            className={inputClasses}
-                          />
-                        </div>
-                      ))}
-                    </div>
-                  ))}
-                </div>
-              )}
+        {/* Body — two panes: form on the left, input/output on the right. */}
+        <div className="flex-1 min-h-0 flex flex-col md:flex-row overflow-hidden">
+          {/* Left: name + evaluator variables */}
+          <div className="w-full md:w-1/2 flex flex-col border-b md:border-b-0 md:border-r border-border overflow-y-auto p-4 md:p-6 space-y-5">
+            <div className="space-y-1">
+              <label className="block text-sm font-medium text-foreground">
+                Name
+              </label>
+              <input
+                type="text"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                placeholder="e.g. Case 1"
+                disabled={submitting}
+                className="w-full h-9 px-3 rounded-md text-sm border border-border bg-background text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-accent disabled:opacity-50"
+              />
             </div>
-          ))}
 
-          {!isEdit && (
-            <button
-              onClick={addRow}
-              disabled={submitting}
-              className="w-full h-10 rounded-md text-sm font-medium border border-dashed border-border bg-background hover:bg-muted/50 text-muted-foreground hover:text-foreground transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-1.5"
-            >
-              <svg
-                className="w-4 h-4"
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke="currentColor"
-                strokeWidth={2}
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  d="M12 4.5v15m7.5-7.5h-15"
-                />
-              </svg>
-              Add another item
-            </button>
-          )}
+            {hasVariables && (
+              <div className="space-y-3">
+                <p className="text-sm font-medium text-foreground">
+                  Evaluator variables
+                </p>
+                {evaluatorsWithVariables.map((e) => (
+                  <div key={e.uuid} className="space-y-2">
+                    <p className="text-xs font-semibold text-foreground">
+                      {e.name}
+                    </p>
+                    {e.variables.map((v) => (
+                      <div key={v.name} className="space-y-1">
+                        <label className="block text-[11px] font-mono text-muted-foreground">
+                          {`{{${v.name}}}`}
+                          {v.description ? ` — ${v.description}` : ""}
+                        </label>
+                        <textarea
+                          value={varValues[e.uuid]?.[v.name] ?? ""}
+                          onChange={(ev) =>
+                            updateVar(e.uuid, v.name, ev.target.value)
+                          }
+                          placeholder={`Value for ${v.name}`}
+                          disabled={submitting}
+                          rows={2}
+                          className={fieldClasses}
+                        />
+                      </div>
+                    ))}
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
 
+          {/* Right: input + output boxes */}
+          <div className="w-full md:w-1/2 flex flex-col bg-muted/30 overflow-y-auto p-4 md:p-6 space-y-4">
+            <div className="space-y-1">
+              <label className="block text-sm font-medium text-foreground">
+                Input
+              </label>
+              <textarea
+                value={input}
+                onChange={(e) => setInput(e.target.value)}
+                placeholder="The prompt or input given to the LLM"
+                disabled={submitting}
+                rows={8}
+                className={fieldClasses}
+              />
+            </div>
+            <div className="space-y-1">
+              <label className="block text-sm font-medium text-foreground">
+                Output
+              </label>
+              <textarea
+                value={output}
+                onChange={(e) => setOutput(e.target.value)}
+                placeholder="The output the LLM produced"
+                disabled={submitting}
+                rows={8}
+                className={fieldClasses}
+              />
+            </div>
+          </div>
+        </div>
+
+        {/* Footer */}
+        <div className="flex items-center justify-end gap-3 px-5 md:px-6 py-4 border-t border-border">
           {error && (
-            <div className="rounded-md border border-red-500/30 bg-red-500/10 p-3 text-sm text-red-500">
+            <div className="mr-auto rounded-md border border-red-500/30 bg-red-500/10 px-3 py-2 text-sm text-red-500">
               {error}
             </div>
           )}
-        </div>
-
-        <div className="flex items-center justify-end gap-2 md:gap-3 px-5 md:px-6 py-4 border-t border-border">
-          <div className="flex items-center gap-2 md:gap-3">
-            <button
-              onClick={handleClose}
-              disabled={submitting}
-              className="h-9 md:h-10 px-4 rounded-md text-sm md:text-base font-medium border border-border bg-background dark:bg-muted hover:bg-muted/50 dark:hover:bg-accent transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
-            >
-              Cancel
-            </button>
-            <button
-              onClick={handleSubmit}
-              disabled={validRows.length === 0 || submitting}
-              className="h-9 md:h-10 px-4 rounded-md text-sm md:text-base font-medium bg-foreground text-background hover:opacity-90 transition-opacity cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
-            >
-              {submitting
-                ? isEdit
-                  ? "Saving..."
-                  : "Adding..."
-                : isEdit
-                  ? validRows.length > 1
-                    ? `Save ${validRows.length} items`
-                    : "Save item"
-                  : validRows.length > 1
-                    ? `Add ${validRows.length} items`
-                    : "Add item"}
-            </button>
-          </div>
+          <button
+            onClick={handleSubmit}
+            disabled={!valid || submitting}
+            className="h-9 md:h-10 px-4 rounded-md text-sm md:text-base font-medium bg-foreground text-background hover:opacity-90 transition-opacity cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {submitting
+              ? isEdit
+                ? "Saving..."
+                : "Adding..."
+              : isEdit
+                ? "Save item"
+                : "Add item"}
+          </button>
         </div>
       </div>
     </div>

--- a/src/components/human-labelling/AddLlmGeneralItemsDialog.tsx
+++ b/src/components/human-labelling/AddLlmGeneralItemsDialog.tsx
@@ -122,11 +122,7 @@ export function AddLlmGeneralItemsDialog({
 
   if (!isOpen) return null;
 
-  const updateVar = (
-    evaluatorUuid: string,
-    varName: string,
-    value: string,
-  ) => {
+  const updateVar = (evaluatorUuid: string, varName: string, value: string) => {
     setVarValues((prev) => ({
       ...prev,
       [evaluatorUuid]: { ...(prev[evaluatorUuid] ?? {}), [varName]: value },
@@ -226,7 +222,7 @@ export function AddLlmGeneralItemsDialog({
         <div className="flex-1 min-h-0 flex flex-col md:flex-row overflow-hidden">
           {/* Left: name + evaluators (with variable inputs) — mirrors the
               AddTestDialog left column. */}
-          <div className="w-full md:w-[27%] flex flex-col border-b md:border-b-0 md:border-r border-border overflow-y-auto p-4 md:p-6 space-y-6">
+          <div className="w-full md:w-[30%] flex flex-col border-b md:border-b-0 md:border-r border-border overflow-y-auto p-4 md:p-6 space-y-6">
             <div>
               <label className="block text-base font-medium text-foreground mb-2">
                 Name

--- a/src/components/human-labelling/AddLlmGeneralItemsDialog.tsx
+++ b/src/components/human-labelling/AddLlmGeneralItemsDialog.tsx
@@ -4,12 +4,22 @@ import { useEffect, useState } from "react";
 import { useHideFloatingButton } from "@/components/AppLayout";
 import { humaniseDetailObject } from "./bulk-upload-shared";
 
+export type LlmGeneralEvaluatorDef = {
+  uuid: string;
+  name: string;
+  variables: { name: string; description?: string; default?: string }[];
+};
+
+// Per-evaluator, per-variable values: { [evaluatorUuid]: { [varName]: value } }.
+type VarValues = Record<string, Record<string, string>>;
+
 type LlmGeneralRowDraft = {
   id: string;
   uuid?: string; // present in edit mode; undefined for new rows
   name: string;
   input: string;
   output: string;
+  varValues: VarValues;
 };
 
 export type LlmGeneralItemRowSubmission = {
@@ -17,16 +27,21 @@ export type LlmGeneralItemRowSubmission = {
   name: string;
   input: string;
   output: string;
+  evaluator_variables: VarValues;
 };
 
 type AddLlmGeneralItemsDialogProps = {
   isOpen: boolean;
   mode?: "add" | "edit";
+  // Linked evaluators with their variable definitions, used to render the
+  // per-item variable inputs and seed defaults.
+  evaluators?: LlmGeneralEvaluatorDef[];
   initialRows?: {
     uuid: string;
     name: string;
     input: string;
     output: string;
+    varValues?: VarValues;
   }[];
   onClose: () => void;
   onSubmit: (rows: LlmGeneralItemRowSubmission[]) => Promise<void> | void;
@@ -50,19 +65,16 @@ function extractApiError(err: unknown, fallback: string): string {
   return err.message || fallback;
 }
 
-const newRow = (): LlmGeneralRowDraft => ({
-  id:
-    typeof crypto !== "undefined" && "randomUUID" in crypto
-      ? crypto.randomUUID()
-      : `${Date.now()}-${Math.random().toString(36).slice(2)}`,
-  name: "",
-  input: "",
-  output: "",
-});
+function makeId(): string {
+  return typeof crypto !== "undefined" && "randomUUID" in crypto
+    ? crypto.randomUUID()
+    : `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+}
 
 export function AddLlmGeneralItemsDialog({
   isOpen,
   mode = "add",
+  evaluators = [],
   initialRows,
   onClose,
   onSubmit,
@@ -70,6 +82,32 @@ export function AddLlmGeneralItemsDialog({
   useHideFloatingButton(isOpen);
 
   const isEdit = mode === "edit";
+  const evaluatorsWithVariables = evaluators.filter(
+    (e) => e.variables.length > 0,
+  );
+  const hasVariables = evaluatorsWithVariables.length > 0;
+
+  // Build the variable-value map for a row, seeding each variable from a
+  // provided value (edit/duplicate) or the variable's default.
+  const seedVarValues = (provided?: VarValues): VarValues => {
+    const out: VarValues = {};
+    for (const e of evaluatorsWithVariables) {
+      const evOut: Record<string, string> = {};
+      for (const v of e.variables) {
+        evOut[v.name] = provided?.[e.uuid]?.[v.name] ?? v.default ?? "";
+      }
+      out[e.uuid] = evOut;
+    }
+    return out;
+  };
+
+  const newRow = (): LlmGeneralRowDraft => ({
+    id: makeId(),
+    name: "",
+    input: "",
+    output: "",
+    varValues: seedVarValues(),
+  });
 
   const buildRows = (): LlmGeneralRowDraft[] =>
     initialRows && initialRows.length > 0
@@ -79,6 +117,7 @@ export function AddLlmGeneralItemsDialog({
           name: r.name,
           input: r.input,
           output: r.output,
+          varValues: seedVarValues(r.varValues),
         }))
       : [newRow()];
 
@@ -102,6 +141,30 @@ export function AddLlmGeneralItemsDialog({
     setRows((prev) => prev.map((r) => (r.id === id ? { ...r, ...patch } : r)));
   };
 
+  const updateVar = (
+    id: string,
+    evaluatorUuid: string,
+    varName: string,
+    value: string,
+  ) => {
+    setRows((prev) =>
+      prev.map((r) =>
+        r.id === id
+          ? {
+              ...r,
+              varValues: {
+                ...r.varValues,
+                [evaluatorUuid]: {
+                  ...(r.varValues[evaluatorUuid] ?? {}),
+                  [varName]: value,
+                },
+              },
+            }
+          : r,
+      ),
+    );
+  };
+
   const removeRow = (id: string) => {
     setRows((prev) =>
       prev.length === 1 ? prev : prev.filter((r) => r.id !== id),
@@ -112,14 +175,38 @@ export function AddLlmGeneralItemsDialog({
     setRows((prev) => [...prev, newRow()]);
   };
 
+  // A row's variable values are complete when every variable on every
+  // evaluator has a non-empty value (mirrors the bulk CSV requirement).
+  const rowVarsComplete = (r: LlmGeneralRowDraft): boolean =>
+    evaluatorsWithVariables.every((e) =>
+      e.variables.every((v) => (r.varValues[e.uuid]?.[v.name] ?? "").trim()),
+    );
+
   const validRows: LlmGeneralItemRowSubmission[] = rows
-    .map((r) => ({
-      uuid: r.uuid,
-      name: r.name.trim(),
-      input: r.input.trim(),
-      output: r.output.trim(),
-    }))
-    .filter((r) => r.name && r.input && r.output);
+    .filter(
+      (r) =>
+        r.name.trim() &&
+        r.input.trim() &&
+        r.output.trim() &&
+        rowVarsComplete(r),
+    )
+    .map((r) => {
+      const evaluator_variables: VarValues = {};
+      for (const e of evaluatorsWithVariables) {
+        const evVals: Record<string, string> = {};
+        for (const v of e.variables) {
+          evVals[v.name] = (r.varValues[e.uuid]?.[v.name] ?? "").trim();
+        }
+        evaluator_variables[e.uuid] = evVals;
+      }
+      return {
+        uuid: r.uuid,
+        name: r.name.trim(),
+        input: r.input.trim(),
+        output: r.output.trim(),
+        evaluator_variables,
+      };
+    });
 
   const handleClose = () => {
     if (!submitting) {
@@ -146,13 +233,16 @@ export function AddLlmGeneralItemsDialog({
     }
   };
 
+  const inputClasses =
+    "w-full min-h-9 px-3 py-2 rounded-md text-sm border border-border bg-background text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-accent disabled:opacity-50 resize-y";
+
   return (
     <div
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm p-4"
       onClick={handleClose}
     >
       <div
-        className="bg-background border border-border rounded-xl w-full max-w-4xl shadow-2xl flex flex-col max-h-[90vh]"
+        className="bg-background border border-border rounded-xl w-full max-w-3xl shadow-2xl flex flex-col max-h-[90vh]"
         onClick={(e) => e.stopPropagation()}
       >
         <div className="flex items-start justify-between gap-3 px-5 md:px-6 py-4 border-b border-border">
@@ -162,7 +252,7 @@ export function AddLlmGeneralItemsDialog({
             </h2>
             <p className="text-xs md:text-sm text-muted-foreground mt-1">
               {isEdit
-                ? "Update the name, input, and output for each row"
+                ? "Update the name, input, and output for each item"
                 : "Annotators will judge the output produced for the given input"}
             </p>
           </div>
@@ -187,57 +277,17 @@ export function AddLlmGeneralItemsDialog({
           </button>
         </div>
 
-        <div className="flex-1 overflow-y-auto p-4 md:p-6 space-y-2">
-          {/* Column headers (shown once) */}
-          <div className="grid grid-cols-[1fr_2fr_2fr_28px] gap-2 px-1 pb-1">
-            <div className="text-xs font-medium text-muted-foreground">
-              Name
-            </div>
-            <div className="text-xs font-medium text-muted-foreground">
-              Input
-            </div>
-            <div className="text-xs font-medium text-muted-foreground">
-              Output
-            </div>
-            <div />
-          </div>
-
+        <div className="flex-1 overflow-y-auto p-4 md:p-6 space-y-4">
           {rows.map((row, idx) => (
             <div
               key={row.id}
-              className="grid grid-cols-[1fr_2fr_2fr_28px] gap-2 items-start"
+              className="rounded-xl border border-border p-4 space-y-3 relative"
             >
-              <input
-                type="text"
-                value={row.name}
-                onChange={(e) => updateRow(row.id, { name: e.target.value })}
-                placeholder="e.g. Case 1"
-                disabled={submitting}
-                className="w-full h-9 px-3 rounded-md text-sm border border-border bg-background text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-accent disabled:opacity-50"
-              />
-              <textarea
-                value={row.input}
-                onChange={(e) => updateRow(row.id, { input: e.target.value })}
-                placeholder="The prompt or input given to the LLM"
-                disabled={submitting}
-                rows={2}
-                className="w-full min-h-9 px-3 py-2 rounded-md text-sm border border-border bg-background text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-accent disabled:opacity-50 resize-y"
-              />
-              <textarea
-                value={row.output}
-                onChange={(e) => updateRow(row.id, { output: e.target.value })}
-                placeholder="The output the LLM produced"
-                disabled={submitting}
-                rows={2}
-                className="w-full min-h-9 px-3 py-2 rounded-md text-sm border border-border bg-background text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-accent disabled:opacity-50 resize-y"
-              />
-              {isEdit ? (
-                <div />
-              ) : (
+              {!isEdit && rows.length > 1 && (
                 <button
                   onClick={() => removeRow(row.id)}
-                  disabled={rows.length === 1 || submitting}
-                  className="w-7 h-7 mt-1 flex items-center justify-center rounded-md text-muted-foreground hover:text-red-500 hover:bg-red-500/10 transition-colors cursor-pointer disabled:opacity-30 disabled:cursor-not-allowed"
+                  disabled={submitting}
+                  className="absolute top-3 right-3 w-7 h-7 flex items-center justify-center rounded-md text-muted-foreground hover:text-red-500 hover:bg-red-500/10 transition-colors cursor-pointer disabled:opacity-30 disabled:cursor-not-allowed"
                   aria-label={`Remove item ${idx + 1}`}
                   title="Remove this item"
                 >
@@ -255,6 +305,86 @@ export function AddLlmGeneralItemsDialog({
                     />
                   </svg>
                 </button>
+              )}
+
+              <div className="space-y-1">
+                <label className="block text-xs font-medium text-muted-foreground">
+                  Name
+                </label>
+                <input
+                  type="text"
+                  value={row.name}
+                  onChange={(e) => updateRow(row.id, { name: e.target.value })}
+                  placeholder="e.g. Case 1"
+                  disabled={submitting}
+                  className="w-full h-9 px-3 rounded-md text-sm border border-border bg-background text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-accent disabled:opacity-50"
+                />
+              </div>
+
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+                <div className="space-y-1">
+                  <label className="block text-xs font-medium text-muted-foreground">
+                    Input
+                  </label>
+                  <textarea
+                    value={row.input}
+                    onChange={(e) =>
+                      updateRow(row.id, { input: e.target.value })
+                    }
+                    placeholder="The prompt or input given to the LLM"
+                    disabled={submitting}
+                    rows={3}
+                    className={inputClasses}
+                  />
+                </div>
+                <div className="space-y-1">
+                  <label className="block text-xs font-medium text-muted-foreground">
+                    Output
+                  </label>
+                  <textarea
+                    value={row.output}
+                    onChange={(e) =>
+                      updateRow(row.id, { output: e.target.value })
+                    }
+                    placeholder="The output the LLM produced"
+                    disabled={submitting}
+                    rows={3}
+                    className={inputClasses}
+                  />
+                </div>
+              </div>
+
+              {hasVariables && (
+                <div className="space-y-3 border-t border-border pt-3">
+                  <p className="text-xs font-medium text-muted-foreground">
+                    Evaluator variables
+                  </p>
+                  {evaluatorsWithVariables.map((e) => (
+                    <div key={e.uuid} className="space-y-2">
+                      <p className="text-xs font-semibold text-foreground">
+                        {e.name}
+                      </p>
+                      {e.variables.map((v) => (
+                        <div key={v.name} className="space-y-1">
+                          <label className="block text-[11px] font-mono text-muted-foreground">
+                            {`{{${v.name}}}`}
+                            {v.description ? ` — ${v.description}` : ""}
+                          </label>
+                          <textarea
+                            value={row.varValues[e.uuid]?.[v.name] ?? ""}
+                            onChange={(ev) =>
+                              updateVar(row.id, e.uuid, v.name, ev.target.value)
+                            }
+                            placeholder={`Value for ${v.name}`}
+                            disabled={submitting}
+                            rows={2}
+                            className={inputClasses}
+                          />
+                        </div>
+                      ))}
+                    </div>
+                  ))}
+                </div>
               )}
             </div>
           ))}

--- a/src/components/human-labelling/AddLlmGeneralItemsDialog.tsx
+++ b/src/components/human-labelling/AddLlmGeneralItemsDialog.tsx
@@ -183,7 +183,7 @@ export function AddLlmGeneralItemsDialog({
       onClick={handleClose}
     >
       <div
-        className="bg-background border border-border rounded-xl w-full max-w-5xl shadow-2xl flex flex-col max-h-[90vh]"
+        className="bg-background border border-border rounded-xl md:rounded-2xl w-full max-w-[90rem] h-[95vh] md:h-[85vh] mx-2 md:mx-4 shadow-2xl flex flex-col overflow-hidden"
         onClick={(e) => e.stopPropagation()}
       >
         {/* Header */}
@@ -293,9 +293,10 @@ export function AddLlmGeneralItemsDialog({
             )}
           </div>
 
-          {/* Right: input + output boxes */}
-          <div className="w-full md:w-1/2 flex flex-col bg-muted/30 overflow-y-auto p-4 md:p-6 space-y-6">
-            <div>
+          {/* Right: input + output boxes shown side by side, each filling
+              the full dialog height. */}
+          <div className="w-full md:w-1/2 flex flex-col md:flex-row bg-muted/30 min-h-0">
+            <div className="flex-1 flex flex-col min-h-0 p-4 md:p-6 border-b md:border-b-0 md:border-r border-border">
               <label className="block text-base font-medium text-foreground mb-2">
                 Input
               </label>
@@ -304,11 +305,10 @@ export function AddLlmGeneralItemsDialog({
                 onChange={(e) => setInput(e.target.value)}
                 placeholder="The prompt or input given to the LLM"
                 disabled={submitting}
-                rows={8}
-                className="w-full px-4 py-3 rounded-lg text-base bg-background text-foreground placeholder:text-muted-foreground border border-border focus:outline-none focus:ring-2 focus:ring-accent resize-y disabled:opacity-50"
+                className="flex-1 min-h-[10rem] w-full px-4 py-3 rounded-lg text-base bg-background text-foreground placeholder:text-muted-foreground border border-border focus:outline-none focus:ring-2 focus:ring-accent resize-none disabled:opacity-50"
               />
             </div>
-            <div>
+            <div className="flex-1 flex flex-col min-h-0 p-4 md:p-6">
               <label className="block text-base font-medium text-foreground mb-2">
                 Output
               </label>
@@ -317,8 +317,7 @@ export function AddLlmGeneralItemsDialog({
                 onChange={(e) => setOutput(e.target.value)}
                 placeholder="The output the LLM produced"
                 disabled={submitting}
-                rows={8}
-                className="w-full px-4 py-3 rounded-lg text-base bg-background text-foreground placeholder:text-muted-foreground border border-border focus:outline-none focus:ring-2 focus:ring-accent resize-y disabled:opacity-50"
+                className="flex-1 min-h-[10rem] w-full px-4 py-3 rounded-lg text-base bg-background text-foreground placeholder:text-muted-foreground border border-border focus:outline-none focus:ring-2 focus:ring-accent resize-none disabled:opacity-50"
               />
             </div>
           </div>

--- a/src/components/human-labelling/AddLlmGeneralItemsDialog.tsx
+++ b/src/components/human-labelling/AddLlmGeneralItemsDialog.tsx
@@ -226,7 +226,7 @@ export function AddLlmGeneralItemsDialog({
         <div className="flex-1 min-h-0 flex flex-col md:flex-row overflow-hidden">
           {/* Left: name + evaluators (with variable inputs) — mirrors the
               AddTestDialog left column. */}
-          <div className="w-full md:w-1/4 flex flex-col border-b md:border-b-0 md:border-r border-border overflow-y-auto p-4 md:p-6 space-y-6">
+          <div className="w-full md:w-[27%] flex flex-col border-b md:border-b-0 md:border-r border-border overflow-y-auto p-4 md:p-6 space-y-6">
             <div>
               <label className="block text-base font-medium text-foreground mb-2">
                 Name

--- a/src/components/human-labelling/AddLlmGeneralItemsDialog.tsx
+++ b/src/components/human-labelling/AddLlmGeneralItemsDialog.tsx
@@ -221,7 +221,7 @@ export function AddLlmGeneralItemsDialog({
         <div className="flex-1 min-h-0 flex flex-col md:flex-row overflow-hidden">
           {/* Left: name + evaluators (with variable inputs) — mirrors the
               AddTestDialog left column. */}
-          <div className="w-full md:w-1/2 flex flex-col border-b md:border-b-0 md:border-r border-border overflow-y-auto p-4 md:p-6 space-y-6">
+          <div className="w-full md:w-1/4 flex flex-col border-b md:border-b-0 md:border-r border-border overflow-y-auto p-4 md:p-6 space-y-6">
             <div>
               <label className="block text-base font-medium text-foreground mb-2">
                 Name
@@ -295,7 +295,7 @@ export function AddLlmGeneralItemsDialog({
 
           {/* Right: input + output boxes shown side by side, each filling
               the full dialog height. */}
-          <div className="w-full md:w-1/2 flex flex-col md:flex-row bg-muted/30 min-h-0">
+          <div className="w-full md:flex-1 flex flex-col md:flex-row bg-muted/30 min-h-0">
             <div className="flex-1 flex flex-col min-h-0 p-4 md:p-6 border-b md:border-b-0 md:border-r border-border">
               <label className="block text-base font-medium text-foreground mb-2">
                 Input

--- a/src/components/human-labelling/AddLlmGeneralItemsDialog.tsx
+++ b/src/components/human-labelling/AddLlmGeneralItemsDialog.tsx
@@ -103,6 +103,8 @@ export function AddLlmGeneralItemsDialog({
   );
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  // Shown when the user tries to close with unsaved changes.
+  const [discardConfirmOpen, setDiscardConfirmOpen] = useState(false);
 
   // Reset whenever the dialog opens so a fresh edit/add starts from the
   // current seed item.
@@ -116,6 +118,7 @@ export function AddLlmGeneralItemsDialog({
       setOutput(s?.output ?? "");
       setVarValues(seedVarValues(s?.varValues));
       setError(null);
+      setDiscardConfirmOpen(false);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isOpen, initialRows]);
@@ -136,11 +139,34 @@ export function AddLlmGeneralItemsDialog({
   const valid =
     !!name.trim() && !!input.trim() && !!output.trim() && varsComplete;
 
-  const handleClose = () => {
-    if (!submitting) {
-      setError(null);
-      onClose();
-    }
+  // Unsaved-changes check: any field differs from what the dialog was seeded
+  // with (blank for add, the item's values for edit).
+  const baseVarValues = seedVarValues(seed?.varValues);
+  const isDirty =
+    name.trim() !== (seed?.name ?? "").trim() ||
+    description.trim() !== (seed?.description ?? "").trim() ||
+    input.trim() !== (seed?.input ?? "").trim() ||
+    output.trim() !== (seed?.output ?? "").trim() ||
+    evaluatorsWithVariables.some((e) =>
+      e.variables.some(
+        (v) =>
+          (varValues[e.uuid]?.[v.name] ?? "").trim() !==
+          (baseVarValues[e.uuid]?.[v.name] ?? "").trim(),
+      ),
+    );
+
+  const doClose = () => {
+    setError(null);
+    setDiscardConfirmOpen(false);
+    onClose();
+  };
+
+  // Close request from the ✕ or (edit mode) the backdrop: close straight away
+  // when clean, otherwise confirm discarding.
+  const attemptClose = () => {
+    if (submitting) return;
+    if (isDirty) setDiscardConfirmOpen(true);
+    else doClose();
   };
 
   const handleSubmit = async () => {
@@ -181,7 +207,12 @@ export function AddLlmGeneralItemsDialog({
   return (
     <div
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm p-4"
-      onClick={handleClose}
+      onClick={() => {
+        // Backdrop click is disabled while adding a new item (so accidental
+        // outside clicks can't discard work). When editing an existing item
+        // it closes if unchanged, or asks to discard if there are edits.
+        if (isEdit) attemptClose();
+      }}
     >
       <div
         className="bg-background border border-border rounded-xl md:rounded-2xl w-full max-w-[90rem] h-[95vh] md:h-[85vh] mx-2 md:mx-4 shadow-2xl flex flex-col overflow-hidden"
@@ -198,7 +229,7 @@ export function AddLlmGeneralItemsDialog({
             </p>
           </div>
           <button
-            onClick={handleClose}
+            onClick={attemptClose}
             disabled={submitting}
             className="flex items-center justify-center w-8 h-8 rounded-md hover:bg-muted transition-colors cursor-pointer flex-shrink-0 disabled:opacity-50 disabled:cursor-not-allowed"
           >
@@ -360,6 +391,43 @@ export function AddLlmGeneralItemsDialog({
           </button>
         </div>
       </div>
+
+      {/* Discard-changes confirmation, shown when closing with unsaved edits. */}
+      {discardConfirmOpen && (
+        <div
+          className="absolute inset-0 z-10 flex items-center justify-center bg-black/50 p-4"
+          onClick={(e) => {
+            e.stopPropagation();
+            setDiscardConfirmOpen(false);
+          }}
+        >
+          <div
+            className="bg-background border border-border rounded-xl w-full max-w-sm shadow-2xl p-5"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <h3 className="text-base font-semibold text-foreground">
+              Discard changes?
+            </h3>
+            <p className="text-sm text-muted-foreground mt-1">
+              You have unsaved changes. If you close now, they&apos;ll be lost.
+            </p>
+            <div className="mt-5 flex items-center justify-end gap-2 md:gap-3">
+              <button
+                onClick={() => setDiscardConfirmOpen(false)}
+                className="h-9 md:h-10 px-4 rounded-md text-sm md:text-base font-medium border border-border bg-background dark:bg-muted hover:bg-muted/50 dark:hover:bg-accent transition-colors cursor-pointer"
+              >
+                Keep editing
+              </button>
+              <button
+                onClick={doClose}
+                className="h-9 md:h-10 px-4 rounded-md text-sm md:text-base font-medium bg-red-600 text-white hover:bg-red-700 transition-colors cursor-pointer"
+              >
+                Discard
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/human-labelling/AddSttItemsDialog.tsx
+++ b/src/components/human-labelling/AddSttItemsDialog.tsx
@@ -3,6 +3,10 @@
 import { useEffect, useState } from "react";
 import { useHideFloatingButton } from "@/components/AppLayout";
 import { humaniseDetailObject } from "./bulk-upload-shared";
+import {
+  DiscardChangesDialog,
+  useUnsavedCloseGuard,
+} from "./unsavedCloseGuard";
 
 type SttRowDraft = {
   id: string;
@@ -84,8 +88,6 @@ export function AddSttItemsDialog({
   );
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  // Shown when the user tries to close with unsaved changes.
-  const [discardConfirmOpen, setDiscardConfirmOpen] = useState(false);
 
   // Reset rows whenever the dialog opens (so a fresh edit starts from the
   // latest selected items, and a reopened add starts blank).
@@ -103,9 +105,34 @@ export function AddSttItemsDialog({
           : [newRow()],
       );
       setError(null);
-      setDiscardConfirmOpen(false);
     }
   }, [isOpen, initialRows]);
+
+  // Unsaved-changes check. Add mode: any field has content. Edit mode: any
+  // field differs from the item it was seeded with (rows align 1:1 with
+  // initialRows since edit mode can't add/remove rows).
+  const isDirty = isEdit
+    ? rows.some((r, i) => {
+        const init = initialRows?.[i];
+        return (
+          r.name.trim() !== (init?.name ?? "").trim() ||
+          r.actual.trim() !== (init?.actual ?? "").trim() ||
+          r.predicted.trim() !== (init?.predicted ?? "").trim()
+        );
+      })
+    : rows.some((r) => r.name.trim() || r.actual.trim() || r.predicted.trim());
+
+  // Note: this dialog intentionally has no backdrop-click close, so
+  // `handleBackdropClick` is not used here.
+  const { discardConfirmOpen, closeDiscardConfirm, doClose, attemptClose } =
+    useUnsavedCloseGuard({
+    isOpen,
+    isDirty,
+    isEdit,
+    submitting,
+    onClose,
+    onBeforeClose: () => setError(null),
+  });
 
   if (!isOpen) return null;
 
@@ -131,36 +158,6 @@ export function AddSttItemsDialog({
       predicted_transcript: r.predicted.trim(),
     }))
     .filter((r) => r.name && r.actual_transcript && r.predicted_transcript);
-
-  // Unsaved-changes check. Add mode: any field has content. Edit mode: any
-  // field differs from the item it was seeded with (rows align 1:1 with
-  // initialRows since edit mode can't add/remove rows).
-  const isDirty = isEdit
-    ? rows.some((r, i) => {
-        const init = initialRows?.[i];
-        return (
-          r.name.trim() !== (init?.name ?? "").trim() ||
-          r.actual.trim() !== (init?.actual ?? "").trim() ||
-          r.predicted.trim() !== (init?.predicted ?? "").trim()
-        );
-      })
-    : rows.some(
-        (r) => r.name.trim() || r.actual.trim() || r.predicted.trim(),
-      );
-
-  const doClose = () => {
-    setError(null);
-    setDiscardConfirmOpen(false);
-    onClose();
-  };
-
-  // Close request from the ✕, footer Cancel, or (edit mode) the backdrop:
-  // close straight away when clean, otherwise confirm discarding.
-  const attemptClose = () => {
-    if (submitting) return;
-    if (isDirty) setDiscardConfirmOpen(true);
-    else doClose();
-  };
 
   const handleSubmit = async () => {
     if (validRows.length === 0 || submitting) return;
@@ -352,42 +349,11 @@ export function AddSttItemsDialog({
         </div>
       </div>
 
-      {/* Discard-changes confirmation, shown when closing with unsaved edits. */}
-      {discardConfirmOpen && (
-        <div
-          className="absolute inset-0 z-10 flex items-center justify-center bg-black/50 p-4"
-          onClick={(e) => {
-            e.stopPropagation();
-            setDiscardConfirmOpen(false);
-          }}
-        >
-          <div
-            className="bg-background border border-border rounded-xl w-full max-w-sm shadow-2xl p-5"
-            onClick={(e) => e.stopPropagation()}
-          >
-            <h3 className="text-base font-semibold text-foreground">
-              Discard changes?
-            </h3>
-            <p className="text-sm text-muted-foreground mt-1">
-              You have unsaved changes. If you close now, they&apos;ll be lost.
-            </p>
-            <div className="mt-5 flex items-center justify-end gap-2 md:gap-3">
-              <button
-                onClick={() => setDiscardConfirmOpen(false)}
-                className="h-9 md:h-10 px-4 rounded-md text-sm md:text-base font-medium border border-border bg-background dark:bg-muted hover:bg-muted/50 dark:hover:bg-accent transition-colors cursor-pointer"
-              >
-                Keep editing
-              </button>
-              <button
-                onClick={doClose}
-                className="h-9 md:h-10 px-4 rounded-md text-sm md:text-base font-medium bg-red-600 text-white hover:bg-red-700 transition-colors cursor-pointer"
-              >
-                Discard
-              </button>
-            </div>
-          </div>
-        </div>
-      )}
+      <DiscardChangesDialog
+        open={discardConfirmOpen}
+        onKeepEditing={closeDiscardConfirm}
+        onDiscard={doClose}
+      />
     </div>
   );
 }

--- a/src/components/human-labelling/AddSttItemsDialog.tsx
+++ b/src/components/human-labelling/AddSttItemsDialog.tsx
@@ -181,15 +181,7 @@ export function AddSttItemsDialog({
   };
 
   return (
-    <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm p-4"
-      onClick={() => {
-        // Backdrop click is disabled while adding new items (so accidental
-        // outside clicks can't discard work). When editing an existing item
-        // it closes if unchanged, or asks to discard if there are edits.
-        if (isEdit) attemptClose();
-      }}
-    >
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm p-4">
       <div
         className="bg-background border border-border rounded-xl w-full max-w-4xl shadow-2xl flex flex-col max-h-[90vh]"
         onClick={(e) => e.stopPropagation()}

--- a/src/components/human-labelling/AddSttItemsDialog.tsx
+++ b/src/components/human-labelling/AddSttItemsDialog.tsx
@@ -84,6 +84,8 @@ export function AddSttItemsDialog({
   );
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  // Shown when the user tries to close with unsaved changes.
+  const [discardConfirmOpen, setDiscardConfirmOpen] = useState(false);
 
   // Reset rows whenever the dialog opens (so a fresh edit starts from the
   // latest selected items, and a reopened add starts blank).
@@ -101,6 +103,7 @@ export function AddSttItemsDialog({
           : [newRow()],
       );
       setError(null);
+      setDiscardConfirmOpen(false);
     }
   }, [isOpen, initialRows]);
 
@@ -129,11 +132,34 @@ export function AddSttItemsDialog({
     }))
     .filter((r) => r.name && r.actual_transcript && r.predicted_transcript);
 
-  const handleClose = () => {
-    if (!submitting) {
-      setError(null);
-      onClose();
-    }
+  // Unsaved-changes check. Add mode: any field has content. Edit mode: any
+  // field differs from the item it was seeded with (rows align 1:1 with
+  // initialRows since edit mode can't add/remove rows).
+  const isDirty = isEdit
+    ? rows.some((r, i) => {
+        const init = initialRows?.[i];
+        return (
+          r.name.trim() !== (init?.name ?? "").trim() ||
+          r.actual.trim() !== (init?.actual ?? "").trim() ||
+          r.predicted.trim() !== (init?.predicted ?? "").trim()
+        );
+      })
+    : rows.some(
+        (r) => r.name.trim() || r.actual.trim() || r.predicted.trim(),
+      );
+
+  const doClose = () => {
+    setError(null);
+    setDiscardConfirmOpen(false);
+    onClose();
+  };
+
+  // Close request from the ✕, footer Cancel, or (edit mode) the backdrop:
+  // close straight away when clean, otherwise confirm discarding.
+  const attemptClose = () => {
+    if (submitting) return;
+    if (isDirty) setDiscardConfirmOpen(true);
+    else doClose();
   };
 
   const handleSubmit = async () => {
@@ -157,7 +183,12 @@ export function AddSttItemsDialog({
   return (
     <div
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm p-4"
-      onClick={handleClose}
+      onClick={() => {
+        // Backdrop click is disabled while adding new items (so accidental
+        // outside clicks can't discard work). When editing an existing item
+        // it closes if unchanged, or asks to discard if there are edits.
+        if (isEdit) attemptClose();
+      }}
     >
       <div
         className="bg-background border border-border rounded-xl w-full max-w-4xl shadow-2xl flex flex-col max-h-[90vh]"
@@ -175,7 +206,7 @@ export function AddSttItemsDialog({
             </p>
           </div>
           <button
-            onClick={handleClose}
+            onClick={attemptClose}
             disabled={submitting}
             className="flex items-center justify-center w-8 h-8 rounded-md hover:bg-muted transition-colors cursor-pointer flex-shrink-0 disabled:opacity-50 disabled:cursor-not-allowed"
           >
@@ -302,7 +333,7 @@ export function AddSttItemsDialog({
         <div className="flex items-center justify-end gap-2 md:gap-3 px-5 md:px-6 py-4 border-t border-border">
           <div className="flex items-center gap-2 md:gap-3">
             <button
-              onClick={handleClose}
+              onClick={attemptClose}
               disabled={submitting}
               className="h-9 md:h-10 px-4 rounded-md text-sm md:text-base font-medium border border-border bg-background dark:bg-muted hover:bg-muted/50 dark:hover:bg-accent transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
             >
@@ -328,6 +359,43 @@ export function AddSttItemsDialog({
           </div>
         </div>
       </div>
+
+      {/* Discard-changes confirmation, shown when closing with unsaved edits. */}
+      {discardConfirmOpen && (
+        <div
+          className="absolute inset-0 z-10 flex items-center justify-center bg-black/50 p-4"
+          onClick={(e) => {
+            e.stopPropagation();
+            setDiscardConfirmOpen(false);
+          }}
+        >
+          <div
+            className="bg-background border border-border rounded-xl w-full max-w-sm shadow-2xl p-5"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <h3 className="text-base font-semibold text-foreground">
+              Discard changes?
+            </h3>
+            <p className="text-sm text-muted-foreground mt-1">
+              You have unsaved changes. If you close now, they&apos;ll be lost.
+            </p>
+            <div className="mt-5 flex items-center justify-end gap-2 md:gap-3">
+              <button
+                onClick={() => setDiscardConfirmOpen(false)}
+                className="h-9 md:h-10 px-4 rounded-md text-sm md:text-base font-medium border border-border bg-background dark:bg-muted hover:bg-muted/50 dark:hover:bg-accent transition-colors cursor-pointer"
+              >
+                Keep editing
+              </button>
+              <button
+                onClick={doClose}
+                className="h-9 md:h-10 px-4 rounded-md text-sm md:text-base font-medium bg-red-600 text-white hover:bg-red-700 transition-colors cursor-pointer"
+              >
+                Discard
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/human-labelling/AnnotationJobView.tsx
+++ b/src/components/human-labelling/AnnotationJobView.tsx
@@ -6,6 +6,7 @@ import { getBackendUrl } from "@/lib/api";
 import { EvaluatorVerdictCard } from "@/components/EvaluatorVerdictCard";
 import { getBinaryLabel, toRatingScale } from "@/lib/binaryLabels";
 import { LlmItemPane } from "./item-panes/LlmItemPane";
+import { LlmGeneralItemPane } from "./item-panes/LlmGeneralItemPane";
 import { Section } from "./item-panes/shared";
 import { ConversationItemPane } from "./item-panes/ConversationItemPane";
 import { SttItemPane } from "./item-panes/SttItemPane";
@@ -42,7 +43,7 @@ type Annotator = { uuid: string; name: string };
 export type Task = {
   uuid: string;
   name: string;
-  type: "llm" | "stt" | "tts" | "conversation";
+  type: "llm" | "llm-general" | "stt" | "tts" | "conversation";
   description: string | null;
 };
 
@@ -877,6 +878,8 @@ export function ItemPane({
   const payload = (item.payload ?? {}) as Record<string, unknown>;
   if (taskType === "stt") return <SttItemPane payload={payload} />;
   if (taskType === "llm") return <LlmItemPane payload={payload} />;
+  if (taskType === "llm-general")
+    return <LlmGeneralItemPane payload={payload} />;
   if (taskType === "conversation")
     return <ConversationItemPane payload={payload} />;
   return (

--- a/src/components/human-labelling/BulkUploadItemsDialog.tsx
+++ b/src/components/human-labelling/BulkUploadItemsDialog.tsx
@@ -1,0 +1,799 @@
+"use client";
+
+import React, { useEffect, useState } from "react";
+import Papa from "papaparse";
+import { apiClient } from "@/lib/api";
+import {
+  AnnotationOptIn,
+  BulkUploadDialogShell,
+  BulkUploadItemsPreviewShell,
+  type EvaluatorMeta,
+  type GuidelineColumn,
+  type GuidelineDoc,
+  type ParsedAnnotation,
+  buildItemAnnotationsPayload,
+  bulkUploadAnnotatedRowBgClass,
+  duplicateEvaluatorNames,
+  evaluatorReasoningColumn,
+  evaluatorValueColumn,
+  findHeaderKey,
+  parseAnnotationCell,
+  parseApiError,
+  sampleEvaluatorValue,
+  useAnnotatedItemsCheck,
+  useAnnotators,
+} from "./bulk-upload-shared";
+
+export type EvaluatorVariableDef = {
+  name: string;
+  description?: string;
+  default?: string;
+};
+
+export type BulkLinkedEvaluator = {
+  uuid: string;
+  name: string;
+  slug: string | null;
+  variables: EvaluatorVariableDef[];
+  output_type: "binary" | "rating" | null;
+  scale_min: number | null;
+  scale_max: number | null;
+};
+
+// Describes one item-content column (the parts that differ between task types,
+// e.g. conversation_history + agent_response for LLM, or input + output for
+// LLM-response). Everything else — name, description, evaluator-variable
+// columns, annotation columns, upload, preview shell — is handled generically.
+export type BulkContentColumn = {
+  // Key written into the item payload (e.g. "chat_history", "input").
+  payloadKey: string;
+  // Canonical CSV header — shown in guidelines, required-errors, and the
+  // sample CSV (may differ from payloadKey, e.g. "conversation_history").
+  csvColumn: string;
+  // Accepted CSV header aliases.
+  headerCandidates: string[];
+  // Preview column header.
+  previewLabel: string;
+  // Preview grid column width.
+  previewWidth: string;
+  // Guidelines copy.
+  guidelineDescription: string;
+  guidelineExample?: string;
+  // Parse a non-empty trimmed cell into the payload value (or an error).
+  parse: (raw: string, rowIndex: number) => { value: unknown } | { error: string };
+  // Render the parsed value in the preview grid.
+  renderPreview: (value: unknown) => React.ReactNode;
+};
+
+export type BulkSampleRow = {
+  name: string;
+  description: string;
+  // Keyed by content column `csvColumn`.
+  content: Record<string, string>;
+  variableValue: string;
+  reasoning: string;
+};
+
+type EvaluatorRef = {
+  evaluator_uuid: string;
+  variable_values?: Record<string, string>;
+};
+
+type ParsedItem = {
+  name: string;
+  description: string;
+  content: Record<string, unknown>;
+  evaluators: EvaluatorRef[];
+  annotations: ParsedAnnotation[];
+};
+
+const NAME_HEADERS = ["name", "title", "label", "item_name"];
+const DESCRIPTION_HEADERS = ["description", "desc", "notes"];
+
+function csvEscape(s: string): string {
+  return `"${s.replace(/"/g, '""')}"`;
+}
+
+// Column header for an evaluator variable, e.g. "Correctness/criteria". One
+// column per variable per evaluator — keeps the CSV flat instead of asking
+// users to hand-author JSON in a single cell.
+function variableColumnName(evalName: string, varName: string): string {
+  return `${evalName}/${varName}`;
+}
+
+export type BulkUploadItemsDialogProps = {
+  isOpen: boolean;
+  accessToken: string;
+  taskUuid: string;
+  linkedEvaluators?: BulkLinkedEvaluator[];
+  contentColumns: BulkContentColumn[];
+  sampleRows: BulkSampleRow[];
+  // Used when there are no linked evaluators, so the sample CSV still shows an
+  // example variable column. Optional.
+  sampleFallbackEvaluators?: BulkLinkedEvaluator[];
+  guidelinesTitle: string;
+  guidelinesIntro: string;
+  sampleFilenameBase: string; // e.g. "llm_items"
+  onClose: () => void;
+  onSuccess: (count: number, withAnnotations: boolean) => void;
+};
+
+export function BulkUploadItemsDialog({
+  isOpen,
+  accessToken,
+  taskUuid,
+  linkedEvaluators = [],
+  contentColumns,
+  sampleRows,
+  sampleFallbackEvaluators = [],
+  guidelinesTitle,
+  guidelinesIntro,
+  sampleFilenameBase,
+  onClose,
+  onSuccess,
+}: BulkUploadItemsDialogProps) {
+  const [csvFile, setCsvFile] = useState<File | null>(null);
+  const [parsedItems, setParsedItems] = useState<ParsedItem[]>([]);
+  const [parseError, setParseError] = useState<string | null>(null);
+  const [isUploading, setIsUploading] = useState(false);
+  const [uploadError, setUploadError] = useState<string | null>(null);
+  const [uploadAnnotations, setUploadAnnotations] = useState(false);
+  const [selectedAnnotatorId, setSelectedAnnotatorId] = useState<string | null>(
+    null,
+  );
+  const annotatorsState = useAnnotators(isOpen, accessToken);
+  const { annotatedCheck, annotatedCheckLoading } = useAnnotatedItemsCheck({
+    enabled:
+      uploadAnnotations && !!selectedAnnotatorId && parsedItems.length > 0,
+    taskUuid,
+    accessToken,
+    annotatorId: selectedAnnotatorId,
+    namedItems: parsedItems,
+  });
+
+  const annotationEvaluatorsMeta: EvaluatorMeta[] = linkedEvaluators.map(
+    (e) => ({
+      uuid: e.uuid,
+      name: e.name,
+      output_type: e.output_type,
+      scale_min: e.scale_min,
+      scale_max: e.scale_max,
+    }),
+  );
+
+  // Evaluators without a usable output_type can't be annotated here — the
+  // parser would silently drop their column and produce a half-labelled
+  // batch. Block the annotation flow rather than failing later.
+  const evaluatorsMissingOutputType = annotationEvaluatorsMeta.filter(
+    (e) => e.output_type !== "binary" && e.output_type !== "rating",
+  );
+
+  // Two linked evaluators with the same name produce duplicate CSV headers —
+  // this also breaks the `<evalName>/<varName>` variable columns, so it has to
+  // block regardless of whether the user is uploading annotations.
+  const duplicateNames = duplicateEvaluatorNames(annotationEvaluatorsMeta);
+
+  const evaluatorsWithVariables = linkedEvaluators.filter(
+    (e) => e.variables.length > 0,
+  );
+
+  const reset = () => {
+    setCsvFile(null);
+    setParsedItems([]);
+    setParseError(null);
+    setUploadError(null);
+    setUploadAnnotations(false);
+    setSelectedAnnotatorId(null);
+  };
+
+  useEffect(() => {
+    if (isOpen) reset();
+  }, [isOpen]);
+
+  // Re-parse when the annotation toggle changes (column requirements differ).
+  useEffect(() => {
+    setParsedItems([]);
+    setParseError(null);
+    setCsvFile(null);
+  }, [uploadAnnotations]);
+
+  const handleFile = (file: File | null) => {
+    setUploadError(null);
+    setParseError(null);
+    setParsedItems([]);
+    setCsvFile(file);
+    if (!file) return;
+    if (duplicateNames.length > 0) {
+      setParseError(
+        `Two or more linked evaluators share the same name (${duplicateNames
+          .map((n) => `"${n}"`)
+          .join(", ")}). Rename one before uploading.`,
+      );
+      return;
+    }
+    Papa.parse<Record<string, string>>(file, {
+      header: true,
+      skipEmptyLines: true,
+      transformHeader: (h) => h.trim(),
+      complete: (results) => {
+        const headers = results.meta.fields ?? [];
+        const nameKey = findHeaderKey(headers, NAME_HEADERS);
+        const descriptionKey = findHeaderKey(headers, DESCRIPTION_HEADERS);
+        const contentKeys = contentColumns.map((col) => ({
+          col,
+          key: findHeaderKey(headers, col.headerCandidates),
+        }));
+        const missingContent = contentKeys.filter((ck) => !ck.key);
+        if (!nameKey || missingContent.length > 0) {
+          const required = ["name", ...contentColumns.map((c) => c.csvColumn)]
+            .map((c) => `"${c}"`)
+            .join(", ");
+          setParseError(
+            `CSV must include ${required} columns. Found: ${headers.join(", ") || "(none)"}`,
+          );
+          return;
+        }
+
+        // Resolve a column for each evaluator variable up front.
+        const variableHeaderMap = new Map<
+          string,
+          {
+            evaluator: BulkLinkedEvaluator;
+            varName: string;
+            columnKey: string;
+          }[]
+        >();
+        const missingColumns: string[] = [];
+        for (const e of evaluatorsWithVariables) {
+          const slots: {
+            evaluator: BulkLinkedEvaluator;
+            varName: string;
+            columnKey: string;
+          }[] = [];
+          for (const v of e.variables) {
+            const expected = variableColumnName(e.name, v.name);
+            const key = headers.find((h) => h === expected);
+            if (!key) {
+              missingColumns.push(expected);
+              continue;
+            }
+            slots.push({ evaluator: e, varName: v.name, columnKey: key });
+          }
+          variableHeaderMap.set(e.uuid, slots);
+        }
+        if (missingColumns.length > 0) {
+          setParseError(
+            `CSV is missing column(s) for evaluator variables: ${missingColumns
+              .map((c) => `"${c}"`)
+              .join(", ")}. Download the sample CSV above for the exact format.`,
+          );
+          return;
+        }
+
+        if (uploadAnnotations) {
+          if (evaluatorsMissingOutputType.length > 0) {
+            setParseError(
+              `Annotation upload is unavailable: evaluator(s) ${evaluatorsMissingOutputType
+                .map((e) => `"${e.name}"`)
+                .join(", ")} have no binary/rating output configured.`,
+            );
+            return;
+          }
+          const missingAnnotationCols: string[] = [];
+          for (const meta of annotationEvaluatorsMeta) {
+            const valueHeader = evaluatorValueColumn(meta.name);
+            if (!headers.includes(valueHeader)) {
+              missingAnnotationCols.push(valueHeader);
+            }
+          }
+          if (missingAnnotationCols.length > 0) {
+            setParseError(
+              `CSV is missing annotation column(s): ${missingAnnotationCols
+                .map((c) => `"${c}"`)
+                .join(", ")}. Download the sample CSV above for the exact format.`,
+            );
+            return;
+          }
+        }
+
+        const items: ParsedItem[] = [];
+
+        for (let i = 0; i < results.data.length; i++) {
+          const row = results.data[i];
+          const name = (row[nameKey] ?? "").trim();
+          const description = descriptionKey
+            ? (row[descriptionKey] ?? "").trim()
+            : "";
+          const contentRaws = contentKeys.map((ck) =>
+            (row[ck.key as string] ?? "").trim(),
+          );
+
+          const anyVariableValue = evaluatorsWithVariables.some((e) =>
+            (variableHeaderMap.get(e.uuid) ?? []).some(
+              (slot) => (row[slot.columnKey] ?? "").trim() !== "",
+            ),
+          );
+          if (
+            !name &&
+            contentRaws.every((c) => !c) &&
+            !anyVariableValue
+          )
+            continue;
+
+          if (!name) {
+            setParseError(`Row ${i + 1}: "name" is required.`);
+            return;
+          }
+
+          // Content columns (all required).
+          const content: Record<string, unknown> = {};
+          let contentError: string | null = null;
+          for (let c = 0; c < contentColumns.length; c++) {
+            const col = contentColumns[c];
+            const raw = contentRaws[c];
+            if (!raw) {
+              contentError = `Row ${i + 1}: "${col.csvColumn}" is required.`;
+              break;
+            }
+            const parsed = col.parse(raw, i);
+            if ("error" in parsed) {
+              contentError = parsed.error;
+              break;
+            }
+            content[col.payloadKey] = parsed.value;
+          }
+          if (contentError) {
+            setParseError(contentError);
+            return;
+          }
+
+          const refs: EvaluatorRef[] = [];
+          let rowError: string | null = null;
+          for (const e of evaluatorsWithVariables) {
+            const slots = variableHeaderMap.get(e.uuid) ?? [];
+            const variableValues: Record<string, string> = {};
+            for (const slot of slots) {
+              const raw = (row[slot.columnKey] ?? "").trim();
+              if (!raw) {
+                rowError = `Row ${i + 1}: missing value for "${variableColumnName(
+                  e.name,
+                  slot.varName,
+                )}".`;
+                break;
+              }
+              variableValues[slot.varName] = raw;
+            }
+            if (rowError) break;
+            refs.push({ evaluator_uuid: e.uuid, variable_values: variableValues });
+          }
+          if (rowError) {
+            setParseError(rowError);
+            return;
+          }
+
+          const annotations: ParsedAnnotation[] = [];
+          if (uploadAnnotations) {
+            for (const meta of annotationEvaluatorsMeta) {
+              if (
+                meta.output_type !== "binary" &&
+                meta.output_type !== "rating"
+              )
+                continue;
+              const valueHeader = evaluatorValueColumn(meta.name);
+              const reasoningHeader = evaluatorReasoningColumn(meta.name);
+              const rawValue = (row[valueHeader] ?? "").trim();
+              const rawReasoning = (row[reasoningHeader] ?? "").trim();
+              if (!rawValue) {
+                setParseError(
+                  `Row ${i + 1}: missing value for "${valueHeader}".`,
+                );
+                return;
+              }
+              const parsed = parseAnnotationCell(rawValue, meta);
+              if ("error" in parsed) {
+                setParseError(`Row ${i + 1}: ${parsed.error}.`);
+                return;
+              }
+              annotations.push({
+                evaluator_uuid: meta.uuid,
+                output_type: meta.output_type,
+                value: parsed.value,
+                reasoning: rawReasoning,
+              });
+            }
+          }
+
+          items.push({ name, description, content, evaluators: refs, annotations });
+        }
+
+        if (items.length === 0) {
+          setParseError("No rows with content were found in the CSV.");
+          return;
+        }
+        setParsedItems(items);
+      },
+      error: (err) => setParseError(err.message || "Failed to parse CSV"),
+    });
+  };
+
+  const handleUpload = async () => {
+    if (parsedItems.length === 0 || isUploading) return;
+    if (uploadAnnotations && !selectedAnnotatorId) {
+      setUploadError("Select an annotator before uploading.");
+      return;
+    }
+    if (uploadAnnotations && evaluatorsMissingOutputType.length > 0) {
+      setUploadError(
+        "One or more evaluators have no binary/rating output configured.",
+      );
+      return;
+    }
+    setIsUploading(true);
+    setUploadError(null);
+    try {
+      const itemsBody = parsedItems.map((p) => {
+        const evaluator_variables: Record<string, Record<string, string>> = {};
+        for (const ref of p.evaluators) {
+          if (ref.variable_values) {
+            evaluator_variables[ref.evaluator_uuid] = { ...ref.variable_values };
+          }
+        }
+        const annotationsObj = uploadAnnotations
+          ? buildItemAnnotationsPayload(p.annotations)
+          : undefined;
+        return {
+          payload: {
+            name: p.name,
+            ...(p.description ? { description: p.description } : {}),
+            ...p.content,
+            evaluator_variables,
+          },
+          ...(annotationsObj ? { annotations: annotationsObj } : {}),
+        };
+      });
+      const anyAnnotated = itemsBody.some((it) => "annotations" in it);
+      await apiClient(`/annotation-tasks/${taskUuid}/items`, accessToken, {
+        method: "POST",
+        body: {
+          ...(anyAnnotated && selectedAnnotatorId
+            ? { annotator_id: selectedAnnotatorId }
+            : {}),
+          items: itemsBody,
+        },
+      });
+      onSuccess(parsedItems.length, uploadAnnotations);
+    } catch (err) {
+      setUploadError(parseApiError(err, "Failed to upload items"));
+    } finally {
+      setIsUploading(false);
+    }
+  };
+
+  const buildSampleCsv = (): string => {
+    const evaluators =
+      linkedEvaluators.length > 0 ? linkedEvaluators : sampleFallbackEvaluators;
+    const variableColumns: { evalName: string; varName: string }[] = [];
+    for (const e of evaluators) {
+      for (const v of e.variables) {
+        variableColumns.push({ evalName: e.name, varName: v.name });
+      }
+    }
+    const headerCells = [
+      "name",
+      "description",
+      ...contentColumns.map((c) => csvEscape(c.csvColumn)),
+      ...variableColumns.map((c) =>
+        csvEscape(variableColumnName(c.evalName, c.varName)),
+      ),
+      ...(uploadAnnotations
+        ? evaluators.flatMap((e) => [
+            csvEscape(evaluatorValueColumn(e.name)),
+            csvEscape(evaluatorReasoningColumn(e.name)),
+          ])
+        : []),
+    ];
+    const lines = sampleRows.map((r) =>
+      [
+        csvEscape(r.name),
+        csvEscape(r.description),
+        ...contentColumns.map((c) => csvEscape(r.content[c.csvColumn] ?? "")),
+        ...variableColumns.map(() => csvEscape(r.variableValue)),
+        ...(uploadAnnotations
+          ? evaluators.flatMap((e) => [
+              csvEscape(sampleEvaluatorValue(e)),
+              csvEscape(r.reasoning),
+            ])
+          : []),
+      ].join(","),
+    );
+    return `${headerCells.join(",")}\n${lines.join("\n")}\n`;
+  };
+
+  const buildGuidelines = (): GuidelineDoc => {
+    const columns: GuidelineColumn[] = [
+      { name: "name", description: "Required. A unique name for the item." },
+      ...contentColumns.map((c) => ({
+        name: c.csvColumn,
+        description: c.guidelineDescription,
+        ...(c.guidelineExample ? { example: c.guidelineExample } : {}),
+      })),
+    ];
+
+    for (const e of evaluatorsWithVariables) {
+      for (const v of e.variables) {
+        const desc = v.description ? ` — ${v.description}` : "";
+        columns.push({
+          name: variableColumnName(e.name, v.name),
+          description: `Used for the "${e.name}" evaluator${desc}`,
+        });
+      }
+    }
+
+    if (uploadAnnotations && annotationEvaluatorsMeta.length > 0) {
+      for (const e of annotationEvaluatorsMeta) {
+        const range =
+          e.output_type === "binary"
+            ? "true/false"
+            : e.output_type === "rating" &&
+                typeof e.scale_min === "number" &&
+                typeof e.scale_max === "number"
+              ? `any value between ${e.scale_min}-${e.scale_max}`
+              : "value";
+        columns.push({
+          name: evaluatorValueColumn(e.name),
+          description: `Required. Value for the "${e.name}" evaluator (${range}).`,
+        });
+        columns.push({
+          name: evaluatorReasoningColumn(e.name),
+          description: `(optional) Reasoning for the value assigned to "${e.name}".`,
+        });
+      }
+    }
+
+    columns.push({
+      name: "description",
+      description:
+        "(optional) A description of this item. Shown to annotators alongside the evaluators while they label.",
+    });
+
+    return { title: guidelinesTitle, intro: guidelinesIntro, columns };
+  };
+
+  const variableColumns = evaluatorsWithVariables.flatMap((e) =>
+    e.variables.map((v) => ({
+      evaluatorUuid: e.uuid,
+      varName: v.name,
+      header: variableColumnName(e.name, v.name),
+    })),
+  );
+  const annotationColumns =
+    uploadAnnotations && annotationEvaluatorsMeta.length > 0
+      ? annotationEvaluatorsMeta.flatMap((e) => [
+          {
+            evaluatorUuid: e.uuid,
+            kind: "value" as const,
+            header: evaluatorValueColumn(e.name),
+          },
+          {
+            evaluatorUuid: e.uuid,
+            kind: "reasoning" as const,
+            header: evaluatorReasoningColumn(e.name),
+          },
+        ])
+      : [];
+  // Surface a Description column in the preview only when at least one row
+  // carries a non-empty description — keeps the preview tight for the common
+  // case where descriptions aren't used.
+  const showDescriptionColumn = parsedItems.some(
+    (p) => p.description.trim().length > 0,
+  );
+  const gridStyle = {
+    gridTemplateColumns: [
+      "minmax(96px, 140px)",
+      ...(showDescriptionColumn ? ["minmax(120px, 200px)"] : []),
+      ...contentColumns.map((c) => c.previewWidth),
+      ...variableColumns.map(() => "minmax(120px, 200px)"),
+      ...annotationColumns.map((c) =>
+        c.kind === "value" ? "minmax(64px, 88px)" : "minmax(100px, 176px)",
+      ),
+    ].join(" "),
+  };
+
+  const itemsPreview = (
+    <BulkUploadItemsPreviewShell
+      itemCount={parsedItems.length}
+      annotatedCheckLoading={annotatedCheckLoading}
+      annotatedCheck={annotatedCheck}
+    >
+      <div
+        className="grid gap-2 px-3 py-2 border-b border-border bg-muted sticky top-0 z-10"
+        style={gridStyle}
+      >
+        <div className="text-xs font-medium text-muted-foreground">Name</div>
+        {showDescriptionColumn && (
+          <div className="text-xs font-medium text-muted-foreground">
+            Description
+          </div>
+        )}
+        {contentColumns.map((c) => (
+          <div
+            key={`h-${c.payloadKey}`}
+            className="text-xs font-medium text-muted-foreground"
+          >
+            {c.previewLabel}
+          </div>
+        ))}
+        {variableColumns.map((c) => (
+          <div
+            key={`h-${c.evaluatorUuid}-${c.varName}`}
+            className="text-xs font-medium text-muted-foreground font-mono truncate"
+            title={c.header}
+          >
+            {c.header}
+          </div>
+        ))}
+        {annotationColumns.map((c) => (
+          <div
+            key={`ah-${c.evaluatorUuid}-${c.kind}`}
+            className="text-xs font-medium text-muted-foreground font-mono truncate"
+            title={c.header}
+          >
+            {c.header}
+          </div>
+        ))}
+      </div>
+      <div className="divide-y divide-border">
+        {parsedItems.slice(0, 50).map((p, idx) => {
+          const valuesByKey = new Map<string, string>();
+          for (const ref of p.evaluators) {
+            if (!ref.variable_values) continue;
+            for (const [varName, value] of Object.entries(
+              ref.variable_values,
+            )) {
+              valuesByKey.set(`${ref.evaluator_uuid}/${varName}`, value);
+            }
+          }
+          return (
+            <div
+              key={idx}
+              className={`grid gap-2 px-3 py-2 text-xs items-start ${bulkUploadAnnotatedRowBgClass(idx, annotatedCheck)}`}
+              style={gridStyle}
+            >
+              <div className="truncate text-foreground" title={p.name}>
+                {p.name || <span className="text-muted-foreground">—</span>}
+              </div>
+              {showDescriptionColumn && (
+                <div
+                  className="min-w-0 max-h-24 overflow-y-auto pr-1 leading-snug text-foreground break-words whitespace-pre-wrap"
+                  title={p.description || undefined}
+                >
+                  {p.description}
+                </div>
+              )}
+              {contentColumns.map((c) => (
+                <div key={`c-${idx}-${c.payloadKey}`} className="min-w-0">
+                  {c.renderPreview(p.content[c.payloadKey])}
+                </div>
+              ))}
+              {variableColumns.map((c) => {
+                const value =
+                  valuesByKey.get(`${c.evaluatorUuid}/${c.varName}`) ?? "";
+                return (
+                  <div
+                    key={`${idx}-${c.evaluatorUuid}-${c.varName}`}
+                    className="min-w-0 max-h-24 overflow-y-auto pr-1 leading-snug text-foreground break-words whitespace-pre-wrap"
+                  >
+                    {value}
+                  </div>
+                );
+              })}
+              {annotationColumns.map((c) => {
+                const ann = p.annotations.find(
+                  (a) => a.evaluator_uuid === c.evaluatorUuid,
+                );
+                const display =
+                  c.kind === "value"
+                    ? ann
+                      ? typeof ann.value === "boolean"
+                        ? ann.value
+                          ? "true"
+                          : "false"
+                        : String(ann.value)
+                      : ""
+                    : (ann?.reasoning ?? "");
+                return (
+                  <div
+                    key={`${idx}-a-${c.evaluatorUuid}-${c.kind}`}
+                    className="min-w-0 max-h-24 overflow-y-auto pr-1 leading-snug text-foreground break-words whitespace-pre-wrap"
+                  >
+                    {display}
+                  </div>
+                );
+              })}
+            </div>
+          );
+        })}
+        {parsedItems.length > 50 && (
+          <div className="px-4 py-2 text-xs text-muted-foreground">
+            + {parsedItems.length - 50} more rows
+          </div>
+        )}
+      </div>
+    </BulkUploadItemsPreviewShell>
+  );
+
+  const annotationOptIn =
+    linkedEvaluators.length > 0 || duplicateNames.length > 0 ? (
+      <div className="space-y-3">
+        {linkedEvaluators.length > 0 && (
+          <AnnotationOptIn
+            annotators={annotatorsState.annotators}
+            loading={annotatorsState.loading}
+            error={annotatorsState.error}
+            uploadAnnotations={uploadAnnotations}
+            onToggle={setUploadAnnotations}
+            selectedAnnotatorId={selectedAnnotatorId}
+            onSelectAnnotator={setSelectedAnnotatorId}
+          />
+        )}
+        {duplicateNames.length > 0 && (
+          <div className="rounded-md border border-red-500/30 bg-red-500/10 p-3 text-xs text-red-600 dark:text-red-400">
+            Two or more linked evaluators share the same name (
+            {duplicateNames.map((n) => `"${n}"`).join(", ")}). Their variable
+            and annotation columns would collide in the CSV — rename one on the
+            evaluators page before uploading.
+          </div>
+        )}
+        {uploadAnnotations && evaluatorsMissingOutputType.length > 0 && (
+          <div className="rounded-md border border-red-500/30 bg-red-500/10 p-3 text-xs text-red-600 dark:text-red-400">
+            Annotation upload isn&apos;t available — evaluator(s){" "}
+            {evaluatorsMissingOutputType.map((e) => `"${e.name}"`).join(", ")}{" "}
+            have no binary/rating output configured.
+          </div>
+        )}
+      </div>
+    ) : null;
+
+  const uploadBlocked =
+    duplicateNames.length > 0 ||
+    (uploadAnnotations &&
+      (annotatorsState.annotators.length === 0 ||
+        !selectedAnnotatorId ||
+        evaluatorsMissingOutputType.length > 0));
+
+  return (
+    <BulkUploadDialogShell
+      isOpen={isOpen}
+      title="Bulk upload items"
+      buildSampleCsv={buildSampleCsv}
+      sampleFilename={() =>
+        uploadAnnotations
+          ? `sample_${sampleFilenameBase}_with_annotations.csv`
+          : `sample_${sampleFilenameBase}.csv`
+      }
+      buildGuidelines={buildGuidelines}
+      guidelinesFilename={() =>
+        uploadAnnotations
+          ? `${sampleFilenameBase}_csv_guidelines_with_annotations.pdf`
+          : `${sampleFilenameBase}_csv_guidelines.pdf`
+      }
+      csvFile={csvFile}
+      onFile={handleFile}
+      onClear={reset}
+      parseError={parseError}
+      uploadError={uploadError}
+      isUploading={isUploading}
+      itemCount={parsedItems.length}
+      itemsPreview={itemsPreview}
+      onUpload={handleUpload}
+      onClose={onClose}
+      topContent={annotationOptIn}
+      uploadBlocked={uploadBlocked}
+      hideUploadSection={
+        duplicateNames.length > 0 ||
+        (uploadAnnotations &&
+          (!selectedAnnotatorId || evaluatorsMissingOutputType.length > 0))
+      }
+    />
+  );
+}

--- a/src/components/human-labelling/BulkUploadLlmGeneralItemsDialog.tsx
+++ b/src/components/human-labelling/BulkUploadLlmGeneralItemsDialog.tsx
@@ -24,6 +24,27 @@ import {
   useAnnotators,
 } from "./bulk-upload-shared";
 
+type EvaluatorVariableDef = {
+  name: string;
+  description?: string;
+  default?: string;
+};
+
+export type LlmGeneralLinkedEvaluator = {
+  uuid: string;
+  name: string;
+  slug: string | null;
+  variables: EvaluatorVariableDef[];
+  output_type: "binary" | "rating" | null;
+  scale_min: number | null;
+  scale_max: number | null;
+};
+
+type EvaluatorRef = {
+  evaluator_uuid: string;
+  variable_values?: Record<string, string>;
+};
+
 const NAME_HEADERS = ["name", "title", "label", "item_name"];
 const INPUT_HEADERS = ["input", "prompt", "question", "request"];
 const OUTPUT_HEADERS = ["output", "response", "completion", "answer", "reply"];
@@ -32,42 +53,57 @@ function csvEscape(s: string): string {
   return `"${s.replace(/"/g, '""')}"`;
 }
 
+// Column header for an evaluator variable, e.g. "Correctness/criteria".
+// One column per variable per evaluator — keeps the CSV flat instead of
+// asking users to hand-author JSON in a single cell.
+function variableColumnName(evalName: string, varName: string): string {
+  return `${evalName}/${varName}`;
+}
+
 const SAMPLE_BASE_ROWS: Array<{
   name: string;
   input: string;
   output: string;
+  sampleVariableValue: string;
   reasoning: string;
 }> = [
   {
     name: "Summary 1",
     input: "Summarise: The cat sat on the mat and then went to sleep.",
     output: "A cat sat on a mat and fell asleep.",
+    sampleVariableValue:
+      "The summary should be accurate, concise, and capture the key facts.",
     reasoning: "Accurate and concise.",
   },
   {
     name: "Classification 1",
     input: "Classify the sentiment: I absolutely loved this product!",
     output: "positive",
-    reasoning: "",
-  },
-  {
-    name: "Extraction 1",
-    input: "Extract the city: The meeting is in Berlin next week.",
-    output: "Berlin",
+    sampleVariableValue:
+      "The label should correctly reflect the sentiment of the text.",
     reasoning: "",
   },
 ];
 
 function buildSampleCsv(
-  evaluators: EvaluatorMeta[],
+  linked: LlmGeneralLinkedEvaluator[],
   includeAnnotations: boolean,
 ): string {
+  const variableColumns: { evalName: string; varName: string }[] = [];
+  for (const e of linked) {
+    for (const v of e.variables) {
+      variableColumns.push({ evalName: e.name, varName: v.name });
+    }
+  }
   const headerCells = [
     "name",
     "input",
     "output",
+    ...variableColumns.map((c) =>
+      csvEscape(variableColumnName(c.evalName, c.varName)),
+    ),
     ...(includeAnnotations
-      ? evaluators.flatMap((e) => [
+      ? linked.flatMap((e) => [
           csvEscape(evaluatorValueColumn(e.name)),
           csvEscape(evaluatorReasoningColumn(e.name)),
         ])
@@ -78,8 +114,9 @@ function buildSampleCsv(
       csvEscape(r.name),
       csvEscape(r.input),
       csvEscape(r.output),
+      ...variableColumns.map(() => csvEscape(r.sampleVariableValue)),
       ...(includeAnnotations
-        ? evaluators.flatMap((e) => [
+        ? linked.flatMap((e) => [
             csvEscape(sampleEvaluatorValue(e)),
             csvEscape(r.reasoning),
           ])
@@ -93,15 +130,8 @@ type ParsedItem = {
   name: string;
   input: string;
   output: string;
+  evaluators: EvaluatorRef[];
   annotations: ParsedAnnotation[];
-};
-
-export type LlmGeneralLinkedEvaluator = {
-  uuid: string;
-  name: string;
-  output_type: "binary" | "rating" | null;
-  scale_min: number | null;
-  scale_max: number | null;
 };
 
 type BulkUploadLlmGeneralItemsDialogProps = {
@@ -157,9 +187,14 @@ export function BulkUploadLlmGeneralItemsDialog({
     (e) => e.output_type !== "binary" && e.output_type !== "rating",
   );
 
-  // Two linked evaluators sharing a name produce duplicate CSV headers that
-  // PapaParse silently overwrites. Block the annotation flow until renamed.
+  // Two linked evaluators with the same name produce duplicate CSV headers —
+  // this also breaks the `<evalName>/<varName>` variable columns, so it has
+  // to block regardless of whether the user is uploading annotations.
   const duplicateNames = duplicateEvaluatorNames(annotationEvaluatorsMeta);
+
+  const evaluatorsWithVariables = linkedEvaluators.filter(
+    (e) => e.variables.length > 0,
+  );
 
   const reset = () => {
     setCsvFile(null);
@@ -186,6 +221,14 @@ export function BulkUploadLlmGeneralItemsDialog({
     setParsedItems([]);
     setCsvFile(file);
     if (!file) return;
+    if (duplicateNames.length > 0) {
+      setParseError(
+        `Two or more linked evaluators share the same name (${duplicateNames
+          .map((n) => `"${n}"`)
+          .join(", ")}). Rename one before uploading.`,
+      );
+      return;
+    }
     Papa.parse<Record<string, string>>(file, {
       header: true,
       skipEmptyLines: true,
@@ -201,6 +244,43 @@ export function BulkUploadLlmGeneralItemsDialog({
           );
           return;
         }
+
+        // Resolve a column for each evaluator variable up front.
+        const variableHeaderMap = new Map<
+          string,
+          {
+            evaluator: LlmGeneralLinkedEvaluator;
+            varName: string;
+            columnKey: string;
+          }[]
+        >();
+        const missingColumns: string[] = [];
+        for (const e of evaluatorsWithVariables) {
+          const slots: {
+            evaluator: LlmGeneralLinkedEvaluator;
+            varName: string;
+            columnKey: string;
+          }[] = [];
+          for (const v of e.variables) {
+            const expected = variableColumnName(e.name, v.name);
+            const key = headers.find((h) => h === expected);
+            if (!key) {
+              missingColumns.push(expected);
+              continue;
+            }
+            slots.push({ evaluator: e, varName: v.name, columnKey: key });
+          }
+          variableHeaderMap.set(e.uuid, slots);
+        }
+        if (missingColumns.length > 0) {
+          setParseError(
+            `CSV is missing column(s) for evaluator variables: ${missingColumns
+              .map((c) => `"${c}"`)
+              .join(", ")}. Download the sample CSV above for the exact format.`,
+          );
+          return;
+        }
+
         if (uploadAnnotations) {
           if (evaluatorsMissingOutputType.length > 0) {
             setParseError(
@@ -230,7 +310,12 @@ export function BulkUploadLlmGeneralItemsDialog({
           const name = (r[nameKey] ?? "").trim();
           const input = (r[inputKey] ?? "").trim();
           const output = (r[outputKey] ?? "").trim();
-          if (!name && !input && !output) continue;
+          const anyVariableValue = evaluatorsWithVariables.some((e) =>
+            (variableHeaderMap.get(e.uuid) ?? []).some(
+              (slot) => (r[slot.columnKey] ?? "").trim() !== "",
+            ),
+          );
+          if (!name && !input && !output && !anyVariableValue) continue;
           if (!name) {
             setParseError(`Row ${i + 1}: "name" is required.`);
             return;
@@ -241,6 +326,31 @@ export function BulkUploadLlmGeneralItemsDialog({
             );
             return;
           }
+
+          const refs: EvaluatorRef[] = [];
+          let rowError: string | null = null;
+          for (const e of evaluatorsWithVariables) {
+            const slots = variableHeaderMap.get(e.uuid) ?? [];
+            const variableValues: Record<string, string> = {};
+            for (const slot of slots) {
+              const raw = (r[slot.columnKey] ?? "").trim();
+              if (!raw) {
+                rowError = `Row ${i + 1}: missing value for "${variableColumnName(
+                  e.name,
+                  slot.varName,
+                )}".`;
+                break;
+              }
+              variableValues[slot.varName] = raw;
+            }
+            if (rowError) break;
+            refs.push({ evaluator_uuid: e.uuid, variable_values: variableValues });
+          }
+          if (rowError) {
+            setParseError(rowError);
+            return;
+          }
+
           const annotations: ParsedAnnotation[] = [];
           if (uploadAnnotations) {
             for (const meta of annotationEvaluatorsMeta) {
@@ -272,7 +382,7 @@ export function BulkUploadLlmGeneralItemsDialog({
               });
             }
           }
-          items.push({ name, input, output, annotations });
+          items.push({ name, input, output, evaluators: refs, annotations });
         }
         if (items.length === 0) {
           setParseError("No rows with content were found in the CSV.");
@@ -300,6 +410,15 @@ export function BulkUploadLlmGeneralItemsDialog({
     setUploadError(null);
     try {
       const itemsBody = parsedItems.map((p) => {
+        const evaluator_variables: Record<
+          string,
+          Record<string, string>
+        > = {};
+        for (const ref of p.evaluators) {
+          if (ref.variable_values) {
+            evaluator_variables[ref.evaluator_uuid] = { ...ref.variable_values };
+          }
+        }
         const annotationsObj = uploadAnnotations
           ? buildItemAnnotationsPayload(p.annotations)
           : undefined;
@@ -308,6 +427,9 @@ export function BulkUploadLlmGeneralItemsDialog({
             name: p.name,
             input: p.input,
             output: p.output,
+            ...(Object.keys(evaluator_variables).length > 0
+              ? { evaluator_variables }
+              : {}),
           },
           ...(annotationsObj ? { annotations: annotationsObj } : {}),
         };
@@ -346,6 +468,16 @@ export function BulkUploadLlmGeneralItemsDialog({
       },
     ];
 
+    for (const e of evaluatorsWithVariables) {
+      for (const v of e.variables) {
+        const desc = v.description ? ` — ${v.description}` : "";
+        columns.push({
+          name: variableColumnName(e.name, v.name),
+          description: `Required. Used for the "${e.name}" evaluator${desc}`,
+        });
+      }
+    }
+
     if (uploadAnnotations && annotationEvaluatorsMeta.length > 0) {
       for (const e of annotationEvaluatorsMeta) {
         const range =
@@ -375,6 +507,13 @@ export function BulkUploadLlmGeneralItemsDialog({
     };
   };
 
+  const variableColumns = evaluatorsWithVariables.flatMap((e) =>
+    e.variables.map((v) => ({
+      evaluatorUuid: e.uuid,
+      varName: v.name,
+      header: variableColumnName(e.name, v.name),
+    })),
+  );
   const annotationColumns =
     uploadAnnotations && annotationEvaluatorsMeta.length > 0
       ? annotationEvaluatorsMeta.flatMap((e) => [
@@ -395,6 +534,7 @@ export function BulkUploadLlmGeneralItemsDialog({
       "minmax(80px, 140px)",
       "minmax(120px, 220px)",
       "minmax(120px, 220px)",
+      ...variableColumns.map(() => "minmax(120px, 200px)"),
       ...annotationColumns.map((c) =>
         c.kind === "value" ? "minmax(64px, 88px)" : "minmax(100px, 176px)",
       ),
@@ -414,6 +554,15 @@ export function BulkUploadLlmGeneralItemsDialog({
         <div className="text-xs font-medium text-muted-foreground">Name</div>
         <div className="text-xs font-medium text-muted-foreground">Input</div>
         <div className="text-xs font-medium text-muted-foreground">Output</div>
+        {variableColumns.map((c) => (
+          <div
+            key={`h-${c.evaluatorUuid}-${c.varName}`}
+            className="text-xs font-medium text-muted-foreground font-mono truncate"
+            title={c.header}
+          >
+            {c.header}
+          </div>
+        ))}
         {annotationColumns.map((c) => (
           <div
             key={`ah-${c.evaluatorUuid}-${c.kind}`}
@@ -425,52 +574,75 @@ export function BulkUploadLlmGeneralItemsDialog({
         ))}
       </div>
       <div className="divide-y divide-border">
-        {parsedItems.slice(0, 50).map((p, idx) => (
-          <div
-            key={idx}
-            className={`grid gap-2 px-3 py-2 text-xs items-start ${bulkUploadAnnotatedRowBgClass(idx, annotatedCheck)}`}
-            style={gridStyle}
-          >
-            <div className="truncate text-foreground" title={p.name}>
-              {p.name || <span className="text-muted-foreground">—</span>}
-            </div>
+        {parsedItems.slice(0, 50).map((p, idx) => {
+          const valuesByKey = new Map<string, string>();
+          for (const ref of p.evaluators) {
+            if (!ref.variable_values) continue;
+            for (const [varName, value] of Object.entries(
+              ref.variable_values,
+            )) {
+              valuesByKey.set(`${ref.evaluator_uuid}/${varName}`, value);
+            }
+          }
+          return (
             <div
-              className="min-w-0 max-h-24 overflow-y-auto pr-1 leading-snug text-foreground break-words whitespace-pre-wrap"
-              title={p.input}
+              key={idx}
+              className={`grid gap-2 px-3 py-2 text-xs items-start ${bulkUploadAnnotatedRowBgClass(idx, annotatedCheck)}`}
+              style={gridStyle}
             >
-              {p.input}
+              <div className="truncate text-foreground" title={p.name}>
+                {p.name || <span className="text-muted-foreground">—</span>}
+              </div>
+              <div
+                className="min-w-0 max-h-24 overflow-y-auto pr-1 leading-snug text-foreground break-words whitespace-pre-wrap"
+                title={p.input}
+              >
+                {p.input}
+              </div>
+              <div
+                className="min-w-0 max-h-24 overflow-y-auto pr-1 leading-snug text-foreground break-words whitespace-pre-wrap"
+                title={p.output}
+              >
+                {p.output}
+              </div>
+              {variableColumns.map((c) => {
+                const value =
+                  valuesByKey.get(`${c.evaluatorUuid}/${c.varName}`) ?? "";
+                return (
+                  <div
+                    key={`${idx}-${c.evaluatorUuid}-${c.varName}`}
+                    className="min-w-0 max-h-24 overflow-y-auto pr-1 leading-snug text-foreground break-words whitespace-pre-wrap"
+                  >
+                    {value}
+                  </div>
+                );
+              })}
+              {annotationColumns.map((c) => {
+                const ann = p.annotations.find(
+                  (a) => a.evaluator_uuid === c.evaluatorUuid,
+                );
+                const display =
+                  c.kind === "value"
+                    ? ann
+                      ? typeof ann.value === "boolean"
+                        ? ann.value
+                          ? "true"
+                          : "false"
+                        : String(ann.value)
+                      : ""
+                    : (ann?.reasoning ?? "");
+                return (
+                  <div
+                    key={`${idx}-a-${c.evaluatorUuid}-${c.kind}`}
+                    className="min-w-0 max-h-24 overflow-y-auto pr-1 leading-snug text-foreground break-words whitespace-pre-wrap"
+                  >
+                    {display}
+                  </div>
+                );
+              })}
             </div>
-            <div
-              className="min-w-0 max-h-24 overflow-y-auto pr-1 leading-snug text-foreground break-words whitespace-pre-wrap"
-              title={p.output}
-            >
-              {p.output}
-            </div>
-            {annotationColumns.map((c) => {
-              const ann = p.annotations.find(
-                (a) => a.evaluator_uuid === c.evaluatorUuid,
-              );
-              const display =
-                c.kind === "value"
-                  ? ann
-                    ? typeof ann.value === "boolean"
-                      ? ann.value
-                        ? "true"
-                        : "false"
-                      : String(ann.value)
-                    : ""
-                  : (ann?.reasoning ?? "");
-              return (
-                <div
-                  key={`${idx}-a-${c.evaluatorUuid}-${c.kind}`}
-                  className="min-w-0 max-h-24 overflow-y-auto pr-1 leading-snug text-foreground break-words whitespace-pre-wrap"
-                >
-                  {display}
-                </div>
-              );
-            })}
-          </div>
-        ))}
+          );
+        })}
         {parsedItems.length > 50 && (
           <div className="px-4 py-2 text-xs text-muted-foreground">
             + {parsedItems.length - 50} more rows
@@ -481,22 +653,25 @@ export function BulkUploadLlmGeneralItemsDialog({
   );
 
   const annotationOptIn =
-    linkedEvaluators.length > 0 ? (
+    linkedEvaluators.length > 0 || duplicateNames.length > 0 ? (
       <div className="space-y-3">
-        <AnnotationOptIn
-          annotators={annotatorsState.annotators}
-          loading={annotatorsState.loading}
-          error={annotatorsState.error}
-          uploadAnnotations={uploadAnnotations}
-          onToggle={setUploadAnnotations}
-          selectedAnnotatorId={selectedAnnotatorId}
-          onSelectAnnotator={setSelectedAnnotatorId}
-        />
-        {uploadAnnotations && duplicateNames.length > 0 && (
+        {linkedEvaluators.length > 0 && (
+          <AnnotationOptIn
+            annotators={annotatorsState.annotators}
+            loading={annotatorsState.loading}
+            error={annotatorsState.error}
+            uploadAnnotations={uploadAnnotations}
+            onToggle={setUploadAnnotations}
+            selectedAnnotatorId={selectedAnnotatorId}
+            onSelectAnnotator={setSelectedAnnotatorId}
+          />
+        )}
+        {duplicateNames.length > 0 && (
           <div className="rounded-md border border-red-500/30 bg-red-500/10 p-3 text-xs text-red-600 dark:text-red-400">
             Two or more linked evaluators share the same name (
-            {duplicateNames.map((n) => `"${n}"`).join(", ")}). Rename one on the
-            evaluators page before uploading annotations.
+            {duplicateNames.map((n) => `"${n}"`).join(", ")}). Their variable
+            and annotation columns would collide in the CSV — rename one on the
+            evaluators page before uploading.
           </div>
         )}
         {uploadAnnotations && evaluatorsMissingOutputType.length > 0 && (
@@ -510,19 +685,17 @@ export function BulkUploadLlmGeneralItemsDialog({
     ) : null;
 
   const uploadBlocked =
-    uploadAnnotations &&
-    (annotatorsState.annotators.length === 0 ||
-      !selectedAnnotatorId ||
-      duplicateNames.length > 0 ||
-      evaluatorsMissingOutputType.length > 0);
+    duplicateNames.length > 0 ||
+    (uploadAnnotations &&
+      (annotatorsState.annotators.length === 0 ||
+        !selectedAnnotatorId ||
+        evaluatorsMissingOutputType.length > 0));
 
   return (
     <BulkUploadDialogShell
       isOpen={isOpen}
       title="Bulk upload items"
-      buildSampleCsv={() =>
-        buildSampleCsv(annotationEvaluatorsMeta, uploadAnnotations)
-      }
+      buildSampleCsv={() => buildSampleCsv(linkedEvaluators, uploadAnnotations)}
       sampleFilename={() =>
         uploadAnnotations
           ? "sample_llm_response_items_with_annotations.csv"
@@ -547,10 +720,9 @@ export function BulkUploadLlmGeneralItemsDialog({
       topContent={annotationOptIn}
       uploadBlocked={uploadBlocked}
       hideUploadSection={
-        uploadAnnotations &&
-        (!selectedAnnotatorId ||
-          duplicateNames.length > 0 ||
-          evaluatorsMissingOutputType.length > 0)
+        duplicateNames.length > 0 ||
+        (uploadAnnotations &&
+          (!selectedAnnotatorId || evaluatorsMissingOutputType.length > 0))
       }
     />
   );

--- a/src/components/human-labelling/BulkUploadLlmGeneralItemsDialog.tsx
+++ b/src/components/human-labelling/BulkUploadLlmGeneralItemsDialog.tsx
@@ -1,0 +1,557 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Papa from "papaparse";
+import { apiClient } from "@/lib/api";
+import {
+  AnnotationOptIn,
+  BulkUploadDialogShell,
+  BulkUploadItemsPreviewShell,
+  type EvaluatorMeta,
+  type GuidelineColumn,
+  type GuidelineDoc,
+  type ParsedAnnotation,
+  buildItemAnnotationsPayload,
+  bulkUploadAnnotatedRowBgClass,
+  duplicateEvaluatorNames,
+  evaluatorReasoningColumn,
+  evaluatorValueColumn,
+  findHeaderKey,
+  parseAnnotationCell,
+  parseApiError,
+  sampleEvaluatorValue,
+  useAnnotatedItemsCheck,
+  useAnnotators,
+} from "./bulk-upload-shared";
+
+const NAME_HEADERS = ["name", "title", "label", "item_name"];
+const INPUT_HEADERS = ["input", "prompt", "question", "request"];
+const OUTPUT_HEADERS = ["output", "response", "completion", "answer", "reply"];
+
+function csvEscape(s: string): string {
+  return `"${s.replace(/"/g, '""')}"`;
+}
+
+const SAMPLE_BASE_ROWS: Array<{
+  name: string;
+  input: string;
+  output: string;
+  reasoning: string;
+}> = [
+  {
+    name: "Summary 1",
+    input: "Summarise: The cat sat on the mat and then went to sleep.",
+    output: "A cat sat on a mat and fell asleep.",
+    reasoning: "Accurate and concise.",
+  },
+  {
+    name: "Classification 1",
+    input: "Classify the sentiment: I absolutely loved this product!",
+    output: "positive",
+    reasoning: "",
+  },
+  {
+    name: "Extraction 1",
+    input: "Extract the city: The meeting is in Berlin next week.",
+    output: "Berlin",
+    reasoning: "",
+  },
+];
+
+function buildSampleCsv(
+  evaluators: EvaluatorMeta[],
+  includeAnnotations: boolean,
+): string {
+  const headerCells = [
+    "name",
+    "input",
+    "output",
+    ...(includeAnnotations
+      ? evaluators.flatMap((e) => [
+          csvEscape(evaluatorValueColumn(e.name)),
+          csvEscape(evaluatorReasoningColumn(e.name)),
+        ])
+      : []),
+  ];
+  const lines = SAMPLE_BASE_ROWS.map((r) =>
+    [
+      csvEscape(r.name),
+      csvEscape(r.input),
+      csvEscape(r.output),
+      ...(includeAnnotations
+        ? evaluators.flatMap((e) => [
+            csvEscape(sampleEvaluatorValue(e)),
+            csvEscape(r.reasoning),
+          ])
+        : []),
+    ].join(","),
+  );
+  return `${headerCells.join(",")}\n${lines.join("\n")}\n`;
+}
+
+type ParsedItem = {
+  name: string;
+  input: string;
+  output: string;
+  annotations: ParsedAnnotation[];
+};
+
+export type LlmGeneralLinkedEvaluator = {
+  uuid: string;
+  name: string;
+  output_type: "binary" | "rating" | null;
+  scale_min: number | null;
+  scale_max: number | null;
+};
+
+type BulkUploadLlmGeneralItemsDialogProps = {
+  isOpen: boolean;
+  accessToken: string;
+  taskUuid: string;
+  linkedEvaluators?: LlmGeneralLinkedEvaluator[];
+  onClose: () => void;
+  onSuccess: (count: number, withAnnotations: boolean) => void;
+};
+
+export function BulkUploadLlmGeneralItemsDialog({
+  isOpen,
+  accessToken,
+  taskUuid,
+  linkedEvaluators = [],
+  onClose,
+  onSuccess,
+}: BulkUploadLlmGeneralItemsDialogProps) {
+  const [csvFile, setCsvFile] = useState<File | null>(null);
+  const [parsedItems, setParsedItems] = useState<ParsedItem[]>([]);
+  const [parseError, setParseError] = useState<string | null>(null);
+  const [isUploading, setIsUploading] = useState(false);
+  const [uploadError, setUploadError] = useState<string | null>(null);
+  const [uploadAnnotations, setUploadAnnotations] = useState(false);
+  const [selectedAnnotatorId, setSelectedAnnotatorId] = useState<string | null>(
+    null,
+  );
+  const annotatorsState = useAnnotators(isOpen, accessToken);
+  const { annotatedCheck, annotatedCheckLoading } = useAnnotatedItemsCheck({
+    enabled:
+      uploadAnnotations && !!selectedAnnotatorId && parsedItems.length > 0,
+    taskUuid,
+    accessToken,
+    annotatorId: selectedAnnotatorId,
+    namedItems: parsedItems,
+  });
+
+  const annotationEvaluatorsMeta: EvaluatorMeta[] = linkedEvaluators.map(
+    (e) => ({
+      uuid: e.uuid,
+      name: e.name,
+      output_type: e.output_type,
+      scale_min: e.scale_min,
+      scale_max: e.scale_max,
+    }),
+  );
+
+  // Evaluators without a usable output_type can't be annotated here — the
+  // parser would silently drop their column and produce a half-labelled
+  // batch. Block the annotation flow rather than failing later.
+  const evaluatorsMissingOutputType = annotationEvaluatorsMeta.filter(
+    (e) => e.output_type !== "binary" && e.output_type !== "rating",
+  );
+
+  // Two linked evaluators sharing a name produce duplicate CSV headers that
+  // PapaParse silently overwrites. Block the annotation flow until renamed.
+  const duplicateNames = duplicateEvaluatorNames(annotationEvaluatorsMeta);
+
+  const reset = () => {
+    setCsvFile(null);
+    setParsedItems([]);
+    setParseError(null);
+    setUploadError(null);
+    setUploadAnnotations(false);
+    setSelectedAnnotatorId(null);
+  };
+
+  useEffect(() => {
+    if (isOpen) reset();
+  }, [isOpen]);
+
+  useEffect(() => {
+    setParsedItems([]);
+    setParseError(null);
+    setCsvFile(null);
+  }, [uploadAnnotations]);
+
+  const handleFile = (file: File | null) => {
+    setUploadError(null);
+    setParseError(null);
+    setParsedItems([]);
+    setCsvFile(file);
+    if (!file) return;
+    Papa.parse<Record<string, string>>(file, {
+      header: true,
+      skipEmptyLines: true,
+      transformHeader: (h) => h.trim(),
+      complete: (results) => {
+        const headers = results.meta.fields ?? [];
+        const nameKey = findHeaderKey(headers, NAME_HEADERS);
+        const inputKey = findHeaderKey(headers, INPUT_HEADERS);
+        const outputKey = findHeaderKey(headers, OUTPUT_HEADERS);
+        if (!nameKey || !inputKey || !outputKey) {
+          setParseError(
+            `CSV must include "name", "input" and "output" columns. Found: ${headers.join(", ") || "(none)"}`,
+          );
+          return;
+        }
+        if (uploadAnnotations) {
+          if (evaluatorsMissingOutputType.length > 0) {
+            setParseError(
+              `Annotation upload is unavailable: evaluator(s) ${evaluatorsMissingOutputType
+                .map((e) => `"${e.name}"`)
+                .join(", ")} have no binary/rating output configured.`,
+            );
+            return;
+          }
+          const missing: string[] = [];
+          for (const meta of annotationEvaluatorsMeta) {
+            const valueHeader = evaluatorValueColumn(meta.name);
+            if (!headers.includes(valueHeader)) missing.push(valueHeader);
+          }
+          if (missing.length > 0) {
+            setParseError(
+              `CSV is missing annotation column(s): ${missing
+                .map((c) => `"${c}"`)
+                .join(", ")}.`,
+            );
+            return;
+          }
+        }
+        const items: ParsedItem[] = [];
+        for (let i = 0; i < results.data.length; i++) {
+          const r = results.data[i];
+          const name = (r[nameKey] ?? "").trim();
+          const input = (r[inputKey] ?? "").trim();
+          const output = (r[outputKey] ?? "").trim();
+          if (!name && !input && !output) continue;
+          if (!name) {
+            setParseError(`Row ${i + 1}: "name" is required.`);
+            return;
+          }
+          if (!input || !output) {
+            setParseError(
+              `Row ${i + 1}: both "input" and "output" are required.`,
+            );
+            return;
+          }
+          const annotations: ParsedAnnotation[] = [];
+          if (uploadAnnotations) {
+            for (const meta of annotationEvaluatorsMeta) {
+              if (
+                meta.output_type !== "binary" &&
+                meta.output_type !== "rating"
+              )
+                continue;
+              const valueHeader = evaluatorValueColumn(meta.name);
+              const reasoningHeader = evaluatorReasoningColumn(meta.name);
+              const rawValue = (r[valueHeader] ?? "").trim();
+              const rawReasoning = (r[reasoningHeader] ?? "").trim();
+              if (!rawValue) {
+                setParseError(
+                  `Row ${i + 1}: missing value for "${valueHeader}".`,
+                );
+                return;
+              }
+              const parsed = parseAnnotationCell(rawValue, meta);
+              if ("error" in parsed) {
+                setParseError(`Row ${i + 1}: ${parsed.error}.`);
+                return;
+              }
+              annotations.push({
+                evaluator_uuid: meta.uuid,
+                output_type: meta.output_type,
+                value: parsed.value,
+                reasoning: rawReasoning,
+              });
+            }
+          }
+          items.push({ name, input, output, annotations });
+        }
+        if (items.length === 0) {
+          setParseError("No rows with content were found in the CSV.");
+          return;
+        }
+        setParsedItems(items);
+      },
+      error: (err) => setParseError(err.message || "Failed to parse CSV"),
+    });
+  };
+
+  const handleUpload = async () => {
+    if (parsedItems.length === 0 || isUploading) return;
+    if (uploadAnnotations && !selectedAnnotatorId) {
+      setUploadError("Select an annotator before uploading.");
+      return;
+    }
+    if (uploadAnnotations && evaluatorsMissingOutputType.length > 0) {
+      setUploadError(
+        "One or more evaluators have no binary/rating output configured.",
+      );
+      return;
+    }
+    setIsUploading(true);
+    setUploadError(null);
+    try {
+      const itemsBody = parsedItems.map((p) => {
+        const annotationsObj = uploadAnnotations
+          ? buildItemAnnotationsPayload(p.annotations)
+          : undefined;
+        return {
+          payload: {
+            name: p.name,
+            input: p.input,
+            output: p.output,
+          },
+          ...(annotationsObj ? { annotations: annotationsObj } : {}),
+        };
+      });
+      const anyAnnotated = itemsBody.some((it) => "annotations" in it);
+      await apiClient(`/annotation-tasks/${taskUuid}/items`, accessToken, {
+        method: "POST",
+        body: {
+          ...(anyAnnotated && selectedAnnotatorId
+            ? { annotator_id: selectedAnnotatorId }
+            : {}),
+          items: itemsBody,
+        },
+      });
+      onSuccess(parsedItems.length, uploadAnnotations);
+    } catch (err) {
+      setUploadError(parseApiError(err, "Failed to upload items"));
+    } finally {
+      setIsUploading(false);
+    }
+  };
+
+  const buildGuidelines = (): GuidelineDoc => {
+    const columns: GuidelineColumn[] = [
+      {
+        name: "name",
+        description: "Required. A unique name for the item.",
+      },
+      {
+        name: "input",
+        description: "Required. The prompt or input given to the LLM.",
+      },
+      {
+        name: "output",
+        description: "Required. The output the LLM produced for that input.",
+      },
+    ];
+
+    if (uploadAnnotations && annotationEvaluatorsMeta.length > 0) {
+      for (const e of annotationEvaluatorsMeta) {
+        const range =
+          e.output_type === "binary"
+            ? "true/false"
+            : e.output_type === "rating" &&
+                typeof e.scale_min === "number" &&
+                typeof e.scale_max === "number"
+              ? `any value between ${e.scale_min}-${e.scale_max}`
+              : "value";
+        columns.push({
+          name: evaluatorValueColumn(e.name),
+          description: `Required. Value for the "${e.name}" evaluator (${range}).`,
+        });
+        columns.push({
+          name: evaluatorReasoningColumn(e.name),
+          description: `(optional) Reasoning for the value assigned to "${e.name}".`,
+        });
+      }
+    }
+
+    return {
+      title: "Bulk upload — LLM response labelling items",
+      intro:
+        "Upload a CSV with the following columns. Each row creates one non-conversational LLM evaluation item.",
+      columns,
+    };
+  };
+
+  const annotationColumns =
+    uploadAnnotations && annotationEvaluatorsMeta.length > 0
+      ? annotationEvaluatorsMeta.flatMap((e) => [
+          {
+            evaluatorUuid: e.uuid,
+            kind: "value" as const,
+            header: evaluatorValueColumn(e.name),
+          },
+          {
+            evaluatorUuid: e.uuid,
+            kind: "reasoning" as const,
+            header: evaluatorReasoningColumn(e.name),
+          },
+        ])
+      : [];
+  const gridStyle = {
+    gridTemplateColumns: [
+      "minmax(80px, 140px)",
+      "minmax(120px, 220px)",
+      "minmax(120px, 220px)",
+      ...annotationColumns.map((c) =>
+        c.kind === "value" ? "minmax(64px, 88px)" : "minmax(100px, 176px)",
+      ),
+    ].join(" "),
+  };
+
+  const itemsPreview = (
+    <BulkUploadItemsPreviewShell
+      itemCount={parsedItems.length}
+      annotatedCheckLoading={annotatedCheckLoading}
+      annotatedCheck={annotatedCheck}
+    >
+      <div
+        className="grid gap-2 px-3 py-2 border-b border-border bg-muted sticky top-0 z-10"
+        style={gridStyle}
+      >
+        <div className="text-xs font-medium text-muted-foreground">Name</div>
+        <div className="text-xs font-medium text-muted-foreground">Input</div>
+        <div className="text-xs font-medium text-muted-foreground">Output</div>
+        {annotationColumns.map((c) => (
+          <div
+            key={`ah-${c.evaluatorUuid}-${c.kind}`}
+            className="text-xs font-medium text-muted-foreground font-mono truncate"
+            title={c.header}
+          >
+            {c.header}
+          </div>
+        ))}
+      </div>
+      <div className="divide-y divide-border">
+        {parsedItems.slice(0, 50).map((p, idx) => (
+          <div
+            key={idx}
+            className={`grid gap-2 px-3 py-2 text-xs items-start ${bulkUploadAnnotatedRowBgClass(idx, annotatedCheck)}`}
+            style={gridStyle}
+          >
+            <div className="truncate text-foreground" title={p.name}>
+              {p.name || <span className="text-muted-foreground">—</span>}
+            </div>
+            <div
+              className="min-w-0 max-h-24 overflow-y-auto pr-1 leading-snug text-foreground break-words whitespace-pre-wrap"
+              title={p.input}
+            >
+              {p.input}
+            </div>
+            <div
+              className="min-w-0 max-h-24 overflow-y-auto pr-1 leading-snug text-foreground break-words whitespace-pre-wrap"
+              title={p.output}
+            >
+              {p.output}
+            </div>
+            {annotationColumns.map((c) => {
+              const ann = p.annotations.find(
+                (a) => a.evaluator_uuid === c.evaluatorUuid,
+              );
+              const display =
+                c.kind === "value"
+                  ? ann
+                    ? typeof ann.value === "boolean"
+                      ? ann.value
+                        ? "true"
+                        : "false"
+                      : String(ann.value)
+                    : ""
+                  : (ann?.reasoning ?? "");
+              return (
+                <div
+                  key={`${idx}-a-${c.evaluatorUuid}-${c.kind}`}
+                  className="min-w-0 max-h-24 overflow-y-auto pr-1 leading-snug text-foreground break-words whitespace-pre-wrap"
+                >
+                  {display}
+                </div>
+              );
+            })}
+          </div>
+        ))}
+        {parsedItems.length > 50 && (
+          <div className="px-4 py-2 text-xs text-muted-foreground">
+            + {parsedItems.length - 50} more rows
+          </div>
+        )}
+      </div>
+    </BulkUploadItemsPreviewShell>
+  );
+
+  const annotationOptIn =
+    linkedEvaluators.length > 0 ? (
+      <div className="space-y-3">
+        <AnnotationOptIn
+          annotators={annotatorsState.annotators}
+          loading={annotatorsState.loading}
+          error={annotatorsState.error}
+          uploadAnnotations={uploadAnnotations}
+          onToggle={setUploadAnnotations}
+          selectedAnnotatorId={selectedAnnotatorId}
+          onSelectAnnotator={setSelectedAnnotatorId}
+        />
+        {uploadAnnotations && duplicateNames.length > 0 && (
+          <div className="rounded-md border border-red-500/30 bg-red-500/10 p-3 text-xs text-red-600 dark:text-red-400">
+            Two or more linked evaluators share the same name (
+            {duplicateNames.map((n) => `"${n}"`).join(", ")}). Rename one on the
+            evaluators page before uploading annotations.
+          </div>
+        )}
+        {uploadAnnotations && evaluatorsMissingOutputType.length > 0 && (
+          <div className="rounded-md border border-red-500/30 bg-red-500/10 p-3 text-xs text-red-600 dark:text-red-400">
+            Annotation upload isn&apos;t available — evaluator(s){" "}
+            {evaluatorsMissingOutputType.map((e) => `"${e.name}"`).join(", ")}{" "}
+            have no binary/rating output configured.
+          </div>
+        )}
+      </div>
+    ) : null;
+
+  const uploadBlocked =
+    uploadAnnotations &&
+    (annotatorsState.annotators.length === 0 ||
+      !selectedAnnotatorId ||
+      duplicateNames.length > 0 ||
+      evaluatorsMissingOutputType.length > 0);
+
+  return (
+    <BulkUploadDialogShell
+      isOpen={isOpen}
+      title="Bulk upload items"
+      buildSampleCsv={() =>
+        buildSampleCsv(annotationEvaluatorsMeta, uploadAnnotations)
+      }
+      sampleFilename={() =>
+        uploadAnnotations
+          ? "sample_llm_response_items_with_annotations.csv"
+          : "sample_llm_response_items.csv"
+      }
+      buildGuidelines={buildGuidelines}
+      guidelinesFilename={() =>
+        uploadAnnotations
+          ? "llm_response_items_csv_guidelines_with_annotations.pdf"
+          : "llm_response_items_csv_guidelines.pdf"
+      }
+      csvFile={csvFile}
+      onFile={handleFile}
+      onClear={reset}
+      parseError={parseError}
+      uploadError={uploadError}
+      isUploading={isUploading}
+      itemCount={parsedItems.length}
+      itemsPreview={itemsPreview}
+      onUpload={handleUpload}
+      onClose={onClose}
+      topContent={annotationOptIn}
+      uploadBlocked={uploadBlocked}
+      hideUploadSection={
+        uploadAnnotations &&
+        (!selectedAnnotatorId ||
+          duplicateNames.length > 0 ||
+          evaluatorsMissingOutputType.length > 0)
+      }
+    />
+  );
+}

--- a/src/components/human-labelling/BulkUploadLlmGeneralItemsDialog.tsx
+++ b/src/components/human-labelling/BulkUploadLlmGeneralItemsDialog.tsx
@@ -46,6 +46,7 @@ type EvaluatorRef = {
 };
 
 const NAME_HEADERS = ["name", "title", "label", "item_name"];
+const DESCRIPTION_HEADERS = ["description", "desc", "notes"];
 const INPUT_HEADERS = ["input", "prompt", "question", "request"];
 const OUTPUT_HEADERS = ["output", "response", "completion", "answer", "reply"];
 
@@ -62,6 +63,7 @@ function variableColumnName(evalName: string, varName: string): string {
 
 const SAMPLE_BASE_ROWS: Array<{
   name: string;
+  description: string;
   input: string;
   output: string;
   sampleVariableValue: string;
@@ -69,6 +71,7 @@ const SAMPLE_BASE_ROWS: Array<{
 }> = [
   {
     name: "Summary 1",
+    description: "Summarisation quality check.",
     input: "Summarise: The cat sat on the mat and then went to sleep.",
     output: "A cat sat on a mat and fell asleep.",
     sampleVariableValue:
@@ -77,6 +80,7 @@ const SAMPLE_BASE_ROWS: Array<{
   },
   {
     name: "Classification 1",
+    description: "",
     input: "Classify the sentiment: I absolutely loved this product!",
     output: "positive",
     sampleVariableValue:
@@ -97,6 +101,7 @@ function buildSampleCsv(
   }
   const headerCells = [
     "name",
+    "description",
     "input",
     "output",
     ...variableColumns.map((c) =>
@@ -112,6 +117,7 @@ function buildSampleCsv(
   const lines = SAMPLE_BASE_ROWS.map((r) =>
     [
       csvEscape(r.name),
+      csvEscape(r.description),
       csvEscape(r.input),
       csvEscape(r.output),
       ...variableColumns.map(() => csvEscape(r.sampleVariableValue)),
@@ -128,6 +134,7 @@ function buildSampleCsv(
 
 type ParsedItem = {
   name: string;
+  description: string;
   input: string;
   output: string;
   evaluators: EvaluatorRef[];
@@ -236,6 +243,7 @@ export function BulkUploadLlmGeneralItemsDialog({
       complete: (results) => {
         const headers = results.meta.fields ?? [];
         const nameKey = findHeaderKey(headers, NAME_HEADERS);
+        const descriptionKey = findHeaderKey(headers, DESCRIPTION_HEADERS);
         const inputKey = findHeaderKey(headers, INPUT_HEADERS);
         const outputKey = findHeaderKey(headers, OUTPUT_HEADERS);
         if (!nameKey || !inputKey || !outputKey) {
@@ -308,6 +316,9 @@ export function BulkUploadLlmGeneralItemsDialog({
         for (let i = 0; i < results.data.length; i++) {
           const r = results.data[i];
           const name = (r[nameKey] ?? "").trim();
+          const description = descriptionKey
+            ? (r[descriptionKey] ?? "").trim()
+            : "";
           const input = (r[inputKey] ?? "").trim();
           const output = (r[outputKey] ?? "").trim();
           const anyVariableValue = evaluatorsWithVariables.some((e) =>
@@ -382,7 +393,14 @@ export function BulkUploadLlmGeneralItemsDialog({
               });
             }
           }
-          items.push({ name, input, output, evaluators: refs, annotations });
+          items.push({
+            name,
+            description,
+            input,
+            output,
+            evaluators: refs,
+            annotations,
+          });
         }
         if (items.length === 0) {
           setParseError("No rows with content were found in the CSV.");
@@ -425,6 +443,7 @@ export function BulkUploadLlmGeneralItemsDialog({
         return {
           payload: {
             name: p.name,
+            ...(p.description ? { description: p.description } : {}),
             input: p.input,
             output: p.output,
             ...(Object.keys(evaluator_variables).length > 0
@@ -499,6 +518,12 @@ export function BulkUploadLlmGeneralItemsDialog({
       }
     }
 
+    columns.push({
+      name: "description",
+      description:
+        "(optional) A description of this item. Shown to annotators alongside the evaluators while they label.",
+    });
+
     return {
       title: "Bulk upload — LLM response labelling items",
       intro:
@@ -529,9 +554,16 @@ export function BulkUploadLlmGeneralItemsDialog({
           },
         ])
       : [];
+  // Surface a Description column in the preview only when at least one row
+  // carries a non-empty description — keeps the preview tight for the common
+  // case where descriptions aren't used.
+  const showDescriptionColumn = parsedItems.some(
+    (p) => p.description.trim().length > 0,
+  );
   const gridStyle = {
     gridTemplateColumns: [
       "minmax(80px, 140px)",
+      ...(showDescriptionColumn ? ["minmax(120px, 200px)"] : []),
       "minmax(120px, 220px)",
       "minmax(120px, 220px)",
       ...variableColumns.map(() => "minmax(120px, 200px)"),
@@ -552,6 +584,11 @@ export function BulkUploadLlmGeneralItemsDialog({
         style={gridStyle}
       >
         <div className="text-xs font-medium text-muted-foreground">Name</div>
+        {showDescriptionColumn && (
+          <div className="text-xs font-medium text-muted-foreground">
+            Description
+          </div>
+        )}
         <div className="text-xs font-medium text-muted-foreground">Input</div>
         <div className="text-xs font-medium text-muted-foreground">Output</div>
         {variableColumns.map((c) => (
@@ -593,6 +630,14 @@ export function BulkUploadLlmGeneralItemsDialog({
               <div className="truncate text-foreground" title={p.name}>
                 {p.name || <span className="text-muted-foreground">—</span>}
               </div>
+              {showDescriptionColumn && (
+                <div
+                  className="min-w-0 max-h-24 overflow-y-auto pr-1 leading-snug text-foreground break-words whitespace-pre-wrap"
+                  title={p.description || undefined}
+                >
+                  {p.description}
+                </div>
+              )}
               <div
                 className="min-w-0 max-h-24 overflow-y-auto pr-1 leading-snug text-foreground break-words whitespace-pre-wrap"
                 title={p.input}

--- a/src/components/human-labelling/BulkUploadLlmGeneralItemsDialog.tsx
+++ b/src/components/human-labelling/BulkUploadLlmGeneralItemsDialog.tsx
@@ -1,145 +1,73 @@
 "use client";
 
-import { useEffect, useState } from "react";
-import Papa from "papaparse";
-import { apiClient } from "@/lib/api";
 import {
-  AnnotationOptIn,
-  BulkUploadDialogShell,
-  BulkUploadItemsPreviewShell,
-  type EvaluatorMeta,
-  type GuidelineColumn,
-  type GuidelineDoc,
-  type ParsedAnnotation,
-  buildItemAnnotationsPayload,
-  bulkUploadAnnotatedRowBgClass,
-  duplicateEvaluatorNames,
-  evaluatorReasoningColumn,
-  evaluatorValueColumn,
-  findHeaderKey,
-  parseAnnotationCell,
-  parseApiError,
-  sampleEvaluatorValue,
-  useAnnotatedItemsCheck,
-  useAnnotators,
-} from "./bulk-upload-shared";
+  BulkUploadItemsDialog,
+  type BulkContentColumn,
+  type BulkLinkedEvaluator,
+  type BulkSampleRow,
+} from "./BulkUploadItemsDialog";
 
-type EvaluatorVariableDef = {
-  name: string;
-  description?: string;
-  default?: string;
-};
+export type LlmGeneralLinkedEvaluator = BulkLinkedEvaluator;
 
-export type LlmGeneralLinkedEvaluator = {
-  uuid: string;
-  name: string;
-  slug: string | null;
-  variables: EvaluatorVariableDef[];
-  output_type: "binary" | "rating" | null;
-  scale_min: number | null;
-  scale_max: number | null;
-};
-
-type EvaluatorRef = {
-  evaluator_uuid: string;
-  variable_values?: Record<string, string>;
-};
-
-const NAME_HEADERS = ["name", "title", "label", "item_name"];
-const DESCRIPTION_HEADERS = ["description", "desc", "notes"];
-const INPUT_HEADERS = ["input", "prompt", "question", "request"];
-const OUTPUT_HEADERS = ["output", "response", "completion", "answer", "reply"];
-
-function csvEscape(s: string): string {
-  return `"${s.replace(/"/g, '""')}"`;
+// Plain-text input/output renderer shared by both content columns.
+function textPreview(value: unknown) {
+  return (
+    <div className="max-h-24 overflow-y-auto pr-1 leading-snug text-foreground break-words whitespace-pre-wrap">
+      {(value as string) ?? ""}
+    </div>
+  );
 }
 
-// Column header for an evaluator variable, e.g. "Correctness/criteria".
-// One column per variable per evaluator — keeps the CSV flat instead of
-// asking users to hand-author JSON in a single cell.
-function variableColumnName(evalName: string, varName: string): string {
-  return `${evalName}/${varName}`;
-}
+// Content columns specific to non-conversational ("llm-general") items: a
+// single input given to the model and the output it produced.
+const CONTENT_COLUMNS: BulkContentColumn[] = [
+  {
+    payloadKey: "input",
+    csvColumn: "input",
+    headerCandidates: ["input", "prompt", "question", "request"],
+    previewLabel: "Input",
+    previewWidth: "minmax(120px, 220px)",
+    guidelineDescription: "Required. The prompt or input given to the LLM.",
+    parse: (raw) => ({ value: raw }),
+    renderPreview: textPreview,
+  },
+  {
+    payloadKey: "output",
+    csvColumn: "output",
+    headerCandidates: ["output", "response", "completion", "answer", "reply"],
+    previewLabel: "Output",
+    previewWidth: "minmax(120px, 220px)",
+    guidelineDescription:
+      "Required. The output the LLM produced for that input.",
+    parse: (raw) => ({ value: raw }),
+    renderPreview: textPreview,
+  },
+];
 
-const SAMPLE_BASE_ROWS: Array<{
-  name: string;
-  description: string;
-  input: string;
-  output: string;
-  sampleVariableValue: string;
-  reasoning: string;
-}> = [
+const SAMPLE_ROWS: BulkSampleRow[] = [
   {
     name: "Summary 1",
     description: "Summarisation quality check.",
-    input: "Summarise: The cat sat on the mat and then went to sleep.",
-    output: "A cat sat on a mat and fell asleep.",
-    sampleVariableValue:
+    content: {
+      input: "Summarise: The cat sat on the mat and then went to sleep.",
+      output: "A cat sat on a mat and fell asleep.",
+    },
+    variableValue:
       "The summary should be accurate, concise, and capture the key facts.",
     reasoning: "Accurate and concise.",
   },
   {
     name: "Classification 1",
     description: "",
-    input: "Classify the sentiment: I absolutely loved this product!",
-    output: "positive",
-    sampleVariableValue:
+    content: {
+      input: "Classify the sentiment: I absolutely loved this product!",
+      output: "positive",
+    },
+    variableValue:
       "The label should correctly reflect the sentiment of the text.",
     reasoning: "",
   },
 ];
-
-function buildSampleCsv(
-  linked: LlmGeneralLinkedEvaluator[],
-  includeAnnotations: boolean,
-): string {
-  const variableColumns: { evalName: string; varName: string }[] = [];
-  for (const e of linked) {
-    for (const v of e.variables) {
-      variableColumns.push({ evalName: e.name, varName: v.name });
-    }
-  }
-  const headerCells = [
-    "name",
-    "description",
-    "input",
-    "output",
-    ...variableColumns.map((c) =>
-      csvEscape(variableColumnName(c.evalName, c.varName)),
-    ),
-    ...(includeAnnotations
-      ? linked.flatMap((e) => [
-          csvEscape(evaluatorValueColumn(e.name)),
-          csvEscape(evaluatorReasoningColumn(e.name)),
-        ])
-      : []),
-  ];
-  const lines = SAMPLE_BASE_ROWS.map((r) =>
-    [
-      csvEscape(r.name),
-      csvEscape(r.description),
-      csvEscape(r.input),
-      csvEscape(r.output),
-      ...variableColumns.map(() => csvEscape(r.sampleVariableValue)),
-      ...(includeAnnotations
-        ? linked.flatMap((e) => [
-            csvEscape(sampleEvaluatorValue(e)),
-            csvEscape(r.reasoning),
-          ])
-        : []),
-    ].join(","),
-  );
-  return `${headerCells.join(",")}\n${lines.join("\n")}\n`;
-}
-
-type ParsedItem = {
-  name: string;
-  description: string;
-  input: string;
-  output: string;
-  evaluators: EvaluatorRef[];
-  annotations: ParsedAnnotation[];
-};
 
 type BulkUploadLlmGeneralItemsDialogProps = {
   isOpen: boolean;
@@ -158,617 +86,19 @@ export function BulkUploadLlmGeneralItemsDialog({
   onClose,
   onSuccess,
 }: BulkUploadLlmGeneralItemsDialogProps) {
-  const [csvFile, setCsvFile] = useState<File | null>(null);
-  const [parsedItems, setParsedItems] = useState<ParsedItem[]>([]);
-  const [parseError, setParseError] = useState<string | null>(null);
-  const [isUploading, setIsUploading] = useState(false);
-  const [uploadError, setUploadError] = useState<string | null>(null);
-  const [uploadAnnotations, setUploadAnnotations] = useState(false);
-  const [selectedAnnotatorId, setSelectedAnnotatorId] = useState<string | null>(
-    null,
-  );
-  const annotatorsState = useAnnotators(isOpen, accessToken);
-  const { annotatedCheck, annotatedCheckLoading } = useAnnotatedItemsCheck({
-    enabled:
-      uploadAnnotations && !!selectedAnnotatorId && parsedItems.length > 0,
-    taskUuid,
-    accessToken,
-    annotatorId: selectedAnnotatorId,
-    namedItems: parsedItems,
-  });
-
-  const annotationEvaluatorsMeta: EvaluatorMeta[] = linkedEvaluators.map(
-    (e) => ({
-      uuid: e.uuid,
-      name: e.name,
-      output_type: e.output_type,
-      scale_min: e.scale_min,
-      scale_max: e.scale_max,
-    }),
-  );
-
-  // Evaluators without a usable output_type can't be annotated here — the
-  // parser would silently drop their column and produce a half-labelled
-  // batch. Block the annotation flow rather than failing later.
-  const evaluatorsMissingOutputType = annotationEvaluatorsMeta.filter(
-    (e) => e.output_type !== "binary" && e.output_type !== "rating",
-  );
-
-  // Two linked evaluators with the same name produce duplicate CSV headers —
-  // this also breaks the `<evalName>/<varName>` variable columns, so it has
-  // to block regardless of whether the user is uploading annotations.
-  const duplicateNames = duplicateEvaluatorNames(annotationEvaluatorsMeta);
-
-  const evaluatorsWithVariables = linkedEvaluators.filter(
-    (e) => e.variables.length > 0,
-  );
-
-  const reset = () => {
-    setCsvFile(null);
-    setParsedItems([]);
-    setParseError(null);
-    setUploadError(null);
-    setUploadAnnotations(false);
-    setSelectedAnnotatorId(null);
-  };
-
-  useEffect(() => {
-    if (isOpen) reset();
-  }, [isOpen]);
-
-  useEffect(() => {
-    setParsedItems([]);
-    setParseError(null);
-    setCsvFile(null);
-  }, [uploadAnnotations]);
-
-  const handleFile = (file: File | null) => {
-    setUploadError(null);
-    setParseError(null);
-    setParsedItems([]);
-    setCsvFile(file);
-    if (!file) return;
-    if (duplicateNames.length > 0) {
-      setParseError(
-        `Two or more linked evaluators share the same name (${duplicateNames
-          .map((n) => `"${n}"`)
-          .join(", ")}). Rename one before uploading.`,
-      );
-      return;
-    }
-    Papa.parse<Record<string, string>>(file, {
-      header: true,
-      skipEmptyLines: true,
-      transformHeader: (h) => h.trim(),
-      complete: (results) => {
-        const headers = results.meta.fields ?? [];
-        const nameKey = findHeaderKey(headers, NAME_HEADERS);
-        const descriptionKey = findHeaderKey(headers, DESCRIPTION_HEADERS);
-        const inputKey = findHeaderKey(headers, INPUT_HEADERS);
-        const outputKey = findHeaderKey(headers, OUTPUT_HEADERS);
-        if (!nameKey || !inputKey || !outputKey) {
-          setParseError(
-            `CSV must include "name", "input" and "output" columns. Found: ${headers.join(", ") || "(none)"}`,
-          );
-          return;
-        }
-
-        // Resolve a column for each evaluator variable up front.
-        const variableHeaderMap = new Map<
-          string,
-          {
-            evaluator: LlmGeneralLinkedEvaluator;
-            varName: string;
-            columnKey: string;
-          }[]
-        >();
-        const missingColumns: string[] = [];
-        for (const e of evaluatorsWithVariables) {
-          const slots: {
-            evaluator: LlmGeneralLinkedEvaluator;
-            varName: string;
-            columnKey: string;
-          }[] = [];
-          for (const v of e.variables) {
-            const expected = variableColumnName(e.name, v.name);
-            const key = headers.find((h) => h === expected);
-            if (!key) {
-              missingColumns.push(expected);
-              continue;
-            }
-            slots.push({ evaluator: e, varName: v.name, columnKey: key });
-          }
-          variableHeaderMap.set(e.uuid, slots);
-        }
-        if (missingColumns.length > 0) {
-          setParseError(
-            `CSV is missing column(s) for evaluator variables: ${missingColumns
-              .map((c) => `"${c}"`)
-              .join(", ")}. Download the sample CSV above for the exact format.`,
-          );
-          return;
-        }
-
-        if (uploadAnnotations) {
-          if (evaluatorsMissingOutputType.length > 0) {
-            setParseError(
-              `Annotation upload is unavailable: evaluator(s) ${evaluatorsMissingOutputType
-                .map((e) => `"${e.name}"`)
-                .join(", ")} have no binary/rating output configured.`,
-            );
-            return;
-          }
-          const missing: string[] = [];
-          for (const meta of annotationEvaluatorsMeta) {
-            const valueHeader = evaluatorValueColumn(meta.name);
-            if (!headers.includes(valueHeader)) missing.push(valueHeader);
-          }
-          if (missing.length > 0) {
-            setParseError(
-              `CSV is missing annotation column(s): ${missing
-                .map((c) => `"${c}"`)
-                .join(", ")}.`,
-            );
-            return;
-          }
-        }
-        const items: ParsedItem[] = [];
-        for (let i = 0; i < results.data.length; i++) {
-          const r = results.data[i];
-          const name = (r[nameKey] ?? "").trim();
-          const description = descriptionKey
-            ? (r[descriptionKey] ?? "").trim()
-            : "";
-          const input = (r[inputKey] ?? "").trim();
-          const output = (r[outputKey] ?? "").trim();
-          const anyVariableValue = evaluatorsWithVariables.some((e) =>
-            (variableHeaderMap.get(e.uuid) ?? []).some(
-              (slot) => (r[slot.columnKey] ?? "").trim() !== "",
-            ),
-          );
-          if (!name && !input && !output && !anyVariableValue) continue;
-          if (!name) {
-            setParseError(`Row ${i + 1}: "name" is required.`);
-            return;
-          }
-          if (!input || !output) {
-            setParseError(
-              `Row ${i + 1}: both "input" and "output" are required.`,
-            );
-            return;
-          }
-
-          const refs: EvaluatorRef[] = [];
-          let rowError: string | null = null;
-          for (const e of evaluatorsWithVariables) {
-            const slots = variableHeaderMap.get(e.uuid) ?? [];
-            const variableValues: Record<string, string> = {};
-            for (const slot of slots) {
-              const raw = (r[slot.columnKey] ?? "").trim();
-              if (!raw) {
-                rowError = `Row ${i + 1}: missing value for "${variableColumnName(
-                  e.name,
-                  slot.varName,
-                )}".`;
-                break;
-              }
-              variableValues[slot.varName] = raw;
-            }
-            if (rowError) break;
-            refs.push({ evaluator_uuid: e.uuid, variable_values: variableValues });
-          }
-          if (rowError) {
-            setParseError(rowError);
-            return;
-          }
-
-          const annotations: ParsedAnnotation[] = [];
-          if (uploadAnnotations) {
-            for (const meta of annotationEvaluatorsMeta) {
-              if (
-                meta.output_type !== "binary" &&
-                meta.output_type !== "rating"
-              )
-                continue;
-              const valueHeader = evaluatorValueColumn(meta.name);
-              const reasoningHeader = evaluatorReasoningColumn(meta.name);
-              const rawValue = (r[valueHeader] ?? "").trim();
-              const rawReasoning = (r[reasoningHeader] ?? "").trim();
-              if (!rawValue) {
-                setParseError(
-                  `Row ${i + 1}: missing value for "${valueHeader}".`,
-                );
-                return;
-              }
-              const parsed = parseAnnotationCell(rawValue, meta);
-              if ("error" in parsed) {
-                setParseError(`Row ${i + 1}: ${parsed.error}.`);
-                return;
-              }
-              annotations.push({
-                evaluator_uuid: meta.uuid,
-                output_type: meta.output_type,
-                value: parsed.value,
-                reasoning: rawReasoning,
-              });
-            }
-          }
-          items.push({
-            name,
-            description,
-            input,
-            output,
-            evaluators: refs,
-            annotations,
-          });
-        }
-        if (items.length === 0) {
-          setParseError("No rows with content were found in the CSV.");
-          return;
-        }
-        setParsedItems(items);
-      },
-      error: (err) => setParseError(err.message || "Failed to parse CSV"),
-    });
-  };
-
-  const handleUpload = async () => {
-    if (parsedItems.length === 0 || isUploading) return;
-    if (uploadAnnotations && !selectedAnnotatorId) {
-      setUploadError("Select an annotator before uploading.");
-      return;
-    }
-    if (uploadAnnotations && evaluatorsMissingOutputType.length > 0) {
-      setUploadError(
-        "One or more evaluators have no binary/rating output configured.",
-      );
-      return;
-    }
-    setIsUploading(true);
-    setUploadError(null);
-    try {
-      const itemsBody = parsedItems.map((p) => {
-        const evaluator_variables: Record<
-          string,
-          Record<string, string>
-        > = {};
-        for (const ref of p.evaluators) {
-          if (ref.variable_values) {
-            evaluator_variables[ref.evaluator_uuid] = { ...ref.variable_values };
-          }
-        }
-        const annotationsObj = uploadAnnotations
-          ? buildItemAnnotationsPayload(p.annotations)
-          : undefined;
-        return {
-          payload: {
-            name: p.name,
-            ...(p.description ? { description: p.description } : {}),
-            input: p.input,
-            output: p.output,
-            ...(Object.keys(evaluator_variables).length > 0
-              ? { evaluator_variables }
-              : {}),
-          },
-          ...(annotationsObj ? { annotations: annotationsObj } : {}),
-        };
-      });
-      const anyAnnotated = itemsBody.some((it) => "annotations" in it);
-      await apiClient(`/annotation-tasks/${taskUuid}/items`, accessToken, {
-        method: "POST",
-        body: {
-          ...(anyAnnotated && selectedAnnotatorId
-            ? { annotator_id: selectedAnnotatorId }
-            : {}),
-          items: itemsBody,
-        },
-      });
-      onSuccess(parsedItems.length, uploadAnnotations);
-    } catch (err) {
-      setUploadError(parseApiError(err, "Failed to upload items"));
-    } finally {
-      setIsUploading(false);
-    }
-  };
-
-  const buildGuidelines = (): GuidelineDoc => {
-    const columns: GuidelineColumn[] = [
-      {
-        name: "name",
-        description: "Required. A unique name for the item.",
-      },
-      {
-        name: "input",
-        description: "Required. The prompt or input given to the LLM.",
-      },
-      {
-        name: "output",
-        description: "Required. The output the LLM produced for that input.",
-      },
-    ];
-
-    for (const e of evaluatorsWithVariables) {
-      for (const v of e.variables) {
-        const desc = v.description ? ` — ${v.description}` : "";
-        columns.push({
-          name: variableColumnName(e.name, v.name),
-          description: `Required. Used for the "${e.name}" evaluator${desc}`,
-        });
-      }
-    }
-
-    if (uploadAnnotations && annotationEvaluatorsMeta.length > 0) {
-      for (const e of annotationEvaluatorsMeta) {
-        const range =
-          e.output_type === "binary"
-            ? "true/false"
-            : e.output_type === "rating" &&
-                typeof e.scale_min === "number" &&
-                typeof e.scale_max === "number"
-              ? `any value between ${e.scale_min}-${e.scale_max}`
-              : "value";
-        columns.push({
-          name: evaluatorValueColumn(e.name),
-          description: `Required. Value for the "${e.name}" evaluator (${range}).`,
-        });
-        columns.push({
-          name: evaluatorReasoningColumn(e.name),
-          description: `(optional) Reasoning for the value assigned to "${e.name}".`,
-        });
-      }
-    }
-
-    columns.push({
-      name: "description",
-      description:
-        "(optional) A description of this item. Shown to annotators alongside the evaluators while they label.",
-    });
-
-    return {
-      title: "Bulk upload — LLM response labelling items",
-      intro:
-        "Upload a CSV with the following columns. Each row creates one non-conversational LLM evaluation item.",
-      columns,
-    };
-  };
-
-  const variableColumns = evaluatorsWithVariables.flatMap((e) =>
-    e.variables.map((v) => ({
-      evaluatorUuid: e.uuid,
-      varName: v.name,
-      header: variableColumnName(e.name, v.name),
-    })),
-  );
-  const annotationColumns =
-    uploadAnnotations && annotationEvaluatorsMeta.length > 0
-      ? annotationEvaluatorsMeta.flatMap((e) => [
-          {
-            evaluatorUuid: e.uuid,
-            kind: "value" as const,
-            header: evaluatorValueColumn(e.name),
-          },
-          {
-            evaluatorUuid: e.uuid,
-            kind: "reasoning" as const,
-            header: evaluatorReasoningColumn(e.name),
-          },
-        ])
-      : [];
-  // Surface a Description column in the preview only when at least one row
-  // carries a non-empty description — keeps the preview tight for the common
-  // case where descriptions aren't used.
-  const showDescriptionColumn = parsedItems.some(
-    (p) => p.description.trim().length > 0,
-  );
-  const gridStyle = {
-    gridTemplateColumns: [
-      "minmax(80px, 140px)",
-      ...(showDescriptionColumn ? ["minmax(120px, 200px)"] : []),
-      "minmax(120px, 220px)",
-      "minmax(120px, 220px)",
-      ...variableColumns.map(() => "minmax(120px, 200px)"),
-      ...annotationColumns.map((c) =>
-        c.kind === "value" ? "minmax(64px, 88px)" : "minmax(100px, 176px)",
-      ),
-    ].join(" "),
-  };
-
-  const itemsPreview = (
-    <BulkUploadItemsPreviewShell
-      itemCount={parsedItems.length}
-      annotatedCheckLoading={annotatedCheckLoading}
-      annotatedCheck={annotatedCheck}
-    >
-      <div
-        className="grid gap-2 px-3 py-2 border-b border-border bg-muted sticky top-0 z-10"
-        style={gridStyle}
-      >
-        <div className="text-xs font-medium text-muted-foreground">Name</div>
-        {showDescriptionColumn && (
-          <div className="text-xs font-medium text-muted-foreground">
-            Description
-          </div>
-        )}
-        <div className="text-xs font-medium text-muted-foreground">Input</div>
-        <div className="text-xs font-medium text-muted-foreground">Output</div>
-        {variableColumns.map((c) => (
-          <div
-            key={`h-${c.evaluatorUuid}-${c.varName}`}
-            className="text-xs font-medium text-muted-foreground font-mono truncate"
-            title={c.header}
-          >
-            {c.header}
-          </div>
-        ))}
-        {annotationColumns.map((c) => (
-          <div
-            key={`ah-${c.evaluatorUuid}-${c.kind}`}
-            className="text-xs font-medium text-muted-foreground font-mono truncate"
-            title={c.header}
-          >
-            {c.header}
-          </div>
-        ))}
-      </div>
-      <div className="divide-y divide-border">
-        {parsedItems.slice(0, 50).map((p, idx) => {
-          const valuesByKey = new Map<string, string>();
-          for (const ref of p.evaluators) {
-            if (!ref.variable_values) continue;
-            for (const [varName, value] of Object.entries(
-              ref.variable_values,
-            )) {
-              valuesByKey.set(`${ref.evaluator_uuid}/${varName}`, value);
-            }
-          }
-          return (
-            <div
-              key={idx}
-              className={`grid gap-2 px-3 py-2 text-xs items-start ${bulkUploadAnnotatedRowBgClass(idx, annotatedCheck)}`}
-              style={gridStyle}
-            >
-              <div className="truncate text-foreground" title={p.name}>
-                {p.name || <span className="text-muted-foreground">—</span>}
-              </div>
-              {showDescriptionColumn && (
-                <div
-                  className="min-w-0 max-h-24 overflow-y-auto pr-1 leading-snug text-foreground break-words whitespace-pre-wrap"
-                  title={p.description || undefined}
-                >
-                  {p.description}
-                </div>
-              )}
-              <div
-                className="min-w-0 max-h-24 overflow-y-auto pr-1 leading-snug text-foreground break-words whitespace-pre-wrap"
-                title={p.input}
-              >
-                {p.input}
-              </div>
-              <div
-                className="min-w-0 max-h-24 overflow-y-auto pr-1 leading-snug text-foreground break-words whitespace-pre-wrap"
-                title={p.output}
-              >
-                {p.output}
-              </div>
-              {variableColumns.map((c) => {
-                const value =
-                  valuesByKey.get(`${c.evaluatorUuid}/${c.varName}`) ?? "";
-                return (
-                  <div
-                    key={`${idx}-${c.evaluatorUuid}-${c.varName}`}
-                    className="min-w-0 max-h-24 overflow-y-auto pr-1 leading-snug text-foreground break-words whitespace-pre-wrap"
-                  >
-                    {value}
-                  </div>
-                );
-              })}
-              {annotationColumns.map((c) => {
-                const ann = p.annotations.find(
-                  (a) => a.evaluator_uuid === c.evaluatorUuid,
-                );
-                const display =
-                  c.kind === "value"
-                    ? ann
-                      ? typeof ann.value === "boolean"
-                        ? ann.value
-                          ? "true"
-                          : "false"
-                        : String(ann.value)
-                      : ""
-                    : (ann?.reasoning ?? "");
-                return (
-                  <div
-                    key={`${idx}-a-${c.evaluatorUuid}-${c.kind}`}
-                    className="min-w-0 max-h-24 overflow-y-auto pr-1 leading-snug text-foreground break-words whitespace-pre-wrap"
-                  >
-                    {display}
-                  </div>
-                );
-              })}
-            </div>
-          );
-        })}
-        {parsedItems.length > 50 && (
-          <div className="px-4 py-2 text-xs text-muted-foreground">
-            + {parsedItems.length - 50} more rows
-          </div>
-        )}
-      </div>
-    </BulkUploadItemsPreviewShell>
-  );
-
-  const annotationOptIn =
-    linkedEvaluators.length > 0 || duplicateNames.length > 0 ? (
-      <div className="space-y-3">
-        {linkedEvaluators.length > 0 && (
-          <AnnotationOptIn
-            annotators={annotatorsState.annotators}
-            loading={annotatorsState.loading}
-            error={annotatorsState.error}
-            uploadAnnotations={uploadAnnotations}
-            onToggle={setUploadAnnotations}
-            selectedAnnotatorId={selectedAnnotatorId}
-            onSelectAnnotator={setSelectedAnnotatorId}
-          />
-        )}
-        {duplicateNames.length > 0 && (
-          <div className="rounded-md border border-red-500/30 bg-red-500/10 p-3 text-xs text-red-600 dark:text-red-400">
-            Two or more linked evaluators share the same name (
-            {duplicateNames.map((n) => `"${n}"`).join(", ")}). Their variable
-            and annotation columns would collide in the CSV — rename one on the
-            evaluators page before uploading.
-          </div>
-        )}
-        {uploadAnnotations && evaluatorsMissingOutputType.length > 0 && (
-          <div className="rounded-md border border-red-500/30 bg-red-500/10 p-3 text-xs text-red-600 dark:text-red-400">
-            Annotation upload isn&apos;t available — evaluator(s){" "}
-            {evaluatorsMissingOutputType.map((e) => `"${e.name}"`).join(", ")}{" "}
-            have no binary/rating output configured.
-          </div>
-        )}
-      </div>
-    ) : null;
-
-  const uploadBlocked =
-    duplicateNames.length > 0 ||
-    (uploadAnnotations &&
-      (annotatorsState.annotators.length === 0 ||
-        !selectedAnnotatorId ||
-        evaluatorsMissingOutputType.length > 0));
-
   return (
-    <BulkUploadDialogShell
+    <BulkUploadItemsDialog
       isOpen={isOpen}
-      title="Bulk upload items"
-      buildSampleCsv={() => buildSampleCsv(linkedEvaluators, uploadAnnotations)}
-      sampleFilename={() =>
-        uploadAnnotations
-          ? "sample_llm_response_items_with_annotations.csv"
-          : "sample_llm_response_items.csv"
-      }
-      buildGuidelines={buildGuidelines}
-      guidelinesFilename={() =>
-        uploadAnnotations
-          ? "llm_response_items_csv_guidelines_with_annotations.pdf"
-          : "llm_response_items_csv_guidelines.pdf"
-      }
-      csvFile={csvFile}
-      onFile={handleFile}
-      onClear={reset}
-      parseError={parseError}
-      uploadError={uploadError}
-      isUploading={isUploading}
-      itemCount={parsedItems.length}
-      itemsPreview={itemsPreview}
-      onUpload={handleUpload}
+      accessToken={accessToken}
+      taskUuid={taskUuid}
+      linkedEvaluators={linkedEvaluators}
+      contentColumns={CONTENT_COLUMNS}
+      sampleRows={SAMPLE_ROWS}
+      guidelinesTitle="Bulk upload — LLM response labelling items"
+      guidelinesIntro="Upload a CSV with the following columns. Each row creates one non-conversational LLM evaluation item."
+      sampleFilenameBase="llm_response_items"
       onClose={onClose}
-      topContent={annotationOptIn}
-      uploadBlocked={uploadBlocked}
-      hideUploadSection={
-        duplicateNames.length > 0 ||
-        (uploadAnnotations &&
-          (!selectedAnnotatorId || evaluatorsMissingOutputType.length > 0))
-      }
+      onSuccess={onSuccess}
     />
   );
 }

--- a/src/components/human-labelling/BulkUploadLlmItemsDialog.tsx
+++ b/src/components/human-labelling/BulkUploadLlmItemsDialog.tsx
@@ -1,173 +1,132 @@
 "use client";
 
-import { useEffect, useState } from "react";
-import Papa from "papaparse";
-import { apiClient } from "@/lib/api";
 import { parseJsonLenient } from "@/lib/jsonSanitize";
+import { ChatHistoryPreview, type TurnObject } from "./bulk-upload-shared";
 import {
-  AnnotationOptIn,
-  BulkUploadDialogShell,
-  BulkUploadItemsPreviewShell,
-  ChatHistoryPreview,
-  type EvaluatorMeta,
-  type GuidelineColumn,
-  type GuidelineDoc,
-  type ParsedAnnotation,
-  type TurnObject,
-  buildItemAnnotationsPayload,
-  bulkUploadAnnotatedRowBgClass,
-  duplicateEvaluatorNames,
-  evaluatorReasoningColumn,
-  evaluatorValueColumn,
-  findHeaderKey,
-  parseAnnotationCell,
-  parseApiError,
-  sampleEvaluatorValue,
-  useAnnotatedItemsCheck,
-  useAnnotators,
-} from "./bulk-upload-shared";
+  BulkUploadItemsDialog,
+  type BulkContentColumn,
+  type BulkLinkedEvaluator,
+  type BulkSampleRow,
+} from "./BulkUploadItemsDialog";
 
-type EvaluatorVariableDef = {
-  name: string;
-  description?: string;
-  default?: string;
-};
+export type LinkedEvaluator = BulkLinkedEvaluator;
 
-export type LinkedEvaluator = {
-  uuid: string;
-  name: string;
-  slug: string | null;
-  variables: EvaluatorVariableDef[];
-  output_type: "binary" | "rating" | null;
-  scale_min: number | null;
-  scale_max: number | null;
-};
-
-type EvaluatorRef = {
-  evaluator_uuid: string;
-  variable_values?: Record<string, string>;
-};
-
-type ParsedItem = {
-  name: string;
-  description: string;
-  chat_history: TurnObject[];
-  agent_response: string;
-  evaluators: EvaluatorRef[];
-  annotations: ParsedAnnotation[];
-};
-
-const NAME_HEADERS = ["name", "title"];
-const DESCRIPTION_HEADERS = ["description", "desc", "notes"];
-const CONVERSATION_HEADERS = [
-  "conversation_history",
-  "conversation",
-  "chat_history",
-  "chat_history_json",
-];
-const RESPONSE_HEADERS = [
-  "agent_response",
-  "response",
-  "assistant_response",
-  "ai_response",
-];
-
-function csvEscape(s: string): string {
-  return `"${s.replace(/"/g, '""')}"`;
-}
-
-// Column header for an evaluator variable, e.g. "Correctness/criteria".
-// One column per variable per evaluator — keeps the CSV flat instead of
-// asking users to hand-author JSON in a single "evaluators" cell.
-function variableColumnName(evalName: string, varName: string): string {
-  return `${evalName}/${varName}`;
-}
-
-function buildSampleCsv(
-  linked: LinkedEvaluator[],
-  includeAnnotations: boolean,
-): string {
-  const fallback: LinkedEvaluator[] = [
-    {
-      uuid: "",
-      name: "Correctness",
-      slug: null,
-      variables: [{ name: "criteria" }],
-      output_type: "binary",
-      scale_min: null,
-      scale_max: null,
+// Content columns specific to conversational ("llm") items: a JSON
+// conversation history plus the single agent reply being judged.
+const CONTENT_COLUMNS: BulkContentColumn[] = [
+  {
+    payloadKey: "chat_history",
+    csvColumn: "conversation_history",
+    headerCandidates: [
+      "conversation_history",
+      "conversation",
+      "chat_history",
+      "chat_history_json",
+    ],
+    previewLabel: "Chat history",
+    previewWidth: "minmax(120px, 200px)",
+    guidelineDescription:
+      'A JSON array of chat messages that represents the conversation that has happened so far, before the agent response being judged. Each message is an object with a "role" and "content" field.\n\nrole — either "user" or "assistant"\ncontent — the message said by that role\ncreated_at — (optional) ISO-8601 timestamp for when this turn happened',
+    guidelineExample: `[
+  {"role": "user", "content": "What is your return policy?", "created_at": "2026-05-18T09:14:02Z"},
+  {"role": "assistant", "content": "You can return any item within 30 days."}
+]`,
+    parse: (raw, rowIndex) => {
+      let conversation: unknown;
+      try {
+        conversation = parseJsonLenient(raw);
+      } catch {
+        return {
+          error: `Row ${rowIndex + 1}: "conversation_history" must be valid JSON. Wrap the JSON in double quotes and escape inner double quotes by doubling them.`,
+        };
+      }
+      if (!Array.isArray(conversation) || conversation.length === 0) {
+        return {
+          error: `Row ${rowIndex + 1}: "conversation_history" must be a non-empty array of turn objects.`,
+        };
+      }
+      for (let j = 0; j < conversation.length; j++) {
+        const t = conversation[j];
+        if (
+          !t ||
+          typeof t !== "object" ||
+          typeof (t as TurnObject).role !== "string"
+        ) {
+          return {
+            error: `Row ${rowIndex + 1}, turn ${j + 1}: each turn must be an object with a string "role".`,
+          };
+        }
+      }
+      return { value: conversation as TurnObject[] };
     },
-  ];
-  const evaluators = linked.length > 0 ? linked : fallback;
-  const variableColumns: { evalName: string; varName: string }[] = [];
-  for (const e of evaluators) {
-    for (const v of e.variables) {
-      variableColumns.push({ evalName: e.name, varName: v.name });
-    }
-  }
-
-  const rows = [
-    {
-      name: "Greeting reply",
-      description: "Return policy explanation, friendly tone expected.",
-      conversation: [{ role: "user", content: "What is your return policy?" }],
-      response: "You can return any item within 30 days for a full refund.",
-      sampleVariableValue:
-        "The agent should clearly explain the return policy in a helpful and friendly tone.",
-      sampleReasoning: "The agent answered the policy clearly and politely.",
-    },
-    {
-      name: "Refund flow",
-      description: "",
-      conversation: [{ role: "user", content: "I was charged twice" }],
-      response:
-        "I'm sorry to hear that. Can you confirm the order ID so I can investigate?",
-      sampleVariableValue:
-        "The agent should apologize for the duplicate charge and offer to investigate the order.",
-      sampleReasoning: "",
-    },
-  ];
-
-  const headerCells = [
-    "name",
-    "description",
-    "conversation_history",
-    "agent_response",
-    ...variableColumns.map((c) =>
-      csvEscape(variableColumnName(c.evalName, c.varName)),
+    renderPreview: (value) => (
+      <ChatHistoryPreview turns={(value as TurnObject[]) ?? []} />
     ),
-    ...(includeAnnotations
-      ? evaluators.flatMap((e) => [
-          csvEscape(evaluatorValueColumn(e.name)),
-          csvEscape(evaluatorReasoningColumn(e.name)),
-        ])
-      : []),
-  ];
-  const lines = rows.map((r) =>
-    [
-      csvEscape(r.name),
-      csvEscape(r.description),
-      csvEscape(JSON.stringify(r.conversation)),
-      csvEscape(r.response),
-      ...variableColumns.map(() => csvEscape(r.sampleVariableValue)),
-      ...(includeAnnotations
-        ? evaluators.flatMap((e) => [
-            csvEscape(sampleEvaluatorValue(e)),
-            csvEscape(r.sampleReasoning),
-          ])
-        : []),
-    ].join(","),
-  );
-  return `${headerCells.join(",")}\n${lines.join("\n")}\n`;
-}
+  },
+  {
+    payloadKey: "agent_response",
+    csvColumn: "agent_response",
+    headerCandidates: [
+      "agent_response",
+      "response",
+      "assistant_response",
+      "ai_response",
+    ],
+    previewLabel: "AI reply",
+    previewWidth: "minmax(120px, 200px)",
+    guidelineDescription: "The agent response being judged.",
+    parse: (raw) => ({ value: raw }),
+    renderPreview: (value) => (
+      <div className="max-h-24 overflow-y-auto pr-1 leading-snug text-foreground break-words whitespace-pre-wrap">
+        {(value as string) ?? ""}
+      </div>
+    ),
+  },
+];
 
-function AgentReplyPreview({ agentResponse }: { agentResponse: string }) {
-  return (
-    <div className="max-h-24 overflow-y-auto pr-1 leading-snug text-foreground break-words whitespace-pre-wrap">
-      {agentResponse}
-    </div>
-  );
-}
+const SAMPLE_ROWS: BulkSampleRow[] = [
+  {
+    name: "Greeting reply",
+    description: "Return policy explanation, friendly tone expected.",
+    content: {
+      conversation_history: JSON.stringify([
+        { role: "user", content: "What is your return policy?" },
+      ]),
+      agent_response: "You can return any item within 30 days for a full refund.",
+    },
+    variableValue:
+      "The agent should clearly explain the return policy in a helpful and friendly tone.",
+    reasoning: "The agent answered the policy clearly and politely.",
+  },
+  {
+    name: "Refund flow",
+    description: "",
+    content: {
+      conversation_history: JSON.stringify([
+        { role: "user", content: "I was charged twice" },
+      ]),
+      agent_response:
+        "I'm sorry to hear that. Can you confirm the order ID so I can investigate?",
+    },
+    variableValue:
+      "The agent should apologize for the duplicate charge and offer to investigate the order.",
+    reasoning: "",
+  },
+];
+
+// Sample CSV shows an example variable column even when no evaluators are
+// linked yet.
+const SAMPLE_FALLBACK_EVALUATORS: BulkLinkedEvaluator[] = [
+  {
+    uuid: "",
+    name: "Correctness",
+    slug: null,
+    variables: [{ name: "criteria" }],
+    output_type: "binary",
+    scale_min: null,
+    scale_max: null,
+  },
+];
 
 type BulkUploadLlmItemsDialogProps = {
   isOpen: boolean;
@@ -186,670 +145,20 @@ export function BulkUploadLlmItemsDialog({
   onClose,
   onSuccess,
 }: BulkUploadLlmItemsDialogProps) {
-  const [csvFile, setCsvFile] = useState<File | null>(null);
-  const [parsedItems, setParsedItems] = useState<ParsedItem[]>([]);
-  const [parseError, setParseError] = useState<string | null>(null);
-  const [isUploading, setIsUploading] = useState(false);
-  const [uploadError, setUploadError] = useState<string | null>(null);
-  const [uploadAnnotations, setUploadAnnotations] = useState(false);
-  const [selectedAnnotatorId, setSelectedAnnotatorId] = useState<string | null>(
-    null,
-  );
-  const annotatorsState = useAnnotators(isOpen, accessToken);
-  const { annotatedCheck, annotatedCheckLoading } = useAnnotatedItemsCheck({
-    enabled:
-      uploadAnnotations && !!selectedAnnotatorId && parsedItems.length > 0,
-    taskUuid,
-    accessToken,
-    annotatorId: selectedAnnotatorId,
-    namedItems: parsedItems,
-  });
-
-  const reset = () => {
-    setCsvFile(null);
-    setParsedItems([]);
-    setParseError(null);
-    setUploadError(null);
-    setUploadAnnotations(false);
-    setSelectedAnnotatorId(null);
-  };
-
-  useEffect(() => {
-    if (isOpen) reset();
-  }, [isOpen]);
-
-  // Re-parse when the annotation toggle changes (column requirements differ).
-  useEffect(() => {
-    setParsedItems([]);
-    setParseError(null);
-    setCsvFile(null);
-  }, [uploadAnnotations]);
-
-  const annotationEvaluatorsMeta: EvaluatorMeta[] = linkedEvaluators.map(
-    (e) => ({
-      uuid: e.uuid,
-      name: e.name,
-      output_type: e.output_type,
-      scale_min: e.scale_min,
-      scale_max: e.scale_max,
-    }),
-  );
-
-  // Evaluators without a usable output_type (no live version, or live
-  // version with neither binary nor rating output) can't be annotated
-  // here — the parser would silently drop their column and produce a
-  // half-labelled batch. Block the annotation flow until that's fixed
-  // upstream rather than failing later.
-  const evaluatorsMissingOutputType = annotationEvaluatorsMeta.filter(
-    (e) => e.output_type !== "binary" && e.output_type !== "rating",
-  );
-
-  // Two linked evaluators with the same name produce duplicate CSV
-  // headers — for LLM items this also breaks the always-present
-  // `<evalName>/<varName>` variable columns, so it has to block
-  // regardless of whether the user is uploading annotations.
-  const duplicateNames = duplicateEvaluatorNames(annotationEvaluatorsMeta);
-
-  const evaluatorsWithVariables = linkedEvaluators.filter(
-    (e) => e.variables.length > 0,
-  );
-
-  const handleFile = (file: File | null) => {
-    setUploadError(null);
-    setParseError(null);
-    setParsedItems([]);
-    setCsvFile(file);
-    if (!file) return;
-    if (duplicateNames.length > 0) {
-      setParseError(
-        `Two or more linked evaluators share the same name (${duplicateNames
-          .map((n) => `"${n}"`)
-          .join(", ")}). Rename one before uploading.`,
-      );
-      return;
-    }
-    Papa.parse<Record<string, string>>(file, {
-      header: true,
-      skipEmptyLines: true,
-      transformHeader: (h) => h.trim(),
-      complete: (results) => {
-        const headers = results.meta.fields ?? [];
-        const nameKey = findHeaderKey(headers, NAME_HEADERS);
-        const descriptionKey = findHeaderKey(headers, DESCRIPTION_HEADERS);
-        const conversationKey = findHeaderKey(headers, CONVERSATION_HEADERS);
-        const responseKey = findHeaderKey(headers, RESPONSE_HEADERS);
-
-        if (!nameKey || !conversationKey || !responseKey) {
-          setParseError(
-            `CSV must include "name", "conversation_history" and "agent_response" columns. Found: ${headers.join(", ") || "(none)"}`,
-          );
-          return;
-        }
-
-        const variableHeaderMap = new Map<
-          string,
-          { evaluator: LinkedEvaluator; varName: string; columnKey: string }[]
-        >();
-        const missingColumns: string[] = [];
-        for (const e of evaluatorsWithVariables) {
-          const slots: {
-            evaluator: LinkedEvaluator;
-            varName: string;
-            columnKey: string;
-          }[] = [];
-          for (const v of e.variables) {
-            const expected = variableColumnName(e.name, v.name);
-            const key = headers.find((h) => h === expected);
-            if (!key) {
-              missingColumns.push(expected);
-              continue;
-            }
-            slots.push({ evaluator: e, varName: v.name, columnKey: key });
-          }
-          variableHeaderMap.set(e.uuid, slots);
-        }
-        if (missingColumns.length > 0) {
-          setParseError(
-            `CSV is missing column(s) for evaluator variables: ${missingColumns
-              .map((c) => `"${c}"`)
-              .join(
-                ", ",
-              )}. Download the sample CSV above for the exact format.`,
-          );
-          return;
-        }
-
-        if (uploadAnnotations) {
-          if (evaluatorsMissingOutputType.length > 0) {
-            setParseError(
-              `Annotation upload is unavailable: evaluator(s) ${evaluatorsMissingOutputType
-                .map((e) => `"${e.name}"`)
-                .join(", ")} have no binary/rating output configured.`,
-            );
-            return;
-          }
-          const missingAnnotationCols: string[] = [];
-          for (const meta of annotationEvaluatorsMeta) {
-            const valueHeader = evaluatorValueColumn(meta.name);
-            if (!headers.includes(valueHeader)) {
-              missingAnnotationCols.push(valueHeader);
-            }
-          }
-          if (missingAnnotationCols.length > 0) {
-            setParseError(
-              `CSV is missing annotation column(s): ${missingAnnotationCols
-                .map((c) => `"${c}"`)
-                .join(
-                  ", ",
-                )}. Download the sample CSV above for the exact format.`,
-            );
-            return;
-          }
-        }
-
-        const items: ParsedItem[] = [];
-
-        for (let i = 0; i < results.data.length; i++) {
-          const row = results.data[i];
-          const name = (row[nameKey] ?? "").trim();
-          const description = descriptionKey
-            ? (row[descriptionKey] ?? "").trim()
-            : "";
-          const conversationRaw = (row[conversationKey] ?? "").trim();
-          const responseRaw = (row[responseKey] ?? "").trim();
-
-          const anyVariableValue = evaluatorsWithVariables.some((e) =>
-            (variableHeaderMap.get(e.uuid) ?? []).some(
-              (slot) => (row[slot.columnKey] ?? "").trim() !== "",
-            ),
-          );
-          if (!name && !conversationRaw && !responseRaw && !anyVariableValue)
-            continue;
-
-          if (!name) {
-            setParseError(`Row ${i + 1}: "name" is required.`);
-            return;
-          }
-          if (!conversationRaw) {
-            setParseError(`Row ${i + 1}: "conversation_history" is required.`);
-            return;
-          }
-          if (!responseRaw) {
-            setParseError(`Row ${i + 1}: "agent_response" is required.`);
-            return;
-          }
-
-          let conversation: unknown;
-          try {
-            conversation = parseJsonLenient(conversationRaw);
-          } catch {
-            setParseError(
-              `Row ${i + 1}: "conversation_history" must be valid JSON. Wrap the JSON in double quotes and escape inner double quotes by doubling them.`,
-            );
-            return;
-          }
-          if (!Array.isArray(conversation) || conversation.length === 0) {
-            setParseError(
-              `Row ${i + 1}: "conversation_history" must be a non-empty array of turn objects.`,
-            );
-            return;
-          }
-          for (let j = 0; j < conversation.length; j++) {
-            const t = conversation[j];
-            if (
-              !t ||
-              typeof t !== "object" ||
-              typeof (t as TurnObject).role !== "string"
-            ) {
-              setParseError(
-                `Row ${i + 1}, turn ${j + 1}: each turn must be an object with a string "role".`,
-              );
-              return;
-            }
-          }
-          const turns = conversation as TurnObject[];
-
-          const refs: EvaluatorRef[] = [];
-          let rowError: string | null = null;
-          for (const e of evaluatorsWithVariables) {
-            const slots = variableHeaderMap.get(e.uuid) ?? [];
-            const variableValues: Record<string, string> = {};
-            for (const slot of slots) {
-              const raw = (row[slot.columnKey] ?? "").trim();
-              if (!raw) {
-                rowError = `Row ${i + 1}: missing value for "${variableColumnName(
-                  e.name,
-                  slot.varName,
-                )}".`;
-                break;
-              }
-              variableValues[slot.varName] = raw;
-            }
-            if (rowError) break;
-            refs.push({
-              evaluator_uuid: e.uuid,
-              variable_values: variableValues,
-            });
-          }
-          if (rowError) {
-            setParseError(rowError);
-            return;
-          }
-
-          const annotations: ParsedAnnotation[] = [];
-          if (uploadAnnotations) {
-            for (const meta of annotationEvaluatorsMeta) {
-              if (
-                meta.output_type !== "binary" &&
-                meta.output_type !== "rating"
-              )
-                continue;
-              const valueHeader = evaluatorValueColumn(meta.name);
-              const reasoningHeader = evaluatorReasoningColumn(meta.name);
-              const rawValue = (row[valueHeader] ?? "").trim();
-              const rawReasoning = (row[reasoningHeader] ?? "").trim();
-              if (!rawValue) {
-                setParseError(
-                  `Row ${i + 1}: missing value for "${valueHeader}".`,
-                );
-                return;
-              }
-              const parsed = parseAnnotationCell(rawValue, meta);
-              if ("error" in parsed) {
-                setParseError(`Row ${i + 1}: ${parsed.error}.`);
-                return;
-              }
-              annotations.push({
-                evaluator_uuid: meta.uuid,
-                output_type: meta.output_type,
-                value: parsed.value,
-                reasoning: rawReasoning,
-              });
-            }
-          }
-
-          items.push({
-            name,
-            description,
-            chat_history: turns,
-            agent_response: responseRaw,
-            evaluators: refs,
-            annotations,
-          });
-        }
-
-        if (items.length === 0) {
-          setParseError("No rows with content were found in the CSV.");
-          return;
-        }
-        setParsedItems(items);
-      },
-      error: (err) => setParseError(err.message || "Failed to parse CSV"),
-    });
-  };
-
-  const handleUpload = async () => {
-    if (parsedItems.length === 0 || isUploading) return;
-    if (uploadAnnotations && !selectedAnnotatorId) {
-      setUploadError("Select an annotator before uploading.");
-      return;
-    }
-    if (uploadAnnotations && evaluatorsMissingOutputType.length > 0) {
-      setUploadError(
-        "One or more evaluators have no binary/rating output configured.",
-      );
-      return;
-    }
-    setIsUploading(true);
-    setUploadError(null);
-    try {
-      const itemsBody = parsedItems.map((p) => {
-        const evaluator_variables: Record<string, Record<string, string>> = {};
-        for (const ref of p.evaluators) {
-          if (ref.variable_values) {
-            evaluator_variables[ref.evaluator_uuid] = {
-              ...ref.variable_values,
-            };
-          }
-        }
-        const annotationsObj = uploadAnnotations
-          ? buildItemAnnotationsPayload(p.annotations)
-          : undefined;
-        return {
-          payload: {
-            name: p.name,
-            ...(p.description ? { description: p.description } : {}),
-            chat_history: p.chat_history,
-            agent_response: p.agent_response,
-            evaluator_variables,
-          },
-          ...(annotationsObj ? { annotations: annotationsObj } : {}),
-        };
-      });
-      const anyAnnotated = itemsBody.some((it) => "annotations" in it);
-      await apiClient(`/annotation-tasks/${taskUuid}/items`, accessToken, {
-        method: "POST",
-        body: {
-          ...(anyAnnotated && selectedAnnotatorId
-            ? { annotator_id: selectedAnnotatorId }
-            : {}),
-          items: itemsBody,
-        },
-      });
-      onSuccess(parsedItems.length, uploadAnnotations);
-    } catch (err) {
-      setUploadError(parseApiError(err, "Failed to upload items"));
-    } finally {
-      setIsUploading(false);
-    }
-  };
-
-  const buildGuidelines = (): GuidelineDoc => {
-    const columns: GuidelineColumn[] = [
-      {
-        name: "name",
-        description: "A unique item name.",
-      },
-      {
-        name: "conversation_history",
-        description:
-          'A JSON array of chat messages that represents the conversation that has happened so far, before the agent response being judged. Each message is an object with a "role" and "content" field.\n\nrole — either "user" or "assistant"\ncontent — the message said by that role\ncreated_at — (optional) ISO-8601 timestamp for when this turn happened',
-        example: `[
-  {"role": "user", "content": "What is your return policy?", "created_at": "2026-05-18T09:14:02Z"},
-  {"role": "assistant", "content": "You can return any item within 30 days."}
-]`,
-      },
-      {
-        name: "agent_response",
-        description: "The agent response being judged.",
-      },
-    ];
-
-    for (const e of evaluatorsWithVariables) {
-      for (const v of e.variables) {
-        const desc = v.description ? ` — ${v.description}` : "";
-        columns.push({
-          name: variableColumnName(e.name, v.name),
-          description: `Used for the "${e.name}" evaluator${desc}`,
-        });
-      }
-    }
-
-    if (uploadAnnotations && annotationEvaluatorsMeta.length > 0) {
-      for (const e of annotationEvaluatorsMeta) {
-        const range =
-          e.output_type === "binary"
-            ? "true/false"
-            : e.output_type === "rating" &&
-                typeof e.scale_min === "number" &&
-                typeof e.scale_max === "number"
-              ? `any value between ${e.scale_min}-${e.scale_max}`
-              : "value";
-        columns.push({
-          name: evaluatorValueColumn(e.name),
-          description: `Required. Value for the "${e.name}" evaluator (${range}).`,
-        });
-        columns.push({
-          name: evaluatorReasoningColumn(e.name),
-          description: `(optional) Reasoning for the value assigned to "${e.name}".`,
-        });
-      }
-    }
-
-    columns.push({
-      name: "description",
-      description:
-        "(optional) A description of this item. Shown to annotators alongside the evaluators while they label.",
-    });
-
-    return {
-      title: "Bulk upload — LLM labelling items",
-      intro:
-        "Upload a CSV with the following columns. Each row creates one LLM annotation item.",
-      columns,
-    };
-  };
-
-  const variableColumns = evaluatorsWithVariables.flatMap((e) =>
-    e.variables.map((v) => ({
-      evaluatorUuid: e.uuid,
-      varName: v.name,
-      header: variableColumnName(e.name, v.name),
-    })),
-  );
-  // Annotation columns shown only when uploadAnnotations is on. Two columns
-  // per evaluator (value + reasoning) so the user can verify everything in
-  // the CSV landed correctly before hitting upload.
-  const annotationColumns =
-    uploadAnnotations && annotationEvaluatorsMeta.length > 0
-      ? annotationEvaluatorsMeta.flatMap((e) => [
-          {
-            evaluatorUuid: e.uuid,
-            kind: "value" as const,
-            header: evaluatorValueColumn(e.name),
-          },
-          {
-            evaluatorUuid: e.uuid,
-            kind: "reasoning" as const,
-            header: evaluatorReasoningColumn(e.name),
-          },
-        ])
-      : [];
-  // Surface a Description column in the preview only when at least one
-  // uploaded row carries a non-empty description — keeps the preview tight
-  // for the common case where descriptions aren't used.
-  const showDescriptionColumn = parsedItems.some(
-    (p) => p.description.trim().length > 0,
-  );
-  // Capped column widths so preview cells stay readable without stretching
-  // to fill the dialog; extra columns scroll horizontally.
-  const gridStyle = {
-    gridTemplateColumns: [
-      "minmax(96px, 132px)",
-      ...(showDescriptionColumn ? ["minmax(120px, 200px)"] : []),
-      "minmax(120px, 200px)",
-      "minmax(120px, 200px)",
-      ...variableColumns.map(() => "minmax(120px, 200px)"),
-      ...annotationColumns.map((c) =>
-        c.kind === "value" ? "minmax(64px, 88px)" : "minmax(100px, 176px)",
-      ),
-    ].join(" "),
-  };
-
-  const itemsPreview = (
-    <BulkUploadItemsPreviewShell
-      itemCount={parsedItems.length}
-      annotatedCheckLoading={annotatedCheckLoading}
-      annotatedCheck={annotatedCheck}
-    >
-      <div
-        className="grid gap-2 px-3 py-2 border-b border-border bg-muted sticky top-0 z-10"
-        style={gridStyle}
-      >
-        <div className="text-xs font-medium text-muted-foreground">Name</div>
-        {showDescriptionColumn && (
-          <div className="text-xs font-medium text-muted-foreground">
-            Description
-          </div>
-        )}
-        <div className="text-xs font-medium text-muted-foreground">
-          Chat history
-        </div>
-        <div className="text-xs font-medium text-muted-foreground">
-          AI reply
-        </div>
-        {variableColumns.map((c) => (
-          <div
-            key={`h-${c.evaluatorUuid}-${c.varName}`}
-            className="text-xs font-medium text-muted-foreground font-mono truncate"
-            title={c.header}
-          >
-            {c.header}
-          </div>
-        ))}
-        {annotationColumns.map((c) => (
-          <div
-            key={`ah-${c.evaluatorUuid}-${c.kind}`}
-            className="text-xs font-medium text-muted-foreground font-mono truncate"
-            title={c.header}
-          >
-            {c.header}
-          </div>
-        ))}
-      </div>
-      <div className="divide-y divide-border">
-        {parsedItems.slice(0, 50).map((p, idx) => {
-          const valuesByKey = new Map<string, string>();
-          for (const ref of p.evaluators) {
-            if (!ref.variable_values) continue;
-            for (const [varName, value] of Object.entries(
-              ref.variable_values,
-            )) {
-              valuesByKey.set(`${ref.evaluator_uuid}/${varName}`, value);
-            }
-          }
-          return (
-            <div
-              key={idx}
-              className={`grid gap-2 px-3 py-2 text-xs items-start ${bulkUploadAnnotatedRowBgClass(idx, annotatedCheck)}`}
-              style={gridStyle}
-            >
-              <div className="truncate text-foreground" title={p.name}>
-                {p.name}
-              </div>
-              {showDescriptionColumn && (
-                <div
-                  className="min-w-0 max-h-24 overflow-y-auto pr-1 leading-snug text-foreground break-words whitespace-pre-wrap"
-                  title={p.description || undefined}
-                >
-                  {p.description}
-                </div>
-              )}
-              <div className="min-w-0">
-                <ChatHistoryPreview turns={p.chat_history} />
-              </div>
-              <div className="min-w-0">
-                <AgentReplyPreview agentResponse={p.agent_response} />
-              </div>
-              {variableColumns.map((c) => {
-                const value =
-                  valuesByKey.get(`${c.evaluatorUuid}/${c.varName}`) ?? "";
-                return (
-                  <div
-                    key={`${idx}-${c.evaluatorUuid}-${c.varName}`}
-                    className="min-w-0 max-h-24 overflow-y-auto pr-1 leading-snug text-foreground break-words whitespace-pre-wrap"
-                  >
-                    {value}
-                  </div>
-                );
-              })}
-              {annotationColumns.map((c) => {
-                const ann = p.annotations.find(
-                  (a) => a.evaluator_uuid === c.evaluatorUuid,
-                );
-                const display =
-                  c.kind === "value"
-                    ? ann
-                      ? typeof ann.value === "boolean"
-                        ? ann.value
-                          ? "true"
-                          : "false"
-                        : String(ann.value)
-                      : ""
-                    : (ann?.reasoning ?? "");
-                return (
-                  <div
-                    key={`${idx}-a-${c.evaluatorUuid}-${c.kind}`}
-                    className="min-w-0 max-h-24 overflow-y-auto pr-1 leading-snug text-foreground break-words whitespace-pre-wrap"
-                  >
-                    {display}
-                  </div>
-                );
-              })}
-            </div>
-          );
-        })}
-        {parsedItems.length > 50 && (
-          <div className="px-4 py-2 text-xs text-muted-foreground">
-            + {parsedItems.length - 50} more rows
-          </div>
-        )}
-      </div>
-    </BulkUploadItemsPreviewShell>
-  );
-
-  const annotationOptIn =
-    linkedEvaluators.length > 0 || duplicateNames.length > 0 ? (
-      <div className="space-y-3">
-        {linkedEvaluators.length > 0 && (
-          <AnnotationOptIn
-            annotators={annotatorsState.annotators}
-            loading={annotatorsState.loading}
-            error={annotatorsState.error}
-            uploadAnnotations={uploadAnnotations}
-            onToggle={setUploadAnnotations}
-            selectedAnnotatorId={selectedAnnotatorId}
-            onSelectAnnotator={setSelectedAnnotatorId}
-          />
-        )}
-        {duplicateNames.length > 0 && (
-          <div className="rounded-md border border-red-500/30 bg-red-500/10 p-3 text-xs text-red-600 dark:text-red-400">
-            Two or more linked evaluators share the same name (
-            {duplicateNames.map((n) => `"${n}"`).join(", ")}). Their variable
-            and annotation columns would collide in the CSV — rename one on the
-            evaluators page before uploading.
-          </div>
-        )}
-        {uploadAnnotations && evaluatorsMissingOutputType.length > 0 && (
-          <div className="rounded-md border border-red-500/30 bg-red-500/10 p-3 text-xs text-red-600 dark:text-red-400">
-            Annotation upload isn&apos;t available — evaluator(s){" "}
-            {evaluatorsMissingOutputType.map((e) => `"${e.name}"`).join(", ")}{" "}
-            have no binary/rating output configured.
-          </div>
-        )}
-      </div>
-    ) : null;
-
-  const uploadBlocked =
-    duplicateNames.length > 0 ||
-    (uploadAnnotations &&
-      (annotatorsState.annotators.length === 0 ||
-        !selectedAnnotatorId ||
-        evaluatorsMissingOutputType.length > 0));
-
   return (
-    <BulkUploadDialogShell
+    <BulkUploadItemsDialog
       isOpen={isOpen}
-      title="Bulk upload items"
-      buildSampleCsv={() => buildSampleCsv(linkedEvaluators, uploadAnnotations)}
-      sampleFilename={() =>
-        uploadAnnotations
-          ? "sample_llm_items_with_annotations.csv"
-          : "sample_llm_items.csv"
-      }
-      buildGuidelines={buildGuidelines}
-      guidelinesFilename={() =>
-        uploadAnnotations
-          ? "llm_items_csv_guidelines_with_annotations.pdf"
-          : "llm_items_csv_guidelines.pdf"
-      }
-      csvFile={csvFile}
-      onFile={handleFile}
-      onClear={reset}
-      parseError={parseError}
-      uploadError={uploadError}
-      isUploading={isUploading}
-      itemCount={parsedItems.length}
-      itemsPreview={itemsPreview}
-      onUpload={handleUpload}
+      accessToken={accessToken}
+      taskUuid={taskUuid}
+      linkedEvaluators={linkedEvaluators}
+      contentColumns={CONTENT_COLUMNS}
+      sampleRows={SAMPLE_ROWS}
+      sampleFallbackEvaluators={SAMPLE_FALLBACK_EVALUATORS}
+      guidelinesTitle="Bulk upload — LLM labelling items"
+      guidelinesIntro="Upload a CSV with the following columns. Each row creates one LLM annotation item."
+      sampleFilenameBase="llm_items"
       onClose={onClose}
-      topContent={annotationOptIn}
-      uploadBlocked={uploadBlocked}
-      hideUploadSection={
-        duplicateNames.length > 0 ||
-        (uploadAnnotations &&
-          (!selectedAnnotatorId || evaluatorsMissingOutputType.length > 0))
-      }
+      onSuccess={onSuccess}
     />
   );
 }

--- a/src/components/human-labelling/CreateLabellingTaskDialog.tsx
+++ b/src/components/human-labelling/CreateLabellingTaskDialog.tsx
@@ -310,8 +310,8 @@ export function CreateLabellingTaskDialog({
                 What are you labelling? <span className="text-red-500">*</span>
               </label>
               <p className="text-xs text-muted-foreground mb-3">
-                Sets the type of item annotators will see. Can&apos;t be changed
-                after the task is created.
+                Select carefully as it cannot be changed after the task is
+                created
               </p>
               <EvaluatorUseCaseCards
                 options={TASK_TYPE_OPTIONS}

--- a/src/components/human-labelling/CreateLabellingTaskDialog.tsx
+++ b/src/components/human-labelling/CreateLabellingTaskDialog.tsx
@@ -6,88 +6,24 @@ import {
   EVALUATOR_TYPE_LABELS,
   type EvaluatorType,
 } from "@/components/EvaluatorPills";
+import {
+  EvaluatorUseCaseCards,
+  EVALUATOR_USE_CASE_OPTIONS,
+} from "@/components/evaluators/evaluatorUseCases";
 import { apiClient } from "@/lib/api";
 import { readNameConflictFromError } from "@/lib/parseBackendError";
 
-// Only these three task types are allowed for labelling tasks. A task's
-// type matches its evaluators' evaluator_type one-to-one.
+// Labelling tasks support every evaluator use case except text-to-speech.
 type TaskType = Extract<
   EvaluatorType,
   "llm" | "llm-general" | "stt" | "conversation"
 >;
 
-// Ordered + grouped + trimmed for onboarding, mirroring the evaluator
-// use-case picker (UseCasePickerDialog): the most common pick leads with a
-// "Most common" badge, descriptions are one plain line, and `group` drives
-// the section headers. Copy is kept identical to the evaluator picker so the
-// same concept reads the same way in both places.
-const TASK_TYPE_OPTIONS: {
-  value: TaskType;
-  title: string;
-  description: string;
-  group: "text" | "audio";
-  recommended?: boolean;
-}[] = [
-  {
-    value: "llm-general",
-    title: "LLM response",
-    description: "Judge a single AI output — classify, extract, summarise",
-    group: "text",
-    recommended: true,
-  },
-  {
-    value: "llm",
-    title: "Conversational reply",
-    description: "Judge a chatbot's next reply in a chat",
-    group: "text",
-  },
-  {
-    value: "conversation",
-    title: "Full conversation",
-    description: "Judge a whole conversation, start to finish",
-    group: "text",
-  },
-  {
-    value: "stt",
-    title: "Speech to Text",
-    description: "Judge transcription accuracy against a reference",
-    group: "audio",
-  },
-];
-
-// Section headers shown above each group of task-type cards, in render order.
-const TASK_GROUP_ORDER: { key: "text" | "audio"; label: string }[] = [
-  { key: "text", label: "Text & LLM" },
-  { key: "audio", label: "Audio" },
-];
-
-// Per-type tints, mirroring EvaluatorTypePill's palette
-// (llm=orange, stt=blue, conversation=pink) so the picker reads as the
-// same "type" affordance the user sees on evaluator cards. We use a
-// subtle tint by default (so the cards announce their type at rest)
-// and a stronger tint + bordered ring when active.
-const TASK_TYPE_INACTIVE_CLASSES: Record<TaskType, string> = {
-  llm: "border-orange-500/20 bg-orange-500/[0.04] hover:bg-orange-500/10 hover:border-orange-500/40",
-  "llm-general":
-    "border-teal-500/20 bg-teal-500/[0.04] hover:bg-teal-500/10 hover:border-teal-500/40",
-  stt: "border-blue-500/20 bg-blue-500/[0.04] hover:bg-blue-500/10 hover:border-blue-500/40",
-  conversation:
-    "border-pink-500/20 bg-pink-500/[0.04] hover:bg-pink-500/10 hover:border-pink-500/40",
-};
-
-const TASK_TYPE_ACTIVE_CLASSES: Record<TaskType, string> = {
-  llm: "border-orange-500/60 bg-orange-500/15 ring-1 ring-orange-500/40",
-  "llm-general": "border-teal-500/60 bg-teal-500/15 ring-1 ring-teal-500/40",
-  stt: "border-blue-500/60 bg-blue-500/15 ring-1 ring-blue-500/40",
-  conversation: "border-pink-500/60 bg-pink-500/15 ring-1 ring-pink-500/40",
-};
-
-const TASK_TYPE_TITLE_CLASSES: Record<TaskType, string> = {
-  llm: "text-orange-700 dark:text-orange-300",
-  "llm-general": "text-teal-700 dark:text-teal-300",
-  stt: "text-blue-700 dark:text-blue-300",
-  conversation: "text-pink-700 dark:text-pink-300",
-};
+// Reuse the shared evaluator use-case cards, minus `tts` (no TTS labelling
+// tasks). Same grouping/copy as the new-evaluator picker.
+const TASK_TYPE_OPTIONS = EVALUATOR_USE_CASE_OPTIONS.filter(
+  (o) => o.value !== "tts",
+);
 
 type EvaluatorListItem = {
   uuid: string;
@@ -118,6 +54,13 @@ type CreateLabellingTaskDialogProps = {
   onCreated: (taskUuid: string) => void;
 };
 
+type Step = 1 | 2 | 3;
+const STEPS: { n: Step; label: string }[] = [
+  { n: 1, label: "Details" },
+  { n: 2, label: "Type" },
+  { n: 3, label: "Evaluators" },
+];
+
 export function CreateLabellingTaskDialog({
   accessToken,
   onClose,
@@ -125,6 +68,7 @@ export function CreateLabellingTaskDialog({
 }: CreateLabellingTaskDialogProps) {
   useHideFloatingButton(true);
 
+  const [step, setStep] = useState<Step>(1);
   const [name, setName] = useState("");
   const [description, setDescription] = useState("");
   const [taskType, setTaskType] = useState<TaskType | null>(null);
@@ -200,11 +144,18 @@ export function CreateLabellingTaskDialog({
     });
   };
 
+  // Per-step validation. Navigation between steps is free (see stepper +
+  // Back/Next), but creating the task still requires every step to be valid.
+  const step1Valid = !!name.trim();
+  const step2Valid = !!taskType;
+  const step3Valid = selectedEvaluatorIds.size >= 1;
   const canSubmit =
-    !!name.trim() &&
-    !!taskType &&
-    !submitting &&
-    selectedEvaluatorIds.size >= 1;
+    step1Valid && step2Valid && step3Valid && !submitting;
+  const stepValid: Record<Step, boolean> = {
+    1: step1Valid,
+    2: step2Valid,
+    3: step3Valid,
+  };
 
   const handleSubmit = async () => {
     if (!canSubmit || !taskType) return;
@@ -231,6 +182,8 @@ export function CreateLabellingTaskDialog({
       const conflict = readNameConflictFromError(err);
       if (conflict) {
         setNameConflictError(conflict);
+        // Surface the conflicting field by returning to the details step.
+        setStep(1);
       } else {
         setSubmitError(parseApiError(err, "Failed to create task"));
       }
@@ -241,117 +194,86 @@ export function CreateLabellingTaskDialog({
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm p-4">
-      <div
-        className={`bg-background border border-border rounded-xl w-full ${
-          taskType ? "max-w-6xl" : "max-w-2xl"
-        } shadow-2xl flex flex-col max-h-[90vh] transition-all`}
-      >
-        <div className="flex items-start justify-between gap-3 px-5 md:px-6 py-4 border-b border-border">
-          <div>
+      <div className="bg-background border border-border rounded-xl w-full max-w-2xl shadow-2xl flex flex-col max-h-[90vh]">
+        {/* Header + stepper */}
+        <div className="px-5 md:px-6 py-4 border-b border-border">
+          <div className="flex items-start justify-between gap-3">
             <h2 className="text-base md:text-lg font-semibold text-foreground">
               Create labelling task
             </h2>
-          </div>
-          <button
-            onClick={onClose}
-            disabled={submitting}
-            className="flex items-center justify-center w-8 h-8 rounded-md hover:bg-muted transition-colors cursor-pointer flex-shrink-0 disabled:opacity-50 disabled:cursor-not-allowed"
-          >
-            <svg
-              className="w-5 h-5"
-              fill="none"
-              viewBox="0 0 24 24"
-              stroke="currentColor"
-              strokeWidth={2}
+            <button
+              onClick={onClose}
+              disabled={submitting}
+              className="flex items-center justify-center w-8 h-8 rounded-md hover:bg-muted transition-colors cursor-pointer flex-shrink-0 disabled:opacity-50 disabled:cursor-not-allowed"
             >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                d="M6 18L18 6M6 6l12 12"
-              />
-            </svg>
-          </button>
+              <svg
+                className="w-5 h-5"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+                strokeWidth={2}
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M6 18L18 6M6 6l12 12"
+                />
+              </svg>
+            </button>
+          </div>
+
+          {/* Stepper — each step is clickable to jump freely between stages. */}
+          <div className="mt-3 flex items-center gap-2">
+            {STEPS.map((s, i) => {
+              const active = step === s.n;
+              const done = stepValid[s.n] && !active;
+              return (
+                <div key={s.n} className="flex items-center gap-2">
+                  <button
+                    type="button"
+                    onClick={() => setStep(s.n)}
+                    className="flex items-center gap-2 cursor-pointer group"
+                  >
+                    <span
+                      className={`flex items-center justify-center w-6 h-6 rounded-full text-xs font-semibold transition-colors ${
+                        active
+                          ? "bg-foreground text-background"
+                          : done
+                            ? "bg-teal-500/15 text-teal-700 dark:text-teal-300 border border-teal-500/40"
+                            : "bg-muted text-muted-foreground"
+                      }`}
+                    >
+                      {done ? "✓" : s.n}
+                    </span>
+                    <span
+                      className={`text-xs md:text-sm font-medium transition-colors ${
+                        active
+                          ? "text-foreground"
+                          : "text-muted-foreground group-hover:text-foreground"
+                      }`}
+                    >
+                      {s.label}
+                    </span>
+                  </button>
+                  {i < STEPS.length - 1 && (
+                    <span className="w-6 h-px bg-border" />
+                  )}
+                </div>
+              );
+            })}
+          </div>
         </div>
 
+        {/* Body */}
         <div className="flex-1 overflow-y-auto p-4 md:p-6">
-          {/* When a type is selected we make the left column the
-              flow-sized parent and float the right column absolutely
-              over its remainder. That way the right column's bottom
-              aligns with the bottom of the type-picker cards (left
-              column's last child) — never extending past it. */}
-          <div className={taskType ? "md:relative" : ""}>
-            <div
-              className={`min-w-0 space-y-5 ${
-                taskType ? "md:max-w-[42rem]" : ""
-              }`}
-            >
-              {/* Type picker — shown first so the user decides what they're
-                  labelling before naming it. */}
-              <div>
-                <label className="block text-sm font-medium mb-1">
-                  What are you labelling?{" "}
-                  <span className="text-red-500">*</span>
-                </label>
-                <p className="text-xs text-muted-foreground mb-3">
-                  Sets the type of item annotators will see. Can&apos;t be
-                  changed after the task is created.
-                </p>
-                <div className="space-y-4">
-                  {TASK_GROUP_ORDER.map(({ key, label }) => {
-                    const groupOptions = TASK_TYPE_OPTIONS.filter(
-                      (o) => o.group === key,
-                    );
-                    if (groupOptions.length === 0) return null;
-                    return (
-                      <div key={key}>
-                        <div className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground mb-2 px-0.5">
-                          {label}
-                        </div>
-                        <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
-                          {groupOptions.map((opt) => {
-                            const active = taskType === opt.value;
-                            return (
-                              <button
-                                key={opt.value}
-                                type="button"
-                                onClick={() => setTaskType(opt.value)}
-                                className={`flex flex-col items-start text-left p-3 rounded-md border transition-colors cursor-pointer ${
-                                  active
-                                    ? TASK_TYPE_ACTIVE_CLASSES[opt.value]
-                                    : TASK_TYPE_INACTIVE_CLASSES[opt.value]
-                                }`}
-                              >
-                                <div className="flex items-start justify-between gap-2 w-full">
-                                  <div
-                                    className={`text-sm font-medium ${TASK_TYPE_TITLE_CLASSES[opt.value]}`}
-                                  >
-                                    {opt.title}
-                                  </div>
-                                  {opt.recommended && (
-                                    <span className="shrink-0 inline-flex items-center px-2 py-0.5 rounded-full text-[10px] font-semibold uppercase tracking-wide bg-teal-500/15 text-teal-700 dark:text-teal-300 border border-teal-500/30">
-                                      Most common
-                                    </span>
-                                  )}
-                                </div>
-                                <div className="text-xs text-muted-foreground mt-1 leading-relaxed">
-                                  {opt.description}
-                                </div>
-                              </button>
-                            );
-                          })}
-                        </div>
-                      </div>
-                    );
-                  })}
-                </div>
-              </div>
-
-              {/* Name */}
+          {step === 1 && (
+            <div className="space-y-5">
               <div>
                 <label className="block text-sm font-medium mb-2">
                   Name <span className="text-red-500">*</span>
                 </label>
                 <input
+                  autoFocus
                   value={name}
                   onChange={(e) => {
                     setName(e.target.value);
@@ -368,8 +290,6 @@ export function CreateLabellingTaskDialog({
                   </p>
                 )}
               </div>
-
-              {/* Description */}
               <div>
                 <label className="block text-sm font-medium mb-2">
                   Description
@@ -383,128 +303,145 @@ export function CreateLabellingTaskDialog({
                 />
               </div>
             </div>
+          )}
 
-            {/* Evaluator picker — only shown once a type is chosen.
-              On md+ this is positioned absolutely so its top/bottom
-              align with the left column's content (bottom = bottom of
-              the type-picker cards). On mobile it falls back to the
-              normal flow underneath. The list inside flexes to fill
-              the remaining vertical space. */}
-            {taskType && (
-              <div className="mt-5 md:mt-0 md:absolute md:top-0 md:bottom-0 md:left-[calc(42rem+1.5rem)] md:right-0 flex flex-col md:overflow-hidden">
-                <label className="block text-sm font-medium mb-2">
-                  Evaluators <span className="text-red-500">*</span>
-                  <span className="ml-2 text-xs font-normal text-muted-foreground">
-                    ({selectedEvaluatorIds.size} selected)
-                  </span>
-                </label>
-                <p className="text-xs text-muted-foreground mb-2">
-                  Pick at least one evaluator that annotators will grade
-                  against.
-                </p>
+          {step === 2 && (
+            <div>
+              <label className="block text-sm font-medium mb-1">
+                What are you labelling? <span className="text-red-500">*</span>
+              </label>
+              <p className="text-xs text-muted-foreground mb-3">
+                Sets the type of item annotators will see. Can&apos;t be changed
+                after the task is created.
+              </p>
+              <EvaluatorUseCaseCards
+                options={TASK_TYPE_OPTIONS}
+                selected={taskType}
+                onSelect={(v) => setTaskType(v as TaskType)}
+              />
+            </div>
+          )}
 
-                <div className="relative mb-2">
-                  <div className="absolute inset-y-0 left-0 flex items-center pl-3 pointer-events-none">
-                    <svg
-                      className="w-4 h-4 text-muted-foreground"
-                      fill="none"
-                      viewBox="0 0 24 24"
-                      stroke="currentColor"
-                      strokeWidth={2}
-                    >
-                      <path
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        d="M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 5.196a7.5 7.5 0 0010.607 10.607z"
-                      />
-                    </svg>
-                  </div>
-                  <input
-                    type="text"
-                    value={evaluatorSearch}
-                    onChange={(e) => setEvaluatorSearch(e.target.value)}
-                    placeholder={`Search evaluators`}
-                    className="w-full h-9 pl-9 pr-3 rounded-md text-sm border border-border bg-background text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-accent"
-                  />
+          {step === 3 && (
+            <div className="flex flex-col min-h-0">
+              <label className="block text-sm font-medium mb-2">
+                Evaluators <span className="text-red-500">*</span>
+                <span className="ml-2 text-xs font-normal text-muted-foreground">
+                  ({selectedEvaluatorIds.size} selected)
+                </span>
+              </label>
+              {!taskType ? (
+                <div className="rounded-md border border-dashed border-border bg-muted/10 px-4 py-8 text-center text-sm text-muted-foreground">
+                  Pick a task type first (step 2) to see matching evaluators.
                 </div>
-
-                <div className="border border-border rounded-md min-h-0 overflow-y-auto divide-y divide-border">
-                  {evaluatorsLoading ? (
-                    <div className="p-4 flex items-center gap-2 text-sm text-muted-foreground">
+              ) : (
+                <>
+                  <p className="text-xs text-muted-foreground mb-2">
+                    Pick at least one evaluator that annotators will grade
+                    against.
+                  </p>
+                  <div className="relative mb-2">
+                    <div className="absolute inset-y-0 left-0 flex items-center pl-3 pointer-events-none">
                       <svg
-                        className="w-4 h-4 animate-spin"
+                        className="w-4 h-4 text-muted-foreground"
                         fill="none"
                         viewBox="0 0 24 24"
+                        stroke="currentColor"
+                        strokeWidth={2}
                       >
-                        <circle
-                          className="opacity-25"
-                          cx="12"
-                          cy="12"
-                          r="10"
-                          stroke="currentColor"
-                          strokeWidth="4"
-                        />
                         <path
-                          className="opacity-75"
-                          fill="currentColor"
-                          d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          d="M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 5.196a7.5 7.5 0 0010.607 10.607z"
                         />
                       </svg>
-                      Loading evaluators
                     </div>
-                  ) : evaluatorsError ? (
-                    <div className="p-4 text-sm text-red-500">
-                      {evaluatorsError}
-                    </div>
-                  ) : filteredEvaluators.length === 0 ? (
-                    <div className="p-4 text-sm text-muted-foreground">
-                      {evaluatorSearch.trim()
-                        ? "No matching evaluators."
-                        : `No ${EVALUATOR_TYPE_LABELS[taskType]} evaluators yet.`}
-                    </div>
-                  ) : (
-                    filteredEvaluators.map((ev) => {
-                      const checked = selectedEvaluatorIds.has(ev.uuid);
-                      return (
-                        <label
-                          key={ev.uuid}
-                          className="flex items-start gap-3 px-3 py-2.5 hover:bg-muted/30 transition-colors cursor-pointer"
+                    <input
+                      type="text"
+                      value={evaluatorSearch}
+                      onChange={(e) => setEvaluatorSearch(e.target.value)}
+                      placeholder="Search evaluators"
+                      className="w-full h-9 pl-9 pr-3 rounded-md text-sm border border-border bg-background text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-accent"
+                    />
+                  </div>
+
+                  <div className="border border-border rounded-md max-h-80 overflow-y-auto divide-y divide-border">
+                    {evaluatorsLoading ? (
+                      <div className="p-4 flex items-center gap-2 text-sm text-muted-foreground">
+                        <svg
+                          className="w-4 h-4 animate-spin"
+                          fill="none"
+                          viewBox="0 0 24 24"
                         >
-                          <input
-                            type="checkbox"
-                            checked={checked}
-                            onChange={() => toggleEvaluator(ev.uuid)}
-                            className="mt-0.5 w-4 h-4 cursor-pointer accent-foreground"
+                          <circle
+                            className="opacity-25"
+                            cx="12"
+                            cy="12"
+                            r="10"
+                            stroke="currentColor"
+                            strokeWidth="4"
                           />
-                          <div className="min-w-0 flex-1">
-                            <div className="text-sm font-medium truncate">
-                              {ev.name}
-                            </div>
-                            {ev.description && (
-                              <div className="text-xs text-muted-foreground line-clamp-2 mt-0.5">
-                                {ev.description}
+                          <path
+                            className="opacity-75"
+                            fill="currentColor"
+                            d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+                          />
+                        </svg>
+                        Loading evaluators
+                      </div>
+                    ) : evaluatorsError ? (
+                      <div className="p-4 text-sm text-red-500">
+                        {evaluatorsError}
+                      </div>
+                    ) : filteredEvaluators.length === 0 ? (
+                      <div className="p-4 text-sm text-muted-foreground">
+                        {evaluatorSearch.trim()
+                          ? "No matching evaluators."
+                          : `No ${EVALUATOR_TYPE_LABELS[taskType]} evaluators yet.`}
+                      </div>
+                    ) : (
+                      filteredEvaluators.map((ev) => {
+                        const checked = selectedEvaluatorIds.has(ev.uuid);
+                        return (
+                          <label
+                            key={ev.uuid}
+                            className="flex items-start gap-3 px-3 py-2.5 hover:bg-muted/30 transition-colors cursor-pointer"
+                          >
+                            <input
+                              type="checkbox"
+                              checked={checked}
+                              onChange={() => toggleEvaluator(ev.uuid)}
+                              className="mt-0.5 w-4 h-4 cursor-pointer accent-foreground"
+                            />
+                            <div className="min-w-0 flex-1">
+                              <div className="text-sm font-medium truncate">
+                                {ev.name}
                               </div>
-                            )}
-                          </div>
-                        </label>
-                      );
-                    })
-                  )}
-                </div>
-              </div>
-            )}
-          </div>
+                              {ev.description && (
+                                <div className="text-xs text-muted-foreground line-clamp-2 mt-0.5">
+                                  {ev.description}
+                                </div>
+                              )}
+                            </div>
+                          </label>
+                        );
+                      })
+                    )}
+                  </div>
+                </>
+              )}
+            </div>
+          )}
 
           {submitError && (
-            <div
-              className={`mt-5 rounded-md border border-red-500/30 bg-red-500/10 p-3 text-sm text-red-500`}
-            >
+            <div className="mt-5 rounded-md border border-red-500/30 bg-red-500/10 p-3 text-sm text-red-500">
               {submitError}
             </div>
           )}
         </div>
 
-        <div className="flex items-center justify-end gap-2 md:gap-3 px-5 md:px-6 py-4 border-t border-border">
+        {/* Footer */}
+        <div className="flex items-center justify-between gap-2 md:gap-3 px-5 md:px-6 py-4 border-t border-border">
           <button
             onClick={onClose}
             disabled={submitting}
@@ -512,13 +449,33 @@ export function CreateLabellingTaskDialog({
           >
             Cancel
           </button>
-          <button
-            onClick={handleSubmit}
-            disabled={!canSubmit}
-            className="h-9 md:h-10 px-4 rounded-md text-sm md:text-base font-medium bg-foreground text-background hover:opacity-90 transition-opacity cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
-          >
-            {submitting ? "Creating..." : "Create task"}
-          </button>
+          <div className="flex items-center gap-2 md:gap-3">
+            {step > 1 && (
+              <button
+                onClick={() => setStep((s) => (s - 1) as Step)}
+                disabled={submitting}
+                className="h-9 md:h-10 px-4 rounded-md text-sm md:text-base font-medium border border-border bg-background dark:bg-muted hover:bg-muted/50 dark:hover:bg-accent transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                Back
+              </button>
+            )}
+            {step < 3 ? (
+              <button
+                onClick={() => setStep((s) => (s + 1) as Step)}
+                className="h-9 md:h-10 px-4 rounded-md text-sm md:text-base font-medium bg-foreground text-background hover:opacity-90 transition-opacity cursor-pointer"
+              >
+                Next
+              </button>
+            ) : (
+              <button
+                onClick={handleSubmit}
+                disabled={!canSubmit}
+                className="h-9 md:h-10 px-4 rounded-md text-sm md:text-base font-medium bg-foreground text-background hover:opacity-90 transition-opacity cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                {submitting ? "Creating..." : "Create task"}
+              </button>
+            )}
+          </div>
         </div>
       </div>
     </div>

--- a/src/components/human-labelling/CreateLabellingTaskDialog.tsx
+++ b/src/components/human-labelling/CreateLabellingTaskDialog.tsx
@@ -149,8 +149,7 @@ export function CreateLabellingTaskDialog({
   const step1Valid = !!name.trim();
   const step2Valid = !!taskType;
   const step3Valid = selectedEvaluatorIds.size >= 1;
-  const canSubmit =
-    step1Valid && step2Valid && step3Valid && !submitting;
+  const canSubmit = step1Valid && step2Valid && step3Valid && !submitting;
   const stepValid: Record<Step, boolean> = {
     1: step1Valid,
     2: step2Valid,
@@ -279,7 +278,7 @@ export function CreateLabellingTaskDialog({
                     setName(e.target.value);
                     if (nameConflictError) setNameConflictError(null);
                   }}
-                  placeholder="e.g., Helpfulness review — Q2 batch"
+                  placeholder="e.g. Copilot review — Q2 batch"
                   className={`w-full h-10 px-3 rounded-md text-sm border bg-background text-foreground focus:outline-none focus:ring-2 focus:ring-accent ${
                     nameConflictError ? "border-red-500" : "border-border"
                   }`}
@@ -440,15 +439,8 @@ export function CreateLabellingTaskDialog({
           )}
         </div>
 
-        {/* Footer */}
-        <div className="flex items-center justify-between gap-2 md:gap-3 px-5 md:px-6 py-4 border-t border-border">
-          <button
-            onClick={onClose}
-            disabled={submitting}
-            className="h-9 md:h-10 px-4 rounded-md text-sm md:text-base font-medium border border-border bg-background dark:bg-muted hover:bg-muted/50 dark:hover:bg-accent transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
-          >
-            Cancel
-          </button>
+        {/* Footer — dismissal is handled by the header ✕, so no Cancel here. */}
+        <div className="flex items-center justify-end gap-2 md:gap-3 px-5 md:px-6 py-4 border-t border-border">
           <div className="flex items-center gap-2 md:gap-3">
             {step > 1 && (
               <button

--- a/src/components/human-labelling/CreateLabellingTaskDialog.tsx
+++ b/src/components/human-labelling/CreateLabellingTaskDialog.tsx
@@ -11,7 +11,10 @@ import { readNameConflictFromError } from "@/lib/parseBackendError";
 
 // Only these three task types are allowed for labelling tasks. A task's
 // type matches its evaluators' evaluator_type one-to-one.
-type TaskType = Extract<EvaluatorType, "llm" | "stt" | "conversation">;
+type TaskType = Extract<
+  EvaluatorType,
+  "llm" | "llm-general" | "stt" | "conversation"
+>;
 
 const TASK_TYPE_OPTIONS: {
   value: TaskType;
@@ -25,9 +28,15 @@ const TASK_TYPE_OPTIONS: {
   },
   {
     value: "llm",
-    title: "Single LLM response",
+    title: "Conversational reply",
     description:
       "Given a conversation history, evaluate the agent's next response.",
+  },
+  {
+    value: "llm-general",
+    title: "LLM response",
+    description:
+      "Evaluate an LLM's output for a single, non-conversational prompt or input.",
   },
   {
     value: "conversation",
@@ -44,6 +53,8 @@ const TASK_TYPE_OPTIONS: {
 // and a stronger tint + bordered ring when active.
 const TASK_TYPE_INACTIVE_CLASSES: Record<TaskType, string> = {
   llm: "border-orange-500/20 bg-orange-500/[0.04] hover:bg-orange-500/10 hover:border-orange-500/40",
+  "llm-general":
+    "border-teal-500/20 bg-teal-500/[0.04] hover:bg-teal-500/10 hover:border-teal-500/40",
   stt: "border-blue-500/20 bg-blue-500/[0.04] hover:bg-blue-500/10 hover:border-blue-500/40",
   conversation:
     "border-pink-500/20 bg-pink-500/[0.04] hover:bg-pink-500/10 hover:border-pink-500/40",
@@ -51,12 +62,14 @@ const TASK_TYPE_INACTIVE_CLASSES: Record<TaskType, string> = {
 
 const TASK_TYPE_ACTIVE_CLASSES: Record<TaskType, string> = {
   llm: "border-orange-500/60 bg-orange-500/15 ring-1 ring-orange-500/40",
+  "llm-general": "border-teal-500/60 bg-teal-500/15 ring-1 ring-teal-500/40",
   stt: "border-blue-500/60 bg-blue-500/15 ring-1 ring-blue-500/40",
   conversation: "border-pink-500/60 bg-pink-500/15 ring-1 ring-pink-500/40",
 };
 
 const TASK_TYPE_TITLE_CLASSES: Record<TaskType, string> = {
   llm: "text-orange-700 dark:text-orange-300",
+  "llm-general": "text-teal-700 dark:text-teal-300",
   stt: "text-blue-700 dark:text-blue-300",
   conversation: "text-pink-700 dark:text-pink-300",
 };

--- a/src/components/human-labelling/CreateLabellingTaskDialog.tsx
+++ b/src/components/human-labelling/CreateLabellingTaskDialog.tsx
@@ -16,34 +16,49 @@ type TaskType = Extract<
   "llm" | "llm-general" | "stt" | "conversation"
 >;
 
+// Ordered + grouped + trimmed for onboarding, mirroring the evaluator
+// use-case picker (UseCasePickerDialog): the most common pick leads with a
+// "Most common" badge, descriptions are one plain line, and `group` drives
+// the section headers. Copy is kept identical to the evaluator picker so the
+// same concept reads the same way in both places.
 const TASK_TYPE_OPTIONS: {
   value: TaskType;
   title: string;
   description: string;
+  group: "text" | "audio";
+  recommended?: boolean;
 }[] = [
   {
-    value: "stt",
-    title: "Speech to Text",
-    description: "Evaluate the transcription quality against a reference text.",
+    value: "llm-general",
+    title: "LLM response",
+    description: "Judge a single AI output — classify, extract, summarise",
+    group: "text",
+    recommended: true,
   },
   {
     value: "llm",
     title: "Conversational reply",
-    description:
-      "Given a conversation history, evaluate the agent's next response.",
-  },
-  {
-    value: "llm-general",
-    title: "LLM response",
-    description:
-      "Evaluate an LLM's output for a single, non-conversational prompt or input.",
+    description: "Judge a chatbot's next reply in a chat",
+    group: "text",
   },
   {
     value: "conversation",
     title: "Full conversation",
-    description:
-      "Evaluate the agent's performance during a complete conversation.",
+    description: "Judge a whole conversation, start to finish",
+    group: "text",
   },
+  {
+    value: "stt",
+    title: "Speech to Text",
+    description: "Judge transcription accuracy against a reference",
+    group: "audio",
+  },
+];
+
+// Section headers shown above each group of task-type cards, in render order.
+const TASK_GROUP_ORDER: { key: "text" | "audio"; label: string }[] = [
+  { key: "text", label: "Text & LLM" },
+  { key: "audio", label: "Audio" },
 ];
 
 // Per-type tints, mirroring EvaluatorTypePill's palette
@@ -270,13 +285,73 @@ export function CreateLabellingTaskDialog({
                 taskType ? "md:max-w-[42rem]" : ""
               }`}
             >
+              {/* Type picker — shown first so the user decides what they're
+                  labelling before naming it. */}
+              <div>
+                <label className="block text-sm font-medium mb-1">
+                  What are you labelling?{" "}
+                  <span className="text-red-500">*</span>
+                </label>
+                <p className="text-xs text-muted-foreground mb-3">
+                  Sets the type of item annotators will see. Can&apos;t be
+                  changed after the task is created.
+                </p>
+                <div className="space-y-4">
+                  {TASK_GROUP_ORDER.map(({ key, label }) => {
+                    const groupOptions = TASK_TYPE_OPTIONS.filter(
+                      (o) => o.group === key,
+                    );
+                    if (groupOptions.length === 0) return null;
+                    return (
+                      <div key={key}>
+                        <div className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground mb-2 px-0.5">
+                          {label}
+                        </div>
+                        <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+                          {groupOptions.map((opt) => {
+                            const active = taskType === opt.value;
+                            return (
+                              <button
+                                key={opt.value}
+                                type="button"
+                                onClick={() => setTaskType(opt.value)}
+                                className={`flex flex-col items-start text-left p-3 rounded-md border transition-colors cursor-pointer ${
+                                  active
+                                    ? TASK_TYPE_ACTIVE_CLASSES[opt.value]
+                                    : TASK_TYPE_INACTIVE_CLASSES[opt.value]
+                                }`}
+                              >
+                                <div className="flex items-start justify-between gap-2 w-full">
+                                  <div
+                                    className={`text-sm font-medium ${TASK_TYPE_TITLE_CLASSES[opt.value]}`}
+                                  >
+                                    {opt.title}
+                                  </div>
+                                  {opt.recommended && (
+                                    <span className="shrink-0 inline-flex items-center px-2 py-0.5 rounded-full text-[10px] font-semibold uppercase tracking-wide bg-teal-500/15 text-teal-700 dark:text-teal-300 border border-teal-500/30">
+                                      Most common
+                                    </span>
+                                  )}
+                                </div>
+                                <div className="text-xs text-muted-foreground mt-1 leading-relaxed">
+                                  {opt.description}
+                                </div>
+                              </button>
+                            );
+                          })}
+                        </div>
+                      </div>
+                    );
+                  })}
+                </div>
+              </div>
+
               {/* Name */}
               <div>
                 <label className="block text-sm font-medium mb-2">
                   Name <span className="text-red-500">*</span>
                 </label>
                 <input
-                  autoFocus
                   value={name}
                   onChange={(e) => {
                     setName(e.target.value);
@@ -306,42 +381,6 @@ export function CreateLabellingTaskDialog({
                   rows={3}
                   className="w-full px-3 py-2 rounded-md text-sm border border-border bg-background text-foreground focus:outline-none focus:ring-2 focus:ring-accent resize-y"
                 />
-              </div>
-
-              {/* Type picker */}
-              <div>
-                <label className="block text-sm font-medium mb-1">
-                  Task type <span className="text-red-500">*</span>
-                </label>
-                <p className="text-xs text-muted-foreground mb-2">
-                  The task type cannot be changed after the task is created
-                </p>
-                <div className="grid grid-cols-1 sm:grid-cols-3 gap-2">
-                  {TASK_TYPE_OPTIONS.map((opt) => {
-                    const active = taskType === opt.value;
-                    return (
-                      <button
-                        key={opt.value}
-                        type="button"
-                        onClick={() => setTaskType(opt.value)}
-                        className={`flex flex-col items-start text-left p-3 rounded-md border transition-colors cursor-pointer ${
-                          active
-                            ? TASK_TYPE_ACTIVE_CLASSES[opt.value]
-                            : TASK_TYPE_INACTIVE_CLASSES[opt.value]
-                        }`}
-                      >
-                        <div
-                          className={`text-sm font-medium ${TASK_TYPE_TITLE_CLASSES[opt.value]}`}
-                        >
-                          {opt.title}
-                        </div>
-                        <div className="text-xs text-muted-foreground mt-1 leading-relaxed">
-                          {opt.description}
-                        </div>
-                      </button>
-                    );
-                  })}
-                </div>
               </div>
             </div>
 

--- a/src/components/human-labelling/EvaluatorRunDetailView.tsx
+++ b/src/components/human-labelling/EvaluatorRunDetailView.tsx
@@ -1374,10 +1374,10 @@ export function ItemDetailPane({
 
   return (
     <div className="flex flex-col md:flex-row min-h-0 flex-1 md:overflow-hidden">
-      <div className="md:flex-1 md:min-h-0 md:overflow-y-auto p-4 md:p-6 md:border-r border-border">
+      <div className="md:flex-[4] md:min-h-0 md:overflow-y-auto p-4 md:p-6 md:border-r border-border">
         <ItemPane item={item} taskType={taskType} />
       </div>
-      <div className="md:flex-1 md:min-h-0 md:overflow-y-auto p-4 md:p-6">
+      <div className="md:flex-[3] md:min-h-0 md:overflow-y-auto p-4 md:p-6">
         <EvaluatorResultsPane
           evaluators={evaluators}
           evaluatorNamesById={evaluatorNamesById}

--- a/src/components/human-labelling/EvaluatorRunDetailView.tsx
+++ b/src/components/human-labelling/EvaluatorRunDetailView.tsx
@@ -1374,7 +1374,7 @@ export function ItemDetailPane({
 
   return (
     <div className="flex flex-col md:flex-row min-h-0 flex-1 md:overflow-hidden">
-      <div className="md:flex-[4] md:min-h-0 md:overflow-y-auto p-4 md:p-6 md:border-r border-border">
+      <div className="md:flex-[5] md:min-h-0 md:overflow-y-auto p-4 md:p-6 md:border-r border-border">
         <ItemPane item={item} taskType={taskType} />
       </div>
       <div className="md:flex-[3] md:min-h-0 md:overflow-y-auto p-4 md:p-6">

--- a/src/components/human-labelling/EvaluatorRunDetailView.tsx
+++ b/src/components/human-labelling/EvaluatorRunDetailView.tsx
@@ -142,7 +142,7 @@ export type EvaluatorRunJob = {
 export type LabellingTaskFull = {
   uuid: string;
   name: string;
-  type: "llm" | "stt" | "tts" | "conversation";
+  type: "llm" | "llm-general" | "stt" | "tts" | "conversation";
   description?: string | null;
   evaluators?: { uuid: string; name: string }[];
   items?: Item[];
@@ -1705,7 +1705,12 @@ export function EvaluatorRunDetailView({
   };
 
   if (
-    !(task.type === "stt" || task.type === "llm" || task.type === "conversation")
+    !(
+      task.type === "stt" ||
+      task.type === "llm" ||
+      task.type === "llm-general" ||
+      task.type === "conversation"
+    )
   ) {
     return null;
   }

--- a/src/components/human-labelling/ItemDetailDialog.tsx
+++ b/src/components/human-labelling/ItemDetailDialog.tsx
@@ -111,7 +111,7 @@ function itemTitle(item: Item | null): string {
 export type ItemDetailDialogTask = {
   uuid: string;
   name: string;
-  type: "llm" | "stt" | "conversation";
+  type: "llm" | "llm-general" | "stt" | "conversation";
   evaluators?: TaskEvaluatorDef[];
 };
 

--- a/src/components/human-labelling/item-panes/LlmGeneralItemPane.tsx
+++ b/src/components/human-labelling/item-panes/LlmGeneralItemPane.tsx
@@ -30,7 +30,7 @@ export function LlmGeneralItemPane({
   }
 
   return (
-    <div className="space-y-4">
+    <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
       <Section title="Input" subtitle="What the LLM was given">
         <p className="text-sm whitespace-pre-wrap break-words">
           {input || "—"}

--- a/src/components/human-labelling/item-panes/LlmGeneralItemPane.tsx
+++ b/src/components/human-labelling/item-panes/LlmGeneralItemPane.tsx
@@ -31,12 +31,12 @@ export function LlmGeneralItemPane({
 
   return (
     <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-      <Section title="Input" subtitle="What the LLM was given">
+      <Section title="Input">
         <p className="text-sm whitespace-pre-wrap break-words">
           {input || "—"}
         </p>
       </Section>
-      <Section title="Output" subtitle="What the LLM produced">
+      <Section title="Output">
         <p className="text-sm whitespace-pre-wrap break-words">
           {output || "—"}
         </p>

--- a/src/components/human-labelling/item-panes/LlmGeneralItemPane.tsx
+++ b/src/components/human-labelling/item-panes/LlmGeneralItemPane.tsx
@@ -1,0 +1,88 @@
+import { Section } from "./shared";
+
+// Common payload keys the backend may use for the model's output on a
+// non-conversational ("llm-general") evaluation item. We render the first
+// one present as the "Output" section.
+const OUTPUT_KEYS = ["output", "response", "completion", "agent_response"];
+// Keys that are metadata rather than evaluation inputs — never shown as a
+// variable/input row.
+const META_KEYS = new Set(["name", ...OUTPUT_KEYS]);
+
+function asDisplayString(value: unknown): string | null {
+  if (typeof value === "string") return value;
+  if (typeof value === "number" || typeof value === "boolean") {
+    return String(value);
+  }
+  return null;
+}
+
+function humanise(key: string): string {
+  const spaced = key.replace(/[_-]+/g, " ").trim();
+  return spaced.charAt(0).toUpperCase() + spaced.slice(1);
+}
+
+/**
+ * Renders a general (non-conversational) LLM evaluation item: the prompt
+ * inputs / variables on the one hand and the model output on the other.
+ * The backend payload shape isn't fixed (it mirrors whatever variables the
+ * evaluator's prompt declares), so we display every scalar field generically
+ * and fall back to a raw JSON dump when nothing is renderable.
+ */
+export function LlmGeneralItemPane({
+  payload,
+}: {
+  payload: Record<string, unknown>;
+}) {
+  const name = typeof payload.name === "string" ? payload.name : "";
+
+  const outputKey = OUTPUT_KEYS.find(
+    (k) => typeof payload[k] === "string" && (payload[k] as string).length > 0,
+  );
+  const output = outputKey ? (payload[outputKey] as string) : "";
+
+  const inputRows = Object.entries(payload)
+    .filter(([key]) => !META_KEYS.has(key))
+    .map(([key, value]) => [key, asDisplayString(value)] as const)
+    .filter((entry): entry is readonly [string, string] => entry[1] !== null);
+
+  const hasContent = output.length > 0 || inputRows.length > 0;
+
+  if (!hasContent) {
+    return (
+      <div className="space-y-2">
+        <Section title="Item payload">
+          <pre className="text-xs font-mono whitespace-pre-wrap break-words text-muted-foreground">
+            {JSON.stringify(payload, null, 2)}
+          </pre>
+        </Section>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      {name && <p className="text-sm font-semibold text-foreground">{name}</p>}
+      {inputRows.length > 0 && (
+        <Section title="Input" subtitle="What the LLM was given">
+          <div className="space-y-3">
+            {inputRows.map(([key, value]) => (
+              <div key={key} className="space-y-1">
+                <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                  {humanise(key)}
+                </p>
+                <p className="text-sm whitespace-pre-wrap break-words">
+                  {value}
+                </p>
+              </div>
+            ))}
+          </div>
+        </Section>
+      )}
+      <Section title="Output" subtitle="What the LLM produced">
+        <p className="text-sm whitespace-pre-wrap break-words">
+          {output || "—"}
+        </p>
+      </Section>
+    </div>
+  );
+}

--- a/src/components/human-labelling/item-panes/LlmGeneralItemPane.tsx
+++ b/src/components/human-labelling/item-panes/LlmGeneralItemPane.tsx
@@ -1,32 +1,13 @@
 import { Section } from "./shared";
 
-// Common payload keys the backend may use for the model's output on a
-// non-conversational ("llm-general") evaluation item. We render the first
-// one present as the "Output" section.
-const OUTPUT_KEYS = ["output", "response", "completion", "agent_response"];
-// Keys that are metadata rather than evaluation inputs — never shown as a
-// variable/input row.
-const META_KEYS = new Set(["name", ...OUTPUT_KEYS]);
-
-function asDisplayString(value: unknown): string | null {
-  if (typeof value === "string") return value;
-  if (typeof value === "number" || typeof value === "boolean") {
-    return String(value);
-  }
-  return null;
-}
-
-function humanise(key: string): string {
-  const spaced = key.replace(/[_-]+/g, " ").trim();
-  return spaced.charAt(0).toUpperCase() + spaced.slice(1);
-}
-
 /**
- * Renders a general (non-conversational) LLM evaluation item: the prompt
- * inputs / variables on the one hand and the model output on the other.
- * The backend payload shape isn't fixed (it mirrors whatever variables the
- * evaluator's prompt declares), so we display every scalar field generically
- * and fall back to a raw JSON dump when nothing is renderable.
+ * Renders a general (non-conversational) "llm-general" evaluation item.
+ *
+ * The backend payload shape for this task type is `{ name, input, output }`
+ * (plus an optional `evaluator_variables` map for per-item `{{variable}}`
+ * substitution, which isn't shown here — it feeds the evaluator prompt, not
+ * the displayed item). We read `input`/`output` explicitly and fall back to a
+ * raw JSON dump if neither is present.
  */
 export function LlmGeneralItemPane({
   payload,
@@ -34,20 +15,10 @@ export function LlmGeneralItemPane({
   payload: Record<string, unknown>;
 }) {
   const name = typeof payload.name === "string" ? payload.name : "";
+  const input = typeof payload.input === "string" ? payload.input : "";
+  const output = typeof payload.output === "string" ? payload.output : "";
 
-  const outputKey = OUTPUT_KEYS.find(
-    (k) => typeof payload[k] === "string" && (payload[k] as string).length > 0,
-  );
-  const output = outputKey ? (payload[outputKey] as string) : "";
-
-  const inputRows = Object.entries(payload)
-    .filter(([key]) => !META_KEYS.has(key))
-    .map(([key, value]) => [key, asDisplayString(value)] as const)
-    .filter((entry): entry is readonly [string, string] => entry[1] !== null);
-
-  const hasContent = output.length > 0 || inputRows.length > 0;
-
-  if (!hasContent) {
+  if (!input && !output) {
     return (
       <div className="space-y-2">
         <Section title="Item payload">
@@ -62,22 +33,11 @@ export function LlmGeneralItemPane({
   return (
     <div className="space-y-4">
       {name && <p className="text-sm font-semibold text-foreground">{name}</p>}
-      {inputRows.length > 0 && (
-        <Section title="Input" subtitle="What the LLM was given">
-          <div className="space-y-3">
-            {inputRows.map(([key, value]) => (
-              <div key={key} className="space-y-1">
-                <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
-                  {humanise(key)}
-                </p>
-                <p className="text-sm whitespace-pre-wrap break-words">
-                  {value}
-                </p>
-              </div>
-            ))}
-          </div>
-        </Section>
-      )}
+      <Section title="Input" subtitle="What the LLM was given">
+        <p className="text-sm whitespace-pre-wrap break-words">
+          {input || "—"}
+        </p>
+      </Section>
       <Section title="Output" subtitle="What the LLM produced">
         <p className="text-sm whitespace-pre-wrap break-words">
           {output || "—"}

--- a/src/components/human-labelling/item-panes/LlmGeneralItemPane.tsx
+++ b/src/components/human-labelling/item-panes/LlmGeneralItemPane.tsx
@@ -14,7 +14,6 @@ export function LlmGeneralItemPane({
 }: {
   payload: Record<string, unknown>;
 }) {
-  const name = typeof payload.name === "string" ? payload.name : "";
   const input = typeof payload.input === "string" ? payload.input : "";
   const output = typeof payload.output === "string" ? payload.output : "";
 
@@ -32,7 +31,6 @@ export function LlmGeneralItemPane({
 
   return (
     <div className="space-y-4">
-      {name && <p className="text-sm font-semibold text-foreground">{name}</p>}
       <Section title="Input" subtitle="What the LLM was given">
         <p className="text-sm whitespace-pre-wrap break-words">
           {input || "—"}

--- a/src/components/human-labelling/unsavedCloseGuard.tsx
+++ b/src/components/human-labelling/unsavedCloseGuard.tsx
@@ -1,0 +1,124 @@
+"use client";
+
+import { useState } from "react";
+
+type UnsavedCloseGuardOptions = {
+  isOpen: boolean;
+  // Whether the form currently has unsaved changes (computed by the caller,
+  // since the dirty check differs per dialog).
+  isDirty: boolean;
+  // Edit mode allows the backdrop to close (with the dirty check); add mode
+  // disables backdrop close entirely so a stray click can't discard work.
+  isEdit: boolean;
+  // Block closing mid-submit.
+  submitting: boolean;
+  onClose: () => void;
+  // Optional cleanup to run right before actually closing (e.g. clear errors).
+  onBeforeClose?: () => void;
+};
+
+/**
+ * Shared "don't lose my work" close handling for item add/edit dialogs.
+ *
+ * Returns handlers that close immediately when the form is clean and pop a
+ * discard confirmation when it's dirty. The backdrop is inert in add mode and
+ * routes through the same check in edit mode.
+ */
+export function useUnsavedCloseGuard({
+  isOpen,
+  isDirty,
+  isEdit,
+  submitting,
+  onClose,
+  onBeforeClose,
+}: UnsavedCloseGuardOptions) {
+  const [discardConfirmOpen, setDiscardConfirmOpen] = useState(false);
+
+  // Reset the confirmation whenever the dialog opens/closes, using the
+  // adjust-state-during-render pattern (no effect) so it stays clean on
+  // reopen without triggering set-state-in-effect.
+  const [wasOpen, setWasOpen] = useState(isOpen);
+  if (isOpen !== wasOpen) {
+    setWasOpen(isOpen);
+    setDiscardConfirmOpen(false);
+  }
+
+  const doClose = () => {
+    onBeforeClose?.();
+    setDiscardConfirmOpen(false);
+    onClose();
+  };
+
+  // Close request from the ✕ / footer Cancel: close when clean, confirm when
+  // dirty.
+  const attemptClose = () => {
+    if (submitting) return;
+    if (isDirty) setDiscardConfirmOpen(true);
+    else doClose();
+  };
+
+  // Backdrop click handler — disabled in add mode, guarded in edit mode.
+  const handleBackdropClick = () => {
+    if (isEdit) attemptClose();
+  };
+
+  return {
+    discardConfirmOpen,
+    closeDiscardConfirm: () => setDiscardConfirmOpen(false),
+    doClose,
+    attemptClose,
+    handleBackdropClick,
+  };
+}
+
+/**
+ * Discard-changes confirmation overlay, rendered on top of the dialog it
+ * guards. Expects to sit inside the dialog's positioned (fixed/relative)
+ * backdrop container.
+ */
+export function DiscardChangesDialog({
+  open,
+  onKeepEditing,
+  onDiscard,
+}: {
+  open: boolean;
+  onKeepEditing: () => void;
+  onDiscard: () => void;
+}) {
+  if (!open) return null;
+  return (
+    <div
+      className="absolute inset-0 z-10 flex items-center justify-center bg-black/50 p-4"
+      onClick={(e) => {
+        e.stopPropagation();
+        onKeepEditing();
+      }}
+    >
+      <div
+        className="bg-background border border-border rounded-xl w-full max-w-sm shadow-2xl p-5"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h3 className="text-base font-semibold text-foreground">
+          Discard changes?
+        </h3>
+        <p className="text-sm text-muted-foreground mt-1">
+          You have unsaved changes. If you close now, they&apos;ll be lost.
+        </p>
+        <div className="mt-5 flex items-center justify-end gap-2 md:gap-3">
+          <button
+            onClick={onKeepEditing}
+            className="h-9 md:h-10 px-4 rounded-md text-sm md:text-base font-medium border border-border bg-background dark:bg-muted hover:bg-muted/50 dark:hover:bg-accent transition-colors cursor-pointer"
+          >
+            Keep editing
+          </button>
+          <button
+            onClick={onDiscard}
+            className="h-9 md:h-10 px-4 rounded-md text-sm md:text-base font-medium bg-red-600 text-white hover:bg-red-700 transition-colors cursor-pointer"
+          >
+            Discard
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## What
- Add a new `llm-general` evaluator/task type for non-conversational LLM judging (single `input → output`), and relabel the existing `llm` type to "Conversational reply" to make its conversation-history bias explicit.
- Build item authoring for `llm-general` tasks: a card-based add/edit dialog and a bulk CSV importer (with `<EvaluatorName>/<variable>` columns), plus CSV export and a read-only annotation display pane — all around the `{ name, input, output }` payload.
- Support per-item `evaluator_variables` when adding items one-by-one or via bulk upload.

## Notes
- Item payload is `{ name, input, output, evaluator_variables? }` — distinct from the conversational `llm` shape (`chat_history`/`agent_response`).
- Bulk upload requires at least one linked evaluator, matching the `llm` task type. Single-item add does not.
- Variable values are treated as required in the UI when an evaluator declares variables (mirrors the `llm` flow), even though the backend treats `evaluator_variables` as optional.