### PR TITLE
Add UI/JSON toggle to test result conversation history

### DIFF
--- a/src/components/ShareButton.tsx
+++ b/src/components/ShareButton.tsx
@@ -2,6 +2,7 @@
 
 import React, { useState, useEffect } from "react";
 import { Tooltip } from "@/components/Tooltip";
+import { copyToClipboard } from "@/lib/clipboard";
 
 export type ShareableEntityType =
   | "stt"
@@ -121,21 +122,9 @@ export function ShareButton({
 
   const copyLink = async () => {
     if (!publicUrl) return;
-    try {
-      await navigator.clipboard.writeText(publicUrl);
-      setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
-    } catch {
-      // Fallback for environments without clipboard API
-      const el = document.createElement("textarea");
-      el.value = publicUrl;
-      document.body.appendChild(el);
-      el.select();
-      document.execCommand("copy");
-      document.body.removeChild(el);
-      setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
-    }
+    await copyToClipboard(publicUrl);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
   };
 
   return (

--- a/src/components/test-results/shared.tsx
+++ b/src/components/test-results/shared.tsx
@@ -769,6 +769,88 @@ export function formatTurnTimestamp(raw: unknown): string | null {
 }
 
 // Shared Test Detail View Component
+// Small segmented control to switch the conversation history between the
+// rendered chat UI and a raw, copyable JSON view. View-only — neither mode
+// edits the underlying data.
+function ConversationViewToggle({
+  view,
+  onChange,
+}: {
+  view: "ui" | "json";
+  onChange: (view: "ui" | "json") => void;
+}) {
+  return (
+    <div className="inline-flex items-center rounded-md border border-border bg-muted/40 p-0.5">
+      {(["ui", "json"] as const).map((option) => (
+        <button
+          key={option}
+          type="button"
+          onClick={() => onChange(option)}
+          className={`px-2.5 py-1 text-[11px] font-medium uppercase tracking-wide rounded cursor-pointer transition-colors ${
+            view === option
+              ? "bg-background text-foreground shadow-sm"
+              : "text-muted-foreground hover:text-foreground"
+          }`}
+          aria-pressed={view === option}
+        >
+          {option === "ui" ? "UI" : "JSON"}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+// Copy-to-clipboard button used by the JSON conversation view. Shows a
+// transient "Copied" confirmation for 2s after a successful copy.
+function CopyJsonButton({ value }: { value: string }) {
+  const [copied, setCopied] = useState(false);
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(value);
+    } catch {
+      const el = document.createElement("textarea");
+      el.value = value;
+      document.body.appendChild(el);
+      el.select();
+      document.execCommand("copy");
+      document.body.removeChild(el);
+    }
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+  return (
+    <button
+      type="button"
+      onClick={handleCopy}
+      className="inline-flex items-center gap-1.5 px-2.5 py-1 text-[11px] font-medium rounded-md border border-border bg-background text-muted-foreground hover:text-foreground cursor-pointer transition-colors"
+    >
+      {copied ? (
+        <>
+          <CheckIcon className="w-3.5 h-3.5 text-green-600 dark:text-green-400" />
+          Copied
+        </>
+      ) : (
+        <>
+          <svg
+            className="w-3.5 h-3.5"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            aria-hidden="true"
+          >
+            <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
+            <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+          </svg>
+          Copy
+        </>
+      )}
+    </button>
+  );
+}
+
 export function TestDetailView({
   history,
   output,
@@ -850,11 +932,35 @@ export function TestDetailView({
   const [legacyReasoningOpen, setLegacyReasoningOpen] = useState(false);
   const showLegacyReasoningToggle =
     !hasJudgeResults && !!reasoning?.trim();
+  const [historyView, setHistoryView] = useState<"ui" | "json">("ui");
+  const historyJson = useMemo(
+    () => JSON.stringify(history, null, 2),
+    [history],
+  );
   return (
     <div className="p-4 md:p-6 space-y-4 md:space-y-6">
       {/* Chat History from test_case.history */}
       {history.length > 0 && (
         <div className="space-y-4">
+          <div className="flex items-center justify-between gap-2">
+            <span className="text-[10px] font-medium text-muted-foreground uppercase tracking-wide">
+              Conversation history
+            </span>
+            <ConversationViewToggle
+              view={historyView}
+              onChange={setHistoryView}
+            />
+          </div>
+          {historyView === "json" ? (
+            <div className="relative rounded-lg border border-border bg-muted/30">
+              <div className="absolute right-2 top-2 z-10">
+                <CopyJsonButton value={historyJson} />
+              </div>
+              <pre className="overflow-x-auto p-3 pr-20 text-xs font-mono text-foreground whitespace-pre-wrap break-words">
+                {historyJson}
+              </pre>
+            </div>
+          ) : (
           <div className="space-y-4">
             {history.map((message, index) => {
               const isEvalTarget = index === evalTargetIndex;
@@ -965,6 +1071,7 @@ export function TestDetailView({
               );
             })}
           </div>
+          )}
         </div>
       )}
 

--- a/src/components/test-results/shared.tsx
+++ b/src/components/test-results/shared.tsx
@@ -1081,8 +1081,10 @@ export function TestDetailView({
         </div>
       )}
 
-      {/* Output Section - Agent's Response/Tool Call */}
-      {output && (
+      {/* Output Section - Agent's Response/Tool Call. Hidden in JSON mode
+          since the JSON view already includes the evaluated agent response
+          as the final turn. */}
+      {output && historyView !== "json" && (
         <div className="space-y-4">
           {/* Text Response */}
           {output.response && (

--- a/src/components/test-results/shared.tsx
+++ b/src/components/test-results/shared.tsx
@@ -933,10 +933,19 @@ export function TestDetailView({
   const showLegacyReasoningToggle =
     !hasJudgeResults && !!reasoning?.trim();
   const [historyView, setHistoryView] = useState<"ui" | "json">("ui");
-  const historyJson = useMemo(
-    () => JSON.stringify(history, null, 2),
-    [history],
-  );
+  const historyJson = useMemo(() => {
+    // Mirror what the UI shows: the prior turns (`history`) followed by the
+    // agent's evaluated response (`output`) appended as the final assistant
+    // turn, so the JSON is the full conversation, not just the prefix.
+    const turns: Array<Record<string, unknown>> = [...history];
+    if (output?.response) {
+      turns.push({ role: "assistant", content: output.response });
+    }
+    if (output?.tool_calls && output.tool_calls.length > 0) {
+      turns.push({ role: "assistant", tool_calls: output.tool_calls });
+    }
+    return JSON.stringify(turns, null, 2);
+  }, [history, output]);
   return (
     <div className="p-4 md:p-6 space-y-4 md:space-y-6">
       {/* Chat History from test_case.history */}

--- a/src/components/test-results/shared.tsx
+++ b/src/components/test-results/shared.tsx
@@ -951,10 +951,7 @@ export function TestDetailView({
       {/* Chat History from test_case.history */}
       {history.length > 0 && (
         <div className="space-y-4">
-          <div className="flex items-center justify-between gap-2">
-            <span className="text-[10px] font-medium text-muted-foreground uppercase tracking-wide">
-              Conversation history
-            </span>
+          <div className="flex items-center justify-end">
             <ConversationViewToggle
               view={historyView}
               onChange={setHistoryView}

--- a/src/components/test-results/shared.tsx
+++ b/src/components/test-results/shared.tsx
@@ -951,7 +951,7 @@ export function TestDetailView({
       {/* Chat History from test_case.history */}
       {history.length > 0 && (
         <div className="space-y-4">
-          <div className="flex items-center justify-end">
+          <div className="sticky top-0 z-20 -mx-4 md:-mx-6 -mt-4 md:-mt-6 px-4 md:px-6 py-2 flex items-center justify-end bg-background/95 backdrop-blur-sm border-b border-border">
             <ConversationViewToggle
               view={historyView}
               onChange={setHistoryView}

--- a/src/components/test-results/shared.tsx
+++ b/src/components/test-results/shared.tsx
@@ -927,14 +927,44 @@ export function TestDetailView({
   const [historyView, setHistoryView] = useState<"ui" | "json">("ui");
   const historyJson = useMemo(() => {
     // Mirror what the UI shows: the prior turns (`history`) followed by the
-    // agent's evaluated response (`output`) appended as the final assistant
-    // turn, so the JSON is the full conversation, not just the prefix.
+    // agent's evaluated response (`output`) appended as the final turn(s),
+    // so the JSON is the full conversation, not just the prefix.
     const turns: Array<Record<string, unknown>> = [...history];
     if (output?.response) {
       turns.push({ role: "assistant", content: output.response });
     }
     if (output?.tool_calls && output.tool_calls.length > 0) {
-      turns.push({ role: "assistant", tool_calls: output.tool_calls });
+      // Normalize the output's tool calls into the same shape used by
+      // `history` (nested `function.name`, JSON-stringified `arguments`,
+      // synthetic `id`/`type`) so the whole array is one consistent schema.
+      // A tool's execution result, when present, is emitted as a separate
+      // `role: "tool"` turn keyed by the same id — exactly as history does.
+      output.tool_calls.forEach((tc, i) => {
+        const id = `output-tool-call-${i}`;
+        turns.push({
+          role: "assistant",
+          tool_calls: [
+            {
+              id,
+              type: "function",
+              function: {
+                name: tc.tool,
+                arguments: JSON.stringify(tc.arguments ?? {}),
+              },
+            },
+          ],
+        });
+        if (tc.output !== undefined && tc.output !== null) {
+          turns.push({
+            role: "tool",
+            tool_call_id: id,
+            content:
+              typeof tc.output === "string"
+                ? tc.output
+                : JSON.stringify(tc.output),
+          });
+        }
+      });
     }
     return JSON.stringify(turns, null, 2);
   }, [history, output]);

--- a/src/components/test-results/shared.tsx
+++ b/src/components/test-results/shared.tsx
@@ -951,7 +951,7 @@ export function TestDetailView({
       {/* Chat History from test_case.history */}
       {history.length > 0 && (
         <div className="space-y-4">
-          <div className="sticky top-0 z-20 -mx-4 md:-mx-6 -mt-4 md:-mt-6 px-4 md:px-6 py-2 flex items-center justify-end bg-background/95 backdrop-blur-sm border-b border-border">
+          <div className="sticky top-0 z-20 -mx-4 md:-mx-6 -mt-4 md:-mt-6 px-4 md:px-6 py-2 flex items-center justify-end bg-background/95 backdrop-blur-sm">
             <ConversationViewToggle
               view={historyView}
               onChange={setHistoryView}

--- a/src/components/test-results/shared.tsx
+++ b/src/components/test-results/shared.tsx
@@ -19,6 +19,7 @@ import {
 } from "@/components/icons";
 import type { DefaultEvaluatorSummary } from "@/lib/defaultEvaluators";
 import { getBinaryLabel, toRatingScale } from "@/lib/binaryLabels";
+import { copyToClipboard } from "@/lib/clipboard";
 
 // Renders the evaluator name. Authenticated result pages can link to the
 // evaluator detail page; public share pages must render plain text because
@@ -805,16 +806,7 @@ function ConversationViewToggle({
 function CopyJsonButton({ value }: { value: string }) {
   const [copied, setCopied] = useState(false);
   const handleCopy = async () => {
-    try {
-      await navigator.clipboard.writeText(value);
-    } catch {
-      const el = document.createElement("textarea");
-      el.value = value;
-      document.body.appendChild(el);
-      el.select();
-      document.execCommand("copy");
-      document.body.removeChild(el);
-    }
+    await copyToClipboard(value);
     setCopied(true);
     setTimeout(() => setCopied(false), 2000);
   };

--- a/src/lib/clipboard.ts
+++ b/src/lib/clipboard.ts
@@ -1,0 +1,17 @@
+/**
+ * Copy `text` to the clipboard, falling back to a hidden textarea +
+ * `execCommand("copy")` for environments without the async Clipboard API
+ * (older browsers, insecure contexts). Resolves once the copy is attempted.
+ */
+export async function copyToClipboard(text: string): Promise<void> {
+  try {
+    await navigator.clipboard.writeText(text);
+  } catch {
+    const el = document.createElement("textarea");
+    el.value = text;
+    document.body.appendChild(el);
+    el.select();
+    document.execCommand("copy");
+    document.body.removeChild(el);
+  }
+}


### PR DESCRIPTION
## What
- Adds a UI/JSON segmented toggle to the conversation history section of the test results dialog (shared `TestDetailView`, so it appears in the test runner, benchmark results, and public result pages).
- JSON view renders the raw `history` array read-only with a one-click copy button; UI view is unchanged.

## Notes
- View-only — nothing is editable in either mode.