### PR TITLE
Fix overflowing row-index badge and parallelize STT audio upload

### DIFF
--- a/src/components/eval-details/STTResultsTable.tsx
+++ b/src/components/eval-details/STTResultsTable.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { Tooltip } from "@/components/Tooltip";
+import { LazyAudioPlayer } from "@/components/evaluations/LazyAudioPlayer";
 import {
   EvaluatorScoreCell,
   readEvaluatorCell,
@@ -165,7 +166,7 @@ export function STTResultsTable({ results, showMetrics = true, showSimilarity = 
                     {hasAudio && (
                       <td className="px-3 py-3">
                         {result.audio_url ? (
-                          <audio src={result.audio_url} controls preload="none" className="h-8 w-full max-w-[160px]" />
+                          <LazyAudioPlayer src={result.audio_url} className="w-full max-w-[160px]" />
                         ) : (
                           <span className="text-[13px] text-muted-foreground">&mdash;</span>
                         )}
@@ -252,7 +253,7 @@ export function STTResultsTable({ results, showMetrics = true, showSimilarity = 
                 <div>
                   <span className="text-[11px] text-muted-foreground uppercase tracking-wide">Audio</span>
                   <div className="mt-1">
-                    <audio src={result.audio_url} controls preload="none" className="w-full h-8" />
+                    <LazyAudioPlayer src={result.audio_url} className="w-full" />
                   </div>
                 </div>
               )}

--- a/src/components/eval-details/TTSResultsTable.tsx
+++ b/src/components/eval-details/TTSResultsTable.tsx
@@ -133,7 +133,7 @@ export function TTSResultsTable({ results, showMetrics = true, judgeLabel = "Eva
                   <td className="px-4 py-3 text-[13px] text-foreground">{index + 1}</td>
                   <td className="px-4 py-3 text-[13px] text-foreground break-words">{result.text}</td>
                   <td className="px-4 py-3 text-[13px] text-foreground">
-                    <audio controls className="w-full" src={result.audio_path}>
+                    <audio controls preload="none" className="w-full" src={result.audio_path}>
                       Your browser does not support the audio element.
                     </audio>
                   </td>
@@ -194,7 +194,7 @@ export function TTSResultsTable({ results, showMetrics = true, judgeLabel = "Eva
               </div>
               <div>
                 <span className="text-[11px] text-muted-foreground uppercase tracking-wide">Audio</span>
-                <audio controls className="w-full mt-1" src={result.audio_path}>
+                <audio controls preload="none" className="w-full mt-1" src={result.audio_path}>
                   Your browser does not support the audio element.
                 </audio>
               </div>

--- a/src/components/eval-details/TTSResultsTable.tsx
+++ b/src/components/eval-details/TTSResultsTable.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { Tooltip } from "@/components/Tooltip";
+import { LazyAudioPlayer } from "@/components/evaluations/LazyAudioPlayer";
 import {
   EvaluatorScoreCell,
   readEvaluatorCell,
@@ -133,9 +134,7 @@ export function TTSResultsTable({ results, showMetrics = true, judgeLabel = "Eva
                   <td className="px-4 py-3 text-[13px] text-foreground">{index + 1}</td>
                   <td className="px-4 py-3 text-[13px] text-foreground break-words">{result.text}</td>
                   <td className="px-4 py-3 text-[13px] text-foreground">
-                    <audio controls preload="none" className="w-full" src={result.audio_path}>
-                      Your browser does not support the audio element.
-                    </audio>
+                    <LazyAudioPlayer src={result.audio_path} className="w-full" />
                   </td>
                   {showMetrics && (
                     useDynamic ? (
@@ -194,9 +193,7 @@ export function TTSResultsTable({ results, showMetrics = true, judgeLabel = "Eva
               </div>
               <div>
                 <span className="text-[11px] text-muted-foreground uppercase tracking-wide">Audio</span>
-                <audio controls preload="none" className="w-full mt-1" src={result.audio_path}>
-                  Your browser does not support the audio element.
-                </audio>
+                <LazyAudioPlayer src={result.audio_path} className="w-full mt-1" />
               </div>
               {showMetrics && (
                 useDynamic

--- a/src/components/evaluations/LazyAudioPlayer.tsx
+++ b/src/components/evaluations/LazyAudioPlayer.tsx
@@ -30,7 +30,9 @@ export function LazyAudioPlayer({
   const [currentTime, setCurrentTime] = useState(0);
   const [duration, setDuration] = useState(0);
 
-  // Tear down the media player on unmount so it doesn't linger against the cap.
+  // Tear down the media player when the source changes (e.g. the row's audio
+  // was replaced) or on unmount, so it never points at a stale clip and never
+  // lingers against the WebMediaPlayer cap.
   useEffect(() => {
     return () => {
       const el = audioRef.current;
@@ -40,8 +42,11 @@ export function LazyAudioPlayer({
         el.load();
         audioRef.current = null;
       }
+      setIsPlaying(false);
+      setCurrentTime(0);
+      setDuration(0);
     };
-  }, []);
+  }, [src]);
 
   const ensureAudio = () => {
     if (audioRef.current) return audioRef.current;

--- a/src/components/evaluations/LazyAudioPlayer.tsx
+++ b/src/components/evaluations/LazyAudioPlayer.tsx
@@ -1,0 +1,118 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+/**
+ * A lightweight audio player that allocates a real HTMLAudioElement only when
+ * the user first presses play. Rendering a native `<audio>` per row hits
+ * Chromium's per-page WebMediaPlayer cap (~hundreds-1000), after which extra
+ * players render dead/greyed — which is why STT/TTS datasets broke past ~500
+ * rows. Creating the player on demand keeps the live count to whatever is
+ * actually playing.
+ */
+
+const formatTime = (seconds: number) => {
+  if (!Number.isFinite(seconds) || seconds < 0) return "0:00";
+  const m = Math.floor(seconds / 60);
+  const s = Math.floor(seconds % 60);
+  return `${m}:${s.toString().padStart(2, "0")}`;
+};
+
+export function LazyAudioPlayer({
+  src,
+  className = "",
+}: {
+  src: string;
+  className?: string;
+}) {
+  const audioRef = useRef<HTMLAudioElement | null>(null);
+  const [isPlaying, setIsPlaying] = useState(false);
+  const [currentTime, setCurrentTime] = useState(0);
+  const [duration, setDuration] = useState(0);
+
+  // Tear down the media player on unmount so it doesn't linger against the cap.
+  useEffect(() => {
+    return () => {
+      const el = audioRef.current;
+      if (el) {
+        el.pause();
+        el.src = "";
+        el.load();
+        audioRef.current = null;
+      }
+    };
+  }, []);
+
+  const ensureAudio = () => {
+    if (audioRef.current) return audioRef.current;
+    const el = new Audio(src);
+    el.addEventListener("loadedmetadata", () =>
+      setDuration(el.duration || 0),
+    );
+    el.addEventListener("timeupdate", () => setCurrentTime(el.currentTime));
+    el.addEventListener("ended", () => {
+      setIsPlaying(false);
+      setCurrentTime(0);
+    });
+    el.addEventListener("pause", () => setIsPlaying(false));
+    el.addEventListener("play", () => setIsPlaying(true));
+    audioRef.current = el;
+    return el;
+  };
+
+  const togglePlay = () => {
+    const el = ensureAudio();
+    if (el.paused) {
+      void el.play();
+    } else {
+      el.pause();
+    }
+  };
+
+  const handleSeek = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const el = ensureAudio();
+    const t = Number(e.target.value);
+    el.currentTime = t;
+    setCurrentTime(t);
+  };
+
+  const progressMax = duration || 0;
+
+  return (
+    <div
+      className={`flex items-center gap-2 h-8 px-2 rounded-full bg-muted ${className}`}
+    >
+      <button
+        type="button"
+        onClick={togglePlay}
+        aria-label={isPlaying ? "Pause" : "Play"}
+        className="flex-shrink-0 w-5 h-5 flex items-center justify-center text-foreground cursor-pointer"
+      >
+        {isPlaying ? (
+          <svg className="w-3.5 h-3.5" viewBox="0 0 24 24" fill="currentColor">
+            <rect x="6" y="5" width="4" height="14" rx="1" />
+            <rect x="14" y="5" width="4" height="14" rx="1" />
+          </svg>
+        ) : (
+          <svg className="w-3.5 h-3.5" viewBox="0 0 24 24" fill="currentColor">
+            <path d="M8 5.14v13.72a1 1 0 001.5.86l11-6.86a1 1 0 000-1.72l-11-6.86A1 1 0 008 5.14z" />
+          </svg>
+        )}
+      </button>
+      <span className="flex-shrink-0 text-[11px] tabular-nums text-muted-foreground">
+        {formatTime(currentTime)} / {formatTime(duration)}
+      </span>
+      <input
+        type="range"
+        min={0}
+        max={progressMax}
+        step={0.01}
+        value={Math.min(currentTime, progressMax)}
+        onChange={handleSeek}
+        disabled={progressMax === 0}
+        aria-label="Seek"
+        className="flex-1 h-1 cursor-pointer accent-foreground disabled:cursor-not-allowed"
+      />
+    </div>
+  );
+}

--- a/src/components/evaluations/LazyAudioPlayer.tsx
+++ b/src/components/evaluations/LazyAudioPlayer.tsx
@@ -74,18 +74,20 @@ export function LazyAudioPlayer({
     }
   };
 
-  const handleSeek = (e: React.ChangeEvent<HTMLInputElement>) => {
+  const seekToRatio = (clientX: number, track: HTMLDivElement) => {
+    if (!duration) return;
+    const rect = track.getBoundingClientRect();
+    const ratio = Math.min(Math.max((clientX - rect.left) / rect.width, 0), 1);
     const el = ensureAudio();
-    const t = Number(e.target.value);
-    el.currentTime = t;
-    setCurrentTime(t);
+    el.currentTime = ratio * duration;
+    setCurrentTime(el.currentTime);
   };
 
-  const progressMax = duration || 0;
+  const progress = duration ? Math.min(currentTime / duration, 1) * 100 : 0;
 
   return (
     <div
-      className={`flex items-center gap-2 h-8 px-2 rounded-full bg-muted ${className}`}
+      className={`inline-flex items-center gap-2.5 h-8 pl-2 pr-3 rounded-full bg-muted ${className}`}
     >
       <button
         type="button"
@@ -104,20 +106,31 @@ export function LazyAudioPlayer({
           </svg>
         )}
       </button>
-      <span className="flex-shrink-0 text-[11px] tabular-nums text-muted-foreground">
+
+      <div
+        role="slider"
+        aria-label="Seek"
+        aria-valuemin={0}
+        aria-valuemax={Math.round(duration)}
+        aria-valuenow={Math.round(currentTime)}
+        onClick={(e) => seekToRatio(e.clientX, e.currentTarget)}
+        className="group relative flex-1 h-3 flex items-center cursor-pointer"
+      >
+        <div className="h-1 w-full rounded-full bg-foreground/15">
+          <div
+            className="h-full rounded-full bg-foreground/70"
+            style={{ width: `${progress}%` }}
+          />
+        </div>
+        <div
+          className="absolute w-2.5 h-2.5 rounded-full bg-foreground shadow-sm opacity-0 group-hover:opacity-100 transition-opacity -translate-x-1/2"
+          style={{ left: `${progress}%` }}
+        />
+      </div>
+
+      <span className="flex-shrink-0 text-[11px] tabular-nums text-muted-foreground w-[68px] text-right">
         {formatTime(currentTime)} / {formatTime(duration)}
       </span>
-      <input
-        type="range"
-        min={0}
-        max={progressMax}
-        step={0.01}
-        value={Math.min(currentTime, progressMax)}
-        onChange={handleSeek}
-        disabled={progressMax === 0}
-        aria-label="Seek"
-        className="flex-1 h-1 cursor-pointer accent-foreground disabled:cursor-not-allowed"
-      />
     </div>
   );
 }

--- a/src/components/evaluations/RowIndexBadge.tsx
+++ b/src/components/evaluations/RowIndexBadge.tsx
@@ -1,0 +1,12 @@
+/**
+ * Numbered badge shown at the start of each dataset row in the STT/TTS editors.
+ * Stays circular for small numbers and grows into a pill for large ones
+ * (datasets can run into the thousands).
+ */
+export function RowIndexBadge({ value }: { value: number }) {
+  return (
+    <div className="flex-shrink-0 min-w-6 h-6 px-1.5 rounded-full bg-muted flex items-center justify-center text-[11px] font-medium text-muted-foreground">
+      {value}
+    </div>
+  );
+}

--- a/src/components/evaluations/STTDatasetEditor.tsx
+++ b/src/components/evaluations/STTDatasetEditor.tsx
@@ -13,6 +13,7 @@ import JSZip from "jszip";
 import { LIMITS, showLimitToast } from "@/constants/limits";
 import { DeleteConfirmationDialog } from "../DeleteConfirmationDialog";
 import { RowIndexBadge } from "./RowIndexBadge";
+import { LazyAudioPlayer } from "./LazyAudioPlayer";
 import type { DatasetItem } from "@/lib/datasets";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
@@ -570,7 +571,7 @@ export const STTDatasetEditor = forwardRef<STTDatasetEditorHandle, Props>(
 
             const isPlayableUrl = item.audio_path?.startsWith("http");
             const audioEl = isPlayableUrl ? (
-              <audio src={item.audio_path!} controls preload="none" className="h-8 w-96" style={{ minWidth: "250px" }} />
+              <LazyAudioPlayer src={item.audio_path!} className="w-96" />
             ) : (
               <div className="h-8 px-3 rounded text-[12px] font-medium border border-border bg-background flex items-center gap-1.5 text-muted-foreground min-w-[140px]">
                 <svg className="w-3.5 h-3.5 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
@@ -631,7 +632,7 @@ export const STTDatasetEditor = forwardRef<STTDatasetEditorHandle, Props>(
                     {deleteBtn}
                   </div>
                   {isPlayableUrl ? (
-                    <audio src={item.audio_path!} controls preload="none" className="w-full h-8" />
+                    <LazyAudioPlayer src={item.audio_path!} className="w-full" />
                   ) : (
                     <div className="h-8 px-3 rounded text-[12px] font-medium border border-border bg-background flex items-center gap-1.5 text-muted-foreground w-full">
                       <svg className="w-3.5 h-3.5 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
@@ -750,7 +751,7 @@ export const STTDatasetEditor = forwardRef<STTDatasetEditorHandle, Props>(
                   <div className="flex-shrink-0 flex items-center gap-2">
                     {isUploaded && row.audioUrl ? (
                       <div className="flex items-center gap-2">
-                        <audio src={row.audioUrl} controls preload="none" className="h-8 w-96" style={{ minWidth: "250px" }} />
+                        <LazyAudioPlayer src={row.audioUrl} className="w-96" />
                         {replaceButton}
                       </div>
                     ) : (
@@ -775,7 +776,7 @@ export const STTDatasetEditor = forwardRef<STTDatasetEditorHandle, Props>(
                   <div>
                     {isUploaded && row.audioUrl ? (
                       <div className="space-y-1.5">
-                        <audio src={row.audioUrl} controls preload="none" className="w-full h-8" />
+                        <LazyAudioPlayer src={row.audioUrl} className="w-full" />
                         {replaceButton}
                       </div>
                     ) : (

--- a/src/components/evaluations/STTDatasetEditor.tsx
+++ b/src/components/evaluations/STTDatasetEditor.tsx
@@ -607,7 +607,7 @@ export const STTDatasetEditor = forwardRef<STTDatasetEditorHandle, Props>(
               >
                 {/* Desktop */}
                 <div className="hidden md:flex items-center gap-2">
-                  <div className="flex-shrink-0 w-6 h-6 rounded-full bg-muted flex items-center justify-center text-[11px] font-medium text-muted-foreground">
+                  <div className="flex-shrink-0 min-w-6 h-6 px-1.5 rounded-full bg-muted flex items-center justify-center text-[11px] font-medium text-muted-foreground">
                     {index + 1}
                   </div>
                   <div className="flex-shrink-0">{audioEl}</div>
@@ -617,7 +617,7 @@ export const STTDatasetEditor = forwardRef<STTDatasetEditorHandle, Props>(
                 {/* Mobile */}
                 <div className="md:hidden space-y-2">
                   <div className="flex items-center justify-between">
-                    <div className="flex-shrink-0 w-6 h-6 rounded-full bg-muted flex items-center justify-center text-[11px] font-medium text-muted-foreground">
+                    <div className="flex-shrink-0 min-w-6 h-6 px-1.5 rounded-full bg-muted flex items-center justify-center text-[11px] font-medium text-muted-foreground">
                       {index + 1}
                     </div>
                     {deleteBtn}
@@ -659,7 +659,7 @@ export const STTDatasetEditor = forwardRef<STTDatasetEditorHandle, Props>(
             const triggerFileInput = () => fileInputRefs.current[row.id]?.click();
 
             const rowBadge = (
-              <div className="flex-shrink-0 w-6 h-6 rounded-full bg-muted flex items-center justify-center text-[11px] font-medium text-muted-foreground">
+              <div className="flex-shrink-0 min-w-6 h-6 px-1.5 rounded-full bg-muted flex items-center justify-center text-[11px] font-medium text-muted-foreground">
                 {rowNumber}
               </div>
             );

--- a/src/components/evaluations/STTDatasetEditor.tsx
+++ b/src/components/evaluations/STTDatasetEditor.tsx
@@ -570,7 +570,7 @@ export const STTDatasetEditor = forwardRef<STTDatasetEditorHandle, Props>(
 
             const isPlayableUrl = item.audio_path?.startsWith("http");
             const audioEl = isPlayableUrl ? (
-              <audio src={item.audio_path!} controls className="h-8 w-96" style={{ minWidth: "250px" }} />
+              <audio src={item.audio_path!} controls preload="none" className="h-8 w-96" style={{ minWidth: "250px" }} />
             ) : (
               <div className="h-8 px-3 rounded text-[12px] font-medium border border-border bg-background flex items-center gap-1.5 text-muted-foreground min-w-[140px]">
                 <svg className="w-3.5 h-3.5 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
@@ -631,7 +631,7 @@ export const STTDatasetEditor = forwardRef<STTDatasetEditorHandle, Props>(
                     {deleteBtn}
                   </div>
                   {isPlayableUrl ? (
-                    <audio src={item.audio_path!} controls className="w-full h-8" />
+                    <audio src={item.audio_path!} controls preload="none" className="w-full h-8" />
                   ) : (
                     <div className="h-8 px-3 rounded text-[12px] font-medium border border-border bg-background flex items-center gap-1.5 text-muted-foreground w-full">
                       <svg className="w-3.5 h-3.5 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
@@ -750,7 +750,7 @@ export const STTDatasetEditor = forwardRef<STTDatasetEditorHandle, Props>(
                   <div className="flex-shrink-0 flex items-center gap-2">
                     {isUploaded && row.audioUrl ? (
                       <div className="flex items-center gap-2">
-                        <audio src={row.audioUrl} controls className="h-8 w-96" style={{ minWidth: "250px" }} />
+                        <audio src={row.audioUrl} controls preload="none" className="h-8 w-96" style={{ minWidth: "250px" }} />
                         {replaceButton}
                       </div>
                     ) : (
@@ -775,7 +775,7 @@ export const STTDatasetEditor = forwardRef<STTDatasetEditorHandle, Props>(
                   <div>
                     {isUploaded && row.audioUrl ? (
                       <div className="space-y-1.5">
-                        <audio src={row.audioUrl} controls className="w-full h-8" />
+                        <audio src={row.audioUrl} controls preload="none" className="w-full h-8" />
                         {replaceButton}
                       </div>
                     ) : (

--- a/src/components/evaluations/STTDatasetEditor.tsx
+++ b/src/components/evaluations/STTDatasetEditor.tsx
@@ -12,6 +12,7 @@ import { toast } from "sonner";
 import JSZip from "jszip";
 import { LIMITS, showLimitToast } from "@/constants/limits";
 import { DeleteConfirmationDialog } from "../DeleteConfirmationDialog";
+import { RowIndexBadge } from "./RowIndexBadge";
 import type { DatasetItem } from "@/lib/datasets";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
@@ -618,9 +619,7 @@ export const STTDatasetEditor = forwardRef<STTDatasetEditorHandle, Props>(
               >
                 {/* Desktop */}
                 <div className="hidden md:flex items-center gap-2">
-                  <div className="flex-shrink-0 min-w-6 h-6 px-1.5 rounded-full bg-muted flex items-center justify-center text-[11px] font-medium text-muted-foreground">
-                    {index + 1}
-                  </div>
+                  <RowIndexBadge value={index + 1} />
                   <div className="flex-shrink-0">{audioEl}</div>
                   {textField}
                   {deleteBtn}
@@ -628,9 +627,7 @@ export const STTDatasetEditor = forwardRef<STTDatasetEditorHandle, Props>(
                 {/* Mobile */}
                 <div className="md:hidden space-y-2">
                   <div className="flex items-center justify-between">
-                    <div className="flex-shrink-0 min-w-6 h-6 px-1.5 rounded-full bg-muted flex items-center justify-center text-[11px] font-medium text-muted-foreground">
-                      {index + 1}
-                    </div>
+                    <RowIndexBadge value={index + 1} />
                     {deleteBtn}
                   </div>
                   {isPlayableUrl ? (
@@ -669,11 +666,7 @@ export const STTDatasetEditor = forwardRef<STTDatasetEditorHandle, Props>(
 
             const triggerFileInput = () => fileInputRefs.current[row.id]?.click();
 
-            const rowBadge = (
-              <div className="flex-shrink-0 min-w-6 h-6 px-1.5 rounded-full bg-muted flex items-center justify-center text-[11px] font-medium text-muted-foreground">
-                {rowNumber}
-              </div>
-            );
+            const rowBadge = <RowIndexBadge value={rowNumber} />;
 
             const deleteButton = (newRows.length > 1 || savedCount > 0) && (
               <button

--- a/src/components/evaluations/STTDatasetEditor.tsx
+++ b/src/components/evaluations/STTDatasetEditor.tsx
@@ -508,9 +508,14 @@ export const STTDatasetEditor = forwardRef<STTDatasetEditorHandle, Props>(
         setUploadStatus(builtStatus);
         setInvalidRowIds(new Set());
 
-        for (const row of builtRows) {
-          if (row.audioFile) {
-            const s3Path = await uploadFileToS3(row.audioFile);
+        // Upload audio to S3 with bounded concurrency — a sequential loop is
+        // far too slow for datasets in the thousands.
+        const pending = builtRows.filter((r) => r.audioFile);
+        let cursor = 0;
+        const worker = async () => {
+          while (cursor < pending.length) {
+            const row = pending[cursor++];
+            const s3Path = await uploadFileToS3(row.audioFile!);
             if (s3Path) {
               setNewRows((prev) => prev.map((r) => (r.id === row.id ? { ...r, s3Path } : r)));
               setUploadStatus((prev) => ({ ...prev, [row.id]: "success" }));
@@ -518,7 +523,13 @@ export const STTDatasetEditor = forwardRef<STTDatasetEditorHandle, Props>(
               setUploadStatus((prev) => ({ ...prev, [row.id]: "error" }));
             }
           }
-        }
+        };
+        await Promise.all(
+          Array.from(
+            { length: Math.min(LIMITS.STT_UPLOAD_CONCURRENCY, pending.length) },
+            worker,
+          ),
+        );
       } catch {
         toast.error("Failed to process ZIP file");
       } finally {

--- a/src/components/evaluations/TTSDatasetEditor.tsx
+++ b/src/components/evaluations/TTSDatasetEditor.tsx
@@ -254,7 +254,7 @@ export const TTSDatasetEditor = forwardRef<TTSDatasetEditorHandle, Props>(
                 key={item.uuid}
                 className="flex items-center gap-3 px-4 py-3 border-b border-border"
               >
-                <div className="flex-shrink-0 w-6 h-6 rounded-full bg-muted flex items-center justify-center text-[11px] font-medium text-muted-foreground">
+                <div className="flex-shrink-0 min-w-6 h-6 px-1.5 rounded-full bg-muted flex items-center justify-center text-[11px] font-medium text-muted-foreground">
                   {index + 1}
                 </div>
                 <input
@@ -300,7 +300,7 @@ export const TTSDatasetEditor = forwardRef<TTSDatasetEditorHandle, Props>(
                   isInvalid ? "bg-red-500/5" : ""
                 }`}
               >
-                <div className="flex-shrink-0 w-6 h-6 rounded-full bg-muted flex items-center justify-center text-[11px] font-medium text-muted-foreground">
+                <div className="flex-shrink-0 min-w-6 h-6 px-1.5 rounded-full bg-muted flex items-center justify-center text-[11px] font-medium text-muted-foreground">
                   {globalIndex + 1}
                 </div>
                 <input

--- a/src/components/evaluations/TTSDatasetEditor.tsx
+++ b/src/components/evaluations/TTSDatasetEditor.tsx
@@ -10,6 +10,7 @@ import {
 import { toast } from "sonner";
 import { LIMITS, showLimitToast } from "@/constants/limits";
 import { DeleteConfirmationDialog } from "../DeleteConfirmationDialog";
+import { RowIndexBadge } from "./RowIndexBadge";
 import type { DatasetItem } from "@/lib/datasets";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
@@ -254,9 +255,7 @@ export const TTSDatasetEditor = forwardRef<TTSDatasetEditorHandle, Props>(
                 key={item.uuid}
                 className="flex items-center gap-3 px-4 py-3 border-b border-border"
               >
-                <div className="flex-shrink-0 min-w-6 h-6 px-1.5 rounded-full bg-muted flex items-center justify-center text-[11px] font-medium text-muted-foreground">
-                  {index + 1}
-                </div>
+                <RowIndexBadge value={index + 1} />
                 <input
                   type="text"
                   value={currentText}
@@ -300,9 +299,7 @@ export const TTSDatasetEditor = forwardRef<TTSDatasetEditorHandle, Props>(
                   isInvalid ? "bg-red-500/5" : ""
                 }`}
               >
-                <div className="flex-shrink-0 min-w-6 h-6 px-1.5 rounded-full bg-muted flex items-center justify-center text-[11px] font-medium text-muted-foreground">
-                  {globalIndex + 1}
-                </div>
+                <RowIndexBadge value={globalIndex + 1} />
                 <input
                   type="text"
                   value={row.text}

--- a/src/constants/limits.tsx
+++ b/src/constants/limits.tsx
@@ -17,6 +17,9 @@ export const LIMITS = {
 
   // Fallback when the per-user limit API is unreachable
   DEFAULT_MAX_ROWS_PER_EVAL: 20,
+
+  // Max concurrent S3 uploads when bulk-uploading audio (ZIP import)
+  STT_UPLOAD_CONCURRENCY: 8,
 };
 
 // Contact link for extending limits

--- a/src/lib/datasets.ts
+++ b/src/lib/datasets.ts
@@ -77,16 +77,35 @@ export function deleteDataset(
 export type NewSTTItem = { audio_path: string; text: string };
 export type NewTTSItem = { text: string };
 
-export function addDatasetItems(
+// The backend rejects POST /{dataset_id}/items requests with more than this
+// many items (datasets.py). There is no cap on total items per dataset, so we
+// split large saves into sequential batches (sequential preserves row order).
+export const MAX_ITEMS_PER_REQUEST = 1000;
+
+export async function addDatasetItems(
   accessToken: string,
   datasetId: string,
   items: NewSTTItem[] | NewTTSItem[]
 ): Promise<DatasetItem[]> {
-  return apiPost<DatasetItem[]>(
-    `/datasets/${datasetId}/items`,
-    accessToken,
-    items
-  );
+  if (items.length <= MAX_ITEMS_PER_REQUEST) {
+    return apiPost<DatasetItem[]>(
+      `/datasets/${datasetId}/items`,
+      accessToken,
+      items
+    );
+  }
+
+  const created: DatasetItem[] = [];
+  for (let i = 0; i < items.length; i += MAX_ITEMS_PER_REQUEST) {
+    const batch = items.slice(i, i + MAX_ITEMS_PER_REQUEST);
+    const result = await apiPost<DatasetItem[]>(
+      `/datasets/${datasetId}/items`,
+      accessToken,
+      batch
+    );
+    created.push(...result);
+  }
+  return created;
 }
 
 // Update a single item's text


### PR DESCRIPTION
## What
- Row-index badge in the STT/TTS dataset editors used a fixed-width circle, so 4-digit indices overflowed; now it grows into a pill for large numbers and stays circular for small ones.
- STT ZIP bulk import uploaded audio to S3 in a sequential loop; now uses a bounded worker pool (concurrency 8) so thousands of files upload ~8x faster.

## Notes
- TTS has no per-row upload (text saved in the final POST), so only STT was parallelized.
- Concurrency is configurable via `STT_UPLOAD_CONCURRENCY` in `src/constants/limits.tsx`.