### PR TITLE
Surface tool-call test results separately in test & benchmark dialogs

### DIFF
--- a/src/app/public/test-run/[token]/page.tsx
+++ b/src/app/public/test-run/[token]/page.tsx
@@ -14,7 +14,10 @@ import { PublicPageLayout, PublicNotFound, PublicLoading } from "@/components/Pu
 import { TestRunOutputsPanel, TestRunSummary } from "@/components/eval-details";
 import { ExportResultsButton } from "@/components/ExportResultsButton";
 import { buildTestRunCsv } from "@/lib/exportTestResults";
-import { buildEvaluatorSummaryFromResults } from "@/lib/testRunSummary";
+import {
+  buildEvaluatorSummaryFromResults,
+  toolCallPassFail,
+} from "@/lib/testRunSummary";
 import type { AggStat } from "@/lib/llmMetrics";
 
 type TestCaseResult = {
@@ -108,15 +111,13 @@ export default function PublicTestRunPage() {
     (r) => getStatus(r) === "failed" && !r.error,
   ).length;
   // Tool-call pass/fail split for the Summary tab's dedicated card.
-  const toolCallResults = results.filter(
-    (r) => r.test_case?.evaluation?.type === "tool_call",
+  const toolCall = toolCallPassFail(
+    results.map((r) => ({
+      toolCall: r.test_case?.evaluation?.type === "tool_call",
+      passed: getStatus(r) === "passed",
+      failed: getStatus(r) === "failed" && !r.error,
+    })),
   );
-  const toolCallPassed = toolCallResults.filter(
-    (r) => getStatus(r) === "passed",
-  ).length;
-  const toolCallScored =
-    toolCallPassed +
-    toolCallResults.filter((r) => getStatus(r) === "failed" && !r.error).length;
 
   return (
     <PublicPageLayout title="LLM unit test" contentClassName="max-w-[92rem]">
@@ -177,7 +178,7 @@ export default function PublicTestRunPage() {
             latency={data.latency_ms ?? null}
             cost={data.cost ?? null}
             tokens={data.total_tokens ?? null}
-            toolCall={{ passed: toolCallPassed, total: toolCallScored }}
+            toolCall={toolCall}
             evaluatorSummary={buildEvaluatorSummaryFromResults(
               results,
               Object.fromEntries(

--- a/src/app/public/test-run/[token]/page.tsx
+++ b/src/app/public/test-run/[token]/page.tsx
@@ -107,6 +107,16 @@ export default function PublicTestRunPage() {
   const failed = results.filter(
     (r) => getStatus(r) === "failed" && !r.error,
   ).length;
+  // Tool-call pass/fail split for the Summary tab's dedicated card.
+  const toolCallResults = results.filter(
+    (r) => r.test_case?.evaluation?.type === "tool_call",
+  );
+  const toolCallPassed = toolCallResults.filter(
+    (r) => getStatus(r) === "passed",
+  ).length;
+  const toolCallScored =
+    toolCallPassed +
+    toolCallResults.filter((r) => getStatus(r) === "failed" && !r.error).length;
 
   return (
     <PublicPageLayout title="LLM unit test" contentClassName="max-w-[92rem]">
@@ -167,6 +177,7 @@ export default function PublicTestRunPage() {
             latency={data.latency_ms ?? null}
             cost={data.cost ?? null}
             tokens={data.total_tokens ?? null}
+            toolCall={{ passed: toolCallPassed, total: toolCallScored }}
             evaluatorSummary={buildEvaluatorSummaryFromResults(
               results,
               Object.fromEntries(

--- a/src/components/TestRunnerDialog.tsx
+++ b/src/components/TestRunnerDialog.tsx
@@ -923,6 +923,17 @@ export function TestRunnerDialog({
   const failedTests = testResults.filter(
     (r) => r.status === "failed" && !r.error,
   );
+  // Tool-call pass/fail split for the Summary tab's dedicated card. Scored
+  // tool-call tests only (errored ones excluded, matching the overall rate).
+  const toolCallResults = testResults.filter(
+    (r) => r.test.type === "tool_call",
+  );
+  const toolCallPassed = toolCallResults.filter(
+    (r) => r.status === "passed",
+  ).length;
+  const toolCallScored =
+    toolCallPassed +
+    toolCallResults.filter((r) => r.status === "failed" && !r.error).length;
   const hasLabellingEligibleTests = testResults.some((r) =>
     isLabellingEligibleRaw({ test_case: r.testCase ?? null }),
   );
@@ -1139,6 +1150,7 @@ export function TestRunnerDialog({
                   latency={latencyAgg}
                   cost={costAgg}
                   tokens={tokensAgg}
+                  toolCall={{ passed: toolCallPassed, total: toolCallScored }}
                   evaluatorSummary={evaluatorSummary}
                 />
               </div>

--- a/src/components/TestRunnerDialog.tsx
+++ b/src/components/TestRunnerDialog.tsx
@@ -26,7 +26,10 @@ import {
 import { useLabellingSelection } from "@/components/human-labelling/useLabellingSelection";
 import { TestRunOutputsPanel, TestRunSummary } from "./eval-details";
 import { buildTestRunCsv } from "@/lib/exportTestResults";
-import { buildEvaluatorSummaryFromResults } from "@/lib/testRunSummary";
+import {
+  buildEvaluatorSummaryFromResults,
+  toolCallPassFail,
+} from "@/lib/testRunSummary";
 import type { AggStat } from "@/lib/llmMetrics";
 import {
   fetchDefaultLLMNextReplyEvaluator,
@@ -923,19 +926,16 @@ export function TestRunnerDialog({
   const failedTests = testResults.filter(
     (r) => r.status === "failed" && !r.error,
   );
-  // Tool-call pass/fail split for the Summary tab's dedicated card. Scored
-  // tool-call tests only (errored ones excluded, matching the overall rate).
-  // Keyed off the test case's evaluation type, not `r.test.type` — the latter
-  // is hardcoded to "response" when results are rebuilt from a viewed past run.
-  const toolCallResults = testResults.filter(
-    (r) => r.testCase?.evaluation?.type === "tool_call",
+  // Tool-call pass/fail split for the Summary tab's dedicated card. Keyed off
+  // the test case's evaluation type, not `r.test.type` — the latter is
+  // hardcoded to "response" when results are rebuilt from a viewed past run.
+  const toolCall = toolCallPassFail(
+    testResults.map((r) => ({
+      toolCall: r.testCase?.evaluation?.type === "tool_call",
+      passed: r.status === "passed",
+      failed: r.status === "failed" && !r.error,
+    })),
   );
-  const toolCallPassed = toolCallResults.filter(
-    (r) => r.status === "passed",
-  ).length;
-  const toolCallScored =
-    toolCallPassed +
-    toolCallResults.filter((r) => r.status === "failed" && !r.error).length;
   const hasLabellingEligibleTests = testResults.some((r) =>
     isLabellingEligibleRaw({ test_case: r.testCase ?? null }),
   );
@@ -1152,7 +1152,7 @@ export function TestRunnerDialog({
                   latency={latencyAgg}
                   cost={costAgg}
                   tokens={tokensAgg}
-                  toolCall={{ passed: toolCallPassed, total: toolCallScored }}
+                  toolCall={toolCall}
                   evaluatorSummary={evaluatorSummary}
                 />
               </div>

--- a/src/components/TestRunnerDialog.tsx
+++ b/src/components/TestRunnerDialog.tsx
@@ -925,8 +925,10 @@ export function TestRunnerDialog({
   );
   // Tool-call pass/fail split for the Summary tab's dedicated card. Scored
   // tool-call tests only (errored ones excluded, matching the overall rate).
+  // Keyed off the test case's evaluation type, not `r.test.type` — the latter
+  // is hardcoded to "response" when results are rebuilt from a viewed past run.
   const toolCallResults = testResults.filter(
-    (r) => r.test.type === "tool_call",
+    (r) => r.testCase?.evaluation?.type === "tool_call",
   );
   const toolCallPassed = toolCallResults.filter(
     (r) => r.status === "passed",

--- a/src/components/eval-details/BenchmarkCombinedLeaderboard.tsx
+++ b/src/components/eval-details/BenchmarkCombinedLeaderboard.tsx
@@ -58,19 +58,6 @@ function columnsFromPayload(
     });
   }
 
-  if (payload.plan.showToolCallPassRate) {
-    cols.push({
-      key: "tool_call_pass_rate",
-      header: "Tool-call pass rate (%)",
-      render: (v) =>
-        typeof v === "number" && Number.isFinite(v) ? (
-          formatPercent(v)
-        ) : (
-          <span className="text-muted-foreground">—</span>
-        ),
-    });
-  }
-
   if (payload.plan.showLatency) {
     cols.push({
       key: "avg_latency_ms",
@@ -104,6 +91,21 @@ function columnsFromPayload(
       render: (v) =>
         typeof v === "number" && Number.isFinite(v) ? (
           formatTokens(v)
+        ) : (
+          <span className="text-muted-foreground">—</span>
+        ),
+    });
+  }
+
+  // Tool-call pass rate sits after the cost/token metrics, just before the
+  // per-evaluator columns.
+  if (payload.plan.showToolCallPassRate) {
+    cols.push({
+      key: "tool_call_pass_rate",
+      header: "Tool-call pass rate (%)",
+      render: (v) =>
+        typeof v === "number" && Number.isFinite(v) ? (
+          formatPercent(v)
         ) : (
           <span className="text-muted-foreground">—</span>
         ),

--- a/src/components/eval-details/BenchmarkCombinedLeaderboard.tsx
+++ b/src/components/eval-details/BenchmarkCombinedLeaderboard.tsx
@@ -58,6 +58,19 @@ function columnsFromPayload(
     });
   }
 
+  if (payload.plan.showToolCallPassRate) {
+    cols.push({
+      key: "tool_call_pass_rate",
+      header: "Tool-call pass rate (%)",
+      render: (v) =>
+        typeof v === "number" && Number.isFinite(v) ? (
+          formatPercent(v)
+        ) : (
+          <span className="text-muted-foreground">—</span>
+        ),
+    });
+  }
+
   if (payload.plan.showLatency) {
     cols.push({
       key: "avg_latency_ms",

--- a/src/components/eval-details/TestRunSummary.tsx
+++ b/src/components/eval-details/TestRunSummary.tsx
@@ -209,7 +209,11 @@ export function TestRunSummary({
   return (
     <div className="p-4 md:p-6 space-y-6 overflow-y-auto h-full">
       <div>
-        <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+        <div
+          className={`grid grid-cols-2 gap-4 ${
+            toolCallRate !== null ? "md:grid-cols-5" : "md:grid-cols-4"
+          }`}
+        >
           <MetricCard
             label="Pass rate"
             value={formatPercent(rate)}
@@ -222,7 +226,7 @@ export function TestRunSummary({
               value={formatPercent(toolCallRate)}
               subtitle={`${toolCall.passed}/${toolCall.total}`}
               progress={toolCallRate}
-              info="Pass rate across tool-call tests only (a subset of the overall pass rate)"
+              info="Pass rate across tool-call tests only"
             />
           )}
           <MetricCard

--- a/src/components/eval-details/TestRunSummary.tsx
+++ b/src/components/eval-details/TestRunSummary.tsx
@@ -28,6 +28,10 @@ type TestRunSummaryProps = {
   cost?: AggStat;
   /** Aggregate per-test total-token block. Null for eval-only runs. */
   tokens?: AggStat;
+  /** Pass/total restricted to tool-call tests. When present with a non-zero
+   * total, a dedicated "Tool calls" pass-rate card is shown alongside the
+   * overall pass rate so tool-call results aren't hidden inside the total. */
+  toolCall?: { passed: number; total: number };
   /** Per-evaluator aggregates (same shape benchmark uses), single model. */
   evaluatorSummary?: BenchmarkEvaluatorSummaryEntry[] | null;
   /** Disable evaluator detail links for public share pages. */
@@ -174,10 +178,15 @@ export function TestRunSummary({
   latency,
   cost,
   tokens,
+  toolCall,
   evaluatorSummary,
   enableEvaluatorLinks = true,
 }: TestRunSummaryProps) {
   const rate = total > 0 ? (passed / total) * 100 : null;
+  const toolCallRate =
+    toolCall && toolCall.total > 0
+      ? (toolCall.passed / toolCall.total) * 100
+      : null;
 
   const evaluators = evaluatorSummary ?? [];
 
@@ -207,6 +216,15 @@ export function TestRunSummary({
             subtitle={`${passed}/${total}`}
             progress={rate ?? undefined}
           />
+          {toolCallRate !== null && toolCall && (
+            <MetricCard
+              label="Tool calls"
+              value={formatPercent(toolCallRate)}
+              subtitle={`${toolCall.passed}/${toolCall.total}`}
+              progress={toolCallRate}
+              info="Pass rate across tool-call tests only (a subset of the overall pass rate)"
+            />
+          )}
           <MetricCard
             label={METRIC_LABELS.latency}
             value={formatLatencyMs(latency?.mean)}

--- a/src/lib/benchmarkEvaluatorSummary.ts
+++ b/src/lib/benchmarkEvaluatorSummary.ts
@@ -345,15 +345,6 @@ export function buildBenchmarkCombinedLeaderboardPayload(
     });
   }
 
-  if (showToolCallPassRate) {
-    allCharts.push({
-      title: "Tool-call pass rate (%)",
-      dataKey: "tool_call_pass_rate",
-      yDomain: [0, 100],
-      formatTooltip: (v) => formatPercent(v),
-    });
-  }
-
   if (showLatency) {
     allCharts.push({
       title: `${METRIC_LABELS.latency} (s)`,
@@ -376,6 +367,17 @@ export function buildBenchmarkCombinedLeaderboardPayload(
       title: METRIC_LABELS.tokens,
       dataKey: "avg_tokens",
       formatTooltip: (v) => formatTokens(v),
+    });
+  }
+
+  // Tool-call pass rate sits after the cost/token metrics, just before the
+  // per-evaluator charts (mirrors the leaderboard column order).
+  if (showToolCallPassRate) {
+    allCharts.push({
+      title: "Tool-call pass rate (%)",
+      dataKey: "tool_call_pass_rate",
+      yDomain: [0, 100],
+      formatTooltip: (v) => formatPercent(v),
     });
   }
 

--- a/src/lib/benchmarkEvaluatorSummary.ts
+++ b/src/lib/benchmarkEvaluatorSummary.ts
@@ -43,10 +43,42 @@ export type BenchmarkEvaluatorSummaryEntry =
   | BenchmarkEvaluatorSummaryBinary
   | BenchmarkEvaluatorSummaryRating;
 
+/** Minimal per-test shape needed to derive the tool-call pass-rate split. */
+export type BenchmarkToolCallTestLike = {
+  passed?: boolean | null;
+  error?: string;
+  test_case?: { evaluation?: { type?: string } | null } | null;
+};
+
 export type BenchmarkModelLike = {
   model: string;
   evaluator_summary?: BenchmarkEvaluatorSummaryEntry[] | null;
+  /** Per-test results, used to derive the tool-call pass-rate column/chart.
+   * Optional — older callers / payloads may omit it. */
+  test_results?: BenchmarkToolCallTestLike[] | null;
 };
+
+/**
+ * Pass/total for the tool-call subset of a model's tests. A test counts toward
+ * the total only when it's a tool-call test that finished scoring (not errored,
+ * not still running). Returns `{passed: 0, total: 0}` when the model has no
+ * tool-call tests or no `test_results`.
+ */
+export function benchmarkToolCallPassFail(model: BenchmarkModelLike): {
+  passed: number;
+  total: number;
+} {
+  let passed = 0;
+  let total = 0;
+  for (const tr of model.test_results ?? []) {
+    if (tr.test_case?.evaluation?.type !== "tool_call") continue;
+    if (tr.error) continue;
+    if (tr.passed === null || tr.passed === undefined) continue;
+    total++;
+    if (tr.passed) passed++;
+  }
+  return { passed, total };
+}
 
 export type BenchmarkLeaderboardSummaryRow = {
   model: string;
@@ -81,6 +113,8 @@ export type BenchmarkCombinedLeaderboardPayload = {
   plan: {
     showPassedTotal: boolean;
     showOverallPassRate: boolean;
+    /** True when at least one model has scored tool-call tests. */
+    showToolCallPassRate: boolean;
     /** True when at least one model reported an average latency. */
     showLatency: boolean;
     /** True when at least one model reported an average cost. */
@@ -241,6 +275,7 @@ export function buildBenchmarkCombinedLeaderboardPayload(
 
   const modelsOrdered = orderedCanonicalModels(leaderboardSummary, modelResults);
   const rows: Record<string, unknown>[] = [];
+  let showToolCallPassRate = false;
   let showLatency = false;
   let showCost = false;
   let showTokens = false;
@@ -275,6 +310,16 @@ export function buildBenchmarkCombinedLeaderboardPayload(
       }
     }
 
+    if (mr) {
+      const tc = benchmarkToolCallPassFail(mr);
+      if (tc.total > 0) {
+        row.tool_call_pass_rate = (tc.passed / tc.total) * 100;
+        row.tool_call_passed = String(tc.passed);
+        row.tool_call_total = String(tc.total);
+        showToolCallPassRate = true;
+      }
+    }
+
     for (const ev of evaluators) {
       const entry = (mr?.evaluator_summary ?? []).find(
         (e) => e.metric_key === ev.metric_key,
@@ -297,6 +342,15 @@ export function buildBenchmarkCombinedLeaderboardPayload(
     allCharts.push({
       title: benchmarkScoreLabel,
       dataKey: "pass_rate",
+      yDomain: [0, 100],
+      formatTooltip: (v) => formatPercent(v),
+    });
+  }
+
+  if (showToolCallPassRate) {
+    allCharts.push({
+      title: "Tool-call pass rate (%)",
+      dataKey: "tool_call_pass_rate",
       yDomain: [0, 100],
       formatTooltip: (v) => formatPercent(v),
     });
@@ -362,6 +416,7 @@ export function buildBenchmarkCombinedLeaderboardPayload(
     plan: {
       showPassedTotal,
       showOverallPassRate,
+      showToolCallPassRate,
       showLatency,
       showCost,
       showTokens,

--- a/src/lib/benchmarkEvaluatorSummary.ts
+++ b/src/lib/benchmarkEvaluatorSummary.ts
@@ -314,8 +314,6 @@ export function buildBenchmarkCombinedLeaderboardPayload(
       const tc = benchmarkToolCallPassFail(mr);
       if (tc.total > 0) {
         row.tool_call_pass_rate = (tc.passed / tc.total) * 100;
-        row.tool_call_passed = String(tc.passed);
-        row.tool_call_total = String(tc.total);
         showToolCallPassRate = true;
       }
     }

--- a/src/lib/testRunSummary.ts
+++ b/src/lib/testRunSummary.ts
@@ -11,6 +11,41 @@ import type { BenchmarkEvaluatorSummaryEntry } from "./benchmarkEvaluatorSummary
 
 type ResultLike = { judge_results?: JudgeResult[] | null };
 
+/** One test row reduced to the flags the tool-call pass rate cares about. */
+type ToolCallStatusLike = {
+  /** Whether this is a tool-call test. */
+  toolCall: boolean;
+  /** Scored as passed. */
+  passed: boolean;
+  /** Scored as failed (errored rows must be `false`). */
+  failed: boolean;
+};
+
+/**
+ * Pass/total over the tool-call subset of a single run's results. Total counts
+ * only scored tool-call tests (passed or failed, errored/running excluded), so
+ * it matches the overall pass-rate denominator. Callers pre-reduce each result
+ * to {@link ToolCallStatusLike} since the dialog and the public page carry
+ * different result shapes.
+ */
+export function toolCallPassFail(rows: ToolCallStatusLike[]): {
+  passed: number;
+  total: number;
+} {
+  let passed = 0;
+  let total = 0;
+  for (const r of rows) {
+    if (!r.toolCall) continue;
+    if (r.passed) {
+      passed++;
+      total++;
+    } else if (r.failed) {
+      total++;
+    }
+  }
+  return { passed, total };
+}
+
 /**
  * Group every row's `judge_results` by evaluator and produce one aggregate
  * entry per evaluator (first-seen order). Binary evaluators count `match`


### PR DESCRIPTION
## What
- Test results dialog Summary tab (and public test-run page): adds a "Tool calls" pass-rate card next to "Pass rate" so tool-call results aren't hidden inside the overall total.
- Benchmark dialog leaderboard (and public benchmark page): adds a "Tool-call pass rate (%)" column and matching chart, derived per-model from tool-call test results.

## Notes
- Both additions only appear when the run/benchmark contains scored tool-call tests; response-only flows are unchanged.
- The tool-call subset excludes errored/running tests, matching the overall pass-rate denominator.