### PR TITLE
Add Compare bulk action to benchmark only selected tests

### DIFF
--- a/src/components/BenchmarkResultsDialog.tsx
+++ b/src/components/BenchmarkResultsDialog.tsx
@@ -421,12 +421,21 @@ export function BenchmarkResultsDialog({
           },
           body: JSON.stringify({
             models: models,
+            test_uuids: testUuids,
           }),
         },
       );
 
       if (!response.ok) {
-        throw new Error("Failed to start benchmark");
+        const detail = await response
+          .json()
+          .then((body) => body?.detail)
+          .catch(() => null);
+        throw new Error(
+          typeof detail === "string" && detail
+            ? detail
+            : "Failed to start benchmark",
+        );
       }
 
       const result: BenchmarkStatusResponse = await response.json();

--- a/src/components/agent-tabs/CompareModelsButton.tsx
+++ b/src/components/agent-tabs/CompareModelsButton.tsx
@@ -1,0 +1,76 @@
+import React from "react";
+
+/**
+ * Shared "compare models" / benchmark trigger button. Used both in the Tests
+ * tab header (compare all linked tests) and in the selection bulk-action bar
+ * (compare only the selected tests). Keeps the disabled rules, the two
+ * disabled-reason tooltips, and the chart icon in one place so the two
+ * surfaces can't drift apart.
+ */
+export function CompareModelsButton({
+  size,
+  label,
+  isConnectionUnverified,
+  isBenchmarkDisabled,
+  onClick,
+}: {
+  size: "header" | "bulk";
+  label: React.ReactNode;
+  isConnectionUnverified: boolean;
+  isBenchmarkDisabled: boolean;
+  onClick: () => void;
+}) {
+  const disabled = isConnectionUnverified || isBenchmarkDisabled;
+  const isHeader = size === "header";
+
+  const buttonClass = isHeader
+    ? `h-9 md:h-10 px-3 md:px-4 rounded-md text-sm md:text-base font-medium border transition-colors flex items-center gap-2 bg-amber-500/12 border-amber-500/45 text-amber-950 dark:text-amber-100 ${
+        disabled
+          ? "opacity-50 cursor-not-allowed"
+          : "hover:bg-amber-500/22 dark:hover:bg-amber-500/18 cursor-pointer"
+      }`
+    : `h-8 px-3 rounded-md text-sm font-medium border bg-amber-500/12 border-amber-500/45 text-amber-950 dark:text-amber-100 transition-colors flex items-center gap-1.5 ${
+        disabled
+          ? "opacity-50 cursor-not-allowed"
+          : "hover:bg-amber-500/22 dark:hover:bg-amber-500/18 cursor-pointer"
+      }`;
+
+  return (
+    <div className="relative group/compare">
+      <button
+        onClick={() => {
+          if (disabled) return;
+          onClick();
+        }}
+        disabled={disabled}
+        className={buttonClass}
+      >
+        <svg
+          className={isHeader ? "w-4 h-4" : "w-3.5 h-3.5"}
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+          strokeWidth={2}
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M3.75 3v11.25A2.25 2.25 0 006 16.5h2.25M3.75 3h-1.5m1.5 0h16.5m0 0h1.5m-1.5 0v11.25A2.25 2.25 0 0118 16.5h-2.25m-7.5 0h7.5m-7.5 0l-1 3m8.5-3l1 3m0 0l.5 1.5m-.5-1.5h-9.5m0 0l-.5 1.5m.75-9l3-3 2.148 2.148A12.061 12.061 0 0116.5 7.605"
+          />
+        </svg>
+        {label}
+      </button>
+      {isConnectionUnverified && (
+        <div className="absolute left-1/2 -translate-x-1/2 bottom-full mb-2 px-3 py-1.5 bg-foreground text-background text-xs rounded-lg shadow-lg opacity-0 group-hover/compare:opacity-100 pointer-events-none transition-opacity whitespace-nowrap z-50">
+          Verify agent connection first
+        </div>
+      )}
+      {!isConnectionUnverified && isBenchmarkDisabled && (
+        <div className="absolute left-1/2 -translate-x-1/2 bottom-full mb-2 px-3 py-1.5 bg-foreground text-background text-xs rounded-lg shadow-lg opacity-0 group-hover/compare:opacity-100 pointer-events-none transition-opacity whitespace-nowrap z-50">
+          You have turned off benchmarking models in connection settings — turn
+          it on to enable this
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/agent-tabs/TestsTabContent.tsx
+++ b/src/components/agent-tabs/TestsTabContent.tsx
@@ -10,6 +10,7 @@ import { DeleteConfirmationDialog } from "@/components/DeleteConfirmationDialog"
 import { TestRunnerDialog } from "@/components/TestRunnerDialog";
 import { BenchmarkDialog } from "@/components/BenchmarkDialog";
 import { BenchmarkResultsDialog } from "@/components/BenchmarkResultsDialog";
+import { CompareModelsButton } from "@/components/agent-tabs/CompareModelsButton";
 import {
   AddTestDialog,
   TestConfig,
@@ -1707,48 +1708,21 @@ export function TestsTabContent({
             </div>
 
             {/* Compare models — amber tint, "analyse" semantic. */}
-            <div className="relative group/compare">
-              <button
-                onClick={() => {
-                  if (isConnectionUnverified || isBenchmarkDisabled) return;
-                  setBenchmarkTestSubset(null);
-                  setBenchmarkDialogOpen(true);
-                }}
-                disabled={isConnectionUnverified || isBenchmarkDisabled}
-                className={`h-9 md:h-10 px-3 md:px-4 rounded-md text-sm md:text-base font-medium border transition-colors flex items-center gap-2 bg-amber-500/12 border-amber-500/45 text-amber-950 dark:text-amber-100 ${
-                  isConnectionUnverified || isBenchmarkDisabled
-                    ? "opacity-50 cursor-not-allowed"
-                    : "hover:bg-amber-500/22 dark:hover:bg-amber-500/18 cursor-pointer"
-                }`}
-              >
-                <svg
-                  className="w-4 h-4"
-                  fill="none"
-                  viewBox="0 0 24 24"
-                  stroke="currentColor"
-                  strokeWidth={2}
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    d="M3.75 3v11.25A2.25 2.25 0 006 16.5h2.25M3.75 3h-1.5m1.5 0h16.5m0 0h1.5m-1.5 0v11.25A2.25 2.25 0 0118 16.5h-2.25m-7.5 0h7.5m-7.5 0l-1 3m8.5-3l1 3m0 0l.5 1.5m-.5-1.5h-9.5m0 0l-.5 1.5m.75-9l3-3 2.148 2.148A12.061 12.061 0 0116.5 7.605"
-                  />
-                </svg>
-                <span className="hidden sm:inline">Compare models</span>
-                <span className="sm:hidden">Compare</span>
-              </button>
-              {isConnectionUnverified && (
-                <div className="absolute left-1/2 -translate-x-1/2 bottom-full mb-2 px-3 py-1.5 bg-foreground text-background text-xs rounded-lg shadow-lg opacity-0 group-hover/compare:opacity-100 pointer-events-none transition-opacity whitespace-nowrap z-50">
-                  Verify agent connection first
-                </div>
-              )}
-              {!isConnectionUnverified && isBenchmarkDisabled && (
-                <div className="absolute left-1/2 -translate-x-1/2 bottom-full mb-2 px-3 py-1.5 bg-foreground text-background text-xs rounded-lg shadow-lg opacity-0 group-hover/compare:opacity-100 pointer-events-none transition-opacity whitespace-nowrap z-50">
-                  You have turned off benchmarking models in connection settings
-                  — turn it on to enable this
-                </div>
-              )}
-            </div>
+            <CompareModelsButton
+              size="header"
+              label={
+                <>
+                  <span className="hidden sm:inline">Compare models</span>
+                  <span className="sm:hidden">Compare</span>
+                </>
+              }
+              isConnectionUnverified={isConnectionUnverified}
+              isBenchmarkDisabled={isBenchmarkDisabled}
+              onClick={() => {
+                setBenchmarkTestSubset(null);
+                setBenchmarkDialogOpen(true);
+              }}
+            />
           </div>
 
           {/* Right group: add-more-tests buttons. */}
@@ -2003,53 +1977,21 @@ export function TestsTabContent({
                   >
                     Delete
                   </button>
-                  <div className="relative group/compareselected">
-                    <button
-                      onClick={() => {
-                        if (isConnectionUnverified || isBenchmarkDisabled)
-                          return;
-                        const selected = agentTests.filter((t) =>
-                          selectedTestUuids.has(t.uuid),
-                        );
-                        if (selected.length === 0) return;
-                        setBenchmarkTestSubset(selected);
-                        setBenchmarkDialogOpen(true);
-                        setSelectedTestUuids(new Set());
-                      }}
-                      disabled={isConnectionUnverified || isBenchmarkDisabled}
-                      className={`h-8 px-3 rounded-md text-sm font-medium border bg-amber-500/12 border-amber-500/45 text-amber-950 dark:text-amber-100 transition-colors flex items-center gap-1.5 ${
-                        isConnectionUnverified || isBenchmarkDisabled
-                          ? "opacity-50 cursor-not-allowed"
-                          : "hover:bg-amber-500/22 dark:hover:bg-amber-500/18 cursor-pointer"
-                      }`}
-                    >
-                      <svg
-                        className="w-3.5 h-3.5"
-                        fill="none"
-                        viewBox="0 0 24 24"
-                        stroke="currentColor"
-                        strokeWidth={2}
-                      >
-                        <path
-                          strokeLinecap="round"
-                          strokeLinejoin="round"
-                          d="M3.75 3v11.25A2.25 2.25 0 006 16.5h2.25M3.75 3h-1.5m1.5 0h16.5m0 0h1.5m-1.5 0v11.25A2.25 2.25 0 0118 16.5h-2.25m-7.5 0h7.5m-7.5 0l-1 3m8.5-3l1 3m0 0l.5 1.5m-.5-1.5h-9.5m0 0l-.5 1.5m.75-9l3-3 2.148 2.148A12.061 12.061 0 0116.5 7.605"
-                        />
-                      </svg>
-                      Compare
-                    </button>
-                    {isConnectionUnverified && (
-                      <div className="absolute left-1/2 -translate-x-1/2 bottom-full mb-2 px-3 py-1.5 bg-foreground text-background text-xs rounded-lg shadow-lg opacity-0 group-hover/compareselected:opacity-100 pointer-events-none transition-opacity whitespace-nowrap z-50">
-                        Verify agent connection first
-                      </div>
-                    )}
-                    {!isConnectionUnverified && isBenchmarkDisabled && (
-                      <div className="absolute left-1/2 -translate-x-1/2 bottom-full mb-2 px-3 py-1.5 bg-foreground text-background text-xs rounded-lg shadow-lg opacity-0 group-hover/compareselected:opacity-100 pointer-events-none transition-opacity whitespace-nowrap z-50">
-                        You have turned off benchmarking models in connection
-                        settings — turn it on to enable this
-                      </div>
-                    )}
-                  </div>
+                  <CompareModelsButton
+                    size="bulk"
+                    label="Compare"
+                    isConnectionUnverified={isConnectionUnverified}
+                    isBenchmarkDisabled={isBenchmarkDisabled}
+                    onClick={() => {
+                      const selected = agentTests.filter((t) =>
+                        selectedTestUuids.has(t.uuid),
+                      );
+                      if (selected.length === 0) return;
+                      setBenchmarkTestSubset(selected);
+                      setBenchmarkDialogOpen(true);
+                      setSelectedTestUuids(new Set());
+                    }}
+                  />
                   <div className="relative group/runselected">
                     <button
                       onClick={() => {

--- a/src/components/agent-tabs/TestsTabContent.tsx
+++ b/src/components/agent-tabs/TestsTabContent.tsx
@@ -301,6 +301,12 @@ export function TestsTabContent({
 
   // Benchmark dialog state
   const [benchmarkDialogOpen, setBenchmarkDialogOpen] = useState(false);
+  // When set, the benchmark dialog is scoped to this subset of tests (the
+  // "Compare" bulk action on selected rows). null → compare all linked tests
+  // (the header "Compare models" button).
+  const [benchmarkTestSubset, setBenchmarkTestSubset] = useState<
+    TestData[] | null
+  >(null);
 
   const isConnectionUnverified =
     agentType === "connection" && connectionVerified === false;
@@ -1705,6 +1711,7 @@ export function TestsTabContent({
               <button
                 onClick={() => {
                   if (isConnectionUnverified || isBenchmarkDisabled) return;
+                  setBenchmarkTestSubset(null);
                   setBenchmarkDialogOpen(true);
                 }}
                 disabled={isConnectionUnverified || isBenchmarkDisabled}
@@ -1996,6 +2003,53 @@ export function TestsTabContent({
                   >
                     Delete
                   </button>
+                  <div className="relative group/compareselected">
+                    <button
+                      onClick={() => {
+                        if (isConnectionUnverified || isBenchmarkDisabled)
+                          return;
+                        const selected = agentTests.filter((t) =>
+                          selectedTestUuids.has(t.uuid),
+                        );
+                        if (selected.length === 0) return;
+                        setBenchmarkTestSubset(selected);
+                        setBenchmarkDialogOpen(true);
+                        setSelectedTestUuids(new Set());
+                      }}
+                      disabled={isConnectionUnverified || isBenchmarkDisabled}
+                      className={`h-8 px-3 rounded-md text-sm font-medium border bg-amber-500/12 border-amber-500/45 text-amber-950 dark:text-amber-100 transition-colors flex items-center gap-1.5 ${
+                        isConnectionUnverified || isBenchmarkDisabled
+                          ? "opacity-50 cursor-not-allowed"
+                          : "hover:bg-amber-500/22 dark:hover:bg-amber-500/18 cursor-pointer"
+                      }`}
+                    >
+                      <svg
+                        className="w-3.5 h-3.5"
+                        fill="none"
+                        viewBox="0 0 24 24"
+                        stroke="currentColor"
+                        strokeWidth={2}
+                      >
+                        <path
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          d="M3.75 3v11.25A2.25 2.25 0 006 16.5h2.25M3.75 3h-1.5m1.5 0h16.5m0 0h1.5m-1.5 0v11.25A2.25 2.25 0 0118 16.5h-2.25m-7.5 0h7.5m-7.5 0l-1 3m8.5-3l1 3m0 0l.5 1.5m-.5-1.5h-9.5m0 0l-.5 1.5m.75-9l3-3 2.148 2.148A12.061 12.061 0 0116.5 7.605"
+                        />
+                      </svg>
+                      Compare
+                    </button>
+                    {isConnectionUnverified && (
+                      <div className="absolute left-1/2 -translate-x-1/2 bottom-full mb-2 px-3 py-1.5 bg-foreground text-background text-xs rounded-lg shadow-lg opacity-0 group-hover/compareselected:opacity-100 pointer-events-none transition-opacity whitespace-nowrap z-50">
+                        Verify agent connection first
+                      </div>
+                    )}
+                    {!isConnectionUnverified && isBenchmarkDisabled && (
+                      <div className="absolute left-1/2 -translate-x-1/2 bottom-full mb-2 px-3 py-1.5 bg-foreground text-background text-xs rounded-lg shadow-lg opacity-0 group-hover/compareselected:opacity-100 pointer-events-none transition-opacity whitespace-nowrap z-50">
+                        You have turned off benchmarking models in connection
+                        settings — turn it on to enable this
+                      </div>
+                    )}
+                  </div>
                   <div className="relative group/runselected">
                     <button
                       onClick={() => {
@@ -2467,10 +2521,13 @@ export function TestsTabContent({
       {/* Benchmark Dialog */}
       <BenchmarkDialog
         isOpen={benchmarkDialogOpen}
-        onClose={() => setBenchmarkDialogOpen(false)}
+        onClose={() => {
+          setBenchmarkDialogOpen(false);
+          setBenchmarkTestSubset(null);
+        }}
         agentUuid={agentUuid}
         agentName={agentName}
-        tests={agentTests}
+        tests={benchmarkTestSubset ?? agentTests}
         onBenchmarkCreated={handleBenchmarkCreated}
         agentType={agentType}
         benchmarkModelsVerified={benchmarkModelsVerified}


### PR DESCRIPTION
## What
- Add a **Compare** button to the Tests-tab selection bulk-actions bar so an LLM benchmark can be scoped to just the checked tests, instead of always running over every linked test.
- The benchmark POST now sends `test_uuids` (backend already supports the filter); the header "Compare models" button still sends all linked uuids, preserving the prior compare-all behaviour.
- Surface the backend's error `detail` on a failed benchmark start instead of a generic message.

## Notes
- Compare is disabled under the same conditions as the header button (unverified connection / benchmarking turned off in connection settings).
- Both entry points derive uuids from the agent's linked tests, so the backend's stricter linkage 404 is unreachable through the UI.